### PR TITLE
feat: standard library support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,8 @@ members = [
     "examples/multi-function/guest",
     "examples/alloc",
     "examples/alloc/guest",
+    "examples/stdlib",
+    "examples/stdlib/guest",
 ]
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ members = [
 ]
 
 [features]
-std = ["jolt-sdk/std"]
+host = ["jolt-sdk/host"]
 
 [lib]
 path = "./src/lib.rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,6 +62,10 @@ clap = { version = "4.5.4", features = ["derive"] }
 eyre = "0.6.12"
 rand = "0.8.5"
 sysinfo = "0.30.8"
+target-lexicon = "0.12.14"
+reqwest = { version = "0.12.3", features = ["json", "blocking"] }
+serde_json = "1.0.116"
+dirs = "5.0.1"
 
 [profile.test]
 opt-level = 3

--- a/examples/alloc/Cargo.toml
+++ b/examples/alloc/Cargo.toml
@@ -4,5 +4,5 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-jolt-sdk = { path = "../../jolt-sdk", features = ["std"] }
+jolt-sdk = { path = "../../jolt-sdk", features = ["host"] }
 guest = { package = "alloc-guest", path = "./guest" }

--- a/examples/collatz/Cargo.toml
+++ b/examples/collatz/Cargo.toml
@@ -4,5 +4,5 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-jolt-sdk = { path = "../../jolt-sdk", features = ["std"] }
+jolt-sdk = { path = "../../jolt-sdk", features = ["host"] }
 guest = { package = "collatz-guest", path = "./guest" }

--- a/examples/fibonacci/Cargo.toml
+++ b/examples/fibonacci/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-jolt-sdk = { path = "../../jolt-sdk", features = ["std"] }
+jolt-sdk = { path = "../../jolt-sdk", features = ["host"] }
 guest = { package = "fibonacci-guest", path = "./guest" }
 
 hex = "0.4.3"

--- a/examples/multi-function/Cargo.toml
+++ b/examples/multi-function/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-jolt-sdk = { path = "../../jolt-sdk", features = ["std"] }
+jolt-sdk = { path = "../../jolt-sdk", features = ["host"] }
 guest = { package = "multi-function-guest", path = "./guest" }
 
 hex = "0.4.3"

--- a/examples/sha2-chain/Cargo.toml
+++ b/examples/sha2-chain/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-jolt-sdk = { path = "../../jolt-sdk", features = ["std"] }
+jolt-sdk = { path = "../../jolt-sdk", features = ["host"] }
 guest = { package = "sha2-chain-guest", path = "./guest" }
 
 hex = "0.4.3"

--- a/examples/sha2-ex/Cargo.toml
+++ b/examples/sha2-ex/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-jolt-sdk = { path = "../../jolt-sdk", features = ["std"] }
+jolt-sdk = { path = "../../jolt-sdk", features = ["host"] }
 guest = { package = "sha2-guest", path = "./guest" }
 
 hex = "0.4.3"

--- a/examples/sha3-chain/Cargo.toml
+++ b/examples/sha3-chain/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-jolt-sdk = { path = "../../jolt-sdk", features = ["std"] }
+jolt-sdk = { path = "../../jolt-sdk", features = ["host"] }
 guest = { package = "sha3-chain-guest", path = "./guest" }
 
 hex = "0.4.3"

--- a/examples/sha3-ex/Cargo.toml
+++ b/examples/sha3-ex/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-jolt-sdk = { path = "../../jolt-sdk", features = ["std"] }
+jolt-sdk = { path = "../../jolt-sdk", features = ["host"] }
 guest = { package = "sha3-guest", path = "./guest" }
 
 hex = "0.4.3"

--- a/examples/stdlib/Cargo.toml
+++ b/examples/stdlib/Cargo.toml
@@ -4,5 +4,5 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-jolt-sdk = { path = "../../jolt-sdk", features = ["std"] }
+jolt-sdk = { path = "../../jolt-sdk", features = ["host"] }
 guest = { package = "stdlib-guest", path = "./guest" }

--- a/examples/stdlib/Cargo.toml
+++ b/examples/stdlib/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "stdlib"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+jolt-sdk = { path = "../../jolt-sdk", features = ["std"] }
+guest = { package = "stdlib-guest", path = "./guest" }

--- a/examples/stdlib/guest/Cargo.toml
+++ b/examples/stdlib/guest/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "stdlib-guest"
+version = "0.1.0"
+edition = "2021"
+
+[[bin]]
+name = "guest"
+path = "./src/lib.rs"
+
+[features]
+guest = []
+
+[dependencies]
+jolt = { package = "jolt-sdk", path = "../../../jolt-sdk" }

--- a/examples/stdlib/guest/Cargo.toml
+++ b/examples/stdlib/guest/Cargo.toml
@@ -11,4 +11,4 @@ path = "./src/lib.rs"
 guest = []
 
 [dependencies]
