### PR TITLE
Deduplicate Rust toolchain settings

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -19,10 +19,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Install toolchain nightly-2023-09-22
-        uses: dtolnay/rust-toolchain@master
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: nightly-2023-09-22
           components: rustfmt
       - uses: Swatinem/rust-cache@v2
         with:
@@ -37,10 +35,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Install toolchain nightly-2023-09-22
-        uses: dtolnay/rust-toolchain@master
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: nightly-2023-09-22
           components: clippy
       - uses: Swatinem/rust-cache@v2
         with:
@@ -55,10 +51,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Install toolchain nightly-2023-09-22
-        uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: nightly-2023-09-22
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true

--- a/src/main.rs
+++ b/src/main.rs
@@ -146,10 +146,7 @@ fn display_sysinfo() {
     );
 }
 
-const RUST_TOOLCHAIN: &str = r#"[toolchain]
-channel = "nightly-2023-09-22"
-targets = ["riscv32i-unknown-none-elf"]
-"#;
+const RUST_TOOLCHAIN: &str = include_str!("../rust-toolchain.toml");
 
 const HOST_CARGO_TEMPLATE: &str = r#"[package]
 name = "{NAME}"


### PR DESCRIPTION
Make updating the toolchain a matter of adjusting the settings in `rust-toolchain.toml` (vs updating them in multiple places):

- CI: install toolchain in actions from rust-toolchain.toml
- Reuse rust-toolchain.toml for guests (as it's exactly the same)