### PR TITLE
Refactor Hyrax Batching

### DIFF
--- a/common/src/constants.rs
+++ b/common/src/constants.rs
@@ -2,7 +2,6 @@ pub const XLEN: usize = 32;
 pub const REGISTER_COUNT: u64 = 32;
 pub const BYTES_PER_INSTRUCTION: usize = 4;
 pub const MEMORY_OPS_PER_INSTRUCTION: usize = 7;
-pub const NUM_R1CS_POLYS: usize = 64;
 
 pub const RAM_START_ADDRESS: u64 = 0x80000000;
 pub const DEFAULT_MEMORY_SIZE: u64 = 10 * 1024 * 1024;

--- a/examples/sha2-ex/src/main.rs
+++ b/examples/sha2-ex/src/main.rs
@@ -5,6 +5,12 @@ pub fn main() {
     let (output, proof) = prove_sha2(input);
     let is_valid = verify_sha2(proof);
 
+    let input = [5u8; 32];
+    let iters = 100;
+    let (program, preprocessing) = guest::preprocess_sha2_chain();
+    let (output, proof) = guest::prove_sha2_chain(program, preprocessing, input, iters);
+    let verify = proof.verify();
+
     println!("output: {}", hex::encode(output));
     println!("valid: {}", is_valid);
 }

--- a/jolt-core/src/jolt/vm/bytecode.rs
+++ b/jolt-core/src/jolt/vm/bytecode.rs
@@ -725,10 +725,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use crate::poly::commitment::{
-        hyrax::{HyraxCommitment, HyraxScheme},
-        pedersen::PedersenGenerators,
-    };
+    use crate::poly::commitment::hyrax::HyraxScheme;
 
     use super::*;
     use ark_bn254::{Fr, G1Projective};

--- a/jolt-core/src/jolt/vm/bytecode.rs
+++ b/jolt-core/src/jolt/vm/bytecode.rs
@@ -311,10 +311,10 @@ impl<F: JoltField, C: CommitmentScheme<Field = F>> BytecodePolynomials<F, C> {
         let max_trace_length = max_trace_length.next_power_of_two();
 
         // a_read_write, t_read, v_read_write (opcode, rs1, rs2, rd, imm)
-        let read_write_gen_shape = GeneratorShape::new(max_trace_length, 7);
+        let read_write_gen_shape = GeneratorShape::new(max_trace_length, BatchType::Big);
 
         // t_final
-        let init_final_gen_shape = GeneratorShape::new(max_bytecode_size, 1);
+        let init_final_gen_shape = GeneratorShape::new(max_bytecode_size, BatchType::Small);
 
         vec![read_write_gen_shape, init_final_gen_shape]
     }

--- a/jolt-core/src/jolt/vm/bytecode.rs
+++ b/jolt-core/src/jolt/vm/bytecode.rs
@@ -356,7 +356,7 @@ where
             &self.v_read_write[4],
         ];
         println!("BytecodePolynomials::commit -- C::batch_commit_polys_ref");
-        let trace_commitments = C::batch_commit_polys_ref(&trace_polys, generators);
+        let trace_commitments = C::batch_commit_polys_ref(&trace_polys, generators, NUM_R1CS_POLYS);
 
         let t_final_commitment = C::commit(&self.t_final, generators);
 
@@ -615,6 +615,7 @@ where
             ],
             opening_point,
             &combined_openings,
+            NUM_R1CS_POLYS,
             transcript,
         )
     }

--- a/jolt-core/src/jolt/vm/bytecode.rs
+++ b/jolt-core/src/jolt/vm/bytecode.rs
@@ -579,7 +579,6 @@ where
 
     #[tracing::instrument(skip_all, name = "BytecodeReadWriteOpenings::open")]
     fn open(polynomials: &BytecodePolynomials<F, C>, opening_point: &[F]) -> Self {
-        println!("BytecodeReadWriteOpenings::open");
         let chis = EqPolynomial::new(opening_point.to_vec()).evals();
         Self {
             a_read_write_opening: polynomials.a_read_write.evaluate_at_chi(&chis),

--- a/jolt-core/src/jolt/vm/instruction_lookups.rs
+++ b/jolt-core/src/jolt/vm/instruction_lookups.rs
@@ -1438,8 +1438,10 @@ where
         let max_trace_length = max_trace_length.next_power_of_two();
         // { dim, read_cts, E_polys, instruction_flag_polys, lookup_outputs }
         let read_write_generator_shape = GeneratorShape::new(max_trace_length, BatchType::Big);
-        let init_final_generator_shape =
-            GeneratorShape::new(M * preprocessing.num_memories.next_power_of_two(), BatchType::Small);
+        let init_final_generator_shape = GeneratorShape::new(
+            M * preprocessing.num_memories.next_power_of_two(),
+            BatchType::Small,
+        );
 
         vec![read_write_generator_shape, init_final_generator_shape]
     }

--- a/jolt-core/src/jolt/vm/instruction_lookups.rs
+++ b/jolt-core/src/jolt/vm/instruction_lookups.rs
@@ -110,10 +110,10 @@ where
             .chain(self.instruction_flag_polys.iter())
             .chain([&self.lookup_outputs].into_iter())
             .collect();
-        let trace_commitment = C::batch_commit_polys_ref(&trace_polys, &generators);
+        let trace_commitment = C::batch_commit_polys_ref(&trace_polys, &generators, NUM_R1CS_POLYS);
 
         let final_commitment =
-            C::batch_commit_polys_ref(&self.final_cts.iter().collect(), &generators);
+            C::batch_commit_polys_ref(&self.final_cts.iter().collect(), &generators, NUM_R1CS_POLYS);
 
         Self::Commitment {
             trace_commitment,
@@ -171,6 +171,7 @@ where
             &primary_sumcheck_polys,
             opening_point,
             &primary_sumcheck_openings,
+            NUM_R1CS_POLYS,
             transcript,
         )
     }
