### PR TITLE
Fix: Chaining Hashes in `sha2-chain` Example

### DIFF
--- a/examples/sha2-chain/Cargo.toml
+++ b/examples/sha2-chain/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 [dependencies]
 jolt-sdk = { path = "../../jolt-sdk", features = ["host"] }
 guest = { package = "sha2-chain-guest", path = "./guest" }
+sha2 = { version = "0.10.8", default-features = false }
 
 hex = "0.4.3"
 sha3 = { version = "0.10.8", default-features = false }

--- a/examples/sha2-chain/Cargo.toml
+++ b/examples/sha2-chain/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2021"
 [dependencies]
 jolt-sdk = { path = "../../jolt-sdk", features = ["host"] }
 guest = { package = "sha2-chain-guest", path = "./guest" }
-sha2 = { version = "0.10.8", default-features = false }
 
 hex = "0.4.3"
 sha3 = { version = "0.10.8", default-features = false }

--- a/examples/sha2-chain/guest/src/lib.rs
+++ b/examples/sha2-chain/guest/src/lib.rs
@@ -8,7 +8,7 @@ fn sha2_chain(input: [u8; 32], num_iters: u32) -> [u8; 32] {
     let mut hash = input;
     for _ in 0..num_iters {
         let mut hasher = Sha256::new();
-        hasher.update(input);
+        hasher.update(&hash);
         let res = &hasher.finalize();
         hash = Into::<[u8; 32]>::into(*res);
     }

--- a/examples/sha2-chain/guest/src/lib.rs
+++ b/examples/sha2-chain/guest/src/lib.rs
@@ -8,7 +8,7 @@ fn sha2_chain(input: [u8; 32], num_iters: u32) -> [u8; 32] {
     let mut hash = input;
     for _ in 0..num_iters {
         let mut hasher = Sha256::new();
-        hasher.update(&hash);
+        hasher.update(hash);
         let res = &hasher.finalize();
         hash = Into::<[u8; 32]>::into(*res);
     }

--- a/examples/sha2-chain/src/main.rs
+++ b/examples/sha2-chain/src/main.rs
@@ -1,23 +1,9 @@
-use sha2::{Digest, Sha256};
-
-fn compute_native(input: [u8; 32], num_iters: u32) -> [u8; 32] {
-    let mut hash = input;
-    for _ in 0..num_iters {
-        let mut hasher = Sha256::new();
-        hasher.update(&hash);
-        let res = &hasher.finalize();
-        hash = Into::<[u8; 32]>::into(*res);
-    }
-
-    hash
-}
-
 pub fn main() {
     let (prove_sha2_chain, verify_sha2_chain) = guest::build_sha2_chain();
 
     let input = [5u8; 32];
     let iters = 100;
-    let native_output = compute_native(input, iters);
+    let native_output = guest::sha2_chain(input, iters);
     let (output, proof) = prove_sha2_chain(input, iters);
     let is_valid = verify_sha2_chain(proof);
 

--- a/examples/sha2-chain/src/main.rs
+++ b/examples/sha2-chain/src/main.rs
@@ -1,11 +1,28 @@
+use sha2::{Digest, Sha256};
+
+fn compute_native(input: [u8; 32], num_iters: u32) -> [u8; 32] {
+    let mut hash = input;
+    for _ in 0..num_iters {
+        let mut hasher = Sha256::new();
+        hasher.update(&hash);
+        let res = &hasher.finalize();
+        hash = Into::<[u8; 32]>::into(*res);
+    }
+
+    hash
+}
+
 pub fn main() {
     let (prove_sha2_chain, verify_sha2_chain) = guest::build_sha2_chain();
 
     let input = [5u8; 32];
     let iters = 100;
+    let native_output = compute_native(input, iters);
     let (output, proof) = prove_sha2_chain(input, iters);
     let is_valid = verify_sha2_chain(proof);
 
+    assert_eq!(output, native_output, "output mismatch");
     println!("output: {}", hex::encode(output));
+    println!("native_output: {}", hex::encode(native_output));
     println!("valid: {}", is_valid);
 }


### PR DESCRIPTION
This PR fixes the chaining of hashes in the `sha2-chain` example.