### PR TITLE
Binius counts

### DIFF
--- a/jolt-core/Cargo.toml
+++ b/jolt-core/Cargo.toml
@@ -69,6 +69,7 @@ common = { path = "../common" }
 tracer = { path = "../tracer" }
 bincode = "1.3.3"
 bytemuck = "1.15.0"
+once_cell = "1.19.0"
 
 [build-dependencies]
 common = { path = "../common" }

--- a/jolt-core/src/field/ark.rs
+++ b/jolt-core/src/field/ark.rs
@@ -37,4 +37,8 @@ impl JoltField for ark_bn254::Fr {
         assert_eq!(bytes.len(), Self::NUM_BYTES);
         ark_bn254::Fr::from_le_bytes_mod_order(bytes)
     }
+
+    fn from_count_index(index: u64) -> Self {
+        <Self as JoltField>::from_u64(index).unwrap()
+    }
 }

--- a/jolt-core/src/field/mod.rs
+++ b/jolt-core/src/field/mod.rs
@@ -42,3 +42,4 @@ pub trait JoltField:
 
 pub mod ark;
 pub mod binius;
+mod precomputed;

--- a/jolt-core/src/field/mod.rs
+++ b/jolt-core/src/field/mod.rs
@@ -37,6 +37,7 @@ pub trait JoltField:
     fn from_u64(n: u64) -> Option<Self>;
     fn square(&self) -> Self;
     fn from_bytes(bytes: &[u8]) -> Self;
+    fn from_count_index(index: u64) -> Self;
 }
 
 pub mod ark;

--- a/jolt-core/src/field/precomputed.rs
+++ b/jolt-core/src/field/precomputed.rs
@@ -1,0 +1,97 @@
+use binius_field::{BinaryField, BinaryField128b, BinaryField128bPolyval};
+use once_cell::sync::Lazy;
+
+pub const LOG_TABLE_SIZE: usize = 16;
+pub const TABLE_SIZE: usize = 1 << LOG_TABLE_SIZE;
+
+// BinaryField128b
+pub static PRECOMPUTED_LOW_128B: Lazy<[BinaryField128b; TABLE_SIZE]> = Lazy::new(|| {
+    compute_powers::<BinaryField128b, TABLE_SIZE>(BinaryField128b::MULTIPLICATIVE_GENERATOR)
+});
+pub static PRECOMPUTED_HIGH_128B: Lazy<[BinaryField128b; TABLE_SIZE]> = Lazy::new(|| {
+    compute_powers_starting_from::<BinaryField128b, TABLE_SIZE>(
+        BinaryField128b::MULTIPLICATIVE_GENERATOR,
+        16,
+    )
+});
+
+// BinaryField128bPolyval
+pub static PRECOMPUTED_LOW_128B_POLYVAL: Lazy<[BinaryField128bPolyval; TABLE_SIZE]> =
+    Lazy::new(|| {
+        compute_powers::<BinaryField128bPolyval, TABLE_SIZE>(
+            BinaryField128bPolyval::MULTIPLICATIVE_GENERATOR,
+        )
+    });
+pub static PRECOMPUTED_HIGH_128B_POLYVAL: Lazy<[BinaryField128bPolyval; TABLE_SIZE]> =
+    Lazy::new(|| {
+        compute_powers_starting_from::<BinaryField128bPolyval, TABLE_SIZE>(
+            BinaryField128bPolyval::MULTIPLICATIVE_GENERATOR,
+            16,
+        )
+    });
+
+/// Computes `N` sequential powers of base^{[0, ... N]}
+const fn compute_powers<F: binius_field::BinaryField, const N: usize>(base: F) -> [F; N] {
+    let mut powers = [F::ZERO; N];
+    powers[0] = F::ONE;
+    powers[1] = base;
+    let mut i = 2;
+    while i < N {
+        powers[i] = powers[i - 1] * base;
+        i += 1;
+    }
+    powers
+}
+
+/// Computes `N` sequential powers of base^{2^starting_power}: {base^{2^starting_power}}^{[1, ... N]}
+const fn compute_powers_starting_from<F: binius_field::BinaryField, const N: usize>(
+    base: F,
+    starting_power: usize,
+) -> [F; N] {
+    let mut starting = base;
+    let mut count = 0;
+    // // Repeated squaring
+    while count < starting_power {
+        starting = starting.mul(starting);
+        count += 1;
+    }
+    compute_powers::<F, N>(starting)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use binius_field::{BinaryField, Field};
+
+    #[test]
+    fn test_compute_powers() {
+        let base = BinaryField128b::MULTIPLICATIVE_GENERATOR;
+        let powers = compute_powers::<BinaryField128b, 5>(base);
+        let expected_powers = [
+            BinaryField128b::ONE,
+            base,
+            base * base,
+            base * base * base,
+            base * base * base * base,
+        ];
+        assert_eq!(powers, expected_powers);
+    }
+
+    #[test]
+    fn test_compute_powers_starting_from() {
+        let base = BinaryField128b::MULTIPLICATIVE_GENERATOR;
+        let powers = compute_powers_starting_from::<BinaryField128b, 5>(base, 2);
+        let expected_starting_base = base * base * base * base;
+        let expected_powers = [
+            BinaryField128b::ONE,
+            expected_starting_base,
+            expected_starting_base * expected_starting_base,
+            expected_starting_base * expected_starting_base * expected_starting_base,
+            expected_starting_base
+                * expected_starting_base
+                * expected_starting_base
+                * expected_starting_base,
+        ];
+        assert_eq!(powers, expected_powers);
+    }
+}