@@ -289,6 +290,7 @@ where
             &read_write_polys,
             opening_point,
             &read_write_openings,
+            NUM_R1CS_POLYS,
             transcript,
         )
     }
@@ -374,6 +376,7 @@ where
             &polynomials.final_cts.iter().collect::<Vec<_>>(),
             opening_point,
             &openings.final_openings,
+            NUM_R1CS_POLYS,
             transcript,
         )
     }

--- a/jolt-core/src/jolt/vm/instruction_lookups.rs
+++ b/jolt-core/src/jolt/vm/instruction_lookups.rs
@@ -1437,13 +1437,9 @@ where
     ) -> Vec<GeneratorShape> {
         let max_trace_length = max_trace_length.next_power_of_two();
         // { dim, read_cts, E_polys, instruction_flag_polys, lookup_outputs }
-        let c: usize = 4;
-        let num_instructions: usize = 20;
-        let trace_batch_size =
-            c + preprocessing.num_memories + preprocessing.num_memories + num_instructions + 1;
-        let read_write_generator_shape = GeneratorShape::new(max_trace_length, trace_batch_size);
+        let read_write_generator_shape = GeneratorShape::new(max_trace_length, BatchType::Big);
         let init_final_generator_shape =
-            GeneratorShape::new(M * preprocessing.num_memories.next_power_of_two(), 1);
+            GeneratorShape::new(M * preprocessing.num_memories.next_power_of_two(), BatchType::Small);
 
         vec![read_write_generator_shape, init_final_generator_shape]
     }

--- a/jolt-core/src/jolt/vm/mod.rs
+++ b/jolt-core/src/jolt/vm/mod.rs
@@ -3,8 +3,7 @@
 use crate::poly::field::JoltField;
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use ark_std::log2;
-use common::constants::{NUM_R1CS_POLYS, RAM_START_ADDRESS};
-use itertools::max;
+use common::constants::RAM_START_ADDRESS;
 use rayon::prelude::*;
 use strum::EnumCount;
 
@@ -14,7 +13,7 @@ use crate::jolt::{
     vm::timestamp_range_check::TimestampValidityProof,
 };
 use crate::lasso::memory_checking::{MemoryCheckingProver, MemoryCheckingVerifier};
-use crate::poly::commitment::commitment_scheme::CommitmentScheme;
+use crate::poly::commitment::commitment_scheme::{BatchType, CommitmentScheme};
 use crate::poly::dense_mlpoly::DensePolynomial;
 use crate::poly::structured_poly::StructuredCommitment;
 use crate::r1cs::snark::{R1CSCommitment, R1CSInputs, R1CSProof};
@@ -166,7 +165,8 @@ where
             .chain(range_check_polys.into_iter())
             .chain(instruction_trace_polys.into_iter())
             .collect::<Vec<_>>();
-        let mut trace_comitments = C::batch_commit_polys_ref(&all_trace_polys, &generators, NUM_R1CS_POLYS);
+        let mut trace_comitments =
+            C::batch_commit_polys_ref(&all_trace_polys, &generators, BatchType::Big);
 
         let bytecode_trace_commitment = trace_comitments
             .drain(..num_bytecode_trace_polys)
