### PR TITLE
feat: Improve Aux computation

### DIFF
--- a/jolt-core/src/r1cs/builder.rs
+++ b/jolt-core/src/r1cs/builder.rs
@@ -712,33 +712,22 @@ impl<F: JoltField, I: ConstraintInput> CombinedUniformBuilder<F, I> {
         assert_eq!(inputs.len(), I::COUNT);
         let num_aux = self.uniform_builder.num_aux();
         assert_eq!(aux.len(), num_aux);
-        inputs
-            .iter()
-            .chain(aux.iter())
-            .for_each(|inner_input| assert_eq!(inner_input.len(), self.uniform_repeat));
+        assert!(inputs.iter().chain(aux.iter()).all(|inner_input| inner_input.len() == self.uniform_repeat));
 
         let uniform_constraint_rows = self.uniform_repeat_constraint_rows();
         // TODO(sragss): Allocation can overshoot by up to a factor of 2, Spartan could handle non-pow-2 Az,Bz,Cz
         let constraint_rows = self.constraint_rows().next_power_of_two();
-
-        let _span = tracing::span!(tracing::Level::TRACE, "alloc Az, Bz, Cz");
-        let _enter = _span.enter();
         let (mut Az, mut Bz, mut Cz) = (
             unsafe_allocate_zero_vec(constraint_rows),
             unsafe_allocate_zero_vec(constraint_rows),
             unsafe_allocate_zero_vec(constraint_rows),
         );
-        drop(_enter);
-        drop(_span);
 
         let batch_inputs = |lc: &LC<I>| {
-            let mut batch: Vec<&[F]> = Vec::new();
+            let mut batch: Vec<&[F]> = Vec::with_capacity(lc.terms().len());
             lc.terms().iter().for_each(|term| match term.0 {
                 Variable::Input(input) => batch.push(&inputs[input.into()]),
-                Variable::Auxiliary(aux_index) => {
-                    assert!(aux_index < self.uniform_builder.num_aux());
-                    batch.push(&aux[aux_index]);
-                },
+                Variable::Auxiliary(aux_index) => batch.push(&aux[aux_index]),
                 _ => {}
             });
             batch
@@ -746,48 +735,49 @@ impl<F: JoltField, I: ConstraintInput> CombinedUniformBuilder<F, I> {
 
         // uniform_constraints: Xz[0..uniform_constraint_rows]
         // TODO(sragss): Attempt moving onto key and computing from materialized rows rather than linear combos
-        for (constraint_index, constraint) in self.uniform_builder.constraints.iter().enumerate() {
+        let span = tracing::span!(tracing::Level::DEBUG, "compute_constraints");
+        let enter = span.enter();
+        let az_chunks = Az.par_chunks_mut(self.uniform_repeat);
+        let bz_chunks = Bz.par_chunks_mut(self.uniform_repeat);
+        let cz_chunks = Cz.par_chunks_mut(self.uniform_repeat);
+
+        self.uniform_builder.constraints.par_iter().zip(az_chunks.zip(bz_chunks.zip(cz_chunks))).for_each(|(constraint, (az_chunk, (bz_chunk, cz_chunk)))| {
             let a_inputs = batch_inputs(&constraint.a);
             let b_inputs = batch_inputs(&constraint.b);
             let c_inputs = batch_inputs(&constraint.c);
 
-            let _span = tracing::span!(tracing::Level::TRACE, "compute_constraint");
-            let _enter = _span.enter();
-
-            let z_start = constraint_index * self.uniform_repeat;
-            let z_end = (constraint_index + 1) * self.uniform_repeat;
-            let z_range = z_start..z_end;
-
-            constraint.a.evaluate_batch_mut(&a_inputs, &mut Az[z_range.clone()]);
-            constraint.b.evaluate_batch_mut(&b_inputs, &mut Bz[z_range.clone()]);
-            constraint.c.evaluate_batch_mut(&c_inputs, &mut Cz[z_range.clone()]);
-        }
+            constraint.a.evaluate_batch_mut(&a_inputs, az_chunk);
+            constraint.b.evaluate_batch_mut(&b_inputs, bz_chunk);
+            constraint.c.evaluate_batch_mut(&c_inputs, cz_chunk);
+        });
+        drop(enter);
 
         // offset_equality_constraints: Xz[uniform_constraint_rows..uniform_constraint_rows + 1]
         // (a - b) * condition == 0
         // For the final step we will not compute the offset terms, and will assume the condition to be set to 0
-        let _span = tracing::span!(tracing::Level::TRACE, "offset eq");
-        let _enter = _span.enter();
+        let span = tracing::span!(tracing::Level::DEBUG, "offset_eq");
+        let _enter = span.enter();
 
         let constr = &self.offset_equality_constraint;
         let condition_evals = constr.cond.1.evaluate_batch(&batch_inputs(&constr.cond.1), self.uniform_repeat);
         let eq_a_evals = constr.a.1.evaluate_batch(&batch_inputs(&constr.a.1), self.uniform_repeat);
         let eq_b_evals = constr.b.1.evaluate_batch(&batch_inputs(&constr.b.1), self.uniform_repeat);
-        for step_index in 0..self.uniform_repeat {
-            let index = uniform_constraint_rows + step_index;
 
+        let Az_off = Az[uniform_constraint_rows..uniform_constraint_rows + self.uniform_repeat].par_iter_mut();
+        let Bz_off = Bz[uniform_constraint_rows..uniform_constraint_rows + self.uniform_repeat].par_iter_mut();
+
+        (0..self.uniform_repeat).into_par_iter().zip(Az_off.zip(Bz_off)).for_each(|(step_index, (az, bz))|{
             // Write corresponding values, if outside the step range, only include the constant.
-
             let a_step = step_index + if constr.a.0 { 1 } else { 0 };
             let b_step = step_index + if constr.b.0 { 1 } else { 0 };
             let a = eq_a_evals.get(a_step).cloned().unwrap_or(constr.a.1.constant_term_field());
             let b = eq_b_evals.get(b_step).cloned().unwrap_or(constr.b.1.constant_term_field());
-            Az[index] = a - b;
+            *az = a - b;
 
             let condition_step = step_index + if constr.cond.0 { 1 } else { 0 };
-            Bz[index] = condition_evals.get(condition_step).cloned().unwrap_or(constr.cond.1.constant_term_field());
-        }
-        
+            *bz = condition_evals.get(condition_step).cloned().unwrap_or(constr.cond.1.constant_term_field());
+        });
+
         (Az, Bz, Cz)
     }
 

--- a/jolt-core/src/r1cs/jolt_constraints.rs
+++ b/jolt-core/src/r1cs/jolt_constraints.rs
@@ -37,6 +37,7 @@ pub fn construct_jolt_constraints<F: JoltField>(
     PartialEq,
     Eq,
     PartialOrd,
+    Hash,
     Ord,
 )]
 #[repr(usize)]

--- a/jolt-core/src/r1cs/ops.rs
+++ b/jolt-core/src/r1cs/ops.rs
@@ -1,7 +1,7 @@
 //! Defines the Linear Combination (LC) object and associated operations.
 //! A LinearCombination is a vector of Terms, where each Term is a pair of a Variable and a coefficient.
 
-use crate::field::JoltField;
+use crate::{field::JoltField, utils::thread::unsafe_allocate_zero_vec};
 use std::fmt::Debug;
 use strum::{EnumCount, IntoEnumIterator};
 use rayon::prelude::*;
@@ -111,7 +111,7 @@ impl<I: ConstraintInput> LC<I> {
     pub fn evaluate_batch<F: JoltField>(&self, inputs: &[&[F]], batch_size: usize) -> Vec<F> {
         assert!(inputs.iter().all(|inner| inner.len() == batch_size));
 
-        let mut output = vec![F::zero(); batch_size];
+        let mut output = unsafe_allocate_zero_vec(batch_size);
         self.evaluate_batch_mut(inputs, &mut output);
         output
     }

--- a/jolt-core/src/r1cs/ops.rs
+++ b/jolt-core/src/r1cs/ops.rs
@@ -2,9 +2,10 @@
 //! A LinearCombination is a vector of Terms, where each Term is a pair of a Variable and a coefficient.
 
 use crate::{field::JoltField, utils::thread::unsafe_allocate_zero_vec};
-use std::fmt::Debug;
-use strum::{EnumCount, IntoEnumIterator};
 use rayon::prelude::*;
+use std::fmt::Debug;
+use std::hash::Hash;
+use strum::{EnumCount, IntoEnumIterator};
 
 pub trait ConstraintInput:
     Clone
@@ -17,23 +18,25 @@ pub trait ConstraintInput:
     + IntoEnumIterator
     + EnumCount
     + Into<usize>
+    + Hash
     + Sync
+    + Send
     + 'static
 {
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum Variable<I: ConstraintInput> {
     Input(I),
     Auxiliary(usize),
     Constant,
 }
 
-#[derive(Clone, Copy, PartialEq)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
 pub struct Term<I: ConstraintInput>(pub Variable<I>, pub i64);
 
 /// Linear Combination of terms.
-#[derive(Clone)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct LC<I: ConstraintInput>(Vec<Term<I>>);
 
 impl<I: ConstraintInput> LC<I> {
@@ -109,28 +112,36 @@ impl<I: ConstraintInput> LC<I> {
     }
 
     pub fn evaluate_batch<F: JoltField>(&self, inputs: &[&[F]], batch_size: usize) -> Vec<F> {
-        assert!(inputs.iter().all(|inner| inner.len() == batch_size));
-
         let mut output = unsafe_allocate_zero_vec(batch_size);
         self.evaluate_batch_mut(inputs, &mut output);
         output
     }
 
+    #[tracing::instrument(skip_all, name = "LC::evaluate_batch_mut")]
     pub fn evaluate_batch_mut<F: JoltField>(&self, inputs: &[&[F]], output: &mut [F]) {
         let batch_size = output.len();
-        assert!(inputs.iter().all(|inner| inner.len() == batch_size));
+        inputs
+            .iter()
+            .for_each(|inner| assert_eq!(inner.len(), batch_size));
 
         let terms: Vec<F> = self.to_field_elements();
 
-        output.par_iter_mut().enumerate().for_each(|(batch_index, output_slot)| {
-            *output_slot = self.terms().iter().enumerate()
-                .map(|(term_index, term)| match term.0 {
-                    Variable::Input(_) | Variable::Auxiliary(_) => 
-                        terms[term_index].mul_01_optimized(inputs[term_index][batch_index]),
-                    Variable::Constant => terms[term_index],
-
-                }).sum();
-        });
+        output
+            .par_iter_mut()
+            .enumerate()
+            .for_each(|(batch_index, output_slot)| {
+                *output_slot = self
+                    .terms()
+                    .iter()
+                    .enumerate()
+                    .map(|(term_index, term)| match term.0 {
+                        Variable::Input(_) | Variable::Auxiliary(_) => {
+                            terms[term_index].mul_01_optimized(inputs[term_index][batch_index])
+                        }
+                        Variable::Constant => terms[term_index],
+                    })
+                    .sum();
+            });
     }
 
     #[cfg(test)]
@@ -454,7 +465,7 @@ mod test {
 
     use super::*;
 
-    #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, EnumCount, EnumIter)]
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, EnumCount, EnumIter, Hash)]
     #[repr(usize)]
     enum Inputs {
         A,

--- a/jolt-core/src/r1cs/test.rs
+++ b/jolt-core/src/r1cs/test.rs
@@ -21,6 +21,7 @@ use super::{
     Eq,
     PartialOrd,
     Ord,
+    Hash,
 )]
 #[repr(usize)]
 pub enum SimpTestIn {
@@ -42,6 +43,7 @@ impl_r1cs_input_lc_conversions!(SimpTestIn);
     Eq,
     PartialOrd,
     Ord,
+    Hash,
 )]
 #[repr(usize)]
 pub enum TestInputs {


### PR DESCRIPTION
Aux computation now deduplicates evaluation of Linear Combinations shared across the auxiliary variables. 28% of Linear Combinations are currently reused in `jolt_constraints.rs` and were previously computed from scratch. 35% speed up over existing on 2^22 trace length 50bps reduction e2e.

In the process removes `AuxComputation.{flat_vars, inputs_to_flat}`.

Separately speeds up + cleans up `CombinedUniformBuilder::compute_spartan_Az_Bz_Cz` by moving the batch LC evaluation logic onto LC.