### PR TITLE
forward-compatibility with future ark_ff

### DIFF
--- a/jolt-core/src/poly/field.rs
+++ b/jolt-core/src/poly/field.rs
@@ -49,7 +49,6 @@ pub trait JoltField:
     fn zero() -> Self;
     fn one() -> Self;
     fn from_u64(n: u64) -> Option<Self>;
-    fn double(&self) -> Self;
     fn square(&self) -> Self;
     fn from_bytes(bytes: &[u8]) -> Self;
     #[inline(always)]
@@ -108,11 +107,7 @@ impl JoltField for ark_bn254::Fr {
     }
 
     fn from_u64(n: u64) -> Option<Self> {
-        <Self as ark_ff::PrimeField>::from_u64(n)
-    }
-
-    fn double(&self) -> Self {
-        <Self as ark_ff::Field>::double(self)
+        Some(Self::from(n))
     }
 
     fn square(&self) -> Self {


### PR DESCRIPTION
We'd like to integrate Jolt as a dependency for [Nexus zkVM](https://github.com/nexus-xyz/nexus-zkvm). 
However, arkworks 0.4 has crucial bugs such as https://github.com/arkworks-rs/r1cs-std/issues/94 and several others.

Thus, nexus code is forced to use patched ark-* crates. Luckily, there aren't many changes needed to be forward compatible with potential arkworks 0.5, hence this PR.

(note that
```rust
    // From JoltField 

    fn double(&self) -> Self;
```
is unused and depends on `AdditiveGroup` instead of `Field` in the future. It's my assumption that it's safe to be removed.)