@@ -187,7 +187,7 @@ where
         let instruction_final_commitment = C::batch_commit_polys_ref(
             &self.instruction_lookups.final_cts.iter().collect(),
             &generators,
-            NUM_R1CS_POLYS,
+            BatchType::Big,
         );
 
         JoltCommitments {

--- a/jolt-core/src/jolt/vm/mod.rs
+++ b/jolt-core/src/jolt/vm/mod.rs
@@ -3,7 +3,7 @@
 use crate::poly::field::JoltField;
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use ark_std::log2;
-use common::constants::RAM_START_ADDRESS;
+use common::constants::{NUM_R1CS_POLYS, RAM_START_ADDRESS};
 use itertools::max;
 use rayon::prelude::*;
 use strum::EnumCount;
@@ -166,7 +166,7 @@ where
             .chain(range_check_polys.into_iter())
             .chain(instruction_trace_polys.into_iter())
             .collect::<Vec<_>>();
-        let mut trace_comitments = C::batch_commit_polys_ref(&all_trace_polys, &generators);
+        let mut trace_comitments = C::batch_commit_polys_ref(&all_trace_polys, &generators, NUM_R1CS_POLYS);
 
         let bytecode_trace_commitment = trace_comitments
             .drain(..num_bytecode_trace_polys)
@@ -187,6 +187,7 @@ where
         let instruction_final_commitment = C::batch_commit_polys_ref(
             &self.instruction_lookups.final_cts.iter().collect(),
             &generators,
+            NUM_R1CS_POLYS,
         );
 
         JoltCommitments {

--- a/jolt-core/src/jolt/vm/read_write_memory.rs
+++ b/jolt-core/src/jolt/vm/read_write_memory.rs
@@ -6,7 +6,7 @@ use rayon::iter::{IntoParallelIterator, IntoParallelRefIterator, ParallelIterato
 use std::collections::HashSet;
 use std::marker::PhantomData;
 
-use crate::poly::commitment::commitment_scheme::{CommitmentScheme, GeneratorShape};
+use crate::poly::commitment::commitment_scheme::{BatchType, CommitmentScheme, GeneratorShape};
 use crate::utils::transcript::AppendToTranscript;
 use crate::{
     lasso::memory_checking::{
@@ -14,8 +14,8 @@ use crate::{
         NoPreprocessing,
     },
     poly::{
-        commitment::hyrax::matrix_dimensions, dense_mlpoly::DensePolynomial, eq_poly::EqPolynomial,
-        identity_poly::IdentityPolynomial, structured_poly::StructuredOpeningProof,
+        dense_mlpoly::DensePolynomial, eq_poly::EqPolynomial, identity_poly::IdentityPolynomial,
+        structured_poly::StructuredOpeningProof,
     },
     subprotocols::sumcheck::SumcheckInstanceProof,
     utils::{errors::ProofVerifyError, math::Math, mul_0_optimized, transcript::ProofTranscript},
@@ -23,7 +23,7 @@ use crate::{
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use common::constants::{
     memory_address_to_witness_index, BYTES_PER_INSTRUCTION, MEMORY_OPS_PER_INSTRUCTION,
-    NUM_R1CS_POLYS, RAM_START_ADDRESS, REGISTER_COUNT,
+    RAM_START_ADDRESS, REGISTER_COUNT,
 };
 use common::rv_trace::{ELFInstruction, JoltDevice, MemoryLayout, MemoryOp, RV32IM};
 use common::to_ram_address;
@@ -780,7 +780,10 @@ impl<F: JoltField, C: CommitmentScheme<Field = F>> ReadWriteMemory<F, C> {
 
     /// Computes the maximum number of group generators needed to commit to read-write
     /// memory polynomials using Hyrax, given the maximum memory address and maximum trace length.
-    pub fn generator_shapes(max_memory_address: usize, max_trace_length: usize) -> Vec<GeneratorShape> {
+    pub fn generator_shapes(
+        max_memory_address: usize,
+        max_trace_length: usize,
+    ) -> Vec<GeneratorShape> {
         let max_memory_address = max_memory_address.next_power_of_two();
         let max_trace_length = max_trace_length.next_power_of_two();
 
@@ -914,7 +917,7 @@ where
             &read_write_polys,
             opening_point,
             &read_write_openings,
-            NUM_R1CS_POLYS,
+            BatchType::Big,
             transcript,
         )
     }
@@ -1016,7 +1019,7 @@ where
             ],
             opening_point,
             &[openings.v_final, openings.t_final],
-            1,
+            BatchType::Small,
             transcript,
         );
 

--- a/jolt-core/src/jolt/vm/read_write_memory.rs
+++ b/jolt-core/src/jolt/vm/read_write_memory.rs
@@ -789,15 +789,13 @@ impl<F: JoltField, C: CommitmentScheme<Field = F>> ReadWriteMemory<F, C> {
 
         // { rs1, rs2, rd, ram_byte_1, ram_byte_2, ram_byte_3, ram_byte_4 }
         let t_read_write_len = (max_trace_length * MEMORY_OPS_PER_INSTRUCTION).next_power_of_two();
-        let t_read_write_shape = GeneratorShape::new(t_read_write_len, 1);
+        let t_read_write_shape = GeneratorShape::new(t_read_write_len, BatchType::Big);
 
-        // TODO(sragss): Low confidence this is correct.
         // { a_ram, v_read, v_write_rd, v_write_ram }
-        let r1cs_poly_count = 1 + MEMORY_OPS_PER_INSTRUCTION + 1 + 4;
-        let r1cs_shape = GeneratorShape::new(max_trace_length, r1cs_poly_count);
+        let r1cs_shape = GeneratorShape::new(max_trace_length, BatchType::Big);
         // v_final, t_final
         let init_final_len = max_memory_address.next_power_of_two();
-        let init_final_shape = GeneratorShape::new(init_final_len, 1);
+        let init_final_shape = GeneratorShape::new(init_final_len, BatchType::Small);
 
         vec![t_read_write_shape, r1cs_shape, init_final_shape]
     }

--- a/jolt-core/src/jolt/vm/read_write_memory.rs
+++ b/jolt-core/src/jolt/vm/read_write_memory.rs
@@ -914,6 +914,7 @@ where
             &read_write_polys,
             opening_point,
             &read_write_openings,
+            NUM_R1CS_POLYS,
             transcript,
         )
     }
@@ -1015,6 +1016,7 @@ where
             ],
             opening_point,
             &[openings.v_final, openings.t_final],
+            1,
             transcript,
         );
 

--- a/jolt-core/src/jolt/vm/timestamp_range_check.rs
+++ b/jolt-core/src/jolt/vm/timestamp_range_check.rs
@@ -195,7 +195,7 @@ where
             .chain(self.final_cts_read_timestamp.iter())
             .chain(self.final_cts_global_minus_read.iter())
             .collect();
-        let commitments = C::batch_commit_polys_ref(&polys, &generators);
+        let commitments = C::batch_commit_polys_ref(&polys, &generators, NUM_R1CS_POLYS);
 
         Self::Commitment { commitments }
     }
