### PR TITLE
feat(observability): Adding visualization for memory consumption

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,7 @@ sysinfo = "0.30.8"
 
 jolt-sdk = { path = "./jolt-sdk" }
 jolt-core = { path = "./jolt-core" }
+allocative = "0.3.3"
 
 [profile.test]
 opt-level = 3

--- a/jolt-core/Cargo.toml
+++ b/jolt-core/Cargo.toml
@@ -67,6 +67,7 @@ tokio = "1.37.0"
 common = { path = "../common" }
 tracer = { path = "../tracer" }
 bincode = "1.3.3"
+allocative = "0.3.3"
 
 [build-dependencies]
 common = { path = "../common" }

--- a/jolt-core/src/jolt/instruction/and.rs
+++ b/jolt-core/src/jolt/instruction/and.rs
@@ -1,3 +1,4 @@
+use allocative::Allocative;
 use ark_std::log2;
 use rand::prelude::StdRng;
 use rand::RngCore;
@@ -8,7 +9,7 @@ use crate::jolt::subtable::{and::AndSubtable, LassoSubtable};
 use crate::poly::field::JoltField;
 use crate::utils::instruction_utils::{chunk_and_concatenate_operands, concatenate_lookups};
 
-#[derive(Copy, Clone, Default, Debug, Serialize, Deserialize)]
+#[derive(Copy, Clone, Default, Debug, Serialize, Deserialize, Allocative)]
 pub struct ANDInstruction(pub u64, pub u64);
 
 impl JoltInstruction for ANDInstruction {

--- a/jolt-core/src/jolt/instruction/beq.rs
+++ b/jolt-core/src/jolt/instruction/beq.rs
@@ -1,3 +1,4 @@
+use allocative::Allocative;
 use rand::prelude::StdRng;
 use rand::RngCore;
 use serde::{Deserialize, Serialize};
@@ -12,7 +13,7 @@ use crate::{
     utils::instruction_utils::chunk_and_concatenate_operands,
 };
 
-#[derive(Copy, Clone, Default, Debug, Serialize, Deserialize)]
+#[derive(Copy, Clone, Default, Debug, Serialize, Deserialize, Allocative)]
 pub struct BEQInstruction(pub u64, pub u64);
 
 impl JoltInstruction for BEQInstruction {

--- a/jolt-core/src/jolt/instruction/bge.rs
+++ b/jolt-core/src/jolt/instruction/bge.rs
@@ -1,3 +1,4 @@
+use allocative::Allocative;
 use rand::prelude::StdRng;
 use rand::RngCore;
 use serde::{Deserialize, Serialize};
@@ -12,7 +13,7 @@ use crate::{
     utils::instruction_utils::chunk_and_concatenate_operands,
 };
 
-#[derive(Copy, Clone, Default, Debug, Serialize, Deserialize)]
+#[derive(Copy, Clone, Default, Debug, Serialize, Deserialize, Allocative)]
 pub struct BGEInstruction(pub u64, pub u64);
 
 impl JoltInstruction for BGEInstruction {

--- a/jolt-core/src/jolt/instruction/bgeu.rs
+++ b/jolt-core/src/jolt/instruction/bgeu.rs
@@ -1,3 +1,4 @@
+use allocative::Allocative;
 use rand::prelude::StdRng;
 use rand::RngCore;
 use serde::{Deserialize, Serialize};
@@ -9,7 +10,7 @@ use crate::{
     utils::instruction_utils::chunk_and_concatenate_operands,
 };
 
-#[derive(Copy, Clone, Default, Debug, Serialize, Deserialize)]
+#[derive(Copy, Clone, Default, Debug, Serialize, Deserialize, Allocative)]
 pub struct BGEUInstruction(pub u64, pub u64);
 
 impl JoltInstruction for BGEUInstruction {

--- a/jolt-core/src/jolt/instruction/bne.rs
+++ b/jolt-core/src/jolt/instruction/bne.rs
@@ -1,3 +1,4 @@
+use allocative::Allocative;
 use rand::prelude::StdRng;
 use rand::RngCore;
 use serde::{Deserialize, Serialize};
@@ -12,7 +13,7 @@ use crate::{
     utils::instruction_utils::chunk_and_concatenate_operands,
 };
 
-#[derive(Copy, Clone, Default, Debug, Serialize, Deserialize)]
+#[derive(Copy, Clone, Default, Debug, Serialize, Deserialize, Allocative)]
 pub struct BNEInstruction(pub u64, pub u64);
 
 impl JoltInstruction for BNEInstruction {

--- a/jolt-core/src/jolt/instruction/lb.rs
+++ b/jolt-core/src/jolt/instruction/lb.rs
@@ -1,3 +1,4 @@
+use allocative::Allocative;
 use rand::prelude::StdRng;
 use rand::RngCore;
 use serde::{Deserialize, Serialize};
@@ -9,7 +10,7 @@ use crate::jolt::subtable::{
 use crate::poly::field::JoltField;
 use crate::utils::instruction_utils::chunk_operand_usize;
 
-#[derive(Copy, Clone, Default, Debug, Serialize, Deserialize)]
+#[derive(Copy, Clone, Default, Debug, Serialize, Deserialize, Allocative)]
 pub struct LBInstruction(pub u64);
 
 impl JoltInstruction for LBInstruction {

--- a/jolt-core/src/jolt/instruction/lh.rs
+++ b/jolt-core/src/jolt/instruction/lh.rs
@@ -1,3 +1,4 @@
+use allocative::Allocative;
 use rand::prelude::StdRng;
 use rand::RngCore;
 use serde::{Deserialize, Serialize};
@@ -9,7 +10,7 @@ use crate::jolt::subtable::{
 use crate::poly::field::JoltField;
 use crate::utils::instruction_utils::chunk_operand_usize;
 
-#[derive(Copy, Clone, Default, Debug, Serialize, Deserialize)]
+#[derive(Copy, Clone, Default, Debug, Serialize, Deserialize, Allocative)]
 pub struct LHInstruction(pub u64);
 
 impl JoltInstruction for LHInstruction {

--- a/jolt-core/src/jolt/instruction/mod.rs
+++ b/jolt-core/src/jolt/instruction/mod.rs
@@ -1,3 +1,4 @@
+use allocative::Allocative;
 use enum_dispatch::enum_dispatch;
 use fixedbitset::*;
 use rand::prelude::StdRng;
@@ -13,7 +14,7 @@ use common::rv_trace::ELFInstruction;
 use std::fmt::Debug;
 
 #[enum_dispatch]
-pub trait JoltInstruction: Clone + Debug + Send + Sync + Serialize {
+pub trait JoltInstruction: Clone + Debug + Send + Sync + Serialize + Allocative {
     fn operands(&self) -> (u64, u64);
     /// Combines `vals` according to the instruction's "collation" polynomial `g`.
     /// If `vals` are subtable entries (as opposed to MLE evaluations), this function returns the

--- a/jolt-core/src/jolt/instruction/or.rs
+++ b/jolt-core/src/jolt/instruction/or.rs
@@ -1,3 +1,4 @@
+use allocative::Allocative;
 use ark_std::log2;
 use rand::prelude::StdRng;
 use rand::RngCore;
@@ -8,7 +9,7 @@ use crate::jolt::subtable::{or::OrSubtable, LassoSubtable};
 use crate::poly::field::JoltField;
 use crate::utils::instruction_utils::{chunk_and_concatenate_operands, concatenate_lookups};
 
-#[derive(Copy, Clone, Default, Debug, Serialize, Deserialize)]
+#[derive(Copy, Clone, Default, Debug, Serialize, Deserialize, Allocative)]
 pub struct ORInstruction(pub u64, pub u64);
 
 impl JoltInstruction for ORInstruction {

--- a/jolt-core/src/jolt/instruction/sb.rs
+++ b/jolt-core/src/jolt/instruction/sb.rs
@@ -1,3 +1,4 @@
+use allocative::Allocative;
 use rand::prelude::StdRng;
 use rand::RngCore;
 use serde::{Deserialize, Serialize};
@@ -7,7 +8,7 @@ use crate::jolt::subtable::{truncate_overflow::TruncateOverflowSubtable, LassoSu
 use crate::poly::field::JoltField;
 use crate::utils::instruction_utils::chunk_operand_usize;
 
-#[derive(Copy, Clone, Default, Debug, Serialize, Deserialize)]
+#[derive(Copy, Clone, Default, Debug, Serialize, Deserialize, Allocative)]
 pub struct SBInstruction(pub u64);
 
 impl JoltInstruction for SBInstruction {

--- a/jolt-core/src/jolt/instruction/sh.rs
+++ b/jolt-core/src/jolt/instruction/sh.rs
@@ -1,3 +1,4 @@
+use allocative::Allocative;
 use rand::prelude::StdRng;
 use rand::RngCore;
 use serde::{Deserialize, Serialize};
@@ -7,7 +8,7 @@ use crate::jolt::subtable::{identity::IdentitySubtable, LassoSubtable};
 use crate::poly::field::JoltField;
 use crate::utils::instruction_utils::chunk_operand_usize;
 
-#[derive(Copy, Clone, Default, Debug, Serialize, Deserialize)]
+#[derive(Copy, Clone, Default, Debug, Serialize, Deserialize, Allocative)]
 pub struct SHInstruction(pub u64);
 
 impl JoltInstruction for SHInstruction {

--- a/jolt-core/src/jolt/instruction/sll.rs
+++ b/jolt-core/src/jolt/instruction/sll.rs
@@ -1,3 +1,4 @@
+use allocative::Allocative;
 use ark_std::log2;
 use rand::prelude::StdRng;
 use rand::RngCore;
@@ -10,7 +11,7 @@ use crate::utils::instruction_utils::{
     assert_valid_parameters, chunk_and_concatenate_for_shift, concatenate_lookups,
 };
 
-#[derive(Copy, Clone, Default, Debug, Serialize, Deserialize)]
+#[derive(Copy, Clone, Default, Debug, Serialize, Deserialize, Allocative)]
 pub struct SLLInstruction<const WORD_SIZE: usize>(pub u64, pub u64);
 
 impl<const WORD_SIZE: usize> JoltInstruction for SLLInstruction<WORD_SIZE> {

--- a/jolt-core/src/jolt/instruction/slt.rs
+++ b/jolt-core/src/jolt/instruction/slt.rs
@@ -1,4 +1,5 @@
 use crate::poly::field::JoltField;
+use allocative::Allocative;
 use rand::prelude::StdRng;
 use rand::RngCore;
 use serde::{Deserialize, Serialize};
@@ -12,7 +13,7 @@ use crate::{
     utils::instruction_utils::chunk_and_concatenate_operands,
 };
 
-#[derive(Copy, Clone, Default, Debug, Serialize, Deserialize)]
+#[derive(Copy, Clone, Default, Debug, Serialize, Deserialize, Allocative)]
 pub struct SLTInstruction(pub u64, pub u64);
 
 impl JoltInstruction for SLTInstruction {

--- a/jolt-core/src/jolt/instruction/sltu.rs
+++ b/jolt-core/src/jolt/instruction/sltu.rs
@@ -1,4 +1,5 @@
 use crate::poly::field::JoltField;
+use allocative::Allocative;
 use rand::prelude::StdRng;
 use rand::RngCore;
 use serde::{Deserialize, Serialize};
@@ -12,7 +13,7 @@ use crate::{
     utils::instruction_utils::chunk_and_concatenate_operands,
 };
 
-#[derive(Copy, Clone, Default, Debug, Serialize, Deserialize)]
+#[derive(Copy, Clone, Default, Debug, Serialize, Deserialize, Allocative)]
 pub struct SLTUInstruction(pub u64, pub u64);
 
 impl JoltInstruction for SLTUInstruction {

--- a/jolt-core/src/jolt/instruction/sra.rs
+++ b/jolt-core/src/jolt/instruction/sra.rs
@@ -1,4 +1,5 @@
 use crate::poly::field::JoltField;
+use allocative::Allocative;
 use rand::prelude::StdRng;
 use rand::RngCore;
 use serde::{Deserialize, Serialize};
@@ -7,7 +8,7 @@ use super::{JoltInstruction, SubtableIndices};
 use crate::jolt::subtable::{sra_sign::SraSignSubtable, srl::SrlSubtable, LassoSubtable};
 use crate::utils::instruction_utils::{assert_valid_parameters, chunk_and_concatenate_for_shift};
 
-#[derive(Copy, Clone, Default, Debug, Serialize, Deserialize)]
+#[derive(Copy, Clone, Default, Debug, Serialize, Deserialize, Allocative)]
 pub struct SRAInstruction<const WORD_SIZE: usize>(pub u64, pub u64);
 
 impl<const WORD_SIZE: usize> JoltInstruction for SRAInstruction<WORD_SIZE> {

--- a/jolt-core/src/jolt/instruction/srl.rs
+++ b/jolt-core/src/jolt/instruction/srl.rs
@@ -1,4 +1,5 @@
 use crate::poly::field::JoltField;
+use allocative::Allocative;
 use rand::prelude::StdRng;
 use rand::RngCore;
 use serde::{Deserialize, Serialize};
@@ -7,7 +8,7 @@ use super::{JoltInstruction, SubtableIndices};
 use crate::jolt::subtable::{srl::SrlSubtable, LassoSubtable};
 use crate::utils::instruction_utils::{assert_valid_parameters, chunk_and_concatenate_for_shift};
 
-#[derive(Copy, Clone, Default, Debug, Serialize, Deserialize)]
+#[derive(Copy, Clone, Default, Debug, Serialize, Deserialize, Allocative)]
 pub struct SRLInstruction<const WORD_SIZE: usize>(pub u64, pub u64);
 
 impl<const WORD_SIZE: usize> JoltInstruction for SRLInstruction<WORD_SIZE> {

--- a/jolt-core/src/jolt/instruction/sub.rs
+++ b/jolt-core/src/jolt/instruction/sub.rs
@@ -1,4 +1,5 @@
 use crate::poly::field::JoltField;
+use allocative::Allocative;
 use ark_std::log2;
 use rand::prelude::StdRng;
 use rand::RngCore;
@@ -12,7 +13,7 @@ use crate::utils::instruction_utils::{
     add_and_chunk_operands, assert_valid_parameters, concatenate_lookups,
 };
 
-#[derive(Copy, Clone, Default, Debug, Serialize, Deserialize)]
+#[derive(Copy, Clone, Default, Debug, Serialize, Deserialize, Allocative)]
 pub struct SUBInstruction<const WORD_SIZE: usize>(pub u64, pub u64);
 
 impl<const WORD_SIZE: usize> JoltInstruction for SUBInstruction<WORD_SIZE> {

--- a/jolt-core/src/jolt/instruction/sw.rs
+++ b/jolt-core/src/jolt/instruction/sw.rs
@@ -1,4 +1,5 @@
 use crate::poly::field::JoltField;
+use allocative::Allocative;
 use ark_std::log2;
 use rand::prelude::StdRng;
 use rand::RngCore;
@@ -8,7 +9,7 @@ use super::{JoltInstruction, SubtableIndices};
 use crate::jolt::subtable::{identity::IdentitySubtable, LassoSubtable};
 use crate::utils::instruction_utils::{chunk_operand_usize, concatenate_lookups};
 
-#[derive(Copy, Clone, Default, Debug, Serialize, Deserialize)]
+#[derive(Copy, Clone, Default, Debug, Serialize, Deserialize, Allocative)]
 pub struct SWInstruction(pub u64);
 
 impl JoltInstruction for SWInstruction {

--- a/jolt-core/src/jolt/instruction/xor.rs
+++ b/jolt-core/src/jolt/instruction/xor.rs
@@ -1,4 +1,5 @@
 use crate::poly::field::JoltField;
+use allocative::Allocative;
 use ark_std::log2;
 use rand::prelude::StdRng;
 use rand::RngCore;
@@ -9,7 +10,7 @@ use crate::jolt::instruction::SubtableIndices;
 use crate::jolt::subtable::{xor::XorSubtable, LassoSubtable};
 use crate::utils::instruction_utils::{chunk_and_concatenate_operands, concatenate_lookups};
 
-#[derive(Copy, Clone, Default, Debug, Serialize, Deserialize)]
+#[derive(Copy, Clone, Default, Debug, Serialize, Deserialize, Allocative)]
 pub struct XORInstruction(pub u64, pub u64);
 
 impl JoltInstruction for XORInstruction {

--- a/jolt-core/src/jolt/subtable/and.rs
+++ b/jolt-core/src/jolt/subtable/and.rs
@@ -1,11 +1,12 @@
 use crate::poly::field::JoltField;
+use allocative::Allocative;
 use ark_std::log2;
 use std::marker::PhantomData;
 
 use super::LassoSubtable;
 use crate::utils::split_bits;
 
-#[derive(Default)]
+#[derive(Default, Allocative)]
 pub struct AndSubtable<F: JoltField> {
     _field: PhantomData<F>,
 }

--- a/jolt-core/src/jolt/subtable/eq.rs
+++ b/jolt-core/src/jolt/subtable/eq.rs
@@ -1,10 +1,11 @@
 use crate::poly::field::JoltField;
+use allocative::Allocative;
 use ark_std::log2;
 use std::marker::PhantomData;
 
 use super::LassoSubtable;
 
-#[derive(Default)]
+#[derive(Default, Allocative)]
 pub struct EqSubtable<F: JoltField> {
     _field: PhantomData<F>,
 }

--- a/jolt-core/src/jolt/subtable/eq_abs.rs
+++ b/jolt-core/src/jolt/subtable/eq_abs.rs
@@ -1,10 +1,11 @@
 use crate::poly::field::JoltField;
+use allocative::Allocative;
 use ark_std::log2;
 use std::marker::PhantomData;
 
 use super::LassoSubtable;
 
-#[derive(Default)]
+#[derive(Default, Allocative)]
 pub struct EqAbsSubtable<F: JoltField> {
     _field: PhantomData<F>,
 }

--- a/jolt-core/src/jolt/subtable/eq_msb.rs
+++ b/jolt-core/src/jolt/subtable/eq_msb.rs
@@ -1,11 +1,12 @@
 use crate::poly::field::JoltField;
+use allocative::Allocative;
 use ark_std::log2;
 use std::marker::PhantomData;
 
 use super::LassoSubtable;
 use crate::utils::split_bits;
 
-#[derive(Default)]
+#[derive(Default, Allocative)]
 pub struct EqMSBSubtable<F: JoltField> {
     _field: PhantomData<F>,
 }

--- a/jolt-core/src/jolt/subtable/gt_msb.rs
+++ b/jolt-core/src/jolt/subtable/gt_msb.rs
@@ -1,11 +1,12 @@
 use crate::poly::field::JoltField;
+use allocative::Allocative;
 use ark_std::log2;
 use std::marker::PhantomData;
 
 use super::LassoSubtable;
 use crate::utils::split_bits;
 
-#[derive(Default)]
+#[derive(Default, Allocative)]
 pub struct GtMSBSubtable<F: JoltField> {
     _field: PhantomData<F>,
 }

--- a/jolt-core/src/jolt/subtable/identity.rs
+++ b/jolt-core/src/jolt/subtable/identity.rs
@@ -1,9 +1,11 @@
+use allocative::Allocative;
+
 use crate::poly::field::JoltField;
 use std::marker::PhantomData;
 
 use super::LassoSubtable;
 
-#[derive(Default)]
+#[derive(Default, Allocative)]
 pub struct IdentitySubtable<F: JoltField> {
     _field: PhantomData<F>,
 }

--- a/jolt-core/src/jolt/subtable/lt_abs.rs
+++ b/jolt-core/src/jolt/subtable/lt_abs.rs
@@ -1,11 +1,12 @@
 use crate::poly::field::JoltField;
+use allocative::Allocative;
 use ark_std::log2;
 use std::marker::PhantomData;
 
 use super::LassoSubtable;
 use crate::utils::split_bits;
 
-#[derive(Default)]
+#[derive(Default, Allocative)]
 pub struct LtAbsSubtable<F: JoltField> {
     _field: PhantomData<F>,
 }

--- a/jolt-core/src/jolt/subtable/ltu.rs
+++ b/jolt-core/src/jolt/subtable/ltu.rs
@@ -1,11 +1,12 @@
 use crate::poly::field::JoltField;
+use allocative::Allocative;
 use ark_std::log2;
 use std::marker::PhantomData;
 
 use super::LassoSubtable;
 use crate::utils::split_bits;
 
-#[derive(Default)]
+#[derive(Default, Allocative)]
 pub struct LtuSubtable<F: JoltField> {
     _field: PhantomData<F>,
 }

--- a/jolt-core/src/jolt/subtable/or.rs
+++ b/jolt-core/src/jolt/subtable/or.rs
@@ -1,11 +1,12 @@
 use crate::poly::field::JoltField;
+use allocative::Allocative;
 use ark_std::log2;
 use std::marker::PhantomData;
 
 use super::LassoSubtable;
 use crate::utils::split_bits;
 
-#[derive(Default)]
+#[derive(Default, Allocative)]
 pub struct OrSubtable<F: JoltField> {
     _field: PhantomData<F>,
 }

--- a/jolt-core/src/jolt/subtable/sign_extend.rs
+++ b/jolt-core/src/jolt/subtable/sign_extend.rs
@@ -1,9 +1,11 @@
+use allocative::Allocative;
+
 use crate::poly::field::JoltField;
 use std::marker::PhantomData;
 
 use super::LassoSubtable;
 
-#[derive(Default)]
+#[derive(Default, Allocative)]
 pub struct SignExtendSubtable<F: JoltField, const WIDTH: usize> {
     _field: PhantomData<F>,
 }

--- a/jolt-core/src/jolt/subtable/sll.rs
+++ b/jolt-core/src/jolt/subtable/sll.rs
@@ -1,4 +1,5 @@
 use crate::poly::field::JoltField;
+use allocative::Allocative;
 use ark_std::log2;
 use std::cmp::min;
 use std::marker::PhantomData;
@@ -7,7 +8,7 @@ use super::LassoSubtable;
 use crate::utils::math::Math;
 use crate::utils::split_bits;
 
-#[derive(Default)]
+#[derive(Default, Allocative)]
 pub struct SllSubtable<F: JoltField, const CHUNK_INDEX: usize, const WORD_SIZE: usize> {
     _field: PhantomData<F>,
 }

--- a/jolt-core/src/jolt/subtable/sra_sign.rs
+++ b/jolt-core/src/jolt/subtable/sra_sign.rs
@@ -1,4 +1,5 @@
 use crate::poly::field::JoltField;
+use allocative::Allocative;
 use ark_std::log2;
 use std::marker::PhantomData;
 
@@ -6,7 +7,7 @@ use super::LassoSubtable;
 use crate::utils::math::Math;
 use crate::utils::split_bits;
 
-#[derive(Default)]
+#[derive(Default, Allocative)]
 pub struct SraSignSubtable<F: JoltField, const WORD_SIZE: usize> {
     _field: PhantomData<F>,
 }

--- a/jolt-core/src/jolt/subtable/srl.rs
+++ b/jolt-core/src/jolt/subtable/srl.rs
@@ -1,4 +1,5 @@
 use crate::poly::field::JoltField;
+use allocative::Allocative;
 use ark_std::log2;
 use std::marker::PhantomData;
 
@@ -6,7 +7,7 @@ use super::LassoSubtable;
 use crate::utils::math::Math;
 use crate::utils::split_bits;
 
-#[derive(Default)]
+#[derive(Default, Allocative)]
 pub struct SrlSubtable<F: JoltField, const CHUNK_INDEX: usize, const WORD_SIZE: usize> {
     _field: PhantomData<F>,
 }

--- a/jolt-core/src/jolt/subtable/truncate_overflow.rs
+++ b/jolt-core/src/jolt/subtable/truncate_overflow.rs
@@ -1,4 +1,5 @@
 use crate::poly::field::JoltField;
+use allocative::Allocative;
 use ark_std::log2;
 use std::marker::PhantomData;
 
@@ -9,7 +10,7 @@ use super::LassoSubtable;
 /// Example usage in ADD:
 /// Input z is of 65 bits, which is split into 20-bit chunks.
 /// This subtable is used to remove the overflow bit from the 4th chunk.
-#[derive(Default)]
+#[derive(Default, Allocative)]
 pub struct TruncateOverflowSubtable<F: JoltField, const WORD_SIZE: usize> {
     _field: PhantomData<F>,
 }

--- a/jolt-core/src/jolt/subtable/xor.rs
+++ b/jolt-core/src/jolt/subtable/xor.rs
@@ -1,11 +1,12 @@
 use crate::poly::field::JoltField;
+use allocative::Allocative;
 use ark_std::log2;
 use std::marker::PhantomData;
 
 use super::LassoSubtable;
 use crate::utils::split_bits;
 
-#[derive(Default)]
+#[derive(Default, Allocative)]
 pub struct XorSubtable<F: JoltField> {
     _field: PhantomData<F>,
 }

--- a/jolt-core/src/jolt/subtable/zero_lsb.rs
+++ b/jolt-core/src/jolt/subtable/zero_lsb.rs
@@ -1,9 +1,11 @@
+use allocative::Allocative;
+
 use crate::poly::field::JoltField;
 use std::marker::PhantomData;
 
 use super::LassoSubtable;
 
-#[derive(Default)]
+#[derive(Default, Allocative)]
 pub struct ZeroLSBSubtable<F: JoltField> {
     _field: PhantomData<F>,
 }

--- a/jolt-core/src/lasso/memory_checking.rs
+++ b/jolt-core/src/lasso/memory_checking.rs
@@ -13,13 +13,14 @@ use crate::utils::errors::ProofVerifyError;
 use crate::utils::transcript::ProofTranscript;
 
 use crate::poly::field::JoltField;
+use allocative::Allocative;
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use itertools::interleave;
 use rayon::iter::{IntoParallelIterator, IntoParallelRefIterator, ParallelIterator};
 use std::iter::zip;
 use std::marker::PhantomData;
 
-#[derive(CanonicalSerialize, CanonicalDeserialize)]
+#[derive(CanonicalSerialize, CanonicalDeserialize, Allocative)]
 pub struct MultisetHashes<F: JoltField> {
     /// Multiset hash of "read" tuples
     pub read_hashes: Vec<F>,
@@ -40,7 +41,7 @@ impl<F: JoltField> MultisetHashes<F> {
     }
 }
 
-#[derive(CanonicalSerialize, CanonicalDeserialize)]
+#[derive(CanonicalSerialize, CanonicalDeserialize, Allocative)]
 pub struct MemoryCheckingProof<F, C, Polynomials, ReadWriteOpenings, InitFinalOpenings>
 where
     F: JoltField,
@@ -67,6 +68,7 @@ where
 }
 
 // Empty struct to represent that no preprocessing data is used.
+#[derive(Allocative)]
 pub struct NoPreprocessing;
 
 pub trait MemoryCheckingProver<F, C, Polynomials>

--- a/jolt-core/src/lasso/surge.rs
+++ b/jolt-core/src/lasso/surge.rs
@@ -1,4 +1,5 @@
 use crate::poly::{commitment::commitment_scheme::BatchType, field::JoltField};
+use allocative::Allocative;
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use rayon::iter::{IntoParallelIterator, IntoParallelRefIterator, ParallelIterator};
 use std::marker::{PhantomData, Sync};
@@ -17,6 +18,7 @@ use crate::{
     utils::{errors::ProofVerifyError, math::Math, mul_0_1_optimized, transcript::ProofTranscript},
 };
 
+#[derive(Allocative)]
 pub struct SurgePolys<F, PCS>
 where
     F: JoltField,
@@ -29,7 +31,7 @@ where
     pub E_polys: Vec<DensePolynomial<F>>,
 }
 
-#[derive(CanonicalSerialize, CanonicalDeserialize)]
+#[derive(CanonicalSerialize, CanonicalDeserialize, Allocative)]
 pub struct SurgeCommitment<CS: CommitmentScheme> {
     /// Commitments to dim_i and read_cts_i polynomials.
     pub dim_read_commitment: Vec<CS::Commitment>,
@@ -122,7 +124,7 @@ where
     }
 }
 
-#[derive(CanonicalSerialize, CanonicalDeserialize)]
+#[derive(CanonicalSerialize, CanonicalDeserialize, Allocative)]
 pub struct SurgeReadWriteOpenings<F>
 where
     F: JoltField,
@@ -208,12 +210,13 @@ where
     }
 }
 
-#[derive(CanonicalSerialize, CanonicalDeserialize)]
+#[derive(CanonicalSerialize, CanonicalDeserialize, Allocative)]
 pub struct SurgeFinalOpenings<F, Instruction, const C: usize, const M: usize>
 where
     F: JoltField,
     Instruction: JoltInstruction + Default,
 {
+    #[allocative(visit = visit_unsupported)]
     _instruction: PhantomData<Instruction>,
     final_openings: Vec<F>,       // C-sized
     a_init_final: Option<F>,      // Computed by verifier
@@ -460,6 +463,7 @@ where
     }
 }
 
+#[derive(Allocative)]
 pub struct SurgePrimarySumcheck<F, PCS>
 where
     F: JoltField,
@@ -472,6 +476,8 @@ where
     opening_proof: PCS::BatchedProof,
 }
 
+#[derive(Allocative)]
+
 pub struct SurgePreprocessing<F, Instruction, const C: usize, const M: usize>
 where
     F: JoltField,
@@ -481,6 +487,7 @@ where
     materialized_subtables: Vec<Vec<F>>,
 }
 
+#[derive(Allocative)]
 #[allow(clippy::type_complexity)]
 pub struct SurgeProof<F, PCS, Instruction, const C: usize, const M: usize>
 where

--- a/jolt-core/src/poly/commitment/commitment_scheme.rs
+++ b/jolt-core/src/poly/commitment/commitment_scheme.rs
@@ -1,3 +1,4 @@
+use allocative::Allocative;
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 
 use crate::{
@@ -8,7 +9,7 @@ use crate::{
     },
 };
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Allocative)]
 pub struct CommitShape {
     pub input_length: usize,
     pub batch_type: BatchType,
@@ -23,7 +24,7 @@ impl CommitShape {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Allocative)]
 pub enum BatchType {
     Big,
     Small,
@@ -31,7 +32,7 @@ pub enum BatchType {
     SurgeReadWrite,
 }
 
-pub trait CommitmentScheme: Clone + Sync + Send + 'static {
+pub trait CommitmentScheme: Clone + Sync + Send + Allocative + 'static {
     type Field: JoltField;
     type Setup: Clone + Sync + Send;
     type Commitment: Sync + Send + CanonicalSerialize + CanonicalDeserialize + AppendToTranscript;

--- a/jolt-core/src/poly/commitment/hyrax.rs
+++ b/jolt-core/src/poly/commitment/hyrax.rs
@@ -9,6 +9,7 @@ use crate::utils::errors::ProofVerifyError;
 use crate::utils::math::Math;
 use crate::utils::transcript::{AppendToTranscript, ProofTranscript};
 use crate::utils::{compute_dotproduct, mul_0_1_optimized};
+use allocative::Allocative;
 use ark_ec::CurveGroup;
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use num_integer::Roots;
@@ -17,7 +18,7 @@ use tracing::trace_span;
 
 use crate::msm::VariableBaseMSM;
 
-#[derive(Clone)]
+#[derive(Clone, Allocative)]
 pub struct HyraxScheme<G: CurveGroup> {
     marker: PhantomData<G>,
 }
@@ -145,12 +146,12 @@ impl<F: JoltField, G: CurveGroup<ScalarField = F>> CommitmentScheme for HyraxSch
     }
 }
 
-#[derive(Clone, CanonicalSerialize, CanonicalDeserialize)]
+#[derive(Clone, CanonicalSerialize, CanonicalDeserialize, Allocative)]
 pub struct HyraxGenerators<G: CurveGroup> {
     pub gens: PedersenGenerators<G>,
 }
 
-#[derive(Clone, Debug, CanonicalSerialize, CanonicalDeserialize)]
+#[derive(Clone, Debug, CanonicalSerialize, CanonicalDeserialize, Allocative)]
 pub struct HyraxCommitment<G: CurveGroup> {
     pub row_commitments: Vec<G>,
 }
@@ -221,7 +222,7 @@ impl<G: CurveGroup> AppendToTranscript for HyraxCommitment<G> {
     }
 }
 
-#[derive(Debug, CanonicalSerialize, CanonicalDeserialize)]
+#[derive(Debug, CanonicalSerialize, CanonicalDeserialize, Allocative)]
 pub struct HyraxOpeningProof<G: CurveGroup> {
     pub vector_matrix_product: Vec<G::ScalarField>,
 }
@@ -318,7 +319,7 @@ impl<F: JoltField, G: CurveGroup<ScalarField = F>> HyraxOpeningProof<G> {
     }
 }
 
-#[derive(Debug, CanonicalSerialize, CanonicalDeserialize)]
+#[derive(Debug, CanonicalSerialize, CanonicalDeserialize, Allocative)]
 pub struct BatchedHyraxOpeningProof<G: CurveGroup> {
     pub joint_proof: HyraxOpeningProof<G>,
     pub ratio: usize,

--- a/jolt-core/src/poly/commitment/pedersen.rs
+++ b/jolt-core/src/poly/commitment/pedersen.rs
@@ -1,3 +1,4 @@
+use allocative::Allocative;
 use ark_ec::CurveGroup;
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use ark_std::rand::SeedableRng;
@@ -8,7 +9,7 @@ use std::io::Read;
 
 use crate::msm::VariableBaseMSM;
 
-#[derive(Clone, CanonicalSerialize, CanonicalDeserialize)]
+#[derive(Clone, CanonicalSerialize, CanonicalDeserialize, Allocative)]
 pub struct PedersenGenerators<G: CurveGroup> {
     pub generators: Vec<G>,
 }
@@ -48,7 +49,6 @@ impl<G: CurveGroup> PedersenGenerators<G> {
         }
     }
 }
-
 pub trait PedersenCommitment<G: CurveGroup>: Sized {
     fn commit(&self, gens: &PedersenGenerators<G>) -> G;
     fn commit_vector(inputs: &[Self], bases: &[G::Affine]) -> G;

--- a/jolt-core/src/poly/dense_mlpoly.rs
+++ b/jolt-core/src/poly/dense_mlpoly.rs
@@ -6,10 +6,11 @@ use crate::utils::{self, compute_dotproduct, compute_dotproduct_low_optimized};
 use crate::poly::field::JoltField;
 use crate::utils::math::Math;
 use core::ops::Index;
+use allocative::Allocative;
 use rayon::prelude::*;
 use std::ops::AddAssign;
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Allocative)]
 pub struct DensePolynomial<F> {
     num_vars: usize, // the number of variables in the multilinear polynomial
     len: usize,

--- a/jolt-core/src/poly/eq_poly.rs
+++ b/jolt-core/src/poly/eq_poly.rs
@@ -1,8 +1,10 @@
 use crate::poly::field::JoltField;
+use allocative::Allocative;
 use rayon::prelude::*;
 
 use crate::utils::{math::Math, thread::unsafe_allocate_zero_vec};
 
+#[derive(Allocative)]
 pub struct EqPolynomial<F> {
     r: Vec<F>,
 }

--- a/jolt-core/src/poly/field.rs
+++ b/jolt-core/src/poly/field.rs
@@ -1,6 +1,7 @@
 use std::fmt::Debug;
 use std::ops::{Add, AddAssign, Div, Mul, MulAssign, Neg, Sub, SubAssign};
 
+use allocative::Allocative;
 use ark_ff::PrimeField;
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use ark_std::UniformRand;
@@ -51,6 +52,22 @@ pub trait JoltField:
     fn from_u64(n: u64) -> Option<Self>;
     fn square(&self) -> Self;
     fn from_bytes(bytes: &[u8]) -> Self;
+}
+
+pub trait Final {
+    fn finalise(&self) -> Self;
+}
+
+// impl Allocative for ark_bn254::Fr {
+//     fn visit<'a, 'b: 'a>(&self, visitor: &'a mut allocative::Visitor<'b>) {
+//         visitor.visit_simple_sized::<Self>();
+//     }
+// }
+
+impl Final for ark_bn254::Fr {
+    fn finalise(&self) -> Self {
+        *self
+    }
 }
 
 impl JoltField for ark_bn254::Fr {

--- a/jolt-core/src/poly/identity_poly.rs
+++ b/jolt-core/src/poly/identity_poly.rs
@@ -1,7 +1,10 @@
+use allocative::Allocative;
+
 use crate::poly::field::JoltField;
 
 use crate::utils::math::Math;
 
+#[derive(Allocative)]
 pub struct IdentityPolynomial {
     size_point: usize,
 }

--- a/jolt-core/src/poly/structured_poly.rs
+++ b/jolt-core/src/poly/structured_poly.rs
@@ -1,4 +1,5 @@
 use crate::poly::field::JoltField;
+use allocative::Allocative;
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 
 use super::commitment::commitment_scheme::CommitmentScheme;
@@ -23,7 +24,7 @@ pub trait StructuredCommitment<C: CommitmentScheme>: Send + Sync + Sized {
 /// different subset of the same polynomials may be opened at different points, resulting in
 /// different opening proofs.
 pub trait StructuredOpeningProof<F, C, Polynomials>:
-    Sync + CanonicalSerialize + CanonicalDeserialize
+    Sync + CanonicalSerialize + CanonicalDeserialize + Allocative
 where
     F: JoltField,
     C: CommitmentScheme<Field = F>,

--- a/jolt-core/src/poly/unipoly.rs
+++ b/jolt-core/src/poly/unipoly.rs
@@ -2,18 +2,19 @@
 use crate::poly::field::JoltField;
 use crate::utils::gaussian_elimination::gaussian_elimination;
 use crate::utils::transcript::{AppendToTranscript, ProofTranscript};
+use allocative::Allocative;
 use ark_serialize::*;
 
 // ax^2 + bx + c stored as vec![c,b,a]
 // ax^3 + bx^2 + cx + d stored as vec![d,c,b,a]
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Allocative)]
 pub struct UniPoly<F> {
     coeffs: Vec<F>,
 }
 
 // ax^2 + bx + c stored as vec![c,a]
 // ax^3 + bx^2 + cx + d stored as vec![d,b,a]
-#[derive(CanonicalSerialize, CanonicalDeserialize, Debug)]
+#[derive(CanonicalSerialize, CanonicalDeserialize, Debug, Allocative)]
 pub struct CompressedUniPoly<F: JoltField> {
     coeffs_except_linear_term: Vec<F>,
 }

--- a/jolt-core/src/r1cs/constraints.rs
+++ b/jolt-core/src/r1cs/constraints.rs
@@ -3,6 +3,7 @@
 /// As the constraint system involved in Jolt is very simple, it's easy to generate the matrices directly
 /// and avoids the need for using the circom library.
 use crate::poly::field::JoltField;
+use allocative::Allocative;
 use common::{constants::RAM_START_ADDRESS, rv_trace::NUM_CIRCUIT_FLAGS};
 use rayon::prelude::*;
 use smallvec::{smallvec, SmallVec};
@@ -97,7 +98,7 @@ const fn GET_INDEX(input_type: InputType, offset: usize) -> usize {
 
 const SMALLVEC_SIZE: usize = 4;
 
-#[derive(Debug)]
+#[derive(Debug, Allocative)]
 pub struct R1CSBuilder {
     pub A: Vec<(usize, usize, i64)>,
     pub B: Vec<(usize, usize, i64)>,

--- a/jolt-core/src/r1cs/r1cs_shape.rs
+++ b/jolt-core/src/r1cs/r1cs_shape.rs
@@ -1,6 +1,7 @@
 use std::cmp::max;
 
 use crate::poly::field::JoltField;
+use allocative::Allocative;
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use rayon::prelude::*;
 
@@ -9,7 +10,7 @@ use crate::utils::mul_0_1_optimized;
 use super::spartan::{IndexablePoly, SpartanError};
 
 /// A type that holds the shape of the R1CS matrices
-#[derive(Clone, Debug, PartialEq, Eq, CanonicalSerialize, CanonicalDeserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, CanonicalSerialize, CanonicalDeserialize, Allocative)]
 pub struct R1CSShape<F: JoltField> {
     pub(crate) num_cons: usize,
     pub(crate) num_vars: usize,

--- a/jolt-core/src/r1cs/snark.rs
+++ b/jolt-core/src/r1cs/snark.rs
@@ -21,6 +21,7 @@ use super::{
 };
 
 use crate::poly::field::JoltField;
+use allocative::Allocative;
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use common::{constants::MEMORY_OPS_PER_INSTRUCTION, rv_trace::NUM_CIRCUIT_FLAGS};
 use rayon::prelude::*;
@@ -85,7 +86,7 @@ fn synthesize_witnesses<F: JoltField>(
     (pc_out, pc, aux)
 }
 
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, Allocative)]
 pub struct R1CSInputs<'a, F: JoltField> {
     padded_trace_len: usize,
     bytecode_a: Vec<F>,
@@ -101,7 +102,7 @@ pub struct R1CSInputs<'a, F: JoltField> {
     instruction_flags_bits: Vec<F>,
 }
 
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, Allocative)]
 pub struct R1CSStepInputs<F: JoltField> {
     pub padded_trace_len: usize,
     pub input_pc: F,

--- a/jolt-core/src/r1cs/spartan.rs
+++ b/jolt-core/src/r1cs/spartan.rs
@@ -7,6 +7,7 @@ use crate::utils::compute_dotproduct_low_optimized;
 use crate::utils::thread::drop_in_background_thread;
 use crate::utils::thread::unsafe_allocate_zero_vec;
 use crate::utils::transcript::ProofTranscript;
+use allocative::Allocative;
 use ark_serialize::CanonicalDeserialize;
 use ark_serialize::CanonicalSerialize;
 use rayon::prelude::*;
@@ -20,7 +21,7 @@ use crate::{
     subprotocols::sumcheck::SumcheckInstanceProof,
 };
 
-#[derive(CanonicalSerialize, CanonicalDeserialize)]
+#[derive(CanonicalSerialize, CanonicalDeserialize, Allocative)]
 pub struct UniformSpartanKey<F: JoltField> {
     shape_single_step: R1CSShape<F>, // Single step shape
     num_cons_total: usize,           // Number of constraints

--- a/jolt-core/src/subprotocols/grand_product.rs
+++ b/jolt-core/src/subprotocols/grand_product.rs
@@ -6,6 +6,7 @@ use crate::subprotocols::sumcheck::CubicSumcheckType;
 use crate::utils::math::Math;
 use crate::utils::mul_0_1_optimized;
 use crate::utils::transcript::ProofTranscript;
+use allocative::Allocative;
 use ark_serialize::*;
 
 #[derive(Debug, Clone)]
@@ -209,7 +210,7 @@ impl<F: JoltField> BatchedGrandProductCircuit<F> {
     }
 }
 
-#[derive(Debug, CanonicalSerialize, CanonicalDeserialize)]
+#[derive(Debug, CanonicalSerialize, CanonicalDeserialize, Allocative)]
 pub struct BatchedGrandProductArgument<F: JoltField> {
     proof: Vec<LayerProofBatched<F>>,
 }

--- a/jolt-core/src/subprotocols/sumcheck.rs
+++ b/jolt-core/src/subprotocols/sumcheck.rs
@@ -9,12 +9,13 @@ use crate::utils::errors::ProofVerifyError;
 use crate::utils::mul_0_optimized;
 use crate::utils::thread::drop_in_background_thread;
 use crate::utils::transcript::{AppendToTranscript, ProofTranscript};
+use allocative::Allocative;
 use ark_serialize::*;
 use itertools::multizip;
 use rayon::prelude::*;
 use tracing::trace_span;
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Allocative)]
 pub enum CubicSumcheckType {
     // eq * A * B
     Prod,
@@ -26,7 +27,7 @@ pub enum CubicSumcheckType {
     Flags,
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Allocative)]
 pub struct CubicSumcheckParams<F: JoltField> {
     poly_As: Vec<DensePolynomial<F>>,
     poly_Bs: Vec<DensePolynomial<F>>,

--- a/jolt-core/src/utils/errors.rs
+++ b/jolt-core/src/utils/errors.rs
@@ -1,7 +1,8 @@
 use core::fmt::Debug;
+use allocative::Allocative;
 use thiserror::Error;
 
-#[derive(Error, Debug, Default)]
+#[derive(Error, Debug, Default, Allocative)]
 pub enum ProofVerifyError {
     #[error("Invalid input length, expected length {0} but got {1}")]
     InvalidInputLength(usize, usize),


### PR DESCRIPTION
We are adding meta's allocative library
(https://github.com/facebookexperimental/allocative) to jolt-core to visualize memory
consumption.