### PR TITLE
move iai-callgrind to dev-depencency

### DIFF
--- a/jolt-core/Cargo.toml
+++ b/jolt-core/Cargo.toml
@@ -55,7 +55,6 @@ tracing-chrome = "0.7.1"
 tracing-flame = "0.2.0"
 tracing-subscriber = "0.3.18"
 tracing-texray = "0.2.0"
-iai-callgrind = "0.10.2"
 target-lexicon = "0.12.14"
 reqwest = { version = "0.12.3", features = ["json", "blocking"] }
 dirs = "5.0.1"
@@ -69,6 +68,7 @@ bincode = "1.3.3"
 
 [dev-dependencies]
 criterion = { version = "0.5.1", features = ["html_reports"] }
+iai-callgrind = "0.10.2"
 
 [build-dependencies]
 common = { path = "../common" }


### PR DESCRIPTION
The only place where `iai-callgrind` is used is jolt-core/bench/iai.rs, which is outside of `jolt-core/src` and should be moved into `dev-depencency`

And, similar to criterion, it will cause jolt to fail to compile into wasm
https://github.com/a16z/jolt/issues/345