@@ -592,7 +592,7 @@ where
             .map(|poly| poly.evaluate_at_chi(&chis))
             .collect::<Vec<F>>();
 
-        let opening_proof = C::batch_prove(&polys, &r_grand_product, &openings, transcript);
+        let opening_proof = C::batch_prove(&polys, &r_grand_product, &openings, NUM_R1CS_POLYS, transcript);
 
         let mut openings = openings.into_iter();
         let read_cts_read_timestamp: [F; MEMORY_OPS_PER_INSTRUCTION] =

--- a/jolt-core/src/jolt/vm/timestamp_range_check.rs
+++ b/jolt-core/src/jolt/vm/timestamp_range_check.rs
@@ -787,10 +787,7 @@ where
     pub fn generator_shapes(max_trace_length: usize) -> Vec<GeneratorShape> {
         let max_trace_length = max_trace_length.next_power_of_two();
 
-        vec![GeneratorShape::new(
-            max_trace_length,
-            BatchType::Big
-        )]
+        vec![GeneratorShape::new(max_trace_length, BatchType::Big)]
     }
 
     fn protocol_name() -> &'static [u8] {

--- a/jolt-core/src/jolt/vm/timestamp_range_check.rs
+++ b/jolt-core/src/jolt/vm/timestamp_range_check.rs
@@ -1,6 +1,6 @@
 use crate::poly::field::JoltField;
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
-use common::constants::{MEMORY_OPS_PER_INSTRUCTION, NUM_R1CS_POLYS};
+use common::constants::MEMORY_OPS_PER_INSTRUCTION;
 use itertools::interleave;
 use rayon::iter::{IntoParallelIterator, IntoParallelRefIterator, ParallelIterator};
 #[cfg(test)]
@@ -8,8 +8,7 @@ use std::collections::HashSet;
 use std::{iter::zip, marker::PhantomData};
 use tracing::trace_span;
 
-use crate::poly::commitment::commitment_scheme::{CommitmentScheme, GeneratorShape};
-use crate::poly::commitment::hyrax::matrix_dimensions;
+use crate::poly::commitment::commitment_scheme::{BatchType, CommitmentScheme, GeneratorShape};
 use crate::utils::transcript::AppendToTranscript;
 use crate::{
     lasso::memory_checking::{
@@ -25,7 +24,7 @@ use crate::{
     subprotocols::grand_product::{
         BatchedGrandProductArgument, BatchedGrandProductCircuit, GrandProductCircuit,
     },
-    utils::{errors::ProofVerifyError, math::Math, mul_0_1_optimized, transcript::ProofTranscript},
+    utils::{errors::ProofVerifyError, mul_0_1_optimized, transcript::ProofTranscript},
 };
 
 use super::read_write_memory::MemoryCommitment;
@@ -195,7 +194,7 @@ where
             .chain(self.final_cts_read_timestamp.iter())
             .chain(self.final_cts_global_minus_read.iter())
             .collect();
-        let commitments = C::batch_commit_polys_ref(&polys, &generators, NUM_R1CS_POLYS);
+        let commitments = C::batch_commit_polys_ref(&polys, &generators, BatchType::Big);
 
         Self::Commitment { commitments }
     }
@@ -592,7 +591,13 @@ where
             .map(|poly| poly.evaluate_at_chi(&chis))
             .collect::<Vec<F>>();
 
-        let opening_proof = C::batch_prove(&polys, &r_grand_product, &openings, NUM_R1CS_POLYS, transcript);
+        let opening_proof = C::batch_prove(
+            &polys,
+            &r_grand_product,
+            &openings,
+            BatchType::Big,
+            transcript,
+        );
 
         let mut openings = openings.into_iter();
         let read_cts_read_timestamp: [F; MEMORY_OPS_PER_INSTRUCTION] =
@@ -782,7 +787,10 @@ where
     pub fn generator_shapes(max_trace_length: usize) -> Vec<GeneratorShape> {
         let max_trace_length = max_trace_length.next_power_of_two();
 
-        vec![GeneratorShape::new(max_trace_length, 4 * MEMORY_OPS_PER_INSTRUCTION)]
+        vec![GeneratorShape::new(
+            max_trace_length,
+            4 * MEMORY_OPS_PER_INSTRUCTION,
+        )]
     }
 
     fn protocol_name() -> &'static [u8] {

--- a/jolt-core/src/jolt/vm/timestamp_range_check.rs
+++ b/jolt-core/src/jolt/vm/timestamp_range_check.rs
@@ -789,7 +789,7 @@ where
 
         vec![GeneratorShape::new(
             max_trace_length,
-            4 * MEMORY_OPS_PER_INSTRUCTION,
+            BatchType::Big
         )]
     }
 

