### PR TITLE
Updates to BatchedProduct to enable Quark section 6

### DIFF
--- a/jolt-core/src/benches/bench.rs
+++ b/jolt-core/src/benches/bench.rs
@@ -110,13 +110,13 @@ where
             preprocessing.clone(),
         );
 
-        // println!("Proof sizing:");
-        // serialize_and_print_size("jolt_commitments", &jolt_commitments);
-        // serialize_and_print_size("jolt_proof", &jolt_proof);
-        // serialize_and_print_size(" jolt_proof.r1cs", &jolt_proof.r1cs);
-        // serialize_and_print_size(" jolt_proof.bytecode", &jolt_proof.bytecode);
-        // serialize_and_print_size(" jolt_proof.read_write_memory", &jolt_proof.read_write_memory);
-        // serialize_and_print_size(" jolt_proof.instruction_lookups", &jolt_proof.instruction_lookups);
+        println!("Proof sizing:");
+        serialize_and_print_size("jolt_commitments", &jolt_commitments);
+        serialize_and_print_size("jolt_proof", &jolt_proof);
+        serialize_and_print_size(" jolt_proof.r1cs", &jolt_proof.r1cs);
+        serialize_and_print_size(" jolt_proof.bytecode", &jolt_proof.bytecode);
+        serialize_and_print_size(" jolt_proof.read_write_memory", &jolt_proof.read_write_memory);
+        serialize_and_print_size(" jolt_proof.instruction_lookups", &jolt_proof.instruction_lookups);
 
         let verification_result = RV32IJoltVM::verify(preprocessing, jolt_proof, jolt_commitments);
         assert!(

--- a/jolt-core/src/benches/bench.rs
+++ b/jolt-core/src/benches/bench.rs
@@ -115,8 +115,14 @@ where
         serialize_and_print_size("jolt_proof", &jolt_proof);
         serialize_and_print_size(" jolt_proof.r1cs", &jolt_proof.r1cs);
         serialize_and_print_size(" jolt_proof.bytecode", &jolt_proof.bytecode);
-        serialize_and_print_size(" jolt_proof.read_write_memory", &jolt_proof.read_write_memory);
-        serialize_and_print_size(" jolt_proof.instruction_lookups", &jolt_proof.instruction_lookups);
+        serialize_and_print_size(
+            " jolt_proof.read_write_memory",
+            &jolt_proof.read_write_memory,
+        );
+        serialize_and_print_size(
+            " jolt_proof.instruction_lookups",
+            &jolt_proof.instruction_lookups,
+        );
 
         let verification_result = RV32IJoltVM::verify(preprocessing, jolt_proof, jolt_commitments);
         assert!(

--- a/jolt-core/src/jolt/vm/bytecode.rs
+++ b/jolt-core/src/jolt/vm/bytecode.rs
@@ -330,7 +330,7 @@ impl<F: JoltField, C: CommitmentScheme<Field = F>> BytecodePolynomials<F, C> {
     /// Computes the shape of all commitment for use in PCS::setup().
     pub fn commit_shapes(max_bytecode_size: usize, max_trace_length: usize) -> Vec<CommitShape> {
         // Account for no-op prepended to bytecode
-        let max_bytecode_size = (max_bytecode_size + 1).next_power_of_two();
+        let max_bytecode_size = (max_bytecode_size + 1).next_power_of_two()*8;
         let max_trace_length = max_trace_length.next_power_of_two();
 
         // a_read_write, t_read, v_read_write (address, opcode, rs1, rs2, rd, imm)

--- a/jolt-core/src/jolt/vm/bytecode.rs
+++ b/jolt-core/src/jolt/vm/bytecode.rs
@@ -330,7 +330,7 @@ impl<F: JoltField, C: CommitmentScheme<Field = F>> BytecodePolynomials<F, C> {
     /// Computes the shape of all commitment for use in PCS::setup().
     pub fn commit_shapes(max_bytecode_size: usize, max_trace_length: usize) -> Vec<CommitShape> {
         // Account for no-op prepended to bytecode
-        let max_bytecode_size = (max_bytecode_size + 1).next_power_of_two() * 8;
+        let max_bytecode_size = (max_bytecode_size + 1).next_power_of_two();
         let max_trace_length = max_trace_length.next_power_of_two();
 
         // a_read_write, t_read, v_read_write (address, opcode, rs1, rs2, rd, imm)

--- a/jolt-core/src/jolt/vm/bytecode.rs
+++ b/jolt-core/src/jolt/vm/bytecode.rs
@@ -330,7 +330,7 @@ impl<F: JoltField, C: CommitmentScheme<Field = F>> BytecodePolynomials<F, C> {
     /// Computes the shape of all commitment for use in PCS::setup().
     pub fn commit_shapes(max_bytecode_size: usize, max_trace_length: usize) -> Vec<CommitShape> {
         // Account for no-op prepended to bytecode
-        let max_bytecode_size = (max_bytecode_size + 1).next_power_of_two()*8;
+        let max_bytecode_size = (max_bytecode_size + 1).next_power_of_two() * 8;
         let max_trace_length = max_trace_length.next_power_of_two();
 
         // a_read_write, t_read, v_read_write (address, opcode, rs1, rs2, rd, imm)

--- a/jolt-core/src/jolt/vm/instruction_lookups.rs
+++ b/jolt-core/src/jolt/vm/instruction_lookups.rs
@@ -277,7 +277,7 @@ where
             .chain(polynomials.E_polys.iter())
             .chain(polynomials.instruction_flag_polys.iter())
             .collect::<Vec<_>>();
-        
+
         let read_write_openings: Vec<F> = [
             openings.dim_openings.as_slice(),
             openings.read_openings.as_slice(),
@@ -448,8 +448,8 @@ where
         gamma: &F,
         tau: &F,
     ) -> (
-        <Self::ReadWriteGrandProduct as BatchedGrandProduct<F,CS>>::Leaves,
-        <Self::InitFinalGrandProduct as BatchedGrandProduct<F,CS>>::Leaves,
+        <Self::ReadWriteGrandProduct as BatchedGrandProduct<F, CS>>::Leaves,
+        <Self::InitFinalGrandProduct as BatchedGrandProduct<F, CS>>::Leaves,
     ) {
         let gamma_squared = gamma.square();
         let num_lookups = polynomials.dim[0].len();

--- a/jolt-core/src/jolt/vm/instruction_lookups.rs
+++ b/jolt-core/src/jolt/vm/instruction_lookups.rs
@@ -277,7 +277,7 @@ where
             .chain(polynomials.E_polys.iter())
             .chain(polynomials.instruction_flag_polys.iter())
             .collect::<Vec<_>>();
-
+        
         let read_write_openings: Vec<F> = [
             openings.dim_openings.as_slice(),
             openings.read_openings.as_slice(),
@@ -448,8 +448,8 @@ where
         gamma: &F,
         tau: &F,
     ) -> (
-        <Self::ReadWriteGrandProduct as BatchedGrandProduct<F>>::Leaves,
-        <Self::InitFinalGrandProduct as BatchedGrandProduct<F>>::Leaves,
+        <Self::ReadWriteGrandProduct as BatchedGrandProduct<F,CS>>::Leaves,
+        <Self::InitFinalGrandProduct as BatchedGrandProduct<F,CS>>::Leaves,
     ) {
         let gamma_squared = gamma.square();
         let num_lookups = polynomials.dim[0].len();

--- a/jolt-core/src/jolt/vm/timestamp_range_check.rs
+++ b/jolt-core/src/jolt/vm/timestamp_range_check.rs
@@ -582,7 +582,7 @@ impl<F: JoltField, C: CommitmentScheme<Field = F>> BatchedGrandProduct<F, C> for
     fn prove_grand_product(
         &mut self,
         _transcript: &mut ProofTranscript,
-        _setup: Option<&C::Setup>
+        _setup: Option<&C::Setup>,
     ) -> (BatchedGrandProductProof<C>, Vec<F>) {
         unimplemented!("init/final grand products are batched with read/write grand products")
     }
@@ -590,7 +590,7 @@ impl<F: JoltField, C: CommitmentScheme<Field = F>> BatchedGrandProduct<F, C> for
         _proof: &BatchedGrandProductProof<C>,
         _claims: &Vec<F>,
         _transcript: &mut ProofTranscript,
-        _setup: Option<&C::Setup>
+        _setup: Option<&C::Setup>,
     ) -> (Vec<F>, Vec<F>) {
         unimplemented!("init/final grand products are batched with read/write grand products")
     }
@@ -687,9 +687,11 @@ where
         let (leaves, _) =
             TimestampValidityProof::compute_leaves(&NoPreprocessing, polynomials, &gamma, &tau);
 
-        let mut batched_circuit = <BatchedDenseGrandProduct<F> as BatchedGrandProduct<F, C>>::construct(leaves);
+        let mut batched_circuit =
+            <BatchedDenseGrandProduct<F> as BatchedGrandProduct<F, C>>::construct(leaves);
 
-        let hashes: Vec<F> = <BatchedDenseGrandProduct<F> as BatchedGrandProduct<F, C>>::claims(&batched_circuit);
+        let hashes: Vec<F> =
+            <BatchedDenseGrandProduct<F> as BatchedGrandProduct<F, C>>::claims(&batched_circuit);
         let (read_write_hashes, init_final_hashes) =
             hashes.split_at(4 * MEMORY_OPS_PER_INSTRUCTION);
         let multiset_hashes = TimestampValidityProof::<F, C>::uninterleave_hashes(
@@ -739,7 +741,7 @@ where
                 &self.batched_grand_product,
                 &concatenated_hashes,
                 transcript,
-                None
+                None,
             );
 
         let openings: Vec<_> = self

--- a/jolt-core/src/jolt/vm/timestamp_range_check.rs
+++ b/jolt-core/src/jolt/vm/timestamp_range_check.rs
@@ -562,7 +562,7 @@ where
 }
 
 pub struct NoopGrandProduct;
-impl<F: JoltField> BatchedGrandProduct<F> for NoopGrandProduct {
+impl<F: JoltField, C: CommitmentScheme<Field = F>> BatchedGrandProduct<F, C> for NoopGrandProduct {
     type Leaves = ();
 
     fn construct(_leaves: Self::Leaves) -> Self {
@@ -582,13 +582,15 @@ impl<F: JoltField> BatchedGrandProduct<F> for NoopGrandProduct {
     fn prove_grand_product(
         &mut self,
         _transcript: &mut ProofTranscript,
-    ) -> (BatchedGrandProductProof<F>, Vec<F>) {
+        _setup: Option<&C::Setup>
+    ) -> (BatchedGrandProductProof<C>, Vec<F>) {
         unimplemented!("init/final grand products are batched with read/write grand products")
     }
     fn verify_grand_product(
-        _proof: &BatchedGrandProductProof<F>,
+        _proof: &BatchedGrandProductProof<C>,
         _claims: &Vec<F>,
         _transcript: &mut ProofTranscript,
+        _setup: Option<&C::Setup>
     ) -> (Vec<F>, Vec<F>) {
         unimplemented!("init/final grand products are batched with read/write grand products")
     }
@@ -603,7 +605,7 @@ where
     multiset_hashes: MultisetHashes<F>,
     openings: RangeCheckOpenings<F, C>,
     opening_proof: C::BatchedProof,
-    batched_grand_product: BatchedGrandProductProof<F>,
+    batched_grand_product: BatchedGrandProductProof<C>,
 }
 
 impl<F, C> TimestampValidityProof<F, C>
@@ -675,7 +677,7 @@ where
     fn prove_grand_products(
         polynomials: &RangeCheckPolynomials<F, C>,
         transcript: &mut ProofTranscript,
-    ) -> (BatchedGrandProductProof<F>, MultisetHashes<F>, Vec<F>) {
+    ) -> (BatchedGrandProductProof<C>, MultisetHashes<F>, Vec<F>) {
         // Fiat-Shamir randomness for multiset hashes
         let gamma: F = transcript.challenge_scalar(b"Memory checking gamma");
         let tau: F = transcript.challenge_scalar(b"Memory checking tau");
@@ -685,9 +687,9 @@ where
         let (leaves, _) =
             TimestampValidityProof::compute_leaves(&NoPreprocessing, polynomials, &gamma, &tau);
 
-        let mut batched_circuit = BatchedDenseGrandProduct::construct(leaves);
+        let mut batched_circuit = <BatchedDenseGrandProduct<F> as BatchedGrandProduct<F, C>>::construct(leaves);
 
-        let hashes: Vec<F> = batched_circuit.claims();
+        let hashes: Vec<F> = <BatchedDenseGrandProduct<F> as BatchedGrandProduct<F, C>>::claims(&batched_circuit);
         let (read_write_hashes, init_final_hashes) =
             hashes.split_at(4 * MEMORY_OPS_PER_INSTRUCTION);
         let multiset_hashes = TimestampValidityProof::<F, C>::uninterleave_hashes(
@@ -699,7 +701,7 @@ where
         multiset_hashes.append_to_transcript(transcript);
 
         let (batched_grand_product, r_grand_product) =
-            batched_circuit.prove_grand_product(transcript);
+            batched_circuit.prove_grand_product(transcript, None);
 
         drop_in_background_thread(batched_circuit);
 
@@ -737,6 +739,7 @@ where
                 &self.batched_grand_product,
                 &concatenated_hashes,
                 transcript,
+                None
             );
 
         let openings: Vec<_> = self

--- a/jolt-core/src/lasso/memory_checking.rs
+++ b/jolt-core/src/lasso/memory_checking.rs
@@ -1,7 +1,6 @@
 #![allow(clippy::too_many_arguments)]
 #![allow(clippy::type_complexity)]
 
-use crate::subprotocols::grand_product_quarks::QuarkGrandProduct;
 use crate::utils::errors::ProofVerifyError;
 use crate::utils::thread::drop_in_background_thread;
 use crate::utils::transcript::ProofTranscript;
@@ -10,7 +9,7 @@ use crate::{
         commitment::commitment_scheme::CommitmentScheme,
         structured_poly::{StructuredCommitment, StructuredOpeningProof},
     },
-    subprotocols::grand_product::{BatchedGrandProduct, BatchedGrandProductProof},
+    subprotocols::grand_product::{BatchedGrandProduct, BatchedGrandProductProof, BatchedDenseGrandProduct},
 };
 
 use crate::field::JoltField;
@@ -77,8 +76,8 @@ where
     Polynomials: StructuredCommitment<C>,
     Self: std::marker::Sync,
 {
-    type ReadWriteGrandProduct: BatchedGrandProduct<F, C> + Send + 'static = QuarkGrandProduct<F>;
-    type InitFinalGrandProduct: BatchedGrandProduct<F, C> + Send + 'static = QuarkGrandProduct<F>;
+    type ReadWriteGrandProduct: BatchedGrandProduct<F, C> + Send + 'static = BatchedDenseGrandProduct<F>;
+    type InitFinalGrandProduct: BatchedGrandProduct<F, C> + Send + 'static = BatchedDenseGrandProduct<F>;
 
     type Preprocessing = NoPreprocessing;
     type ReadWriteOpenings: StructuredOpeningProof<

--- a/jolt-core/src/lasso/memory_checking.rs
+++ b/jolt-core/src/lasso/memory_checking.rs
@@ -9,7 +9,9 @@ use crate::{
         commitment::commitment_scheme::CommitmentScheme,
         structured_poly::{StructuredCommitment, StructuredOpeningProof},
     },
-    subprotocols::grand_product::{BatchedGrandProduct, BatchedGrandProductProof, BatchedDenseGrandProduct},
+    subprotocols::grand_product::{
+        BatchedDenseGrandProduct, BatchedGrandProduct, BatchedGrandProductProof,
+    },
 };
 
 use crate::field::JoltField;
@@ -76,8 +78,10 @@ where
     Polynomials: StructuredCommitment<C>,
     Self: std::marker::Sync,
 {
-    type ReadWriteGrandProduct: BatchedGrandProduct<F, C> + Send + 'static = BatchedDenseGrandProduct<F>;
-    type InitFinalGrandProduct: BatchedGrandProduct<F, C> + Send + 'static = BatchedDenseGrandProduct<F>;
+    type ReadWriteGrandProduct: BatchedGrandProduct<F, C> + Send + 'static =
+        BatchedDenseGrandProduct<F>;
+    type InitFinalGrandProduct: BatchedGrandProduct<F, C> + Send + 'static =
+        BatchedDenseGrandProduct<F>;
 
     type Preprocessing = NoPreprocessing;
     type ReadWriteOpenings: StructuredOpeningProof<

--- a/jolt-core/src/lasso/memory_checking.rs
+++ b/jolt-core/src/lasso/memory_checking.rs
@@ -148,7 +148,7 @@ where
         preprocessing: &Self::Preprocessing,
         polynomials: &Polynomials,
         transcript: &mut ProofTranscript,
-        generators: &C::Setup,
+        pcs_setup: &C::Setup,
     ) -> (
         BatchedGrandProductProof<C>,
         BatchedGrandProductProof<C>,

--- a/jolt-core/src/lasso/memory_checking.rs
+++ b/jolt-core/src/lasso/memory_checking.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::too_many_arguments)]
 #![allow(clippy::type_complexity)]
 
-use crate::subprotocols::grand_product::BatchedDenseGrandProduct;
+use crate::subprotocols::grand_product_quarks::QuarkGrandProduct;
 use crate::utils::errors::ProofVerifyError;
 use crate::utils::thread::drop_in_background_thread;
 use crate::utils::transcript::ProofTranscript;
@@ -55,10 +55,10 @@ where
     pub multiset_hashes: MultisetHashes<F>,
     /// The read and write grand products for every memory has the same size,
     /// so they can be batched.
-    pub read_write_grand_product: BatchedGrandProductProof<F>,
+    pub read_write_grand_product: BatchedGrandProductProof<C>,
     /// The init and final grand products for every memory has the same size,
     /// so they can be batched.
-    pub init_final_grand_product: BatchedGrandProductProof<F>,
+    pub init_final_grand_product: BatchedGrandProductProof<C>,
     /// The opening proofs associated with the read/write grand product.
     pub read_write_openings: ReadWriteOpenings,
     pub read_write_opening_proof: ReadWriteOpenings::Proof,
@@ -77,10 +77,10 @@ where
     Polynomials: StructuredCommitment<C>,
     Self: std::marker::Sync,
 {
-    type ReadWriteGrandProduct: BatchedGrandProduct<F> + Send + 'static =
-        BatchedDenseGrandProduct<F>;
-    type InitFinalGrandProduct: BatchedGrandProduct<F> + Send + 'static =
-        BatchedDenseGrandProduct<F>;
+    type ReadWriteGrandProduct: BatchedGrandProduct<F, C> + Send + 'static =
+        QuarkGrandProduct<F>;
+    type InitFinalGrandProduct: BatchedGrandProduct<F, C> + Send + 'static =
+        QuarkGrandProduct<F>;
 
     type Preprocessing = NoPreprocessing;
     type ReadWriteOpenings: StructuredOpeningProof<
@@ -113,7 +113,7 @@ where
             multiset_hashes,
             r_read_write,
             r_init_final,
-        ) = Self::prove_grand_products(preprocessing, polynomials, transcript);
+        ) = Self::prove_grand_products(preprocessing, polynomials, transcript, generators);
 
         let read_write_openings = Self::ReadWriteOpenings::open(polynomials, &r_read_write);
         let read_write_opening_proof = Self::ReadWriteOpenings::prove_openings(
@@ -150,9 +150,10 @@ where
         preprocessing: &Self::Preprocessing,
         polynomials: &Polynomials,
         transcript: &mut ProofTranscript,
+        generators: &C::Setup
     ) -> (
-        BatchedGrandProductProof<F>,
-        BatchedGrandProductProof<F>,
+        BatchedGrandProductProof<C>,
+        BatchedGrandProductProof<C>,
         MultisetHashes<F>,
         Vec<F>,
         Vec<F>,
@@ -176,9 +177,9 @@ where
         multiset_hashes.append_to_transcript(transcript);
 
         let (read_write_grand_product, r_read_write) =
-            read_write_circuit.prove_grand_product(transcript);
+            read_write_circuit.prove_grand_product(transcript, Some(generators));
         let (init_final_grand_product, r_init_final) =
-            init_final_circuit.prove_grand_product(transcript);
+            init_final_circuit.prove_grand_product(transcript, Some(generators));
 
         drop_in_background_thread(read_write_circuit);
         drop_in_background_thread(init_final_circuit);
@@ -198,7 +199,7 @@ where
     fn read_write_grand_product(
         _preprocessing: &Self::Preprocessing,
         _polynomials: &Polynomials,
-        read_write_leaves: <Self::ReadWriteGrandProduct as BatchedGrandProduct<F>>::Leaves,
+        read_write_leaves: <Self::ReadWriteGrandProduct as BatchedGrandProduct<F, C>>::Leaves,
     ) -> (Self::ReadWriteGrandProduct, Vec<F>) {
         let batched_circuit = Self::ReadWriteGrandProduct::construct(read_write_leaves);
         let claims = batched_circuit.claims();
@@ -211,7 +212,7 @@ where
     fn init_final_grand_product(
         _preprocessing: &Self::Preprocessing,
         _polynomials: &Polynomials,
-        init_final_leaves: <Self::InitFinalGrandProduct as BatchedGrandProduct<F>>::Leaves,
+        init_final_leaves: <Self::InitFinalGrandProduct as BatchedGrandProduct<F, C>>::Leaves,
     ) -> (Self::InitFinalGrandProduct, Vec<F>) {
         let batched_circuit = Self::InitFinalGrandProduct::construct(init_final_leaves);
         let claims = batched_circuit.claims();
@@ -297,8 +298,8 @@ where
         gamma: &F,
         tau: &F,
     ) -> (
-        <Self::ReadWriteGrandProduct as BatchedGrandProduct<F>>::Leaves,
-        <Self::InitFinalGrandProduct as BatchedGrandProduct<F>>::Leaves,
+        <Self::ReadWriteGrandProduct as BatchedGrandProduct<F, C>>::Leaves,
+        <Self::InitFinalGrandProduct as BatchedGrandProduct<F, C>>::Leaves,
     );
 
     /// Computes the Reed-Solomon fingerprint (parametrized by `gamma` and `tau`) of the given memory `tuple`.
@@ -346,11 +347,13 @@ where
             &proof.read_write_grand_product,
             &read_write_hashes,
             transcript,
+            Some(generators)
         );
         let (claims_init_final, r_init_final) = Self::InitFinalGrandProduct::verify_grand_product(
             &proof.init_final_grand_product,
             &init_final_hashes,
             transcript,
+            Some(generators)
         );
 
         proof.read_write_openings.verify_openings(

--- a/jolt-core/src/lasso/memory_checking.rs
+++ b/jolt-core/src/lasso/memory_checking.rs
@@ -175,9 +175,9 @@ where
         multiset_hashes.append_to_transcript(transcript);
 
         let (read_write_grand_product, r_read_write) =
-            read_write_circuit.prove_grand_product(transcript, Some(generators));
+            read_write_circuit.prove_grand_product(transcript, Some(pcs_setup));
         let (init_final_grand_product, r_init_final) =
-            init_final_circuit.prove_grand_product(transcript, Some(generators));
+            init_final_circuit.prove_grand_product(transcript, Some(pcs_setup));
 
         drop_in_background_thread(read_write_circuit);
         drop_in_background_thread(init_final_circuit);

--- a/jolt-core/src/lasso/memory_checking.rs
+++ b/jolt-core/src/lasso/memory_checking.rs
@@ -77,10 +77,8 @@ where
     Polynomials: StructuredCommitment<C>,
     Self: std::marker::Sync,
 {
-    type ReadWriteGrandProduct: BatchedGrandProduct<F, C> + Send + 'static =
-        QuarkGrandProduct<F>;
-    type InitFinalGrandProduct: BatchedGrandProduct<F, C> + Send + 'static =
-        QuarkGrandProduct<F>;
+    type ReadWriteGrandProduct: BatchedGrandProduct<F, C> + Send + 'static = QuarkGrandProduct<F>;
+    type InitFinalGrandProduct: BatchedGrandProduct<F, C> + Send + 'static = QuarkGrandProduct<F>;
 
     type Preprocessing = NoPreprocessing;
     type ReadWriteOpenings: StructuredOpeningProof<
@@ -150,7 +148,7 @@ where
         preprocessing: &Self::Preprocessing,
         polynomials: &Polynomials,
         transcript: &mut ProofTranscript,
-        generators: &C::Setup
+        generators: &C::Setup,
     ) -> (
         BatchedGrandProductProof<C>,
         BatchedGrandProductProof<C>,
@@ -347,13 +345,13 @@ where
             &proof.read_write_grand_product,
             &read_write_hashes,
             transcript,
-            Some(generators)
+            Some(generators),
         );
         let (claims_init_final, r_init_final) = Self::InitFinalGrandProduct::verify_grand_product(
             &proof.init_final_grand_product,
             &init_final_hashes,
             transcript,
-            Some(generators)
+            Some(generators),
         );
 
         proof.read_write_openings.verify_openings(

--- a/jolt-core/src/lasso/surge.rs
+++ b/jolt-core/src/lasso/surge.rs
@@ -807,7 +807,7 @@ mod tests {
         let mut transcript = ProofTranscript::new(b"test_transcript");
         let preprocessing = SurgePreprocessing::preprocess();
         let generators = PedersenGenerators::new(
-            SurgeProof::<Fr, HyraxScheme<G1Projective>, XORInstruction, C, M>::num_generators(16),
+            SurgeProof::<Fr, HyraxScheme<G1Projective>, XORInstruction, C, M>::num_generators(128),
             b"LassoV1",
         );
         let proof = SurgeProof::<Fr, HyraxScheme<G1Projective>, XORInstruction, C, M>::prove(
@@ -837,7 +837,7 @@ mod tests {
         let mut transcript = ProofTranscript::new(b"test_transcript");
         let preprocessing = SurgePreprocessing::preprocess();
         let generators = PedersenGenerators::new(
-            SurgeProof::<Fr, HyraxScheme<G1Projective>, XORInstruction, C, M>::num_generators(16),
+            SurgeProof::<Fr, HyraxScheme<G1Projective>, XORInstruction, C, M>::num_generators(128),
             b"LassoV1",
         );
         let proof = SurgeProof::<Fr, HyraxScheme<G1Projective>, XORInstruction, C, M>::prove(

--- a/jolt-core/src/subprotocols/grand_product.rs
+++ b/jolt-core/src/subprotocols/grand_product.rs
@@ -446,8 +446,8 @@ impl<F: JoltField, C: CommitmentScheme<Field = F>> BatchedGrandProduct<F, C>
 
     fn claims(&self) -> Vec<F> {
         let num_layers =
-            <BatchedDenseGrandProduct<F> as BatchedGrandProduct<F, C>>::num_layers(self) - 1;
-        let last_layers = &self.layers[num_layers];
+            <BatchedDenseGrandProduct<F> as BatchedGrandProduct<F, C>>::num_layers(self);
+        let last_layers = &self.layers[num_layers - 1];
         assert_eq!(last_layers.layer_len, 2);
         last_layers
             .layers

--- a/jolt-core/src/subprotocols/grand_product.rs
+++ b/jolt-core/src/subprotocols/grand_product.rs
@@ -1,7 +1,7 @@
 use super::grand_product_quarks::QuarkGrandProductProof;
 use super::sumcheck::{BatchedCubicSumcheck, SumcheckInstanceProof};
-use crate::poly::commitment::commitment_scheme::CommitmentScheme;
 use crate::field::JoltField;
+use crate::poly::commitment::commitment_scheme::CommitmentScheme;
 use crate::poly::eq_poly::EqPolynomial;
 use crate::poly::{dense_mlpoly::DensePolynomial, unipoly::UniPoly};
 use crate::utils::math::Math;

--- a/jolt-core/src/subprotocols/grand_product.rs
+++ b/jolt-core/src/subprotocols/grand_product.rs
@@ -124,7 +124,7 @@ pub trait BatchedGrandProduct<F: JoltField, C: CommitmentScheme<Field = F>>: Siz
         r_start: Vec<F>,
     ) -> (Vec<F>, Vec<F>) {
         let mut claims_to_verify = claims.to_owned();
-        // We allow a non empty start in this function call because the quark hybrid form provides presepcifed random for
+        // We allow a non empty start in this function call because the quark hybrid form provides prespecified random for
         // most of the positions and then we proceed with GKR on the remaining layers using the preset random values.
         // For default thaler '13 layered grand products this should be empty.
         let mut r_grand_product = r_start.clone();

--- a/jolt-core/src/subprotocols/grand_product.rs
+++ b/jolt-core/src/subprotocols/grand_product.rs
@@ -124,6 +124,9 @@ pub trait BatchedGrandProduct<F: JoltField, C: CommitmentScheme<Field = F>>: Siz
         r_start: Vec<F>,
     ) -> (Vec<F>, Vec<F>) {
         let mut claims_to_verify = claims.to_owned();
+        // We allow a non empty start in this function call because the quark hybrid form provides presepcifed random for
+        // most of the positions and then we proceed with GKR on the remaining layers using the preset random values.
+        // For default thaler '13 layered grand products this should be empty.
         let mut r_grand_product = r_start.clone();
         let fixed_at_start = r_start.len();
 

--- a/jolt-core/src/subprotocols/grand_product.rs
+++ b/jolt-core/src/subprotocols/grand_product.rs
@@ -121,7 +121,7 @@ pub trait BatchedGrandProduct<F: JoltField, C: CommitmentScheme<Field = F>>: Siz
         proof_layers: &[BatchedGrandProductLayerProof<F>],
         claims: &Vec<F>,
         transcript: &mut ProofTranscript,
-        r_start: Vec<F>
+        r_start: Vec<F>,
     ) -> (Vec<F>, Vec<F>) {
         let mut claims_to_verify = claims.to_owned();
         let mut r_grand_product = r_start.clone();
@@ -187,7 +187,7 @@ pub trait BatchedGrandProduct<F: JoltField, C: CommitmentScheme<Field = F>>: Siz
         // Pass the inputs to the layer verification function, by default we have no quarks and so we do not
         // use the quark proof fields.
         let r_start = Vec::<F>::new();
-        Self::verify_layers(&proof.layers, claims, transcript,  r_start)
+        Self::verify_layers(&proof.layers, claims, transcript, r_start)
     }
 }
 

--- a/jolt-core/src/subprotocols/grand_product_quarks.rs
+++ b/jolt-core/src/subprotocols/grand_product_quarks.rs
@@ -85,7 +85,7 @@ impl<F: JoltField, C: CommitmentScheme<Field = F>> BatchedGrandProduct<F, C>
     /// The claimed outputs of the grand products.
     fn claims(&self) -> Vec<F> {
         self.polynomials
-            .iter()
+            .par_iter()
             .map(|f| f.iter().product())
             .collect()
     }


### PR DESCRIPTION
Updates the batched product type to support a quark proof or a thaler 13 proof type and changes the invocations of the product. In addition makes edits to the quark product type to support section six of the quarks paper which does a hybrid of Thaler '13 grand products by applying quarks at the 4th layer of the GKR for grand products.

Resolves #250 