-jolt = { package = "jolt-sdk", path = "../../../jolt-sdk" }
+jolt = { package = "jolt-sdk", path = "../../../jolt-sdk", features = ["std"] }

--- a/examples/stdlib/guest/Cargo.toml
+++ b/examples/stdlib/guest/Cargo.toml
@@ -11,4 +11,4 @@ path = "./src/lib.rs"
 guest = []
 
 [dependencies]
-jolt = { package = "jolt-sdk", path = "../../../jolt-sdk", features = ["std"] }
+jolt = { package = "jolt-sdk", path = "../../../jolt-sdk", features = ["guest-std"] }

--- a/examples/stdlib/guest/src/lib.rs
+++ b/examples/stdlib/guest/src/lib.rs
@@ -1,0 +1,11 @@
+#![no_main]
+
+#[jolt::provable]
+fn fun_with_strings(n: u32) -> u32 {
+    let mut v = Vec::<String>::new();
+    for i in 0..100 {
+        v.push(i.to_string());
+    }
+
+    v[n as usize].parse().unwrap()
+}

--- a/examples/stdlib/guest/src/lib.rs
+++ b/examples/stdlib/guest/src/lib.rs
@@ -1,6 +1,6 @@
 #![no_main]
 
-#[jolt::provable(std)]
+#[jolt::provable]
 fn int_to_string(n: i32) -> String {
     n.to_string()
 }

--- a/examples/stdlib/guest/src/lib.rs
+++ b/examples/stdlib/guest/src/lib.rs
@@ -4,4 +4,3 @@
 fn int_to_string(n: i32) -> String {
     n.to_string()
 }
-

--- a/examples/stdlib/guest/src/lib.rs
+++ b/examples/stdlib/guest/src/lib.rs
@@ -1,6 +1,6 @@
 #![no_main]
 
-#[jolt::provable]
+#[jolt::provable(std)]
 fn int_to_string(n: i32) -> String {
     n.to_string()
 }

--- a/examples/stdlib/guest/src/lib.rs
+++ b/examples/stdlib/guest/src/lib.rs
@@ -1,11 +1,6 @@
 #![no_main]
 
 #[jolt::provable]
