### PR TITLE
Update links and add more instructions to install the book locally

### DIFF
--- a/book/src/background.md
+++ b/book/src/background.md
@@ -4,4 +4,5 @@ If you're interested in learning the nitty gritty details of SNARKs including qu
 - [GKR](./background/gkr.md)
 - [Multilinear Extensions](./background/multilinear-extensions.md)
 - [EQ Polynomial](./background/eq-polynomial.md)
+- [Batched Openings](./background/batched-openings.md)
 - [Memory Checking](./background/memory-checking.md)

--- a/book/src/dev/install.md
+++ b/book/src/dev/install.md
@@ -11,4 +11,8 @@ guest programs manually use `rustup target add riscv32i-unknown-none-elf`.
 
 For building this book:
 
-`cargo install mdbook`
+`cargo install mdbook mdbook-katex`
+
+For watching the changes in your local browser:
+
+`mdbook watch book --open`

--- a/book/src/how_it_works.md
+++ b/book/src/how_it_works.md
@@ -1,5 +1,5 @@
 # How it works
-- [Jolt](./jolt.md)
+- [Jolt](./how/jolt.md)
     - [Instruction lookups](./how/instruction_lookups.md)
     - [Read-write memory](./how/read_write_memory.md)
     - [R1CS constraints](./how/r1cs_constraints.md)


### PR DESCRIPTION
- A link of the book is invalid: https://jolt.a16zcrypto.com/how_it_works.html (Jolt link)
- The Background note is missing the batched polynomial opening notes in the summary https://jolt.a16zcrypto.com/background.html
- Added more instructions on how to install the book locally https://jolt.a16zcrypto.com/dev/install.html