### PR TITLE
chore: Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Unit and end-to-end tests for `jolt-core` can be run using the following command
 
 Examples in the [`examples`](./examples/) directory can be run using e.g.
 
-```cargo run --release -p sha2-chain`
+```cargo run --release -p sha2-chain```
 
 
 ## Performance profiling


### PR DESCRIPTION
Closes unbalanced '`' in README.md