--- a/jolt-core/src/lasso/surge.rs
+++ b/jolt-core/src/lasso/surge.rs
@@ -29,6 +29,10 @@ where
     pub E_polys: Vec<DensePolynomial<F>>,
 }
 
+// TODO(moodlezoup): Make these tunable
+const SURGE_HYRAX_RATIO_READ_WRITE: usize = 16;
+const SURGE_HYRAX_RATIO_FINAL: usize = 4;
+
 #[derive(CanonicalSerialize, CanonicalDeserialize)]
 pub struct SurgeCommitment<CS: CommitmentScheme> {
     /// Commitments to dim_i and read_cts_i polynomials.
@@ -51,12 +55,12 @@ where
         let _read_write_num_vars = self.dim[0].get_num_vars();
         let dim_read_polys: Vec<&DensePolynomial<F>> =
             self.dim.iter().chain(self.read_cts.iter()).collect();
-        let dim_read_commitment = CS::batch_commit_polys_ref(&dim_read_polys, &generators);
-        let E_commitment = CS::batch_commit_polys_ref(&self.E_polys.iter().collect(), &generators);
+        let dim_read_commitment = CS::batch_commit_polys_ref(&dim_read_polys, &generators, SURGE_HYRAX_RATIO_READ_WRITE);
+        let E_commitment = CS::batch_commit_polys_ref(&self.E_polys.iter().collect(), &generators, SURGE_HYRAX_RATIO_READ_WRITE);
 
         let _final_num_vars = self.final_cts[0].get_num_vars();
         let final_commitment =
-            CS::batch_commit_polys_ref(&self.final_cts.iter().collect(), &generators);
+            CS::batch_commit_polys_ref(&self.final_cts.iter().collect(), &generators, SURGE_HYRAX_RATIO_FINAL);
 
         Self::Commitment {
             dim_read_commitment,
@@ -96,6 +100,7 @@ where
             &polynomials.E_polys.iter().collect::<Vec<_>>(),
             opening_point,
             E_poly_openings,
+            16,
             transcript,
         )
     }
@@ -171,6 +176,7 @@ where
             &read_write_polys,
             opening_point,
             &read_write_openings,
+            SURGE_HYRAX_RATIO_READ_WRITE,
             transcript,
         )
     }
@@ -253,6 +259,7 @@ where
             &polynomials.final_cts.iter().collect::<Vec<_>>(),
             opening_point,
             &openings.final_openings,
+            SURGE_HYRAX_RATIO_FINAL,
             transcript,
         )
     }

--- a/jolt-core/src/lasso/surge.rs
+++ b/jolt-core/src/lasso/surge.rs
@@ -1,4 +1,4 @@
-use crate::poly::field::JoltField;
+use crate::poly::{commitment::commitment_scheme::BatchType, field::JoltField};
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use rayon::iter::{IntoParallelIterator, IntoParallelRefIterator, ParallelIterator};
 use std::marker::{PhantomData, Sync};
@@ -29,10 +29,6 @@ where
     pub E_polys: Vec<DensePolynomial<F>>,
 }
 
-// TODO(moodlezoup): Make these tunable
-const SURGE_HYRAX_RATIO_READ_WRITE: usize = 16;
-const SURGE_HYRAX_RATIO_FINAL: usize = 4;
-
 #[derive(CanonicalSerialize, CanonicalDeserialize)]
 pub struct SurgeCommitment<CS: CommitmentScheme> {
     /// Commitments to dim_i and read_cts_i polynomials.
@@ -55,12 +51,20 @@ where
         let _read_write_num_vars = self.dim[0].get_num_vars();
         let dim_read_polys: Vec<&DensePolynomial<F>> =
             self.dim.iter().chain(self.read_cts.iter()).collect();
-        let dim_read_commitment = CS::batch_commit_polys_ref(&dim_read_polys, &generators, SURGE_HYRAX_RATIO_READ_WRITE);
-        let E_commitment = CS::batch_commit_polys_ref(&self.E_polys.iter().collect(), &generators, SURGE_HYRAX_RATIO_READ_WRITE);
+        let dim_read_commitment =
+            CS::batch_commit_polys_ref(&dim_read_polys, &generators, BatchType::SurgeReadWrite);
+        let E_commitment = CS::batch_commit_polys_ref(
+            &self.E_polys.iter().collect(),
+            &generators,
+            BatchType::SurgeReadWrite,
+        );
 
         let _final_num_vars = self.final_cts[0].get_num_vars();
-        let final_commitment =
-            CS::batch_commit_polys_ref(&self.final_cts.iter().collect(), &generators, SURGE_HYRAX_RATIO_FINAL);
+        let final_commitment = CS::batch_commit_polys_ref(
+            &self.final_cts.iter().collect(),
+            &generators,
+            BatchType::SurgeInitFinal,
+        );
 
         Self::Commitment {
             dim_read_commitment,
@@ -100,7 +104,7 @@ where
             &polynomials.E_polys.iter().collect::<Vec<_>>(),
             opening_point,
             E_poly_openings,
-            16,
+            BatchType::SurgeReadWrite,
             transcript,
         )
     }
