### PR TITLE
SegmentedPaddedWitness: Drop EqPoly Bkg

### DIFF
--- a/jolt-core/src/r1cs/spartan.rs
+++ b/jolt-core/src/r1cs/spartan.rs
@@ -137,10 +137,13 @@ impl<F: PrimeField> SegmentedPaddedWitness<F> {
 
     pub fn evaluate_all(&self, point: Vec<F>) -> Vec<F> {
         let chi = EqPolynomial::new(point).evals();
-        self.segments
+        let evals = self
+            .segments
             .par_iter()
             .map(|segment| compute_dotproduct_low_optimized(&chi, segment))
-            .collect()
+            .collect();
+        drop_in_background_thread(chi);
+        evals
     }
 
     pub fn into_dense_polys(self) -> Vec<DensePolynomial<F>> {


### PR DESCRIPTION
Saves ~1.75% e2e time on 4M trace length on the default linux allocator.