### PR TITLE
Implementation of section 5 of the Quarks Paper

### DIFF
--- a/jolt-core/src/poly/commitment/commitment_scheme.rs
+++ b/jolt-core/src/poly/commitment/commitment_scheme.rs
@@ -32,7 +32,7 @@ pub enum BatchType {
 }
 
 pub trait CommitmentScheme: Clone + Sync + Send + 'static {
-    type Field: JoltField;
+    type Field: JoltField + Sized;
     type Setup: Clone + Sync + Send;
     type Commitment: Sync + Send + CanonicalSerialize + CanonicalDeserialize + AppendToTranscript;
     type Proof: Sync + Send + CanonicalSerialize + CanonicalDeserialize;

--- a/jolt-core/src/subprotocols/grand_product_quarks.rs
+++ b/jolt-core/src/subprotocols/grand_product_quarks.rs
@@ -113,7 +113,7 @@ impl<C: CommitmentScheme> QuarkGrandProduct<C> for QuarkGrandProductProof<C> {
 
         // Now we do the sumcheck using the prove arbitrary
 
-        // First insatiate our polynomials
+        // First instantiate our polynomials
         let tau = transcript.challenge_vector(b"element for eval poly", v_variables);
         let evals = DensePolynomial::new(EqPolynomial::evals(&tau));
         let mut sumcheck_polys = vec![

--- a/jolt-core/src/subprotocols/grand_product_quarks.rs
+++ b/jolt-core/src/subprotocols/grand_product_quarks.rs
@@ -7,8 +7,8 @@ use crate::utils::math::Math;
 use crate::utils::transcript::{AppendToTranscript, ProofTranscript};
 use ark_serialize::*;
 use itertools::Itertools;
-use thiserror::Error;
 use rayon::prelude::*;
+use thiserror::Error;
 
 #[derive(CanonicalSerialize, CanonicalDeserialize)]
 pub struct QuarkGrandProductProof<C: CommitmentScheme> {
@@ -323,7 +323,13 @@ impl<C: CommitmentScheme> QuarkBatchedGrandProduct<C> for QuarkGrandProductProof
 #[allow(clippy::type_complexity)]
 fn v_into_f<C: CommitmentScheme>(
     v: &DensePolynomial<C::Field>,
-) -> (DensePolynomial<C::Field>, DensePolynomial<C::Field>, DensePolynomial<C::Field>, DensePolynomial<C::Field>, C::Field) {
+) -> (
+    DensePolynomial<C::Field>,
+    DensePolynomial<C::Field>,
+    DensePolynomial<C::Field>,
+    DensePolynomial<C::Field>,
+    C::Field,
+) {
     let v_length = v.len();
     let mut f_evals = vec![C::Field::zero(); 2 * v_length];
     let (evals, _) = v.split_evals(v.len());
@@ -369,7 +375,10 @@ fn open_and_prove<C: CommitmentScheme>(
     transcript: &mut ProofTranscript,
 ) -> (Vec<C::Field>, C::BatchedProof) {
     let chis = EqPolynomial::evals(x);
-    let openings: Vec<C::Field> = f_polys.iter().map(|f| f.evaluate_at_chi_low_optimized(&chis)).collect();
+    let openings: Vec<C::Field> = f_polys
+        .iter()
+        .map(|f| f.evaluate_at_chi_low_optimized(&chis))
+        .collect();
     // Batch proof requires  &[&]
     let borrowed: Vec<&DensePolynomial<C::Field>> = f_polys.iter().collect();
 

--- a/jolt-core/src/subprotocols/grand_product_quarks.rs
+++ b/jolt-core/src/subprotocols/grand_product_quarks.rs
@@ -1,8 +1,8 @@
 use super::sumcheck::SumcheckInstanceProof;
+use crate::field::JoltField;
 use crate::poly::commitment::commitment_scheme::{BatchType, CommitmentScheme};
 use crate::poly::dense_mlpoly::DensePolynomial;
 use crate::poly::eq_poly::EqPolynomial;
-use crate::field::JoltField;
 use crate::utils::math::Math;
 use crate::utils::transcript::{AppendToTranscript, ProofTranscript};
 use ark_serialize::*;

--- a/jolt-core/src/subprotocols/grand_product_quarks.rs
+++ b/jolt-core/src/subprotocols/grand_product_quarks.rs
@@ -1,0 +1,220 @@
+use super::sumcheck::{BatchedCubicSumcheck, SumcheckInstanceProof};
+use crate::poly::eq_poly::EqPolynomial;
+use crate::poly::field::JoltField;
+use crate::poly::{dense_mlpoly::DensePolynomial, unipoly::UniPoly};
+// todo specify 
+use crate::poly::commitment::commitment_scheme::{CommitmentScheme};
+use crate::utils::math::Math;
+use crate::utils::thread::drop_in_background_thread;
+use crate::utils::transcript::{AppendToTranscript, ProofTranscript};
+use ark_ff::Zero;
+use ark_serialize::*;
+use itertools::Itertools;
+use rayon::prelude::*;
+
+#[derive(CanonicalSerialize, CanonicalDeserialize)]
+pub struct QuarkGrandProductProof<C: CommitmentScheme> {
+    sumcheck_proof: SumcheckInstanceProof<C::Field>,
+    v_commitment: C::Commitment,
+    f_commitment: C::Commitment,
+    claimed_eval_f_0_r: (C::Field, C::Proof),
+    claimed_eval_f_1_r: (C::Field, C::Proof),
+    claimed_eval_f_r_0: (C::Field, C::Proof),
+    claimed_eval_f_r_1: (C::Field, C::Proof),
+    sum_opening: C::Proof,
+    v_opening_proof: C::Proof
+}
+
+pub trait QuarkGrandProduct<C: CommitmentScheme>: Sized {
+
+    /// Computes a grand product proof using the Section 5 technique from Quarks Paper
+    /// First - Extends the evals of v to create an f poly, then commits to it and evals
+    /// Then - Constructs a g poly and preforms sumcheck proof that sum == 0
+    /// Finally - computes opening proofs for a random sampled during sumcheck proof and returns
+    fn prove_grand_product(
+        &mut self,
+        v: &DensePolynomial<C::Field>,
+        transcript: &mut ProofTranscript,
+        setup: &C::Setup
+    ) -> (QuarkGrandProductProof<C>, C::Field) {
+        let v_length = v.len();
+        let v_variables = v_length.log_2();
+
+        assert_eq!(v_length, v_variables.pow2(), "Only grand products on length power of two are currently supported");
+        let mut f_evals = vec![C::Field::zero(); 2*v_length];
+        let (evals, _) = v.split_evals(v.len());
+        f_evals[..v_length].clone_from_slice(evals);
+
+        // Todo - problems when f length is equal to the usize
+        for i in v_length..2*v_length {
+            let i_shift_mod = (i << 1) % 2*v_length;
+            // this just works tm
+            f_evals[i] = f_evals[i_shift_mod]*f_evals[i_shift_mod + 1]
+        }
+
+        // We pull out the co-efficient which instantiate the lower d polys for the sumcheck
+        let mut f_1_x = Vec::new();
+        f_1_x.clone_from_slice(&f_evals[v_length..]);
+
+        let mut f_x_0 = Vec::new();
+        let mut f_x_1 = Vec::new();
+        for (i, x) in (&f_evals).into_iter().enumerate() {
+            if i % 2 == 0 {
+                f_x_0.push(x.clone());
+            } else {
+                f_x_1.push(x.clone());
+            }
+        }
+
+        let product = f_evals[2*v_length - 2];
+        let f = DensePolynomial::new(f_evals);
+
+        // We bind to these polynomials
+        transcript.append_scalar(b"grand product claim",&product);
+        let v_commitment = C::commit(v, setup);
+        let f_commitment = C::commit(&f, setup);
+        v_commitment.append_to_transcript(b"v commitment", transcript);
+        f_commitment.append_to_transcript(b"f commitment", transcript);
+
+        // Now we do the sumcheck using the prove arbitrary
+
+        // First insatiate our polynomials
+        let tau = transcript.challenge_vector(b"element for eval poly", v_variables);
+        let evals = DensePolynomial::new(EqPolynomial::evals(&tau));
+        let mut sumcheck_polys = vec![evals, DensePolynomial::new(f_1_x), DensePolynomial::new(f_x_0), DensePolynomial::new(f_x_1)];
+
+        // We define a closure using vals[0] = eq(tau, x), vals[1] = f(1, x), vals[1] = f(x, 0), vals[2] = f(x, 0)
+        let output_check_fn = |vals: &[C::Field]| -> C::Field { vals[0]*(vals[1] - vals[2]*vals[3]) };
+
+        // Now run the sumcheck in arbitrary mode
+        // TODO (aleph_v): Use a trait implementation as is done for batched cubic
+        // Note - We use the final randomness from binding all variables (x) as the source random for the openings so the verifier can
+        //        check that the base layer is the same as is committed too.
+        // TODO - Do we need final_evals in struct
+        let (sumcheck_proof, x, final_evals) = SumcheckInstanceProof::<C::Field>::prove_arbitrary::<_>(
+            &C::Field::zero(),
+            v_variables,
+            &mut sumcheck_polys,
+            output_check_fn,
+            3,
+            transcript,
+        );
+
+        // TODO (aleph_v) - Batch opens and a line reduction to make this 3 openings
+        let mut challenge_0_x = vec![C::Field::zero()];
+        challenge_0_x.append(&mut x.clone());
+        let point_0_x = f.evaluate(&challenge_0_x);
+        let proof_0_x = C::prove(&f, &challenge_0_x, transcript);
+        let claimed_eval_f_0_r = (point_0_x, proof_0_x);
+
+        let mut challenge_1_x = vec![C::Field::one()];
+        challenge_1_x.append(&mut x.clone());
+        let point_1_x = f.evaluate(&challenge_1_x);
+        let proof_1_x = C::prove(&f, &challenge_1_x, transcript);
+        let claimed_eval_f_1_r = (point_1_x, proof_1_x);
+
+        let mut challenge_x_0 = x.clone();
+        challenge_x_0.push(C::Field::zero());
+        let point_x_0 = f.evaluate(&challenge_x_0);
+        let proof_x_0 = C::prove(&f, &challenge_x_0, transcript);
+        let claimed_eval_f_r_0 = (point_x_0, proof_x_0);
+
+        let mut challenge_x_1 = x.clone();
+        challenge_x_1.push(C::Field::one());
+        let point_x_1 = f.evaluate(&challenge_x_1);
+        let proof_x_1 = C::prove(&f, &challenge_x_1, transcript);
+        let claimed_eval_f_r_1 = (point_x_1, proof_x_1);
+
+        let mut challenge_sum = vec![C::Field::one()];
+        challenge_sum.push(C::Field::zero());
+        // Here we don't calculate an eval because we should know it from the product recorded above
+        let sum_opening = C::prove(&f, &challenge_sum, transcript);
+
+        // Here we don't calculate an eval because it should be equal to f(0, x) which is the first point we open
+        let v_opening_proof = C::prove(&v, &x, transcript);
+
+
+        (QuarkGrandProductProof::<C>{
+            sumcheck_proof,
+            v_commitment,
+            f_commitment,
+            claimed_eval_f_0_r,
+            claimed_eval_f_1_r,
+            claimed_eval_f_r_0,
+            claimed_eval_f_r_1,
+            sum_opening,
+            v_opening_proof
+        }, product)
+    }
+
+
+    // Verifies the given grand product proof.
+    // fn verify_grand_product(
+    //     proof: &QuarkGrandProductProof<F>,
+    //     transcript: &mut ProofTranscript,
+    // ) -> (Vec<F>, Vec<F>) {
+    //     let mut r_grand_product: Vec<F> = Vec::new();
+    //     let mut claims_to_verify = claims.to_owned();
+
+    //     for (layer_index, layer_proof) in proof.layers.iter().enumerate() {
+    //         // produce a fresh set of coeffs
+    //         let coeffs: Vec<F> =
+    //             transcript.challenge_vector(b"rand_coeffs_next_layer", claims_to_verify.len());
+    //         // produce a joint claim
+    //         let claim = claims_to_verify
+    //             .iter()
+    //             .zip(coeffs.iter())
+    //             .map(|(&claim, &coeff)| claim * coeff)
+    //             .sum();
+
+    //         let (sumcheck_claim, r_sumcheck) =
+    //             layer_proof.verify(claim, layer_index, 3, transcript);
+    //         assert_eq!(claims.len(), layer_proof.left_claims.len());
+    //         assert_eq!(claims.len(), layer_proof.right_claims.len());
+
+    //         for (left, right) in layer_proof
+    //             .left_claims
+    //             .iter()
+    //             .zip(layer_proof.right_claims.iter())
+    //         {
+    //             transcript.append_scalar(b"sumcheck left claim", left);
+    //             transcript.append_scalar(b"sumcheck right claim", right);
+    //         }
+
+    //         assert_eq!(r_grand_product.len(), r_sumcheck.len());
+
+    //         let eq_eval: F = r_grand_product
+    //             .iter()
+    //             .zip_eq(r_sumcheck.iter().rev())
+    //             .map(|(&r_gp, &r_sc)| r_gp * r_sc + (F::one() - r_gp) * (F::one() - r_sc))
+    //             .product();
+
+    //         r_grand_product = r_sumcheck.into_iter().rev().collect();
+
+    //         Self::verify_sumcheck_claim(
+    //             &proof.layers,
+    //             layer_index,
+    //             &coeffs,
+    //             sumcheck_claim,
+    //             eq_eval,
+    //             &mut claims_to_verify,
+    //             &mut r_grand_product,
+    //             transcript,
+    //         );
+    //     }
+
+    //     (claims_to_verify, r_grand_product)
+    // }
+}
+
+
+
+#[cfg(test)]
+mod grand_product_tests {
+    use super::*;
+    use ark_bn254::Fr;
+    use ark_std::test_rng;
+    use rand_core::RngCore;
+
+
+}

--- a/jolt-core/src/subprotocols/grand_product_quarks.rs
+++ b/jolt-core/src/subprotocols/grand_product_quarks.rs
@@ -55,7 +55,6 @@ pub trait QuarkGrandProduct<C: CommitmentScheme>: Sized {
     ) -> Result<(), QuarkError>;
 }
 
-
 impl<C: CommitmentScheme> QuarkGrandProduct<C> for QuarkGrandProductProof<C> {
     /// Computes a grand product proof using the Section 5 technique from Quarks Paper
     /// First - Extends the evals of v to create an f poly, then commits to it and evals
@@ -88,7 +87,7 @@ impl<C: CommitmentScheme> QuarkGrandProduct<C> for QuarkGrandProductProof<C> {
         }
 
         // We pull out the co-efficient which instantiate the lower d polys for the sumcheck
-        let mut f_1_x = vec![C::Field::zero(); f_evals.len()/2];
+        let mut f_1_x = vec![C::Field::zero(); f_evals.len() / 2];
         f_1_x.clone_from_slice(&f_evals[v_length..]);
 
         let mut f_x_0 = Vec::new();
@@ -144,34 +143,34 @@ impl<C: CommitmentScheme> QuarkGrandProduct<C> for QuarkGrandProductProof<C> {
         let mut challenge_0_x = vec![C::Field::zero()];
         challenge_0_x.append(&mut x.clone());
         let point_0_x = f.evaluate(&challenge_0_x);
-        let proof_0_x = C::prove(&setup,&f, &challenge_0_x, transcript);
+        let proof_0_x = C::prove(setup, &f, &challenge_0_x, transcript);
         let claimed_eval_f_0_r = (point_0_x, proof_0_x);
 
         let mut challenge_1_x = vec![C::Field::one()];
         challenge_1_x.append(&mut x.clone());
         let point_1_x = f.evaluate(&challenge_1_x);
-        let proof_1_x = C::prove(&setup,&f, &challenge_1_x, transcript);
+        let proof_1_x = C::prove(setup, &f, &challenge_1_x, transcript);
         let claimed_eval_f_1_r = (point_1_x, proof_1_x);
 
         let mut challenge_x_0 = x.clone();
         challenge_x_0.push(C::Field::zero());
         let point_x_0 = f.evaluate(&challenge_x_0);
-        let proof_x_0 = C::prove(&setup,&f, &challenge_x_0, transcript);
+        let proof_x_0 = C::prove(setup, &f, &challenge_x_0, transcript);
         let claimed_eval_f_r_0 = (point_x_0, proof_x_0);
 
         let mut challenge_x_1 = x.clone();
         challenge_x_1.push(C::Field::one());
         let point_x_1 = f.evaluate(&challenge_x_1);
-        let proof_x_1 = C::prove(&setup,&f, &challenge_x_1, transcript);
+        let proof_x_1 = C::prove(setup, &f, &challenge_x_1, transcript);
         let claimed_eval_f_r_1 = (point_x_1, proof_x_1);
 
         let mut challenge_sum = vec![C::Field::one(); x.len()];
         challenge_sum.push(C::Field::zero());
         // Here we don't calculate an eval because we should know it from the product recorded above
-        let sum_opening = C::prove(&setup,&f, &challenge_sum, transcript);
+        let sum_opening = C::prove(setup, &f, &challenge_sum, transcript);
 
         // Here we don't calculate an eval because it should be equal to f(0, x) which is the first point we open
-        let v_opening_proof = C::prove(&setup,v, &x, transcript);
+        let v_opening_proof = C::prove(setup, v, &x, transcript);
 
         (
             Self {
@@ -199,11 +198,9 @@ impl<C: CommitmentScheme> QuarkGrandProduct<C> for QuarkGrandProductProof<C> {
     ) -> Result<(), QuarkError> {
         // First we append the claimed values for the commitment and the product
         transcript.append_scalar(b"grand product claim", claim);
-        self
-            .v_commitment
+        self.v_commitment
             .append_to_transcript(b"v commitment", transcript);
-        self
-            .f_commitment
+        self.f_commitment
             .append_to_transcript(b"f commitment", transcript);
 
         //Next sample the tau and construct the evals poly
@@ -306,8 +303,8 @@ impl<C: CommitmentScheme> QuarkGrandProduct<C> for QuarkGrandProductProof<C> {
 #[cfg(test)]
 mod quark_grand_product_tests {
     use super::*;
-    use ark_bn254::{Bn254, Fr};
     use crate::poly::commitment::zeromorph::*;
+    use ark_bn254::{Bn254, Fr};
     use rand_core::SeedableRng;
 
     #[test]
@@ -315,10 +312,10 @@ mod quark_grand_product_tests {
         const LAYER_SIZE: usize = 1 << 8;
 
         let mut rng = rand_chacha::ChaCha20Rng::seed_from_u64(9 as u64);
-        
+
         let leaves: Vec<Fr> = std::iter::repeat_with(|| Fr::random(&mut rng))
-                .take(LAYER_SIZE)
-                .collect();
+            .take(LAYER_SIZE)
+            .collect();
         let known_product: Fr = leaves.iter().product();
         let v = DensePolynomial::new(leaves);
         let mut transcript: ProofTranscript = ProofTranscript::new(b"test_transcript");
@@ -326,11 +323,8 @@ mod quark_grand_product_tests {
         let srs = ZeromorphSRS::<Bn254>::setup(&mut rng, 1 << 9);
         let setup = srs.trim(1 << 9);
 
-        let (proof, product) = QuarkGrandProductProof::<Zeromorph<Bn254>>::prove(
-            &v,
-            &mut transcript,
-            &setup
-        );
+        let (proof, product) =
+            QuarkGrandProductProof::<Zeromorph<Bn254>>::prove(&v, &mut transcript, &setup);
 
         assert_eq!(&product, &known_product, "Not the product of v");
 

--- a/jolt-core/src/subprotocols/grand_product_quarks.rs
+++ b/jolt-core/src/subprotocols/grand_product_quarks.rs
@@ -7,7 +7,6 @@ use crate::utils::math::Math;
 use crate::utils::transcript::{AppendToTranscript, ProofTranscript};
 use ark_serialize::*;
 use itertools::Itertools;
-use rayon::prelude::*;
 use thiserror::Error;
 
 #[derive(CanonicalSerialize, CanonicalDeserialize)]

--- a/jolt-core/src/subprotocols/grand_product_quarks.rs
+++ b/jolt-core/src/subprotocols/grand_product_quarks.rs
@@ -100,6 +100,7 @@ impl<C: CommitmentScheme> QuarkGrandProduct<C> for QuarkGrandProductProof<C> {
             }
         }
 
+        // f(1, ..., 1, 0) = P
         let product = f_evals[2 * v_length - 2];
         let f = DensePolynomial::new(f_evals);
 

--- a/jolt-core/src/subprotocols/grand_product_quarks.rs
+++ b/jolt-core/src/subprotocols/grand_product_quarks.rs
@@ -1,5 +1,5 @@
 use super::sumcheck::SumcheckInstanceProof;
-use crate::poly::commitment::commitment_scheme::CommitmentScheme;
+use crate::poly::commitment::commitment_scheme::{BatchType, CommitmentScheme};
 use crate::poly::dense_mlpoly::DensePolynomial;
 use crate::poly::eq_poly::EqPolynomial;
 use crate::poly::field::JoltField;
@@ -12,14 +12,14 @@ use thiserror::Error;
 #[derive(CanonicalSerialize, CanonicalDeserialize)]
 pub struct QuarkGrandProductProof<C: CommitmentScheme> {
     sumcheck_proof: SumcheckInstanceProof<C::Field>,
-    v_commitment: C::Commitment,
-    f_commitment: C::Commitment,
-    claimed_eval_f_0_r: (C::Field, C::Proof),
-    claimed_eval_f_1_r: (C::Field, C::Proof),
-    claimed_eval_f_r_0: (C::Field, C::Proof),
-    claimed_eval_f_r_1: (C::Field, C::Proof),
-    sum_opening: C::Proof,
-    v_opening_proof: C::Proof,
+    v_commitment: Vec<C::Commitment>,
+    f_commitment: Vec<C::Commitment>,
+    claimed_eval_f_0_r: (Vec<C::Field>, C::BatchedProof),
+    claimed_eval_f_1_r: (Vec<C::Field>, C::BatchedProof),
+    claimed_eval_f_r_0: (Vec<C::Field>, C::BatchedProof),
+    claimed_eval_f_r_1: (Vec<C::Field>, C::BatchedProof),
+    sum_openings: C::BatchedProof,
+    v_opening_proof: C::BatchedProof,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Error)]
@@ -35,97 +35,84 @@ pub enum QuarkError {
     InvalidBinding,
 }
 
-pub trait QuarkGrandProduct<C: CommitmentScheme>: Sized {
+pub trait QuarkBatchedGrandProduct<C: CommitmentScheme>: Sized {
+    type Leaves = Vec<C::Field>;
     /// Computes a grand product proof using the Section 5 technique from Quarks Paper
     /// First - Extends the evals of v to create an f poly, then commits to it and evals
     /// Then - Constructs a g poly and preforms sumcheck proof that sum == 0
     /// Finally - computes opening proofs for a random sampled during sumcheck proof and returns
     fn prove(
-        v: &DensePolynomial<C::Field>,
+        v: Vec<DensePolynomial<C::Field>>,
         transcript: &mut ProofTranscript,
         setup: &C::Setup,
-    ) -> (Self, C::Field);
+    ) -> (Self, Vec<C::Field>);
 
     /// Verifies the given grand product proof.
     fn verify(
         self,
-        claim: &C::Field,
+        claim: &[C::Field],
         transcript: &mut ProofTranscript,
         n_rounds: usize,
         setup: &C::Setup,
     ) -> Result<(), QuarkError>;
 }
 
-impl<C: CommitmentScheme> QuarkGrandProduct<C> for QuarkGrandProductProof<C> {
+impl<C: CommitmentScheme> QuarkBatchedGrandProduct<C> for QuarkGrandProductProof<C> {
     /// Computes a grand product proof using the Section 5 technique from Quarks Paper
     /// First - Extends the evals of v to create an f poly, then commits to it and evals
     /// Then - Constructs a g poly and preforms sumcheck proof that sum == 0
     /// Finally - computes opening proofs for a random sampled during sumcheck proof and returns
     fn prove(
-        v: &DensePolynomial<C::Field>,
+        v_polys: Vec<DensePolynomial<C::Field>>,
         transcript: &mut ProofTranscript,
         setup: &C::Setup,
-    ) -> (Self, C::Field) {
-        let v_length = v.len();
+    ) -> (Self, Vec<C::Field>) {
+        // TODO (alpeh_v): all v the same size?
+        let v_length = v_polys[0].len();
         let v_variables = v_length.log_2();
 
-        assert_eq!(
-            v_length,
-            v_variables.pow2(),
-            "Only grand products on length power of two are currently supported"
-        );
+        let mut f_polys = Vec::<DensePolynomial<C::Field>>::new();
+        let mut sumcheck_polys = Vec::<DensePolynomial<C::Field>>::new();
+        let mut products = Vec::<C::Field>::new();
 
-        let mut f_evals = vec![C::Field::zero(); 2 * v_length];
-        let (evals, _) = v.split_evals(v.len());
-        f_evals[..v_length].clone_from_slice(evals);
-
-        // Todo (aleph_v) - problems when f length is equal to the usize
-        for i in v_length..2 * v_length {
-            let i_shift_mod = (i << 1) % (2 * v_length);
-            // The transform follows the logic of the paper and to accumulate
-            // the partial sums into the correct indices.
-            f_evals[i] = f_evals[i_shift_mod] * f_evals[i_shift_mod + 1]
+        for v in v_polys.iter() {
+            let (f, p) = v_into_f::<C>(v, &mut sumcheck_polys);
+            f_polys.push(f);
+            products.push(p);
         }
-
-        // We pull out the co-efficient which instantiate the lower d polys for the sumcheck
-        let f_1_x = f_evals[v_length..].to_vec();
-
-        let mut f_x_0 = Vec::new();
-        let mut f_x_1 = Vec::new();
-        for (i, x) in f_evals.iter().enumerate() {
-            if i % 2 == 0 {
-                f_x_0.push(*x);
-            } else {
-                f_x_1.push(*x);
-            }
-        }
-
-        // f(1, ..., 1, 0) = P
-        let product = f_evals[2 * v_length - 2];
-        let f = DensePolynomial::new(f_evals);
 
         // We bind to these polynomials
-        transcript.append_scalar(b"grand product claim", &product);
-        let v_commitment = C::commit(v, setup);
-        let f_commitment = C::commit(&f, setup);
-        v_commitment.append_to_transcript(b"v commitment", transcript);
-        f_commitment.append_to_transcript(b"f commitment", transcript);
+        transcript.append_scalars(b"grand product claim", &products);
+        let v_commitment = C::batch_commit_polys(&v_polys, setup, BatchType::Big);
+        let f_commitment = C::batch_commit_polys(&f_polys, setup, BatchType::Big);
+        for v in v_commitment.iter() {
+            v.append_to_transcript(b"v commitment", transcript);
+        }
+        for f in f_commitment.iter() {
+            f.append_to_transcript(b"f commitment", transcript);
+        }
 
         // Now we do the sumcheck using the prove arbitrary
-
         // First instantiate our polynomials
-        let tau = transcript.challenge_vector(b"element for eval poly", v_variables);
+        let tau: Vec<C::Field> = transcript.challenge_vector(b"element for eval poly", v_variables);
         let evals = DensePolynomial::new(EqPolynomial::evals(&tau));
-        let mut sumcheck_polys = vec![
-            evals,
-            DensePolynomial::new(f_1_x),
-            DensePolynomial::new(f_x_0),
-            DensePolynomial::new(f_x_1),
-        ];
+        //We add evals as the last polynomial in the sumcheck
+        sumcheck_polys.push(evals);
+
+        // Sample a constant to do a random linear combination to combine the sumchecks
+        let r_combination: Vec<C::Field> =
+            transcript.challenge_vector(b"for the random linear comb", v_polys.len());
 
         // We define a closure using vals[0] = eq(tau, x), vals[1] = f(1, x), vals[1] = f(x, 0), vals[2] = f(x, 1)
-        let output_check_fn =
-            |vals: &[C::Field]| -> C::Field { vals[0] * (vals[1] - vals[2] * vals[3]) };
+        let output_check_fn = |vals: &[C::Field]| -> C::Field {
+            let eval = vals[vals.len() - 1];
+            let mut sum = C::Field::zero();
+
+            for i in 0..(vals.len() / 3) {
+                sum += r_combination[i] * eval * (vals[i * 3] - vals[3 * i + 1] * vals[3 * i + 2]);
+            }
+            sum
+        };
 
         // Now run the sumcheck in arbitrary mode
         // TODO (aleph_v): Use a trait implementation as is done for batched cubic
@@ -140,38 +127,48 @@ impl<C: CommitmentScheme> QuarkGrandProduct<C> for QuarkGrandProductProof<C> {
             transcript,
         );
 
+        // Interface for the batch proof is &[&Poly] but we have &[Poly]
+        let borrowed_f: Vec<&DensePolynomial<C::Field>> = f_polys.iter().collect();
+        let borrowed_v: Vec<&DensePolynomial<C::Field>> = v_polys.iter().collect();
+
         // TODO (aleph_v) - Batch opens and a line reduction to make this 3 openings
         let mut challenge_0_x = vec![C::Field::zero()];
         challenge_0_x.append(&mut x.clone());
-        let point_0_x = f.evaluate(&challenge_0_x);
-        let proof_0_x = C::prove(setup, &f, &challenge_0_x, transcript);
-        let claimed_eval_f_0_r = (point_0_x, proof_0_x);
+        let claimed_eval_f_0_r = open_and_prove::<C>(&challenge_0_x, &f_polys, setup, transcript);
 
         let mut challenge_1_x = vec![C::Field::one()];
         challenge_1_x.append(&mut x.clone());
-        let point_1_x = f.evaluate(&challenge_1_x);
-        let proof_1_x = C::prove(setup, &f, &challenge_1_x, transcript);
-        let claimed_eval_f_1_r = (point_1_x, proof_1_x);
+        let claimed_eval_f_1_r = open_and_prove::<C>(&challenge_1_x, &f_polys, setup, transcript);
 
         let mut challenge_x_0 = x.clone();
         challenge_x_0.push(C::Field::zero());
-        let point_x_0 = f.evaluate(&challenge_x_0);
-        let proof_x_0 = C::prove(setup, &f, &challenge_x_0, transcript);
-        let claimed_eval_f_r_0 = (point_x_0, proof_x_0);
+        let claimed_eval_f_r_0 = open_and_prove::<C>(&challenge_x_0, &f_polys, setup, transcript);
 
         let mut challenge_x_1 = x.clone();
         challenge_x_1.push(C::Field::one());
-        let point_x_1 = f.evaluate(&challenge_x_1);
-        let proof_x_1 = C::prove(setup, &f, &challenge_x_1, transcript);
-        let claimed_eval_f_r_1 = (point_x_1, proof_x_1);
+        let claimed_eval_f_r_1 = open_and_prove::<C>(&challenge_x_1, &f_polys, setup, transcript);
 
         let mut challenge_sum = vec![C::Field::one(); x.len()];
         challenge_sum.push(C::Field::zero());
         // Here we don't calculate an eval because we should know it from the product recorded above
-        let sum_opening = C::prove(setup, &f, &challenge_sum, transcript);
+        let sum_openings = C::batch_prove(
+            setup,
+            &borrowed_f,
+            &challenge_sum,
+            &products,
+            BatchType::Big,
+            transcript,
+        );
 
         // Here we don't calculate an eval because it should be equal to f(0, x) which is the first point we open
-        let v_opening_proof = C::prove(setup, v, &x, transcript);
+        let v_opening_proof = C::batch_prove(
+            setup,
+            &borrowed_v,
+            &x,
+            &claimed_eval_f_0_r.0,
+            BatchType::Big,
+            transcript,
+        );
 
         (
             Self {
@@ -182,30 +179,34 @@ impl<C: CommitmentScheme> QuarkGrandProduct<C> for QuarkGrandProductProof<C> {
                 claimed_eval_f_1_r,
                 claimed_eval_f_r_0,
                 claimed_eval_f_r_1,
-                sum_opening,
+                sum_openings,
                 v_opening_proof,
             },
-            product,
+            products,
         )
     }
 
     /// Verifies the given grand product proof.
     fn verify(
         self,
-        claim: &C::Field,
+        claims: &[C::Field],
         transcript: &mut ProofTranscript,
         n_rounds: usize,
         setup: &C::Setup,
     ) -> Result<(), QuarkError> {
         // First we append the claimed values for the commitment and the product
-        transcript.append_scalar(b"grand product claim", claim);
-        self.v_commitment
-            .append_to_transcript(b"v commitment", transcript);
-        self.f_commitment
-            .append_to_transcript(b"f commitment", transcript);
+        transcript.append_scalars(b"grand product claim", claims);
+        for v in self.v_commitment.iter() {
+            v.append_to_transcript(b"v commitment", transcript);
+        }
+        for f in self.f_commitment.iter() {
+            f.append_to_transcript(b"f commitment", transcript);
+        }
 
         //Next sample the tau and construct the evals poly
         let tau: Vec<C::Field> = transcript.challenge_vector(b"element for eval poly", n_rounds);
+        let r_combination: Vec<C::Field> =
+            transcript.challenge_vector(b"for the random linear comb", self.v_commitment.len());
 
         // To complete the sumcheck proof we have to validate that our polynomial openings match and are right.
         let (expected, r) = self
@@ -213,79 +214,83 @@ impl<C: CommitmentScheme> QuarkGrandProduct<C> for QuarkGrandProductProof<C> {
             .verify(C::Field::zero(), n_rounds, 3, transcript)
             .map_err(|_| QuarkError::InvalidQuarkSumcheck)?;
 
+        // Again the batch verify expects we have a slice of borrows but we have a slice of Commitments
+        let borrowed_f: Vec<&C::Commitment> = self.f_commitment.iter().collect();
+        let borrowed_v: Vec<&C::Commitment> = self.v_commitment.iter().collect();
+
         // First we will confirm that the various opening of f are correct at the points defined by r
         let mut challenge_0_r = vec![C::Field::zero()];
         challenge_0_r.append(&mut r.clone());
-        C::verify(
+        C::batch_verify(
             &self.claimed_eval_f_0_r.1,
             setup,
-            transcript,
             &challenge_0_r,
             &self.claimed_eval_f_0_r.0,
-            &self.f_commitment,
+            &borrowed_f,
+            transcript,
         )
         .map_err(|_| QuarkError::InvalidOpeningProof)?;
 
         let mut challenge_1_r = vec![C::Field::one()];
         challenge_1_r.append(&mut r.clone());
-        let point_f_1_r = &self.claimed_eval_f_1_r.0;
-        C::verify(
+        let one_r = self.claimed_eval_f_1_r.0;
+        C::batch_verify(
             &self.claimed_eval_f_1_r.1,
             setup,
-            transcript,
             &challenge_1_r,
-            point_f_1_r,
-            &self.f_commitment,
+            &one_r,
+            &borrowed_f,
+            transcript,
         )
         .map_err(|_| QuarkError::InvalidOpeningProof)?;
 
         let mut challenge_r_0 = r.clone();
         challenge_r_0.push(C::Field::zero());
-        let point_f_r_0 = &self.claimed_eval_f_r_0.0;
-        C::verify(
+        let r_0 = self.claimed_eval_f_r_0.0;
+        C::batch_verify(
             &self.claimed_eval_f_r_0.1,
             setup,
-            transcript,
             &challenge_r_0,
-            point_f_r_0,
-            &self.f_commitment,
+            &r_0,
+            &borrowed_f,
+            transcript,
         )
         .map_err(|_| QuarkError::InvalidOpeningProof)?;
 
         let mut challenge_r_1 = r.clone();
         challenge_r_1.push(C::Field::one());
-        let point_f_r_1 = &self.claimed_eval_f_r_1.0;
-        C::verify(
+        let r_1 = self.claimed_eval_f_r_1.0;
+        C::batch_verify(
             &self.claimed_eval_f_r_1.1,
             setup,
-            transcript,
             &challenge_r_1,
-            point_f_r_1,
-            &self.f_commitment,
+            &r_1,
+            &borrowed_f,
+            transcript,
         )
         .map_err(|_| QuarkError::InvalidOpeningProof)?;
 
         // We enforce that f opened at (1,1,...,1, 0) is in fact the product
         let mut challenge_sum = vec![C::Field::one(); r.len()];
         challenge_sum.push(C::Field::zero());
-        C::verify(
-            &self.sum_opening,
+        C::batch_verify(
+            &self.sum_openings,
             setup,
-            transcript,
             &challenge_sum,
-            claim,
-            &self.f_commitment,
+            claims,
+            &borrowed_f,
+            transcript,
         )
         .map_err(|_| QuarkError::InvalidOpeningProof)?;
 
         // Now we enforce that f(0, r) = v(r) via an opening proof on v
-        C::verify(
+        C::batch_verify(
             &self.v_opening_proof,
             setup,
-            transcript,
             &r,
             &self.claimed_eval_f_0_r.0,
-            &self.v_commitment,
+            &borrowed_v,
+            transcript,
         )
         .map_err(|_| QuarkError::InvalidOpeningProof)?;
 
@@ -297,13 +302,82 @@ impl<C: CommitmentScheme> QuarkGrandProduct<C> for QuarkGrandProductProof<C> {
             .product();
 
         // Finally we check that in fact the polynomial bound by the sumcheck is equal to eq(tau, r)*(f(1, r) - f(r, 0)*f(r,1))
-        let result_from_openings = eq_eval * (*point_f_1_r - *point_f_r_0 * point_f_r_1);
+        let mut result_from_openings = C::Field::zero();
+        for i in 0..r_0.len() {
+            result_from_openings += r_combination[i] * eq_eval * (one_r[i] - r_0[i] * r_1[i]);
+        }
+
         if result_from_openings != expected {
             return Err(QuarkError::InvalidBinding);
         }
 
         Ok(())
     }
+}
+
+fn v_into_f<C: CommitmentScheme>(
+    v: &DensePolynomial<C::Field>,
+    sumcheck_polys: &mut Vec<DensePolynomial<C::Field>>,
+) -> (DensePolynomial<C::Field>, C::Field) {
+    let v_length = v.len();
+    let mut f_evals = vec![C::Field::zero(); 2 * v_length];
+    let (evals, _) = v.split_evals(v.len());
+    f_evals[..v_length].clone_from_slice(evals);
+
+    // Todo (aleph_v) - problems when f length is equal to the usize
+    for i in v_length..2 * v_length {
+        let i_shift_mod = (i << 1) % (2 * v_length);
+        // The transform follows the logic of the paper and to accumulate
+        // the partial sums into the correct indices.
+        f_evals[i] = f_evals[i_shift_mod] * f_evals[i_shift_mod + 1]
+    }
+
+    // We pull out the co-efficient which instantiate the lower d polys for the sumcheck
+    let f_1_x = f_evals[v_length..].to_vec();
+
+    let mut f_x_0 = Vec::new();
+    let mut f_x_1 = Vec::new();
+    for (i, x) in f_evals.iter().enumerate() {
+        if i % 2 == 0 {
+            f_x_0.push(*x);
+        } else {
+            f_x_1.push(*x);
+        }
+    }
+
+    let f_r_0 = DensePolynomial::new(f_x_0);
+    let f_r_1 = DensePolynomial::new(f_x_1);
+    let f_1_r = DensePolynomial::new(f_1_x);
+
+    // f(1, ..., 1, 0) = P
+    let product = f_evals[2 * v_length - 2];
+    let f = DensePolynomial::new(f_evals);
+
+    // Here we push the sumcheck polys into the vector which is accumulating them.
+    // Order is important and defined by the closure of our prove arbitrary sumcheck
+    // NOTE - I don't love the pattern of passing in the mut vector but clippy fails
+    //        when we return 4 polys and a field element as its too complex of a type
+    sumcheck_polys.push(f_1_r);
+    sumcheck_polys.push(f_r_0);
+    sumcheck_polys.push(f_r_1);
+
+    (f, product)
+}
+
+// Open a set of polynomials at a point and return the openings and proof
+fn open_and_prove<C: CommitmentScheme>(
+    x: &[C::Field],
+    f_polys: &[DensePolynomial<C::Field>],
+    setup: &C::Setup,
+    transcript: &mut ProofTranscript,
+) -> (Vec<C::Field>, C::BatchedProof) {
+    let openings: Vec<C::Field> = f_polys.iter().map(|f| f.evaluate(x)).collect();
+    // Batch proof requires  &[&]
+    let borrowed: Vec<&DensePolynomial<C::Field>> = f_polys.iter().collect();
+
+    let proof = C::batch_prove(setup, &borrowed, x, &openings, BatchType::Big, transcript);
+
+    (openings, proof)
 }
 
 #[cfg(test)]
@@ -319,20 +393,27 @@ mod quark_grand_product_tests {
 
         let mut rng = rand_chacha::ChaCha20Rng::seed_from_u64(9 as u64);
 
-        let leaves: Vec<Fr> = std::iter::repeat_with(|| Fr::random(&mut rng))
+        let leaves_1: Vec<Fr> = std::iter::repeat_with(|| Fr::random(&mut rng))
             .take(LAYER_SIZE)
             .collect();
-        let known_product: Fr = leaves.iter().product();
-        let v = DensePolynomial::new(leaves);
+        let leaves_2: Vec<Fr> = std::iter::repeat_with(|| Fr::random(&mut rng))
+            .take(LAYER_SIZE)
+            .collect();
+        let known_products = vec![leaves_1.iter().product(), leaves_2.iter().product()];
+        let v_1 = DensePolynomial::new(leaves_1);
+        let v_2 = DensePolynomial::new(leaves_2);
+        let v = vec![v_1, v_2];
         let mut transcript: ProofTranscript = ProofTranscript::new(b"test_transcript");
 
         let srs = ZeromorphSRS::<Bn254>::setup(&mut rng, 1 << 9);
         let setup = srs.trim(1 << 9);
 
         let (proof, product) =
-            QuarkGrandProductProof::<Zeromorph<Bn254>>::prove(&v, &mut transcript, &setup);
+            QuarkGrandProductProof::<Zeromorph<Bn254>>::prove(v, &mut transcript, &setup);
 
-        assert_eq!(&product, &known_product, "Not the product of v");
+        for (x, y) in product.iter().zip(known_products.iter()) {
+            assert_eq!(x, y, "Proof doesn't produce correct products");
+        }
 
         // Note resetting the transcript is important
         transcript = ProofTranscript::new(b"test_transcript");

--- a/jolt-core/src/subprotocols/grand_product_quarks.rs
+++ b/jolt-core/src/subprotocols/grand_product_quarks.rs
@@ -2,7 +2,7 @@ use super::sumcheck::SumcheckInstanceProof;
 use crate::poly::commitment::commitment_scheme::{BatchType, CommitmentScheme};
 use crate::poly::dense_mlpoly::DensePolynomial;
 use crate::poly::eq_poly::EqPolynomial;
-use crate::poly::field::JoltField;
+use crate::field::JoltField;
 use crate::utils::math::Math;
 use crate::utils::transcript::{AppendToTranscript, ProofTranscript};
 use ark_serialize::*;

--- a/jolt-core/src/subprotocols/mod.rs
+++ b/jolt-core/src/subprotocols/mod.rs
@@ -1,4 +1,5 @@
 #![allow(clippy::too_many_arguments)]
 
 pub mod grand_product;
+pub mod grand_product_quarks;
 pub mod sumcheck;


### PR DESCRIPTION
Implements a version of the grand product argument from the Quarks [paper](https://eprint.iacr.org/2020/1275), this version is the simpler version from the section 5 of the paper which directly trades off increased prover time for reducing proof size from log^2(n) to just log(n). Depending on the performance we may or may not followup with a hybrid approach from section 6.

Note - This just adds the sub protocol, it doesn't wire a default proof to use quarks.