@@ -176,7 +180,7 @@ where
             &read_write_polys,
             opening_point,
             &read_write_openings,
-            SURGE_HYRAX_RATIO_READ_WRITE,
+            BatchType::SurgeReadWrite,
             transcript,
         )
     }
@@ -259,7 +263,7 @@ where
             &polynomials.final_cts.iter().collect::<Vec<_>>(),
             opening_point,
             &openings.final_openings,
-            SURGE_HYRAX_RATIO_FINAL,
+            BatchType::SurgeInitFinal,
             transcript,
         )
     }

--- a/jolt-core/src/poly/commitment/commitment_scheme.rs
+++ b/jolt-core/src/poly/commitment/commitment_scheme.rs
@@ -11,7 +11,7 @@ use crate::{
 #[derive(Clone, Debug)]
 pub struct GeneratorShape {
     pub input_length: usize,
-    pub batch_size: usize
+    pub batch_size: usize,
 }
 
 impl GeneratorShape {
@@ -21,6 +21,13 @@ impl GeneratorShape {
             batch_size,
         }
     }
+}
+
+pub enum BatchType {
+    Big,
+    Small,
+    SurgeInitFinal,
+    SurgeReadWrite,
 }
 
 pub trait CommitmentScheme: Clone + Sync + Send + 'static {
@@ -35,18 +42,18 @@ pub trait CommitmentScheme: Clone + Sync + Send + 'static {
     fn batch_commit(
         evals: &[&[Self::Field]],
         gens: &Self::Generators,
-        batch_size: usize,
+        batch_type: BatchType,
     ) -> Vec<Self::Commitment>;
     fn commit_slice(evals: &[Self::Field], gens: &Self::Generators) -> Self::Commitment;
     fn batch_commit_polys(
         polys: &Vec<DensePolynomial<Self::Field>>,
         gens: &Self::Generators,
-        batch_size: usize
+        batch_type: BatchType,
     ) -> Vec<Self::Commitment>;
     fn batch_commit_polys_ref(
         polys: &Vec<&DensePolynomial<Self::Field>>,
         gens: &Self::Generators,
-        batch_size: usize
+        batch_type: BatchType,
     ) -> Vec<Self::Commitment>;
     fn prove(
         poly: &DensePolynomial<Self::Field>,
@@ -57,7 +64,7 @@ pub trait CommitmentScheme: Clone + Sync + Send + 'static {
         polynomials: &[&DensePolynomial<Self::Field>],
         opening_point: &[Self::Field],
         openings: &[Self::Field],
-        batch_size: usize,
+        batch_type: BatchType,
         transcript: &mut ProofTranscript,
     ) -> Self::BatchedProof;
 

--- a/jolt-core/src/poly/commitment/commitment_scheme.rs
+++ b/jolt-core/src/poly/commitment/commitment_scheme.rs
@@ -50,12 +50,18 @@ pub trait CommitmentScheme: Clone + Sync + Send + 'static {
         polys: &Vec<DensePolynomial<Self::Field>>,
         gens: &Self::Generators,
         batch_type: BatchType,
