### PR TITLE
Efficent opening proofs in verifier

### DIFF
--- a/jolt-core/src/jolt/vm/read_write_memory.rs
+++ b/jolt-core/src/jolt/vm/read_write_memory.rs
@@ -1622,7 +1622,7 @@ where
         let memory_layout = &preprocessing.program_io.as_ref().unwrap().memory_layout;
 
         let nonzero_memory_size = memory_layout.ram_witness_offset as usize;
-        let log_nonzero_memory_size = nonzero_memory_size.log_2() as usize;
+        let log_nonzero_memory_size = nonzero_memory_size.log_2();
         assert!(
             nonzero_memory_size.is_power_of_two(),
             "Ram witness offset must be a power of two"

--- a/jolt-core/src/jolt/vm/read_write_memory.rs
+++ b/jolt-core/src/jolt/vm/read_write_memory.rs
@@ -1623,9 +1623,8 @@ where
 
         let nonzero_memory_size = memory_layout.ram_witness_offset as usize;
         let log_nonzero_memory_size = nonzero_memory_size.trailing_zeros() as usize;
-        assert_eq!(
-            1 << log_nonzero_memory_size,
-            nonzero_memory_size,
+        assert!(
+            nonzero_memory_size.is_power_of_two(),
             "Ram witness offset must be a power of two"
         );
 

--- a/jolt-core/src/jolt/vm/read_write_memory.rs
+++ b/jolt-core/src/jolt/vm/read_write_memory.rs
@@ -1622,7 +1622,7 @@ where
         let memory_layout = &preprocessing.program_io.as_ref().unwrap().memory_layout;
 
         let nonzero_memory_size = memory_layout.ram_witness_offset as usize;
-        let log_nonzero_memory_size = nonzero_memory_size.trailing_zeros() as usize;
+        let log_nonzero_memory_size = nonzero_memory_size.log_2() as usize;
         assert!(
             nonzero_memory_size.is_power_of_two(),
             "Ram witness offset must be a power of two"


### PR DESCRIPTION
Resolves two of the three todos reducing the memory use of the verifier when calculating the evaluations of the initial memory polynomials. Resolves #350