### PR TITLE
Install Jolt RISC-V toolchain before running tests

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -46,10 +46,13 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: actions-rust-lang/setup-rust-toolchain@v1
-      - name: Build and install Jolt
-        run: cargo install --path .
+      - name: Cache Jolt RISC-V Rust toolchain
+        uses: actions/cache@v4
+        with:
+          key: jolt-rust-toolchain-${{hashFiles('.jolt.rust.toolchain-tag')}}
+          path: ~/.jolt
       - name: Install Jolt RISC-V Rust toolchain
-        run: jolt install-toolchain
+        run: cargo run install-toolchain
       - name: Install nextest
         uses: taiki-e/install-action@nextest
       - name: Run jolt-core tests

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -22,9 +22,6 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           components: rustfmt
-      - uses: Swatinem/rust-cache@v2
-        with:
-          cache-on-failure: true
       - name: cargo fmt
         uses: actions-rs/cargo@v1
         with:
@@ -38,9 +35,6 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           components: clippy
-      - uses: Swatinem/rust-cache@v2
-        with:
-          cache-on-failure: true
       - name: cargo clippy
         uses: actions-rs/cargo@v1
         with:
@@ -52,10 +46,11 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: actions-rust-lang/setup-rust-toolchain@v1
-      - uses: Swatinem/rust-cache@v2
-        with:
-          cache-on-failure: true
+      - name: Build and install Jolt
+        run: cargo install --path .
+      - name: Install Jolt RISC-V Rust toolchain
+        run: jolt install-toolchain
       - name: Install nextest
         uses: taiki-e/install-action@nextest
-      - name: run jolt-core tests
+      - name: Run jolt-core tests
         run: cargo nextest run -p jolt-core

--- a/.jolt.rust.toolchain-tag
+++ b/.jolt.rust.toolchain-tag
@@ -1,0 +1,1 @@
+nightly-3c5f0ec3f4f98a2d211061a83bade8d62c6a6135

--- a/jolt-core/src/host/toolchain.rs
+++ b/jolt-core/src/host/toolchain.rs
@@ -11,7 +11,7 @@ use indicatif::{ProgressBar, ProgressStyle};
 use reqwest::Client;
 use tokio::runtime::Runtime;
 
-const TOOLCHAIN_TAG: &str = "nightly-3c5f0ec3f4f98a2d211061a83bade8d62c6a6135";
+const TOOLCHAIN_TAG: &str = include_str!("../../../.jolt.rust.toolchain-tag");
 const DOWNLOAD_RETRIES: usize = 5;
 const DELAY_BASE_MS: u64 = 500;
 


### PR DESCRIPTION
Let tests rely on toolchain already being present.

Fix #376 