-    ) -> Vec<Self::Commitment>;
+    ) -> Vec<Self::Commitment> {
+        let slices: Vec<&[Self::Field]> = polys.iter().map(|poly| poly.evals_ref()).collect();
+        Self::batch_commit(&slices, gens, batch_type)
+    }
     fn batch_commit_polys_ref(
         polys: &Vec<&DensePolynomial<Self::Field>>,
         gens: &Self::Generators,
         batch_type: BatchType,
-    ) -> Vec<Self::Commitment>;
+    ) -> Vec<Self::Commitment> {
+        let slices: Vec<&[Self::Field]> = polys.iter().map(|poly| poly.evals_ref()).collect();
+        Self::batch_commit(&slices, gens, batch_type)
+    }
     fn prove(
         poly: &DensePolynomial<Self::Field>,
         opening_point: &[Self::Field], // point at which the polynomial is evaluated

--- a/jolt-core/src/poly/commitment/commitment_scheme.rs
+++ b/jolt-core/src/poly/commitment/commitment_scheme.rs
@@ -33,17 +33,20 @@ pub trait CommitmentScheme: Clone + Sync + Send + 'static {
     fn generators(shapes: &[GeneratorShape]) -> Self::Generators;
     fn commit(poly: &DensePolynomial<Self::Field>, gens: &Self::Generators) -> Self::Commitment;
     fn batch_commit(
-        evals: &Vec<Vec<Self::Field>>,
+        evals: &[&[Self::Field]],
         gens: &Self::Generators,
+        batch_size: usize,
     ) -> Vec<Self::Commitment>;
     fn commit_slice(evals: &[Self::Field], gens: &Self::Generators) -> Self::Commitment;
     fn batch_commit_polys(
         polys: &Vec<DensePolynomial<Self::Field>>,
         gens: &Self::Generators,
+        batch_size: usize
     ) -> Vec<Self::Commitment>;
     fn batch_commit_polys_ref(
         polys: &Vec<&DensePolynomial<Self::Field>>,
         gens: &Self::Generators,
+        batch_size: usize
     ) -> Vec<Self::Commitment>;
     fn prove(
         poly: &DensePolynomial<Self::Field>,
@@ -54,6 +57,7 @@ pub trait CommitmentScheme: Clone + Sync + Send + 'static {
         polynomials: &[&DensePolynomial<Self::Field>],
         opening_point: &[Self::Field],
         openings: &[Self::Field],
+        batch_size: usize,
         transcript: &mut ProofTranscript,
     ) -> Self::BatchedProof;
 

--- a/jolt-core/src/poly/commitment/commitment_scheme.rs
+++ b/jolt-core/src/poly/commitment/commitment_scheme.rs
@@ -11,18 +11,19 @@ use crate::{
 #[derive(Clone, Debug)]
 pub struct GeneratorShape {
     pub input_length: usize,
-    pub batch_size: usize,
+    pub batch_type: BatchType,
 }
 
 impl GeneratorShape {
-    pub fn new(input_length: usize, batch_size: usize) -> Self {
+    pub fn new(input_length: usize, batch_type: BatchType) -> Self {
         Self {
             input_length,
-            batch_size,
+            batch_type,
         }
     }
 }
 
+#[derive(Clone, Debug)]
 pub enum BatchType {
     Big,
     Small,

--- a/jolt-core/src/r1cs/snark.rs
+++ b/jolt-core/src/r1cs/snark.rs
@@ -22,6 +22,7 @@ use super::{
 
 use crate::poly::field::JoltField;
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
+use common::constants::NUM_R1CS_POLYS;
 use common::{constants::MEMORY_OPS_PER_INSTRUCTION, rv_trace::NUM_CIRCUIT_FLAGS};
 use rayon::prelude::*;
 use std::borrow::Borrow;
@@ -296,9 +297,9 @@ impl<'a, F: JoltField> R1CSInputs<'a, F> {
 pub struct R1CSCommitment<C: CommitmentScheme> {
     io: Vec<C::Commitment>,
     aux: Vec<C::Commitment>,
-    chunks_x: Vec<C::Commitment>,
-    chunks_y: Vec<C::Commitment>,
-    circuit_flags: Vec<C::Commitment>,
+    /// Operand chunks { x, y }
+    chunks: Vec<C::Commitment>,
+    circuit_flags: Vec<C::Commitment>
 }
 
 impl<C: CommitmentScheme> AppendToTranscript for R1CSCommitment<C> {
@@ -310,11 +311,8 @@ impl<C: CommitmentScheme> AppendToTranscript for R1CSCommitment<C> {
         for commitment in &self.aux {
             commitment.append_to_transcript(b"aux", transcript);
         }
-        for commitment in &self.chunks_x {
-            commitment.append_to_transcript(b"chunks_x", transcript);
-        }
-        for commitment in &self.chunks_y {
-            commitment.append_to_transcript(b"chunks_y", transcript);
+        for commitment in &self.chunks{
+            commitment.append_to_transcript(b"chunks_s", transcript);
         }
         for commitment in &self.circuit_flags {
             commitment.append_to_transcript(b"circuit_flags", transcript);
@@ -352,32 +350,31 @@ impl<F: JoltField, C: CommitmentScheme<Field = F>> R1CSProof<F, C> {
         drop(_enter);
         drop(span);
 
-        // let (io_segments, aux_segments) = synthesize_state_aux_segments(&inputs, 2, jolt_shape.num_internal);
         let (pc_out, pc, aux) = synthesize_witnesses(inputs, jolt_shape.num_internal);
         let io_segments = vec![pc_out, pc];
-        let io_comms = C::batch_commit(&io_segments, &generators);
-        let aux_comms = C::batch_commit(&aux, &generators);
-
-        // Commit to R1CS specific items
-        let commit_to_chunks = |data: &Vec<F>| -> Vec<C::Commitment> {
-            data.par_chunks(padded_trace_len)
-                .map(|chunk| C::commit_slice(chunk, generators))
-                .collect()
-        };
+        let io_segments_ref = vec![io_segments[0].as_slice(), io_segments[1].as_slice()];
+        let aux_ref: Vec<&[F]> = aux.iter().map(AsRef::as_ref).collect();
+        let io_comms = C::batch_commit(&io_segments_ref.as_slice(), &generators, NUM_R1CS_POLYS);
+        let aux_comms = C::batch_commit(aux_ref.as_slice(), &generators, NUM_R1CS_POLYS);
 
         let span = tracing::span!(tracing::Level::INFO, "new_commitments");
         let _guard = span.enter();
-        let chunks_x_comms = commit_to_chunks(&inputs.chunks_x);
-        let chunks_y_comms = commit_to_chunks(&inputs.chunks_y);
-        let circuit_flags_comm = commit_to_chunks(&inputs.circuit_flags_bits);
+        let chunk_batch_size = inputs.chunks_x.len() / padded_trace_len + inputs.chunks_y.len() / padded_trace_len;
+        let mut chunk_batch_slices: Vec<&[F]> = Vec::with_capacity(chunk_batch_size);
+        for batchee in [&inputs.chunks_x, &inputs.chunks_y].iter() {
+            chunk_batch_slices.extend(batchee.chunks(padded_trace_len));
+        }
+        let chunks_comms = C::batch_commit(chunk_batch_slices.as_slice(), &generators, NUM_R1CS_POLYS);
+
+        let circuit_flag_slices: Vec<&[F]> = inputs.circuit_flags_bits.chunks(padded_trace_len).collect();
+        let circuit_flags_comms = C::batch_commit(circuit_flag_slices.as_slice(), &generators, NUM_R1CS_POLYS);
         drop(_guard);
 
         let r1cs_commitments = R1CSCommitment {
             io: io_comms,
             aux: aux_comms,
-            chunks_x: chunks_x_comms,
-            chunks_y: chunks_y_comms,
-            circuit_flags: circuit_flags_comm,
+            chunks: chunks_comms,
+            circuit_flags: circuit_flags_comms
         };
 
         let cloning_stuff_span =
@@ -387,8 +384,7 @@ impl<F: JoltField, C: CommitmentScheme<Field = F>> R1CSProof<F, C> {
 
         let mut w_segments: Vec<Vec<F>> =
             Vec::with_capacity(io_segments.len() + inputs_segments.len() + aux.len());
-        // TODO(sragss / arasuarun): rm clones in favor of references -- can be removed when HyraxCommitment can take Vec<Vec<F>>.
-        w_segments.par_extend(io_segments.into_par_iter());
+        w_segments.extend(io_segments.into_iter());
         w_segments.par_extend(inputs_segments.into_par_iter());
         w_segments.par_extend(aux.into_par_iter());
 
@@ -432,8 +428,7 @@ impl<F: JoltField, C: CommitmentScheme<Field = F>> R1CSProof<F, C> {
 
         combined_commitments.extend(memory_trace_commitments.iter());
 
-        combined_commitments.extend(r1cs_commitments.as_ref().unwrap().chunks_x.iter());
-        combined_commitments.extend(r1cs_commitments.as_ref().unwrap().chunks_y.iter());
+        combined_commitments.extend(r1cs_commitments.as_ref().unwrap().chunks.iter());
 
         combined_commitments.extend(instruction_lookup_indices_commitments.iter());
 

--- a/jolt-core/src/r1cs/spartan.rs
+++ b/jolt-core/src/r1cs/spartan.rs
@@ -1,5 +1,6 @@
 #![allow(clippy::len_without_is_empty)]
 
+use crate::poly::commitment::commitment_scheme::BatchType;
 use crate::poly::commitment::commitment_scheme::CommitmentScheme;
 use crate::poly::field::JoltField;
 use crate::utils::compute_dotproduct_low_optimized;
@@ -8,7 +9,6 @@ use crate::utils::thread::unsafe_allocate_zero_vec;
 use crate::utils::transcript::ProofTranscript;
 use ark_serialize::CanonicalDeserialize;
 use ark_serialize::CanonicalSerialize;
-use common::constants::NUM_R1CS_POLYS;
 use rayon::prelude::*;
 use sha3::Digest;
 use sha3::Sha3_256;
@@ -428,7 +428,7 @@ impl<F: JoltField, C: CommitmentScheme<Field = F>> UniformSpartanProof<F, C> {
             &witness_segment_polys_ref,
             r_y_point,
             &witness_evals,
-            NUM_R1CS_POLYS,
+            BatchType::Big,
             transcript,
         );
 

--- a/jolt-core/src/r1cs/spartan.rs
+++ b/jolt-core/src/r1cs/spartan.rs
@@ -8,6 +8,7 @@ use crate::utils::thread::unsafe_allocate_zero_vec;
 use crate::utils::transcript::ProofTranscript;
 use ark_serialize::CanonicalDeserialize;
 use ark_serialize::CanonicalSerialize;
+use common::constants::NUM_R1CS_POLYS;
 use rayon::prelude::*;
 use sha3::Digest;
 use sha3::Sha3_256;
@@ -427,6 +428,7 @@ impl<F: JoltField, C: CommitmentScheme<Field = F>> UniformSpartanProof<F, C> {
             &witness_segment_polys_ref,
             r_y_point,
             &witness_evals,
+            NUM_R1CS_POLYS,
             transcript,
         );
 


### PR DESCRIPTION
Includes a `batch_size` param in calls to `CommitmentScheme::{batch_commit, batch_prove}` and includes the `batch_size` param in the `CommitmentScheme::BatchedProof` struct if needed.

Two unfortunate things:
- Leaky abstraction: Hyrax is the only commitment scheme we know about that needs the `batch_size` param to be used as the Hyrax sizing ratio. Theoretically this could be refactored to be an associated type on `CommitmentScheme` called `BatchCommitConfig` which could store other info, we just aren't aware of another commitment scheme that needs it.
- Bad parameter naming: `batch_size` isn't quite the correct parameter name. Currently we call `CommitmentScheme::{batch_commit, batch_prove}` for a range of *real* batch sizes {163, 40}. Across all of these `NUM_R1CS_POLYS=64` is close enough to get desired performance. Also `batch_prove` is often passed a subset of the batch's polynomials, but still needs the matching `batch_size` param to whatever was committed. We could return to `RATIO` but only makes sense in the context of Hyrax.