### PR TITLE
fib_e2e: Actually use the type parameters 🙃

### DIFF
--- a/jolt-core/src/jolt/vm/rv32i_vm.rs
+++ b/jolt-core/src/jolt/vm/rv32i_vm.rs
@@ -218,13 +218,12 @@ mod tests {
 
         let preprocessing =
             RV32IJoltVM::preprocess(bytecode.clone(), memory_init, 1 << 20, 1 << 20, 1 << 20);
-        let (proof, commitments) =
-            <RV32IJoltVM as Jolt<Fr, HyraxScheme<G1Projective>, C, M>>::prove(
-                io_device,
-                trace,
-                circuit_flags,
-                preprocessing.clone(),
-            );
+        let (proof, commitments) = <RV32IJoltVM as Jolt<F, PCS, C, M>>::prove(
+            io_device,
+            trace,
+            circuit_flags,
+            preprocessing.clone(),
+        );
         let verification_result = RV32IJoltVM::verify(preprocessing, proof, commitments);
         assert!(
             verification_result.is_ok(),


### PR DESCRIPTION
`fib_e2e` is parameterized with `<F: JoltField, PCS: CommitmentScheme<Field = F>>`, but is currently using a concrete field and commitment scheme instead of them:
```rust
let (proof, commitments) =
    <RV32IJoltVM as Jolt<Fr, HyraxScheme<G1Projective>, C, M>>::prove(
        io_device,
        trace,
        circuit_flags,
        preprocessing.clone(),
    );
```

Given there are multiple tests calling `fib_e2e` with different implementations of JoltField and CommitmentScheme, this is probably not intended. 