-fn fun_with_strings(n: u32) -> u32 {
-    let mut v = Vec::<String>::new();
-    for i in 0..100 {
-        v.push(i.to_string());
-    }
-
-    v[n as usize].parse().unwrap()
+fn int_to_string(n: i32) -> String {
+    n.to_string()
 }

--- a/examples/stdlib/guest/src/lib.rs
+++ b/examples/stdlib/guest/src/lib.rs
@@ -4,3 +4,4 @@
 fn int_to_string(n: i32) -> String {
     n.to_string()
 }
+

--- a/examples/stdlib/src/main.rs
+++ b/examples/stdlib/src/main.rs
@@ -1,7 +1,7 @@
 pub fn main() {
-    let (prove, verify) = guest::build_fun_with_strings();
+    let (prove, verify) = guest::build_int_to_string();
 
-    let (output, proof) = prove(41);
+    let (output, proof) = prove(81);
     let is_valid = verify(proof);
 
     println!("output: {:?}", output);

--- a/examples/stdlib/src/main.rs
+++ b/examples/stdlib/src/main.rs
@@ -1,0 +1,9 @@
+pub fn main() {
+    let (prove, verify) = guest::build_fun_with_strings();
+
+    let (output, proof) = prove(41);
+    let is_valid = verify(proof);
+
+    println!("output: {:?}", output);
+    println!("valid: {}", is_valid);
+}

--- a/jolt-core/src/host/mod.rs
+++ b/jolt-core/src/host/mod.rs
@@ -85,7 +85,11 @@ impl Program {
         if self.elf.is_none() {
             self.save_linker();
 
-            let mut envs = vec![("RUSTFLAGS", format!("-C link-arg=-T{}", self.linker_path()))];
+            let mut envs = vec![
+                ("RUSTFLAGS", format!("-C link-arg=-T{}", self.linker_path())),
+                ("RUSTUP_TOOLCHAIN", "riscv32i-jolt-zkvm-elf".to_string()),
+            ];
+
             if let Some(func) = &self.func {
                 envs.push(("JOLT_FUNC_NAME", func.to_string()));
             }
@@ -108,7 +112,7 @@ impl Program {
                     "--target-dir",
                     &target,
                     "--target",
-                    "riscv32i-unknown-none-elf",
+                    "riscv32i-jolt-zkvm-elf",
                     "--bin",
                     "guest",
                 ])
@@ -120,7 +124,7 @@ impl Program {
                 panic!("failed to compile guest");
             }
 
-            let elf = format!("{}/riscv32i-unknown-none-elf/release/guest", target,);
+            let elf = format!("{}/riscv32i-jolt-zkvm-elf/release/guest", target,);
             self.elf = Some(PathBuf::from_str(&elf).unwrap());
         }
     }

--- a/jolt-core/src/host/mod.rs
+++ b/jolt-core/src/host/mod.rs
@@ -85,8 +85,17 @@ impl Program {
         if self.elf.is_none() {
             self.save_linker();
 
+            let rust_flags = [
+                "-C",
+                &format!("link-arg=-T{}" ,self.linker_path()),
+                "-C",
+                "passes=loweratomic",
+                "-C",
+                "panic=abort",
+            ];
+
             let mut envs = vec![
-                ("RUSTFLAGS", format!("-C link-arg=-T{}", self.linker_path())),
+                ("CARGO_ENCODED_RUSTFLAGS", rust_flags.join("\x1f")),
                 ("RUSTUP_TOOLCHAIN", "riscv32i-jolt-zkvm-elf".to_string()),
             ];
 

--- a/jolt-core/src/host/mod.rs
+++ b/jolt-core/src/host/mod.rs
@@ -106,9 +106,7 @@ impl Program {
                 "riscv32i-unknown-none-elf"
             };
 
-            let mut envs = vec![
-                ("CARGO_ENCODED_RUSTFLAGS", rust_flags.join("\x1f")),
-            ];
+            let mut envs = vec![("CARGO_ENCODED_RUSTFLAGS", rust_flags.join("\x1f"))];
 
             if self.std {
                 envs.push(("RUSTUP_TOOLCHAIN", toolchain.to_string()));

--- a/jolt-core/src/host/mod.rs
+++ b/jolt-core/src/host/mod.rs
@@ -87,7 +87,7 @@ impl Program {
 
             let rust_flags = [
                 "-C",
-                &format!("link-arg=-T{}" ,self.linker_path()),
+                &format!("link-arg=-T{}", self.linker_path()),
                 "-C",
                 "passes=loweratomic",
                 "-C",

--- a/jolt-sdk/Cargo.toml
+++ b/jolt-sdk/Cargo.toml
@@ -25,9 +25,14 @@ host = [
     "postcard/use-std",
 ]
 
+std = [
+    "postcard/use-std",
+    "serde/std",
+]
+
 [dependencies]
-postcard = { version = "1.0.8", features = ["use-std"] }
-serde = "1.0.196"
+postcard = { version = "1.0.8", default-features = false }
+serde = { version = "1.0.196", default-features = false }
 eyre = { version = "0.6.12", optional = true }
 ark-ec = { version = "0.4.2", default-features = false, optional = true }
 ark-ff = { version = "0.4.2", default-features = false, optional = true }

--- a/jolt-sdk/Cargo.toml
+++ b/jolt-sdk/Cargo.toml
@@ -28,6 +28,7 @@ host = [
 std = [
     "postcard/use-std",
     "serde/std",
+    "jolt-sdk-macros/std",
 ]
 
 [dependencies]

--- a/jolt-sdk/Cargo.toml
+++ b/jolt-sdk/Cargo.toml
@@ -22,12 +22,11 @@ std = [
     "dep:ark-bn254",
     "dep:ark-serialize",
     "dep:eyre",
-    "postcard/use-std",
 ]
 
 [dependencies]
-postcard = { version = "1.0.8", default-features = false }
-serde = { version = "1.0.*", default-features = false }
+postcard = "1.0.8"
+serde = "1.0.196"
 eyre = { version = "0.6.12", optional = true }
 ark-ec = { version = "0.4.2", default-features = false, optional = true }
 ark-ff = { version = "0.4.2", default-features = false, optional = true }

--- a/jolt-sdk/Cargo.toml
+++ b/jolt-sdk/Cargo.toml
@@ -25,10 +25,10 @@ host = [
     "postcard/use-std",
 ]
 
-std = [
+guest-std = [
     "postcard/use-std",
     "serde/std",
-    "jolt-sdk-macros/std",
+    "jolt-sdk-macros/guest-std",
 ]
 
 [dependencies]

--- a/jolt-sdk/Cargo.toml
+++ b/jolt-sdk/Cargo.toml
@@ -13,7 +13,7 @@ repository = "https://github.com/a16z/jolt"
 edition = "2021"
 
 [features]
-std = [
+host = [
     "dep:tracer",
     "dep:common",
     "dep:jolt-core",
@@ -22,10 +22,11 @@ std = [
     "dep:ark-bn254",
     "dep:ark-serialize",
     "dep:eyre",
+    "postcard/use-std",
 ]
 
 [dependencies]
-postcard = "1.0.8"
+postcard = { version = "1.0.8", features = ["use-std"] }
 serde = "1.0.196"
 eyre = { version = "0.6.12", optional = true }
 ark-ec = { version = "0.4.2", default-features = false, optional = true }

--- a/jolt-sdk/macros/Cargo.toml
+++ b/jolt-sdk/macros/Cargo.toml
@@ -15,6 +15,9 @@ edition="2021"
 [lib]
 proc-macro = true
 
+[features]
+std = []
+
 [dependencies]
 syn = { version = "1.0", features = ["full"] }
 quote = "1.0"

--- a/jolt-sdk/macros/Cargo.toml
+++ b/jolt-sdk/macros/Cargo.toml
@@ -21,5 +21,5 @@ quote = "1.0"
 proc-macro2 = "1.0.79"
 
 postcard = "1.0.8"
-serde = { version = "1.0.196", features = [] }
+serde = "1.0.196"
 common = { path = "../../common" }

--- a/jolt-sdk/macros/Cargo.toml
+++ b/jolt-sdk/macros/Cargo.toml
@@ -20,6 +20,6 @@ syn = { version = "1.0", features = ["full"] }
 quote = "1.0"
 proc-macro2 = "1.0.79"
 
-postcard = "1.0.8"
-serde = "1.0.196"
+# postcard = "1.0.8"
+# serde = "1.0.196"
 common = { path = "../../common" }

--- a/jolt-sdk/macros/Cargo.toml
+++ b/jolt-sdk/macros/Cargo.toml
@@ -16,7 +16,7 @@ edition="2021"
 proc-macro = true
 
 [features]
-std = []
+guest-std = []
 
 [dependencies]
 syn = { version = "1.0", features = ["full"] }

--- a/jolt-sdk/macros/Cargo.toml
+++ b/jolt-sdk/macros/Cargo.toml
@@ -20,6 +20,4 @@ syn = { version = "1.0", features = ["full"] }
 quote = "1.0"
 proc-macro2 = "1.0.79"
 
-# postcard = "1.0.8"
-# serde = "1.0.196"
 common = { path = "../../common" }

--- a/jolt-sdk/macros/src/lib.rs
+++ b/jolt-sdk/macros/src/lib.rs
@@ -343,6 +343,7 @@ impl MacroBuilder {
     fn make_panic(&self, panic_address: u64) -> TokenStream2 {
         if self.std {
             quote! {
+                #[cfg(feature = "guest")]
                 #[no_mangle]
                 pub extern "C" fn jolt_panic() {
                     unsafe {

--- a/jolt-sdk/macros/src/lib.rs
+++ b/jolt-sdk/macros/src/lib.rs
@@ -36,9 +36,9 @@ struct MacroBuilder {
 impl MacroBuilder {
     fn new(attr: AttributeArgs, func: ItemFn) -> Self {
         let func_args = Self::get_func_args(&func);
-        #[cfg(feature = "std")]
+        #[cfg(feature = "guest-std")]
         let std = true;
-        #[cfg(not(feature = "std"))]
+        #[cfg(not(feature = "guest-std"))]
         let std = false;
 
         Self {

--- a/jolt-sdk/macros/src/lib.rs
+++ b/jolt-sdk/macros/src/lib.rs
@@ -327,15 +327,15 @@ impl MacroBuilder {
                 #handle_return
             }
 
-            #[cfg(feature = "guest")]
-            #[panic_handler]
-            fn panic(_info: &PanicInfo) -> ! {
-                unsafe {
-                    core::ptr::write_volatile(#panic_address as *mut u8, 1);
-                }
+            // #[cfg(feature = "guest")]
+            // #[panic_handler]
+            // fn panic(_info: &PanicInfo) -> ! {
+            //     unsafe {
+            //         core::ptr::write_volatile(#panic_address as *mut u8, 1);
+            //     }
 
-                loop {}
-            }
+            //     loop {}
+            // }
         }
     }
 

--- a/jolt-sdk/macros/src/lib.rs
+++ b/jolt-sdk/macros/src/lib.rs
@@ -312,9 +312,9 @@ impl MacroBuilder {
                     j .\n\
             ");
 
-            #[cfg(feature = "guest")]
-            #[global_allocator]
-            static ALLOCATOR: jolt::BumpAllocator = jolt::BumpAllocator::new();
+            // #[cfg(feature = "guest")]
+            // #[global_allocator]
+            // static ALLOCATOR: jolt::BumpAllocator = jolt::BumpAllocator::new();
 
             #[cfg(feature = "guest")]
             #[no_mangle]

--- a/jolt-sdk/macros/src/lib.rs
+++ b/jolt-sdk/macros/src/lib.rs
@@ -138,6 +138,7 @@ impl MacroBuilder {
         let set_mem_size = self.make_set_linker_parameters();
         let guest_name = self.get_guest_name();
         let imports = self.make_imports();
+        let set_std = self.make_set_std();
 
         let fn_name = self.get_func_name();
         let fn_name_str = fn_name.to_string();
@@ -156,6 +157,7 @@ impl MacroBuilder {
 
                 let mut program = Program::new(#guest_name);
                 program.set_func(#fn_name_str);
+                #set_std
                 #set_mem_size
                 #(#set_program_args;)*
 
@@ -168,16 +170,7 @@ impl MacroBuilder {
         let set_mem_size = self.make_set_linker_parameters();
         let guest_name = self.get_guest_name();
         let imports = self.make_imports();
-
-        let set_std = if self.std {
-            quote! {
-                program.set_std(true);
-            }
-        } else {
-            quote! {
-                program.set_std(false);
-            }
-        };
+        let set_std = self.make_set_std();
 
         let fn_name = self.get_func_name();
         let fn_name_str = fn_name.to_string();
@@ -437,6 +430,18 @@ impl MacroBuilder {
 
         quote! {
             #(#code;)*
+        }
+    }
+
+    fn make_set_std(&self) -> TokenStream2 {
+        if self.std {
+            quote! {
+                program.set_std(true);
+            }
+        } else {
+            quote! {
+                program.set_std(false);
+            }
         }
     }
 

--- a/jolt-sdk/src/alloc.rs
+++ b/jolt-sdk/src/alloc.rs
@@ -1,4 +1,7 @@
-use core::{alloc::{GlobalAlloc, Layout}, cell::UnsafeCell};
+use core::{
+    alloc::{GlobalAlloc, Layout},
+    cell::UnsafeCell,
+};
 
 pub struct BumpAllocator {
     offset: UnsafeCell<usize>,

--- a/jolt-sdk/src/alloc.rs
+++ b/jolt-sdk/src/alloc.rs
@@ -1,0 +1,43 @@
+use core::{alloc::{GlobalAlloc, Layout}, cell::UnsafeCell};
+
+pub struct BumpAllocator {
+    offset: UnsafeCell<usize>,
+}
+
+unsafe impl Sync for BumpAllocator {}
+
+extern "C" {
+    static _HEAP_PTR: u8;
+}
+
+fn heap_start() -> usize {
+    unsafe { _HEAP_PTR as *const u8 as usize }
+}
+
+impl BumpAllocator {
+    pub const fn new() -> Self {
+        Self {
+            offset: UnsafeCell::new(0),
+        }
+    }
+
+    pub fn free_memory(&self) -> usize {
+        heap_start() + (self.offset.get() as usize)
+    }
+}
+
+unsafe impl GlobalAlloc for BumpAllocator {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        let alloc_start = align_up(self.free_memory(), layout.align());
+        let alloc_end = alloc_start + layout.size();
+        *self.offset.get() = alloc_end - self.free_memory();
+
+        alloc_start as *mut u8
+    }
+
+    unsafe fn dealloc(&self, _ptr: *mut u8, _layout: Layout) {}
+}
+
+fn align_up(addr: usize, align: usize) -> usize {
+    (addr + align - 1) & !(align - 1)
+}

--- a/jolt-sdk/src/host_utils.rs
+++ b/jolt-sdk/src/host_utils.rs
@@ -1,0 +1,47 @@
+use eyre::Result;
+use std::fs::File;
+use std::path::PathBuf;
+use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
+pub use ark_bn254::{Fr as F, G1Projective as G};
+pub use ark_ec::CurveGroup;
+pub use ark_ff::PrimeField;
+pub use common::{
+    constants::MEMORY_OPS_PER_INSTRUCTION,
+    rv_trace::{MemoryOp, RV32IM},
+};
+pub use jolt_core::host;
+pub use jolt_core::jolt::instruction;
+pub use jolt_core::jolt::vm::{
+    bytecode::BytecodeRow,
+    rv32i_vm::{RV32IJoltProof, RV32IJoltVM, RV32I},
+    Jolt, JoltCommitments, JoltPreprocessing, JoltProof,
+};
+pub use tracer;
+
+#[derive(CanonicalSerialize, CanonicalDeserialize)]
+pub struct Proof {
+    pub proof: RV32IJoltProof<F, G>,
+    pub commitments: JoltCommitments<G>,
+}
+
+impl Proof {
+    /// Gets the byte size of the full proof
+    pub fn size(&self) -> Result<usize> {
+        let mut buffer = Vec::new();
+        self.serialize_compressed(&mut buffer)?;
+        Ok(buffer.len())
+    }
+
+    /// Saves the proof to a file
+    pub fn save_to_file<P: Into<PathBuf>>(&self, path: P) -> Result<()> {
+        let file = File::create(path.into())?;
+        self.serialize_compressed(file)?;
+        Ok(())
+    }
+
+    /// Reads a proof from a file
+    pub fn from_file<P: Into<PathBuf>>(path: P) -> Result<Self> {
+        let file = File::open(path.into())?;
+        Ok(Proof::deserialize_compressed(file)?)
+    }
+}

--- a/jolt-sdk/src/host_utils.rs
+++ b/jolt-sdk/src/host_utils.rs
@@ -1,10 +1,13 @@
-use eyre::Result;
 use std::fs::File;
 use std::path::PathBuf;
+
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
+use eyre::Result;
+
 pub use ark_bn254::{Fr as F, G1Projective as G};
 pub use ark_ec::CurveGroup;
 pub use ark_ff::PrimeField;
+
 pub use common::{
     constants::MEMORY_OPS_PER_INSTRUCTION,
     rv_trace::{MemoryOp, RV32IM},

--- a/jolt-sdk/src/lib.rs
+++ b/jolt-sdk/src/lib.rs
@@ -2,11 +2,6 @@
 
 extern crate jolt_sdk_macros;
 
-use core::{
-    alloc::{GlobalAlloc, Layout},
-    cell::UnsafeCell,
-};
-
 pub use jolt_sdk_macros::provable;
 pub use postcard;
 
@@ -15,44 +10,5 @@ pub mod host_utils;
 #[cfg(feature = "host")]
 pub use host_utils::*;
 
-pub struct BumpAllocator {
-    offset: UnsafeCell<usize>,
-}
-
-unsafe impl Sync for BumpAllocator {}
-
-extern "C" {
-    static _HEAP_PTR: u8;
-}
-
-fn heap_start() -> usize {
-    unsafe { _HEAP_PTR as *const u8 as usize }
-}
-
-impl BumpAllocator {
-    pub const fn new() -> Self {
-        Self {
-            offset: UnsafeCell::new(0),
-        }
-    }
-
-    pub fn free_memory(&self) -> usize {
-        heap_start() + (self.offset.get() as usize)
-    }
-}
-
-unsafe impl GlobalAlloc for BumpAllocator {
-    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
-        let alloc_start = align_up(self.free_memory(), layout.align());
-        let alloc_end = alloc_start + layout.size();
-        *self.offset.get() = alloc_end - self.free_memory();
-
-        alloc_start as *mut u8
-    }
-
-    unsafe fn dealloc(&self, _ptr: *mut u8, _layout: Layout) {}
-}
-
-fn align_up(addr: usize, align: usize) -> usize {
-    (addr + align - 1) & !(align - 1)
-}
+pub mod alloc;
+pub use alloc::*;

--- a/jolt-sdk/src/lib.rs
+++ b/jolt-sdk/src/lib.rs
@@ -2,77 +2,18 @@
 
 extern crate jolt_sdk_macros;
 
-#[cfg(feature = "host")]
-use std::fs::File;
-#[cfg(feature = "host")]
-use std::path::PathBuf;
-
 use core::{
     alloc::{GlobalAlloc, Layout},
     cell::UnsafeCell,
 };
 
-#[cfg(feature = "host")]
-use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
-#[cfg(feature = "host")]
-use eyre::Result;
-
 pub use jolt_sdk_macros::provable;
 pub use postcard;
 
 #[cfg(feature = "host")]
-pub use ark_bn254::{Fr as F, G1Projective as G};
+pub mod host_utils;
 #[cfg(feature = "host")]
-pub use ark_ec::CurveGroup;
-#[cfg(feature = "host")]
-pub use ark_ff::PrimeField;
-#[cfg(feature = "host")]
-pub use common::{
-    constants::MEMORY_OPS_PER_INSTRUCTION,
-    rv_trace::{MemoryOp, RV32IM},
-};
-#[cfg(feature = "host")]
-pub use jolt_core::host;
-#[cfg(feature = "host")]
-pub use jolt_core::jolt::instruction;
-#[cfg(feature = "host")]
-pub use jolt_core::jolt::vm::{
-    bytecode::BytecodeRow,
-    rv32i_vm::{RV32IJoltProof, RV32IJoltVM, RV32I},
-    Jolt, JoltCommitments, JoltPreprocessing, JoltProof,
-};
-#[cfg(feature = "host")]
-pub use tracer;
-
-#[cfg(feature = "host")]
-#[derive(CanonicalSerialize, CanonicalDeserialize)]
-pub struct Proof {
-    pub proof: RV32IJoltProof<F, G>,
-    pub commitments: JoltCommitments<G>,
-}
-
-#[cfg(feature = "host")]
-impl Proof {
-    /// Gets the byte size of the full proof
-    pub fn size(&self) -> Result<usize> {
-        let mut buffer = Vec::new();
-        self.serialize_compressed(&mut buffer)?;
-        Ok(buffer.len())
-    }
-
-    /// Saves the proof to a file
-    pub fn save_to_file<P: Into<PathBuf>>(&self, path: P) -> Result<()> {
-        let file = File::create(path.into())?;
-        self.serialize_compressed(file)?;
-        Ok(())
-    }
-
-    /// Reads a proof from a file
-    pub fn from_file<P: Into<PathBuf>>(path: P) -> Result<Self> {
-        let file = File::open(path.into())?;
-        Ok(Proof::deserialize_compressed(file)?)
-    }
-}
+pub use host_utils::*;
 
 pub struct BumpAllocator {
     offset: UnsafeCell<usize>,

--- a/jolt-sdk/src/lib.rs
+++ b/jolt-sdk/src/lib.rs
@@ -1,10 +1,10 @@
-#![cfg_attr(not(feature = "std"), no_std)]
+#![cfg_attr(not(feature = "host"), no_std)]
 
 extern crate jolt_sdk_macros;
 
-#[cfg(feature = "std")]
+#[cfg(feature = "host")]
 use std::fs::File;
-#[cfg(feature = "std")]
+#[cfg(feature = "host")]
 use std::path::PathBuf;
 
 use core::{
@@ -12,46 +12,46 @@ use core::{
     cell::UnsafeCell,
 };
 
-#[cfg(feature = "std")]
+#[cfg(feature = "host")]
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
-#[cfg(feature = "std")]
+#[cfg(feature = "host")]
 use eyre::Result;
 
 pub use jolt_sdk_macros::provable;
 pub use postcard;
 
-#[cfg(feature = "std")]
+#[cfg(feature = "host")]
 pub use ark_bn254::{Fr as F, G1Projective as G};
-#[cfg(feature = "std")]
+#[cfg(feature = "host")]
 pub use ark_ec::CurveGroup;
-#[cfg(feature = "std")]
+#[cfg(feature = "host")]
 pub use ark_ff::PrimeField;
-#[cfg(feature = "std")]
+#[cfg(feature = "host")]
 pub use common::{
     constants::MEMORY_OPS_PER_INSTRUCTION,
     rv_trace::{MemoryOp, RV32IM},
 };
-#[cfg(feature = "std")]
+#[cfg(feature = "host")]
 pub use jolt_core::host;
-#[cfg(feature = "std")]
+#[cfg(feature = "host")]
 pub use jolt_core::jolt::instruction;
-#[cfg(feature = "std")]
+#[cfg(feature = "host")]
 pub use jolt_core::jolt::vm::{
     bytecode::BytecodeRow,
     rv32i_vm::{RV32IJoltProof, RV32IJoltVM, RV32I},
     Jolt, JoltCommitments, JoltPreprocessing, JoltProof,
 };
-#[cfg(feature = "std")]
+#[cfg(feature = "host")]
 pub use tracer;
 
-#[cfg(feature = "std")]
+#[cfg(feature = "host")]
 #[derive(CanonicalSerialize, CanonicalDeserialize)]
 pub struct Proof {
     pub proof: RV32IJoltProof<F, G>,
     pub commitments: JoltCommitments<G>,
 }
 
-#[cfg(feature = "std")]
+#[cfg(feature = "host")]
 impl Proof {
     /// Gets the byte size of the full proof
     pub fn size(&self) -> Result<usize> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,7 @@
-use std::{fs::{self, File}, io::Write};
+use std::{
+    fs::{self, File},
+    io::Write,
+};
 
 use clap::{Parser, Subcommand};
 use eyre::Result;
@@ -68,7 +71,11 @@ fn link_toolchain() {
             "toolchain",
             "link",
             "riscv32i-jolt-zkvm-elf",
-            dirs::home_dir().unwrap().join(".jolt/rust/build/host/stage2").to_str().unwrap(),
+            dirs::home_dir()
+                .unwrap()
+                .join(".jolt/rust/build/host/stage2")
+                .to_str()
+                .unwrap(),
         ])
         .output()
         .expect("failed to link toolchain");

--- a/src/main.rs
+++ b/src/main.rs
@@ -105,7 +105,7 @@ fn download_jolt_toolchain(client: &Client, url: &str) {
     }
 
     let path = jolt_dir.join("rust-toolchain.tar.gz");
-    fs::write(&path, &bytes).unwrap();
+    fs::write(path, &bytes).unwrap();
 }
 
 fn get_jolt_toolchain_url(client: &Client, target: &str) -> String {

--- a/src/main.rs
+++ b/src/main.rs
@@ -165,7 +165,7 @@ codegen-units = 1
 lto = "fat"
 
 [dependencies]
-jolt = { package = "jolt-sdk", git = "https://github.com/a16z/jolt", features = ["std"] }
+jolt = { package = "jolt-sdk", git = "https://github.com/a16z/jolt", features = ["host"] }
 guest = { path = "./guest" }
 
 [patch.crates-io]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,11 +1,10 @@
-use std::{
-    fs::{self, File},
-    io::Write,
-};
+use std::{fs::{self, File}, io::Write};
 
 use clap::{Parser, Subcommand};
 use eyre::Result;
 use rand::prelude::SliceRandom;
+use reqwest::blocking::Client;
+use serde_json::Value;
 use sysinfo::System;
 
 #[derive(Parser)]
@@ -22,7 +21,7 @@ enum Command {
         /// Project name
         name: String,
     },
-    /// Installs the required RISC-V toolchain for Rust
+    /// Installs the required RISC-V toolchains for Rust
     InstallToolchain,
 }
 
@@ -30,7 +29,7 @@ fn main() {
     let cli = Cli::parse();
     match cli.command {
         Command::New { name } => create_project(name),
-        Command::InstallToolchain => install_toolchain(),
+        Command::InstallToolchain => install_toolchains(),
     }
 }
 
@@ -40,13 +39,82 @@ fn create_project(name: String) {
     create_guest_files(&name).expect("file creation failed");
 }
 
-fn install_toolchain() {
+fn install_toolchains() {
+    install_no_std_toolchain();
+    install_jolt_toolchain();
+    display_welcome();
+}
+
+fn install_no_std_toolchain() {
     std::process::Command::new("rustup")
         .args(["target", "add", "riscv32i-unknown-none-elf"])
         .output()
         .expect("could not install toolchain");
+}
 
-    display_welcome();
+fn install_jolt_toolchain() {
+    let target = target_lexicon::HOST.to_string();
+    let client = Client::builder().user_agent("Mozilla/5.0").build().unwrap();
+    let url = get_jolt_toolchain_url(&client, &target);
+    println!("downloading toolchain...");
+    download_jolt_toolchain(&client, &url);
+    unpack_toolchain();
+    link_toolchain();
+}
+
+fn link_toolchain() {
+    let output = std::process::Command::new("rustup")
+        .args([
+            "toolchain",
+            "link",
+            "riscv32i-jolt-zkvm-elf",
+            dirs::home_dir().unwrap().join(".jolt/rust/build/host/stage2").to_str().unwrap(),
+        ])
+        .output()
+        .expect("failed to link toolchain");
+
+    if !output.status.success() {
+        println!("{}", String::from_utf8(output.stderr).unwrap());
+    }
+}
+
+fn unpack_toolchain() {
+    let output = std::process::Command::new("tar")
+        .args(["-xzf", "rust-toolchain.tar.gz"])
+        .current_dir(dirs::home_dir().unwrap().join(".jolt"))
+        .output()
+        .expect("unpacking toolchain failed");
+
+    if !output.status.success() {
+        println!("{}", String::from_utf8(output.stderr).unwrap());
+    }
+}
+
+fn download_jolt_toolchain(client: &Client, url: &str) {
+    let bytes = client.get(url).send().unwrap().bytes().unwrap();
+    let jolt_dir = dirs::home_dir().unwrap().join(".jolt");
+    if !jolt_dir.exists() {
+        fs::create_dir(&jolt_dir).unwrap();
+    }
+
+    let path = jolt_dir.join("rust-toolchain.tar.gz");
+    fs::write(&path, &bytes).unwrap();
+}
+
+fn get_jolt_toolchain_url(client: &Client, target: &str) -> String {
+    let json = client
+        .get("https://api.github.com/repos/a16z/rust/releases/latest")
+        .send()
+        .unwrap()
+        .json::<Value>()
+        .unwrap();
+
+    let tag = json["tag_name"].as_str().unwrap();
+
+    format!(
+        "https://github.com/a16z/rust/releases/download/{}/rust-toolchain-{}.tar.gz",
+        tag, target
+    )
 }
 
 fn create_folder_structure(name: &str) -> Result<()> {

--- a/tracer/src/emulator/cpu.rs
+++ b/tracer/src/emulator/cpu.rs
@@ -331,6 +331,7 @@ impl Cpu {
         match self.decode(word).cloned() {
             Ok(inst) => {
                 // setup trace
+                println!("{}", inst.name);
                 let trace_inst = inst.trace.unwrap()(&inst, &self.xlen, word, instruction_address);
                 self.tracer.start_instruction(trace_inst);
                 self.tracer.capture_pre_state(self.x.clone(), &self.xlen);

--- a/tracer/src/emulator/cpu.rs
+++ b/tracer/src/emulator/cpu.rs
@@ -331,7 +331,6 @@ impl Cpu {
         match self.decode(word).cloned() {
             Ok(inst) => {
                 // setup trace
-                println!("{}", inst.name);
                 let trace_inst = inst.trace.unwrap()(&inst, &self.xlen, word, instruction_address);
                 self.tracer.start_instruction(trace_inst);
                 self.tracer.capture_pre_state(self.x.clone(), &self.xlen);


### PR DESCRIPTION
Adds support for the standard library in guests. This is done by adding the `guest-std` flag when importing jolt in the guest. Also note that the flag supplied to the sdk when called from the host has changed from `std` to `host` to avoid confusion (although existing programs will need to be updated).

To use this, you need to have a custom rust toolchain by running `jolt install-toolchain` with this version of the jolt tool.

I've also noticed a few bugs that crop up when tracing and proving some programs generated with the standard library which we should get to the bottom of.