### PR TITLE
fix: remove redundant bin target definition to resolve build conflict

### DIFF
--- a/examples/alloc/guest/Cargo.toml
+++ b/examples/alloc/guest/Cargo.toml
@@ -3,10 +3,6 @@ name = "alloc-guest"
 version = "0.1.0"
 edition = "2021"
 
-[[bin]]
-name = "guest"
-path = "./src/lib.rs"
-
 [features]
 guest = []
 

--- a/examples/collatz/guest/Cargo.toml
+++ b/examples/collatz/guest/Cargo.toml
@@ -3,10 +3,6 @@ name = "collatz-guest"
 version = "0.1.0"
 edition = "2021"
 
-[[bin]]
-name = "guest"
-path = "./src/lib.rs"
-
 [features]
 guest = []
 

--- a/examples/fibonacci/guest/Cargo.toml
+++ b/examples/fibonacci/guest/Cargo.toml
@@ -3,10 +3,6 @@ name = "fibonacci-guest"
 version = "0.1.0"
 edition = "2021"
 
-[[bin]]
-name = "guest"
-path = "./src/lib.rs"
-
 [features]
 guest = []
 

--- a/examples/multi-function/guest/Cargo.toml
+++ b/examples/multi-function/guest/Cargo.toml
@@ -3,10 +3,6 @@ name = "multi-function-guest"
 version = "0.1.0"
 edition = "2021"
 
-[[bin]]
-name = "guest"
-path = "./src/lib.rs"
-
 [features]
 guest = []
 

--- a/examples/sha2-chain/guest/Cargo.toml
+++ b/examples/sha2-chain/guest/Cargo.toml
@@ -3,10 +3,6 @@ name = "sha2-chain-guest"
 version = "0.1.0"
 edition = "2021"
 
-[[bin]]
-name = "guest"
-path = "./src/lib.rs"
-
 [features]
 guest = []
 

--- a/examples/sha2-ex/guest/Cargo.toml
+++ b/examples/sha2-ex/guest/Cargo.toml
@@ -3,10 +3,6 @@ name = "sha2-guest"
 version = "0.1.0"
 edition = "2021"
 
-[[bin]]
-name = "guest"
-path = "./src/lib.rs"
-
 [features]
 guest = []
 

--- a/examples/sha3-chain/guest/Cargo.toml
+++ b/examples/sha3-chain/guest/Cargo.toml
@@ -3,10 +3,6 @@ name = "sha3-chain-guest"
 version = "0.1.0"
 edition = "2021"
 
-[[bin]]
-name = "guest"
-path = "./src/lib.rs"
-
 [features]
 guest = []
 

--- a/examples/sha3-ex/guest/Cargo.toml
+++ b/examples/sha3-ex/guest/Cargo.toml
@@ -3,10 +3,6 @@ name = "sha3-guest"
 version = "0.1.0"
 edition = "2021"
 
-[[bin]]
-name = "guest"
-path = "./src/lib.rs"
-
 [features]
 guest = []
 

--- a/examples/stdlib/guest/Cargo.toml
+++ b/examples/stdlib/guest/Cargo.toml
@@ -3,10 +3,6 @@ name = "stdlib-guest"
 version = "0.1.0"
 edition = "2021"
 
-[[bin]]
-name = "guest"
-path = "./src/lib.rs"
-
 [features]
 guest = []
 

--- a/jolt-core/src/host/mod.rs
+++ b/jolt-core/src/host/mod.rs
@@ -137,9 +137,7 @@ impl Program {
                     "--target-dir",
                     &target,
                     "--target",
-                    toolchain,
-                    "--bin",
-                    "guest",
+                    toolchain
                 ])
                 .output()
                 .expect("failed to build guest");

--- a/src/main.rs
+++ b/src/main.rs
@@ -189,10 +189,6 @@ name = "guest"
 version = "0.1.0"
 edition = "2021"
 
-[[bin]]
-name = "guest"
-path = "./src/lib.rs"
-
 [features]
 guest = []
 


### PR DESCRIPTION
The file `src/lib.rs` was included in several build targets and caused a warning during the build process. This was because the file was implicitly treated as an entry point for the library (lib.rs) and explicitly defined as a binary target.

The `[[bin]]` section has been removed from the `Cargo.toml` file to resolve this conflict. In addition, the build command has been updated to remove the `--bin` flag, which is no longer necessary. The project can now be built cleanly and without warnings while maintaining the expected functionality.

Closes #323