### PR TITLE
add host feature to jolt-core

### DIFF
--- a/jolt-core/Cargo.toml
+++ b/jolt-core/Cargo.toml
@@ -56,11 +56,14 @@ tracing-flame = "0.2.0"
 tracing-subscriber = "0.3.18"
 tracing-texray = "0.2.0"
 target-lexicon = "0.12.14"
-reqwest = { version = "0.12.3", features = ["json", "blocking"] }
+reqwest = { version = "0.12.3", features = [
+    "json",
+    "blocking",
+], optional = true }
 dirs = "5.0.1"
 eyre = "0.6.12"
 indicatif = "0.17.8"
-tokio = "1.37.0"
+tokio = { version = "1.37.0", optional = true }
 
 common = { path = "../common" }
 tracer = { path = "../tracer" }
@@ -88,5 +91,7 @@ default = [
     "ark-std/parallel",
     "ark-ff/asm",
     "multicore",
+    "host",
 ]
 multicore = ["rayon"]
+host = ["dep:reqwest", "dep:tokio"]

--- a/jolt-core/src/lib.rs
+++ b/jolt-core/src/lib.rs
@@ -9,7 +9,9 @@
 #![allow(long_running_const_eval)]
 #![feature(return_position_impl_trait_in_trait)]
 
+#[cfg(feature = "host")]
 pub mod benches;
+#[cfg(feature = "host")]
 pub mod host;
 pub mod jolt;
 pub mod lasso;


### PR DESCRIPTION
When I comiple the jolt-core to wasm:
```shell
   Compiling jolt-core v0.1.0 (https://github.com/a16z/jolt#6083da83)
error[E0432]: unresolved import `tokio::runtime::Runtime`
  --> /Users/flyq/.cargo/git/checkouts/jolt-6b856340b98daf0c/6083da8/jolt-core/src/host/toolchain.rs:12:5
   |
12 | use tokio::runtime::Runtime;
   |     ^^^^^^^^^^^^^^^^^^^^^^^ no `Runtime` in `runtime`

error[E0433]: failed to resolve: could not find `time` in `tokio`
   --> /Users/flyq/.cargo/git/checkouts/jolt-6b856340b98daf0c/6083da8/jolt-core/src/host/toolchain.rs:49:24
    |
49  |                 tokio::time::sleep(std::time::Duration::from_millis(timeout)).await;
    |                        ^^^^ could not find `time` in `tokio`
    |
note: found an item that was configured out
   --> /Users/flyq/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.37.0/src/lib.rs:549:13
    |
549 |     pub mod time;
    |             ^^^^
    = note: the item is gated behind the `time` feature

error[E0603]: module `runtime` is private
   --> /Users/flyq/.cargo/git/checkouts/jolt-6b856340b98daf0c/6083da8/jolt-core/src/host/toolchain.rs:12:12
    |
12  | use tokio::runtime::Runtime;
    |            ^^^^^^^ private module
    |
note: the module `runtime` is defined here
   --> /Users/flyq/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.37.0/src/lib.rs:522:5
    |
522 |     pub(crate) mod runtime;
    |     ^^^^^^^^^^^^^^^^^^^^^^

error[E0599]: no method named `chunk` found for struct `Response` in the current scope
   --> /Users/flyq/.cargo/git/checkouts/jolt-6b856340b98daf0c/6083da8/jolt-core/src/host/toolchain.rs:120:42
    |
120 |         while let Some(chunk) = response.chunk().await.unwrap() {
    |                                          ^^^^^ method not found in `Response`

error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
   --> /Users/flyq/.cargo/git/checkouts/jolt-6b856340b98daf0c/6083da8/jolt-core/src/host/toolchain.rs:120:19
    |
120 |         while let Some(chunk) = response.chunk().await.unwrap() {
    |                   ^^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `[u8]`
note: required by a bound in `std::prelude::v1::Some`
   --> /Users/flyq/.rustup/toolchains/nightly-aarch64-apple-darwin/lib/rustlib/src/rust/library/core/src/option.rs:571:17
    |
571 | pub enum Option<T> {
    |                 ^ required by this bound in `std::prelde::v1::Some`
...
579 |     Some(#[stable(feature = "rust1", since = "1.0.0")] T),
    |     ---- required by a bound in this tuple variant

Some errors have detailed explanations: E0277, E0432, E0433, E0599, E0603.
For more information about an error, try `rustc --explain E0277`.
error: could not compile `jolt-core` (lib) due to 5 previous errors
```
`tokio` and `reqwest` are not friendly to wasm, and only the host mod depends on them. So I added host features to achieve conditional compilation