### PR TITLE
feat: add WASM compatibility for verification functions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,10 @@ clap = { version = "4.5.4", features = ["derive"] }
 eyre = "0.6.12"
 rand = "0.8.5"
 sysinfo = "0.30.8"
+syn = { version = "2.0.66", features = ["full"] }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0.68"
+rmp-serde = "1.3.0"
 
 jolt-sdk = { path = "./jolt-sdk" }
 jolt-core = { path = "./jolt-core" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,7 @@ clap = { version = "4.5.4", features = ["derive"] }
 eyre = "0.6.12"
 rand = "0.8.5"
 sysinfo = "0.30.8"
-syn = { version = "2.0.66", features = ["full"] }
+syn = { version = "1.0.0", features = ["full"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.68"
 rmp-serde = "1.3.0"
@@ -69,6 +69,7 @@ toml_edit = "0.22.14"
 
 jolt-sdk = { path = "./jolt-sdk" }
 jolt-core = { path = "./jolt-core" }
+common = { path = "./common" }
 
 [profile.test]
 opt-level = 3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,6 +65,7 @@ syn = { version = "2.0.66", features = ["full"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.68"
 rmp-serde = "1.3.0"
+toml_edit = "0.22.14"
 
 jolt-sdk = { path = "./jolt-sdk" }
 jolt-core = { path = "./jolt-core" }

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -8,3 +8,4 @@ ark-serialize = { version = "0.4.2", features = ["derive"] }
 serde = { version = "1.0.193", features = ["derive"] }
 serde_json = "1.0.108"
 strum_macros = "0.25.3"
+syn = { version = "1.0", features = ["full"] }

--- a/common/src/attributes.rs
+++ b/common/src/attributes.rs
@@ -1,0 +1,61 @@
+use std::collections::HashMap;
+use syn::{Lit, Meta, MetaNameValue, NestedMeta};
+
+use crate::constants::{
+    DEFAULT_MAX_INPUT_SIZE, DEFAULT_MAX_OUTPUT_SIZE, DEFAULT_MEMORY_SIZE, DEFAULT_STACK_SIZE,
+};
+
+pub struct Attributes {
+    pub wasm: bool,
+    pub memory_size: u64,
+    pub stack_size: u64,
+    pub max_input_size: u64,
+    pub max_output_size: u64,
+}
+
+pub fn parse_attributes(attr: &Vec<NestedMeta>) -> Attributes {
+    let mut attributes = HashMap::<_, u64>::new();
+    let mut wasm = false;
+
+    for attr in attr {
+        match attr {
+            NestedMeta::Meta(Meta::NameValue(MetaNameValue { path, lit, .. })) => {
+                let value: u64 = match lit {
+                    Lit::Int(lit) => lit.base10_parse().unwrap(),
+                    _ => panic!("expected integer literal"),
+                };
+                let ident = &path.get_ident().expect("Expected identifier");
+                match ident.to_string().as_str() {
+                    "memory_size" => attributes.insert("memory_size", value),
+                    "stack_size" => attributes.insert("stack_size", value),
+                    "max_input_size" => attributes.insert("max_input_size", value),
+                    "max_output_size" => attributes.insert("max_output_size", value),
+                    _ => panic!("invalid attribute"),
+                };
+            }
+            NestedMeta::Meta(Meta::Path(path)) if path.is_ident("wasm") => {
+                wasm = true;
+            }
+            _ => panic!("expected integer literal"),
+        }
+    }
+
+    let memory_size = *attributes
+        .get("memory_size")
+        .unwrap_or(&DEFAULT_MEMORY_SIZE);
+    let stack_size = *attributes.get("stack_size").unwrap_or(&DEFAULT_STACK_SIZE);
+    let max_input_size = *attributes
+        .get("max_input_size")
+        .unwrap_or(&DEFAULT_MAX_INPUT_SIZE);
+    let max_output_size = *attributes
+        .get("max_output_size")
+        .unwrap_or(&DEFAULT_MAX_OUTPUT_SIZE);
+
+    Attributes {
+        wasm,
+        memory_size,
+        stack_size,
+        max_input_size,
+        max_output_size,
+    }
+}

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -2,6 +2,7 @@ pub fn to_ram_address(index: usize) -> usize {
     index * constants::BYTES_PER_INSTRUCTION + constants::RAM_START_ADDRESS as usize
 }
 
+pub mod attributes;
 pub mod constants;
 pub mod parallel;
 pub mod rv_trace;

--- a/jolt-core/Cargo.toml
+++ b/jolt-core/Cargo.toml
@@ -64,9 +64,6 @@ reqwest = { version = "0.12.3", features = [
 dirs = "5.0.1"
 eyre = "0.6.12"
 indicatif = "0.17.8"
-memory-stats = "1.0.0"
-tokio = { version = "1.38.0", optional = true, features = ["rt-multi-thread"] }
-
 common = { path = "../common" }
 tracer = { path = "../tracer" }
 bincode = "1.3.3"
@@ -100,6 +97,8 @@ host = ["dep:reqwest", "dep:tokio"]
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 memory-stats = "1.0.0" 
+tokio = { version = "1.38.0", optional = true, features = ["rt-multi-thread"] }
+
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 getrandom = { version = "0.2", features = ["js"] }

--- a/jolt-core/Cargo.toml
+++ b/jolt-core/Cargo.toml
@@ -97,3 +97,6 @@ default = [
     "rayon",
 ]
 host = ["dep:reqwest", "dep:tokio"]
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+getrandom = { version = "0.2", features = ["js"] }

--- a/jolt-core/Cargo.toml
+++ b/jolt-core/Cargo.toml
@@ -68,6 +68,8 @@ common = { path = "../common" }
 tracer = { path = "../tracer" }
 bincode = "1.3.3"
 bytemuck = "1.15.0"
+tokio = { version = "1.38.0", optional = true }
+
 
 [dev-dependencies]
 criterion = { version = "0.5.1", features = ["html_reports"] }

--- a/jolt-core/Cargo.toml
+++ b/jolt-core/Cargo.toml
@@ -98,5 +98,8 @@ default = [
 ]
 host = ["dep:reqwest", "dep:tokio"]
 
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+memory-stats = "1.0.0" 
+
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 getrandom = { version = "0.2", features = ["js"] }

--- a/jolt-core/src/host/mod.rs
+++ b/jolt-core/src/host/mod.rs
@@ -19,7 +19,7 @@ use common::{
     rv_trace::{JoltDevice, NUM_CIRCUIT_FLAGS},
 };
 use strum::EnumCount;
-use tracer::ELFInstruction;
+pub use tracer::ELFInstruction;
 
 use crate::{
     field::JoltField,

--- a/jolt-core/src/host/mod.rs
+++ b/jolt-core/src/host/mod.rs
@@ -32,7 +32,9 @@ use crate::{
     utils::thread::unsafe_allocate_zero_vec,
 };
 
-use self::{analyze::ProgramSummary, toolchain::install_toolchain};
+use self::analyze::ProgramSummary;
+#[cfg(not(target_arch = "wasm32"))]
+use self::toolchain::install_toolchain;
 
 pub mod analyze;
 pub mod toolchain;
@@ -97,6 +99,7 @@ impl Program {
     #[tracing::instrument(skip_all, name = "Program::build")]
     pub fn build(&mut self) {
         if self.elf.is_none() {
+            #[cfg(not(target_arch = "wasm32"))]
             install_toolchain().unwrap();
             self.save_linker();
 

--- a/jolt-core/src/host/mod.rs
+++ b/jolt-core/src/host/mod.rs
@@ -37,6 +37,7 @@ use self::analyze::ProgramSummary;
 use self::toolchain::install_toolchain;
 
 pub mod analyze;
+#[cfg(not(target_arch = "wasm32"))]
 pub mod toolchain;
 
 #[derive(Clone)]

--- a/jolt-core/src/host/mod.rs
+++ b/jolt-core/src/host/mod.rs
@@ -142,8 +142,6 @@ impl Program {
                     &target,
                     "--target",
                     toolchain,
-                    "--bin",
-                    "guest",
                 ])
                 .output()
                 .expect("failed to build guest");

--- a/jolt-core/src/host/toolchain.rs
+++ b/jolt-core/src/host/toolchain.rs
@@ -9,12 +9,14 @@ use dirs::home_dir;
 use eyre::{bail, eyre, Result};
 use indicatif::{ProgressBar, ProgressStyle};
 use reqwest::Client;
+#[cfg(not(target_arch = "wasm32"))]
 use tokio::runtime::Runtime;
 
 const TOOLCHAIN_TAG: &str = include_str!("../../../.jolt.rust.toolchain-tag");
 const DOWNLOAD_RETRIES: usize = 5;
 const DELAY_BASE_MS: u64 = 500;
 
+#[cfg(not(target_arch = "wasm32"))]
 /// Installs the toolchain if it is not already
 pub fn install_toolchain() -> Result<()> {
     if !has_toolchain() {
@@ -31,6 +33,7 @@ pub fn install_toolchain() -> Result<()> {
     link_toolchain()
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 async fn retry_times<F, T, E>(times: usize, base_ms: u64, f: F) -> Result<T>
 where
     F: Fn() -> E,
@@ -93,6 +96,7 @@ fn unpack_toolchain() -> Result<()> {
     Ok(())
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 async fn download_toolchain(client: &Client, url: &str) -> Result<()> {
     let jolt_dir = jolt_dir();
     let output_path = jolt_dir.join("rust-toolchain.tar.gz");

--- a/jolt-core/src/utils/profiling.rs
+++ b/jolt-core/src/utils/profiling.rs
@@ -1,6 +1,6 @@
-use std::{collections::HashMap, sync::Mutex};
-
+#[cfg(not(target_arch = "wasm32"))]
 use memory_stats::memory_stats;
+use std::{collections::HashMap, sync::Mutex};
 
 lazy_static::lazy_static! {
     static ref MEMORY_USAGE_MAP: Mutex<HashMap<&'static str, f64>> = {
@@ -14,6 +14,7 @@ lazy_static::lazy_static! {
     };
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 pub fn start_memory_tracing_span(label: &'static str) {
     let memory_usage = memory_stats().unwrap().physical_mem;
     let mut map = MEMORY_USAGE_MAP.lock().unwrap();
@@ -23,6 +24,7 @@ pub fn start_memory_tracing_span(label: &'static str) {
     );
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 pub fn end_memory_tracing_span(label: &'static str) {
     let memory_usage_end = memory_stats().unwrap().physical_mem as f64 / 1_000_000_000.0;
     let mut memory_usage_map = MEMORY_USAGE_MAP.lock().unwrap();
@@ -53,6 +55,7 @@ pub fn report_memory_usage() {
     println!("=====================================================");
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 pub fn print_current_memory_usage(label: &str) {
     if let Some(usage) = memory_stats() {
         let memory_usage_gb = usage.physical_mem as f64 / 1_000_000_000.0;

--- a/jolt-sdk/macros/Cargo.toml
+++ b/jolt-sdk/macros/Cargo.toml
@@ -22,5 +22,6 @@ guest-std = []
 syn = { version = "1.0", features = ["full"] }
 quote = "1.0"
 proc-macro2 = "1.0.79"
+lazy_static = "1.4"
 
 common = { path = "../../common" }

--- a/jolt-sdk/macros/src/lib.rs
+++ b/jolt-sdk/macros/src/lib.rs
@@ -33,6 +33,7 @@ pub fn provable(attr: TokenStream, item: TokenStream) -> TokenStream {
 
     let mut token_stream = builder.build();
 
+    // Add wasm utilities and functions if the function is marked as wasm
     if builder.has_wasm_attr() {
         // wasm utilities should only be added once
         let mut module_added = WASM_IMPORTS_ADDED.lock().unwrap();

--- a/jolt-sdk/src/host_utils.rs
+++ b/jolt-sdk/src/host_utils.rs
@@ -50,4 +50,17 @@ impl Proof {
         let file = File::open(path.into())?;
         Ok(Proof::deserialize_compressed(file)?)
     }
+
+    /// Serializes the proof to a byte vector
+    pub fn serialize_to_bytes(&self) -> Result<Vec<u8>> {
+        let mut buffer = Vec::new();
+        self.serialize_compressed(&mut buffer)?;
+        Ok(buffer)
+    }
+
+    /// Deserializes a proof from a byte vector
+    pub fn deserialize_from_bytes(bytes: &[u8]) -> Result<Self> {
+        let cursor = std::io::Cursor::new(bytes);
+        Ok(Proof::deserialize_compressed(cursor)?)
+    }
 }

--- a/src/build_wasm.rs
+++ b/src/build_wasm.rs
@@ -1,0 +1,324 @@
+use common::attributes::{parse_attributes, Attributes};
+
+use std::{
+    fs::{self, File},
+    io::Write,
+    path::Path,
+};
+
+use eyre::Result;
+use jolt_core::host::{ELFInstruction, Program};
+use rmp_serde::Serializer;
+use serde::{Deserialize, Serialize};
+use syn::{Attribute, ItemFn, Meta};
+use toml_edit::{value, Array, DocumentMut, InlineTable, Item, Table, Value};
+
+#[derive(Serialize, Deserialize)]
+struct DecodedData {
+    bytecode: Vec<ELFInstruction>,
+    memory_init: Vec<(u64, u8)>,
+}
+
+struct FunctionAttributes {
+    pub func_name: String,
+    pub attributes: Attributes,
+}
+
+fn preprocess_and_save(func_name: &str, attributes: &Attributes, is_std: bool) -> Result<()> {
+    let mut program = Program::new("guest");
+
+    program.set_func(func_name);
+    program.set_std(is_std);
+    program.set_memory_size(attributes.memory_size);
+    program.set_stack_size(attributes.stack_size);
+    program.set_max_input_size(attributes.max_input_size);
+    program.set_max_output_size(attributes.max_output_size);
+
+    let (bytecode, memory_init) = program.decode();
+    let decoded_data = DecodedData {
+        bytecode,
+        memory_init,
+    };
+
+    let mut buf = Vec::new();
+    decoded_data.serialize(&mut Serializer::new(&mut buf))?;
+
+    let target_dir = Path::new("target/wasm32-unknown-unknown/release");
+    fs::create_dir_all(target_dir)?;
+
+    let output_path = target_dir.join(format!("preprocessed_{}.bin", func_name));
+    let mut file = File::create(output_path)?;
+    file.write_all(&buf)?;
+    Ok(())
+}
+
+fn extract_provable_functions() -> Vec<FunctionAttributes> {
+    let content = fs::read_to_string("guest/src/lib.rs").expect("Unable to read file");
+    let syntax: syn::File = syn::parse_file(&content).expect("Unable to parse file");
+
+    syntax
+        .items
+        .iter()
+        .filter_map(|item| {
+            if let syn::Item::Fn(ItemFn { attrs, sig, .. }) = item {
+                if let Some(provable_attr) = attrs.iter().find(|attr| is_provable(attr)) {
+                    let meta = provable_attr.parse_meta().expect("Unable to parse meta");
+                    if let Meta::List(meta_list) = meta {
+                        let attributes =
+                            parse_attributes(&meta_list.nested.iter().cloned().collect());
+                        return Some(FunctionAttributes {
+                            func_name: sig.ident.to_string(),
+                            attributes,
+                        });
+                    }
+                }
+            }
+            None
+        })
+        .collect()
+}
+
+fn is_provable(attr: &Attribute) -> bool {
+    if let Some(ident) = attr.path.get_ident() {
+        if ident == "jolt" {
+            if let Some(nested_meta) = attr.parse_meta().ok() {
+                if let syn::Meta::List(meta_list) = nested_meta {
+                    return meta_list.nested.iter().any(|nested| {
+                        if let syn::NestedMeta::Meta(syn::Meta::Path(path)) = nested {
+                            if let Some(ident) = path.get_ident() {
+                                return ident == "provable";
+                            }
+                        }
+                        false
+                    });
+                }
+            }
+        }
+    }
+
+    false
+}
+
+fn get_project_name() -> Option<String> {
+    let content = fs::read_to_string("Cargo.toml").ok()?;
+    let doc = content.parse::<DocumentMut>().ok()?;
+    // replace "-" with "_" to make it a valid identifier
+    doc["package"]["name"].as_str().map(|s| {
+        s.chars()
+            .map(|c| if c == '-' { '_' } else { c })
+            .collect::<String>()
+    })
+}
+
+fn is_std() -> Option<bool> {
+    let content = fs::read_to_string("guest/Cargo.toml").expect("Failed to read Cargo.toml");
+    let doc = content
+        .parse::<DocumentMut>()
+        .expect("Failed to parse Cargo.toml");
+
+    let dependencies = doc["dependencies"]["jolt"].as_inline_table()?;
+    let package = dependencies.get("package")?.as_str()?;
+
+    let path = dependencies
+        .get("path")
+        .expect("Failed to get path")
+        .as_str()
+        .expect("Failed to get path");
+
+    if package == "jolt-sdk" && path == "../../wasm-jolt/jolt-sdk" {
+        return Some(
+            dependencies
+                .get("features")
+                .and_then(|v| v.as_array())
+                .map_or(false, |features| {
+                    features.iter().any(|f| f.as_str() == Some("guest-std"))
+                }),
+        );
+    }
+    None
+}
+
+fn create_index_html(func_names: Vec<String>) -> Result<()> {
+    let func_names_with_verify_prefix: Vec<String> = func_names
+        .iter()
+        .map(|name| format!("verify_{}", name))
+        .collect();
+
+    let mut html_content = String::from(HTML_HEAD);
+
+    for func_name in &func_names {
+        html_content.push_str(&format!(
+            r#"
+    <div style="margin-bottom: 10px;">
+        <input type="file" id="proofFile_{0}" />
+        <button id="verifyButton_{0}">Verify Proof for {0}-Function</button>
+    </div>
+"#,
+            func_name
+        ));
+    }
+
+    html_content.push_str(&format!(
+        r#"
+    <script type="module">
+        import init, {{ {} }} from './pkg/{}.js';
+
+        async function run() {{
+            await init();
+"#,
+        func_names_with_verify_prefix.join(", "),
+        get_project_name().unwrap()
+    ));
+
+    for func_name in &func_names {
+        html_content.push_str(&format!(
+            r#"
+            document.getElementById('verifyButton_{0}').addEventListener('click', async () => {{
+                const fileInput = document.getElementById('proofFile_{0}');
+                if (fileInput.files.length === 0) {{
+                    alert("Please select a proof file first.");
+                    return;
+                }}
+
+                const file = fileInput.files[0];
+                const reader = new FileReader();
+
+                reader.onload = async (event) => {{
+                    const proofArrayBuffer = event.target.result;
+                    const proofData = new Uint8Array(proofArrayBuffer);
+
+                    // Fetch preprocessing data and prepare wasm binary to json conversion
+                    const response = await fetch('target/wasm32-unknown-unknown/release/preprocessed_{0}.bin')
+                    const wasmBinary = await response.arrayBuffer();
+                    const wasmData = new Uint8Array(wasmBinary);
+
+                    const result = verify_{0}(wasmData, proofData);
+                    alert(result ? "Proof is valid!" : "Proof is invalid.");
+                }};
+
+                reader.readAsArrayBuffer(file);
+            }});
+"#,
+            func_name
+        ));
+    }
+
+    html_content.push_str(HTML_TAIL);
+
+    let mut file = File::create("index.html")?;
+    file.write_all(html_content.as_bytes())?;
+    Ok(())
+}
+
+pub fn modify_cargo_toml(name: &str) -> Result<()> {
+    fn add_dependencies(dependencies: &mut Table) {
+        dependencies.insert("wasm-bindgen", toml_edit::value("0.2.73"));
+        dependencies.insert("serde", {
+            let mut table = InlineTable::new();
+            table.insert("version", Value::from("1.0"));
+            let mut features_array = Array::new();
+            features_array.push("derive");
+            table.insert("features", Value::Array(features_array));
+            Item::Value(Value::InlineTable(table))
+        });
+        dependencies.insert("serde_json", toml_edit::value("1.0"));
+        dependencies.insert("serde-wasm-bindgen", toml_edit::value("=0.6.5"));
+        dependencies.insert("rmp-serde", toml_edit::value("1.3.0"));
+    }
+
+    {
+        // first we need to edit the Cargo.toml file in the root directory
+        let cargo_toml_path = format!("{}/Cargo.toml", name);
+        let content = fs::read_to_string(&cargo_toml_path)?;
+        let mut doc = content.parse::<DocumentMut>()?;
+        if !doc.contains_key("lib") {
+            doc["lib"] = toml_edit::table();
+        }
+
+        let lib_section = doc["lib"].as_table_mut().unwrap();
+
+        // add lib section with cdylib crate-type if it doesn't exist
+        if !lib_section.contains_key("crate-type") {
+            let mut array = Array::new();
+            array.push("cdylib");
+            lib_section["crate-type"] = Item::Value(toml_edit::Value::Array(array));
+            lib_section["path"] = value("guest/src/lib.rs");
+        }
+        let dependencies = doc["dependencies"].as_table_mut().unwrap();
+        add_dependencies(dependencies);
+
+        fs::write(cargo_toml_path, doc.to_string())?;
+    }
+
+    // then we need to edit the Cargo.toml file in the guest directory
+    {
+        let cargo_toml_path = format!("{}/guest/Cargo.toml", name);
+        let content = fs::read_to_string(&cargo_toml_path)?;
+        let mut doc = content.parse::<DocumentMut>()?;
+
+        if !doc
+            .as_table()
+            .get("target")
+            .and_then(|target| target.get("cfg(target_arch = \"wasm32\")"))
+            .and_then(|cfg| cfg.get("dependencies"))
+            .map_or(false, |dependencies| dependencies.is_table())
+        {
+            let mut toml_str = doc.to_string();
+            toml_str.push_str("\n[target.'cfg(target_arch = \"wasm32\")'.dependencies]\n");
+            doc = toml_str.parse::<DocumentMut>()?;
+
+            let mut table = Table::new();
+            add_dependencies(&mut table);
+
+            doc["target"]["cfg(target_arch = \"wasm32\")"]["dependencies"] = Item::Table(table);
+            fs::write(cargo_toml_path, doc.to_string())?;
+        }
+    }
+    Ok(())
+}
+
+pub fn build_wasm() {
+    println!("Building the project with wasm-pack...");
+    let functions = extract_provable_functions();
+    let function_names: Vec<String> = functions.iter().map(|f| f.func_name.clone()).collect();
+    let is_std = is_std().expect("Failed to check if std feature is enabled");
+    for function in functions {
+        preprocess_and_save(&function.func_name, &function.attributes, is_std)
+            .expect("Failed to preprocess functions");
+    }
+
+    create_index_html(function_names).expect("Failed to create example index.html");
+
+    // todo implement test if wasm-pack is installed
+    let output = std::process::Command::new("wasm-pack")
+        .args(["build", "--release", "--target", "web"])
+        .output()
+        .expect("Failed to execute wasm-pack command");
+
+    if !output.status.success() {
+        eprintln!("Error: Failed to build the project with wasm-pack");
+        eprintln!("stdout: {}", String::from_utf8_lossy(&output.stdout));
+        eprintln!("stderr: {}", String::from_utf8_lossy(&output.stderr));
+        panic!("wasm-pack build failed");
+    }
+}
+
+const HTML_HEAD: &str = r#"
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8">
+        <title>Jolt x WASMn</title>
+    </head>
+    <body>
+        <h1>Jolt x WASM</h1>
+"#;
+
+const HTML_TAIL: &str = r#"
+            }
+
+            run();
+        </script>
+    </body>
+</html>
+"#;

--- a/src/build_wasm.rs
+++ b/src/build_wasm.rs
@@ -81,17 +81,15 @@ fn extract_provable_functions() -> Vec<FunctionAttributes> {
 fn is_provable(attr: &Attribute) -> bool {
     if let Some(ident) = attr.path.get_ident() {
         if ident == "jolt" {
-            if let Some(nested_meta) = attr.parse_meta().ok() {
-                if let syn::Meta::List(meta_list) = nested_meta {
-                    return meta_list.nested.iter().any(|nested| {
-                        if let syn::NestedMeta::Meta(syn::Meta::Path(path)) = nested {
-                            if let Some(ident) = path.get_ident() {
-                                return ident == "provable";
-                            }
+            if let Ok(syn::Meta::List(meta_list)) = attr.parse_meta() {
+                return meta_list.nested.iter().any(|nested| {
+                    if let syn::NestedMeta::Meta(syn::Meta::Path(path)) = nested {
+                        if let Some(ident) = path.get_ident() {
+                            return ident == "provable";
                         }
-                        false
-                    });
-                }
+                    }
+                    false
+                });
             }
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -227,9 +227,8 @@ fn is_provable(attr: &Attribute) -> bool {
     false
 }
 
-fn get_project_name(name: Option<&str>) -> Option<String> {
-    let name = name.unwrap_or(".");
-    let cargo_toml_path = format!("{}/Cargo.toml", name);
+fn get_project_name() -> Option<String> {
+    let cargo_toml_path = format!("Cargo.toml");
     let content = fs::read_to_string(cargo_toml_path).ok()?;
     let doc = content.parse::<DocumentMut>().ok()?;
     doc["package"]["name"].as_str().map(|s| s.replace("-", "_"))
@@ -264,7 +263,7 @@ fn create_index_html(func_names: Vec<String>) -> Result<()> {
             await init();
 "#,
         func_names_with_verify_prefix.join(", "),
-        get_project_name(None).unwrap()
+        get_project_name().unwrap()
     ));
 
     for func_name in &func_names {
@@ -341,7 +340,6 @@ fn modify_cargo_toml(name: &str) -> Result<()> {
             let mut array = Array::new();
             array.push("cdylib");
             lib_section["crate-type"] = Item::Value(toml_edit::Value::Array(array));
-            lib_section["name"] = value(format!("{}", get_project_name(Some(name)).unwrap()));
             lib_section["path"] = value("guest/src/lib.rs");
         }
         let dependencies = doc["dependencies"].as_table_mut().unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -378,6 +378,7 @@ fn modify_cargo_toml(name: &str) -> Result<()> {
 }
 
 fn build_wasm() {
+    println!("Building the project with wasm-pack...");
     let func_names = extract_provable_functions();
     for func_name in func_names.clone() {
         preprocess_and_save(&func_name).expect("Failed to preprocess functions");

--- a/src/main.rs
+++ b/src/main.rs
@@ -282,7 +282,6 @@ fn create_index_html(func_names: Vec<String>) -> Result<()> {
                 reader.onload = async (event) => {{
                     const proofArrayBuffer = event.target.result;
                     const proofData = new Uint8Array(proofArrayBuffer);
-                    console.log(proofData);
 
                     // Fetch preprocessing data and prepare wasm binary to json conversion
                     const response = await fetch('target/wasm32-unknown-unknown/release/preprocessed_{0}.bin')
@@ -290,7 +289,6 @@ fn create_index_html(func_names: Vec<String>) -> Result<()> {
                     const wasmData = new Uint8Array(wasmBinary);
 
                     const result = verify_{0}(wasmData, proofData);
-                    console.log(result);
                     alert(result ? "Proof is valid!" : "Proof is invalid.");
                 }};
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,8 @@
+mod build_wasm;
+
 use std::{
     fs::{self, File},
     io::Write,
-    path::Path,
 };
 
 use clap::{Parser, Subcommand};
@@ -9,11 +10,8 @@ use eyre::Result;
 use rand::prelude::SliceRandom;
 use sysinfo::System;
 
-use jolt_core::host::{toolchain, ELFInstruction, Program};
-use rmp_serde::Serializer;
-use serde::{Deserialize, Serialize};
-use syn::{Attribute, ItemFn};
-use toml_edit::{value, Array, DocumentMut, InlineTable, Item, Table, Value};
+use build_wasm::{build_wasm, modify_cargo_toml};
+use jolt_core::host::toolchain;
 
 #[derive(Parser)]
 #[command(version, about, long_about = None)]
@@ -160,240 +158,6 @@ fn display_sysinfo() {
     );
 }
 
-#[derive(Serialize, Deserialize)]
-struct DecodedData {
-    bytecode: Vec<ELFInstruction>,
-    memory_init: Vec<(u64, u8)>,
-}
-
-fn preprocess_and_save(func_name: &str) -> Result<()> {
-    let mut program = Program::new("guest");
-    program.set_func(func_name);
-    program.set_std(false);
-    // Set memory and stack sizes to 10MB and 4KB respectively for now (standard values in jolt-core)
-    // TODO: Make these configurable / dynamic depending on how set by the user
-    program.set_memory_size(10485760u64);
-    program.set_stack_size(4096u64);
-    program.set_max_input_size(4096u64);
-    program.set_max_output_size(4096u64);
-
-    let (bytecode, memory_init) = program.decode();
-    let decoded_data = DecodedData {
-        bytecode,
-        memory_init,
-    };
-
-    let mut buf = Vec::new();
-    decoded_data.serialize(&mut Serializer::new(&mut buf))?;
-
-    let target_dir = Path::new("target/wasm32-unknown-unknown/release");
-    fs::create_dir_all(target_dir)?;
-
-    let output_path = target_dir.join(format!("preprocessed_{}.bin", func_name));
-    let mut file = File::create(output_path)?;
-    file.write_all(&buf)?;
-    Ok(())
-}
-
-fn extract_provable_functions() -> Vec<String> {
-    let content = fs::read_to_string("guest/src/lib.rs").expect("Unable to read file");
-    let syntax: syn::File = syn::parse_file(&content).expect("Unable to parse file");
-
-    syntax
-        .items
-        .iter()
-        .filter_map(|item| {
-            if let syn::Item::Fn(ItemFn { attrs, sig, .. }) = item {
-                if attrs.iter().any(is_provable) {
-                    return Some(sig.ident.to_string());
-                }
-            }
-            None
-        })
-        .collect()
-}
-
-fn is_provable(attr: &Attribute) -> bool {
-    if let Some(first_segment) = attr.path().segments.first() {
-        if first_segment.ident == "jolt" {
-            if let Some(second_segment) = attr.path().segments.iter().nth(1) {
-                if second_segment.ident == "provable" {
-                    return true;
-                }
-            }
-        }
-    }
-
-    false
-}
-
-fn get_project_name() -> Option<String> {
-    let content = fs::read_to_string("Cargo.toml").ok()?;
-    let doc = content.parse::<DocumentMut>().ok()?;
-    // replace "-" with "_" to make it a valid identifier
-    doc["package"]["name"].as_str().map(|s| {
-        s.chars()
-            .map(|c| if c == '-' { '_' } else { c })
-            .collect::<String>()
-    })
-}
-
-fn create_index_html(func_names: Vec<String>) -> Result<()> {
-    let func_names_with_verify_prefix: Vec<String> = func_names
-        .iter()
-        .map(|name| format!("verify_{}", name))
-        .collect();
-
-    let mut html_content = String::from(HTML_HEAD);
-
-    for func_name in &func_names {
-        html_content.push_str(&format!(
-            r#"
-    <div style="margin-bottom: 10px;">
-        <input type="file" id="proofFile_{0}" />
-        <button id="verifyButton_{0}">Verify Proof for {0}-Function</button>
-    </div>
-"#,
-            func_name
-        ));
-    }
-
-    html_content.push_str(&format!(
-        r#"
-    <script type="module">
-        import init, {{ {} }} from './pkg/{}.js';
-
-        async function run() {{
-            await init();
-"#,
-        func_names_with_verify_prefix.join(", "),
-        get_project_name().unwrap()
-    ));
-
-    for func_name in &func_names {
-        html_content.push_str(&format!(
-            r#"
-            document.getElementById('verifyButton_{0}').addEventListener('click', async () => {{
-                const fileInput = document.getElementById('proofFile_{0}');
-                if (fileInput.files.length === 0) {{
-                    alert("Please select a proof file first.");
-                    return;
-                }}
-
-                const file = fileInput.files[0];
-                const reader = new FileReader();
-
-                reader.onload = async (event) => {{
-                    const proofArrayBuffer = event.target.result;
-                    const proofData = new Uint8Array(proofArrayBuffer);
-
-                    // Fetch preprocessing data and prepare wasm binary to json conversion
-                    const response = await fetch('target/wasm32-unknown-unknown/release/preprocessed_{0}.bin')
-                    const wasmBinary = await response.arrayBuffer();
-                    const wasmData = new Uint8Array(wasmBinary);
-
-                    const result = verify_{0}(wasmData, proofData);
-                    alert(result ? "Proof is valid!" : "Proof is invalid.");
-                }};
-
-                reader.readAsArrayBuffer(file);
-            }});
-"#,
-            func_name
-        ));
-    }
-
-    html_content.push_str(HTML_TAIL);
-
-    let mut file = File::create("index.html")?;
-    file.write_all(html_content.as_bytes())?;
-    Ok(())
-}
-
-fn modify_cargo_toml(name: &str) -> Result<()> {
-    fn add_dependencies(dependencies: &mut Table) {
-        dependencies.insert("wasm-bindgen", toml_edit::value("0.2.73"));
-        dependencies.insert("serde", {
-            let mut table = InlineTable::new();
-            table.insert("version", Value::from("1.0"));
-            let mut features_array = Array::new();
-            features_array.push("derive");
-            table.insert("features", Value::Array(features_array));
-            Item::Value(Value::InlineTable(table))
-        });
-        dependencies.insert("serde_json", toml_edit::value("1.0"));
-        dependencies.insert("serde-wasm-bindgen", toml_edit::value("=0.6.5"));
-        dependencies.insert("rmp-serde", toml_edit::value("1.3.0"));
-    }
-
-    {
-        // first we need to edit the Cargo.toml file in the root directory
-        let cargo_toml_path = format!("{}/Cargo.toml", name);
-        let content = fs::read_to_string(&cargo_toml_path)?;
-        let mut doc = content.parse::<DocumentMut>()?;
-        if !doc.contains_key("lib") {
-            doc["lib"] = toml_edit::table();
-        }
-
-        let lib_section = doc["lib"].as_table_mut().unwrap();
-
-        // add lib section with cdylib crate-type if it doesn't exist
-        if !lib_section.contains_key("crate-type") {
-            let mut array = Array::new();
-            array.push("cdylib");
-            lib_section["crate-type"] = Item::Value(toml_edit::Value::Array(array));
-            lib_section["path"] = value("guest/src/lib.rs");
-        }
-        let dependencies = doc["dependencies"].as_table_mut().unwrap();
-        add_dependencies(dependencies);
-
-        fs::write(cargo_toml_path, doc.to_string())?;
-    }
-
-    // then we need to edit the Cargo.toml file in the guest directory
-    {
-        let cargo_toml_path = format!("{}/guest/Cargo.toml", name);
-        let content = fs::read_to_string(&cargo_toml_path)?;
-        let mut doc = content.parse::<DocumentMut>()?;
-
-        if !doc
-            .as_table()
-            .get("target")
-            .and_then(|target| target.get("cfg(target_arch = \"wasm32\")"))
-            .and_then(|cfg| cfg.get("dependencies"))
-            .map_or(false, |dependencies| dependencies.is_table())
-        {
-            let mut toml_str = doc.to_string();
-            toml_str.push_str("\n[target.'cfg(target_arch = \"wasm32\")'.dependencies]\n");
-            doc = toml_str.parse::<DocumentMut>()?;
-
-            let mut table = Table::new();
-            add_dependencies(&mut table);
-
-            doc["target"]["cfg(target_arch = \"wasm32\")"]["dependencies"] = Item::Table(table);
-            fs::write(cargo_toml_path, doc.to_string())?;
-        }
-    }
-    Ok(())
-}
-
-fn build_wasm() {
-    println!("Building the project with wasm-pack...");
-    let func_names = extract_provable_functions();
-    for func_name in func_names.clone() {
-        preprocess_and_save(&func_name).expect("Failed to preprocess functions");
-    }
-
-    create_index_html(func_names).expect("Failed to create example index.html");
-
-    // todo implement test if wasm-pack is installed
-
-    std::process::Command::new("wasm-pack")
-        .args(["build", "--release", "--target", "web"])
-        .output()
-        .expect("Failed to build the project with wasm-pack");
-}
-
 const RUST_TOOLCHAIN: &str = include_str!("../rust-toolchain.toml");
 
 const HOST_CARGO_TEMPLATE: &str = r#"[package]
@@ -464,24 +228,4 @@ fn fib(n: u32) -> u128 {
 
     b
 }
-"#;
-
-const HTML_HEAD: &str = r#"
-<!DOCTYPE html>
-<html lang="en">
-    <head>
-        <meta charset="UTF-8">
-        <title>Jolt x WASMn</title>
-    </head>
-    <body>
-        <h1>Jolt x WASM</h1>
-"#;
-
-const HTML_TAIL: &str = r#"
-            }
-
-            run();
-        </script>
-    </body>
-</html>
 "#;

--- a/src/main.rs
+++ b/src/main.rs
@@ -187,10 +187,10 @@ fn preprocess_and_save(func_name: &str) -> Result<()> {
     decoded_data.serialize(&mut Serializer::new(&mut buf))?;
 
     let target_dir = Path::new("target/wasm32-unknown-unknown/release");
-    fs::create_dir_all(&target_dir)?;
+    fs::create_dir_all(target_dir)?;
 
     let output_path = target_dir.join(format!("preprocessed_{}.bin", func_name));
-    let mut file = File::create(&output_path)?;
+    let mut file = File::create(output_path)?;
     file.write_all(&buf)?;
     Ok(())
 }
@@ -228,10 +228,14 @@ fn is_provable(attr: &Attribute) -> bool {
 }
 
 fn get_project_name() -> Option<String> {
-    let cargo_toml_path = format!("Cargo.toml");
-    let content = fs::read_to_string(cargo_toml_path).ok()?;
+    let content = fs::read_to_string("Cargo.toml").ok()?;
     let doc = content.parse::<DocumentMut>().ok()?;
-    doc["package"]["name"].as_str().map(|s| s.replace("-", "_"))
+    // replace "-" with "_" to make it a valid identifier
+    doc["package"]["name"].as_str().map(|s| {
+        s.chars()
+            .map(|c| if c == '-' { '_' } else { c })
+            .collect::<String>()
+    })
 }
 
 fn create_index_html(func_names: Vec<String>) -> Result<()> {
@@ -385,7 +389,7 @@ fn build_wasm() {
     // todo implement test if wasm-pack is installed
 
     std::process::Command::new("wasm-pack")
-        .args(&["build", "--release", "--target", "web"])
+        .args(["build", "--release", "--target", "web"])
         .output()
         .expect("Failed to build the project with wasm-pack");
 }


### PR DESCRIPTION
This pull request introduces WebAssembly (WASM) compatibility for the verification process of Jolt. The main changes include:

- Extension of `jolt new` command with `--wasm` flag:
    - The `jolt new <project-name> --wasm` command modifies both the `root/Cargo.toml` and `guest/Cargo.toml` files to include the necessary dependencies for WASM. It also marks the project as a `cdylib` crate type, which is required for WASM compilation.
- Addition of `jolt build-wasm` command
   - The `build-wasm` command extracts all functions declared with `jolt::provable`. It then performs preprocessing steps to build and decode the program, storing the resulting data in binary form. An example `index.html` file is created to demonstrate how to use the functions generated by the macro extension. Finally, optimized WASM files are created using `wasm-pack` to make the project ready for use. 
 - Extension of macros:
    - The macros are enhanced to check if functions are marked with `jolt::provable(wasm)`. If so, necessary imports and helper functions are defined. The output of the preprocessing process is then used to build the WASM-compatible verify-functions. 

**Current Limitations**
- Dependencies used in `guest/src/lib.rs` need to be defined both in `guest/Cargo.toml` and `root/Cargo.toml`. This redundancy is known and could be optimized in future iterations.
- Currently, this only provides WASM support for proof verification. The proving itself is not yet WASM-compatible, bc it's unclear whether this is a desired requirement.

#314