--- a/jolt-core/src/lib.rs
+++ b/jolt-core/src/lib.rs
@@ -7,8 +7,7 @@
 #![feature(generic_const_exprs)]
 #![feature(iter_next_chunk)]
 #![allow(long_running_const_eval)]
-
-// Note: Used exclusively by const fn BiniusConstructable::compute_powers. 
+// Note: Used exclusively by const fn BiniusConstructable::compute_powers.
 // Can be removed with a manual const fn for BinaryField multiplication.
 #![feature(const_trait_impl)]
 #![feature(effects)]

--- a/jolt-core/src/lib.rs
+++ b/jolt-core/src/lib.rs
@@ -8,6 +8,12 @@
 #![feature(iter_next_chunk)]
 #![allow(long_running_const_eval)]
 
+// Note: Used exclusively by const fn BiniusConstructable::compute_powers. 
+// Can be removed with a manual const fn for BinaryField multiplication.
+#![feature(const_trait_impl)]
+#![feature(effects)]
+#![feature(const_refs_to_cell)]
+
 pub mod benches;
 pub mod field;
 pub mod host;


### PR DESCRIPTION
Implements the conversion to multiplicities for Binius counts as described in Section 4.4 of the [Binius paper](https://eprint.iacr.org/2023/1784.pdf). Does not wire it into the offline memory checking system yet.

Runs a similar strategy to halo2curves::PrimeField and our [fork of Arkworks](https://github.com/a16z/arkworks-algebra/pull/2/files) to precompute some tables to reduce the cost of calls to `from_count_index`. Unfortunately does not move all the pre-computation work to compile time as the Binius library does not currently have a `const fn` impl. If this does get implemented we can revert back to `1241739007964a4e2c2ba71fc07e76082a0ca925` which is substantially simpler.

Thaler's optimization strategy:
- Split the count $x$ such that $x = a \cdot 2^{16} + b$ with $a$ and $b$ each ranging from $0$ to $2^{16}$. 
- Maintain two lookup tables: 
  - One for $2^{16}$ powers of $g^{2^{16}}$.
  - Another for $2^{16}$ powers of $g$.
- Any count up to $2^{32}$ can be computed using two lookups and one multiplication: 
  $$g^x = (g^{2^{16}})^a \cdot g^b$$

2^32 may be overkill and we would get significant speedups on the initialization time of tables by reducing size.
