### PR TITLE
Optimize Zeromorph and HyperKZG batch opening proofs

### DIFF
--- a/jolt-core/Cargo.toml
+++ b/jolt-core/Cargo.toml
@@ -2,7 +2,7 @@
 name = "jolt-core"
 version = "0.1.0"
 authors = [
-    # author of original Spartan paper and code base 
+    # author of original Spartan paper and code base
     "Srinath Setty <srinath@microsoft.com>",
     # authors who contributed to the Arkworks Spartan fork
     "Zhenfei Zhang <zhenfei.zhang@hotmail.com>",
@@ -90,8 +90,7 @@ default = [
     "ark-ff/parallel",
     "ark-std/parallel",
     "ark-ff/asm",
-    "multicore",
     "host",
+    "rayon",
 ]
-multicore = ["rayon"]
 host = ["dep:reqwest", "dep:tokio"]

--- a/jolt-core/src/msm/mod.rs
+++ b/jolt-core/src/msm/mod.rs
@@ -84,7 +84,8 @@ fn msm_bigint_wnaf<V: VariableBaseMSM>(
         .flat_map_iter(|s| make_digits_bigint(s, c, num_bits))
         .collect::<Vec<_>>();
     let zero = V::zero();
-    let window_sums: Vec<_> = ark_std::cfg_into_iter!(0..digits_count)
+    let window_sums: Vec<_> = (0..digits_count)
+        .into_par_iter()
         .map(|i| {
             let mut buckets = vec![zero; 1 << c];
             for (digits, base) in scalar_digits.chunks(digits_count).zip(bases) {

--- a/jolt-core/src/poly/commitment/kzg.rs
+++ b/jolt-core/src/poly/commitment/kzg.rs
@@ -118,6 +118,7 @@ impl<P: Pairing> UnivariateKZG<P>
 where
     <P as Pairing>::ScalarField: JoltField,
 {
+    #[tracing::instrument(skip_all, name = "KZG::commit_offset")]
     pub fn commit_offset(
         pk: &KZGProverKey<P>,
         poly: &UniPoly<P::ScalarField>,
@@ -140,6 +141,7 @@ where
         Ok(c.into_affine())
     }
 
+    #[tracing::instrument(skip_all, name = "KZG::commit")]
     pub fn commit(
         pk: &KZGProverKey<P>,
         poly: &UniPoly<P::ScalarField>,
@@ -158,6 +160,7 @@ where
         Ok(c.into_affine())
     }
 
+    #[tracing::instrument(skip_all, name = "KZG::open")]
     pub fn open(
         pk: &KZGProverKey<P>,
         poly: &UniPoly<P::ScalarField>,

--- a/jolt-core/src/poly/unipoly.rs
+++ b/jolt-core/src/poly/unipoly.rs
@@ -57,6 +57,7 @@ impl<F: JoltField> UniPoly<F> {
 
     /// Divide self by another polynomial, and returns the
     /// quotient and remainder.
+    #[tracing::instrument(skip_all, name = "UniPoly::divide_with_remainder")]
     pub fn divide_with_remainder(&self, divisor: &Self) -> Option<(Self, Self)> {
         if self.is_zero() {
             Some((Self::zero(), Self::zero()))
@@ -114,6 +115,7 @@ impl<F: JoltField> UniPoly<F> {
         (0..self.coeffs.len()).map(|i| self.coeffs[i]).sum()
     }
 
+    #[tracing::instrument(skip_all, name = "UniPoly::evaluate")]
     pub fn evaluate(&self, r: &F) -> F {
         let mut eval = self.coeffs[0];
         let mut power = *r;
@@ -171,10 +173,7 @@ impl<F: JoltField> Mul<F> for UniPoly<F> {
     type Output = Self;
 
     fn mul(self, rhs: F) -> Self {
-        #[cfg(feature = "multicore")]
         let iter = self.coeffs.into_par_iter();
-        #[cfg(not(feature = "multicore"))]
-        let iter = self.coeffs.iter();
         Self::from_coeff(iter.map(|c| c * rhs).collect::<Vec<_>>())
     }
 }
@@ -183,10 +182,7 @@ impl<F: JoltField> Mul<&F> for UniPoly<F> {
     type Output = Self;
 
     fn mul(self, rhs: &F) -> Self {
-        #[cfg(feature = "multicore")]
         let iter = self.coeffs.into_par_iter();
-        #[cfg(not(feature = "multicore"))]
-        let iter = self.coeffs.iter();
         Self::from_coeff(iter.map(|c| c * rhs).collect::<Vec<_>>())
     }
 }

--- a/jolt-core/src/utils/mod.rs
+++ b/jolt-core/src/utils/mod.rs
@@ -1,7 +1,6 @@
 use crate::poly::field::JoltField;
 
 use ark_std::test_rng;
-#[cfg(feature = "multicore")]
 use rayon::prelude::*;
 
 pub mod errors;


### PR DESCRIPTION
Also adds some tracing spans for Zeromorph/HyperKZG and removes the last vestiges of the `multicore` feature