### PR TITLE
Fix tokio — this fixes latest compile errors in CI

### DIFF
--- a/jolt-core/Cargo.toml
+++ b/jolt-core/Cargo.toml
@@ -65,7 +65,7 @@ dirs = "5.0.1"
 eyre = "0.6.12"
 indicatif = "0.17.8"
 memory-stats = "1.0.0"
-tokio = { version = "1.37.0", optional = true }
+tokio = { version = "1.38.0", optional = true, features = ["rt-multi-thread"] }
 
 common = { path = "../common" }
 tracer = { path = "../tracer" }


### PR DESCRIPTION
This fixes errors that have started popping up in clippy and test CI runs today:

```
    Checking jolt-core v0.1.0 (/home/runner/work/jolt/jolt/jolt-core)
error[E0599]: no function or associated item named `new` found for struct `tokio::runtime::Runtime` in the current scope
Error:    --> jolt-core/src/host/toolchain.rs:24:27
    |
24  |         let rt = Runtime::new().unwrap();
    |                           ^^^ function or associated item not found in `Runtime`
    |
note: if you're trying to build a new `tokio::runtime::Runtime`, consider using `tokio::runtime::Runtime::from_parts` which returns `tokio::runtime::Runtime`
   --> /home/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.38.0/src/runtime/runtime.rs:138:5
    |
138 | /     pub(super) fn from_parts(
139 | |         scheduler: Scheduler,
140 | |         handle: Handle,
141 | |         blocking_pool: BlockingPool,
142 | |     ) -> Runtime {
    | |________________^
    = help: items from traits can only be used if the trait is implemented and in scope
note: `field::binius::BiniusConstructable` defines an item `new`, perhaps you need to implement it
   --> jolt-core/src/field/binius.rs:25:1
    |
25  | pub trait BiniusConstructable {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

For more information about this error, try `rustc --explain E0599`.
error: could not compile `jolt-core` (lib) due to 1 previous error
Error: The process '/home/runner/.cargo/bin/cargo' failed with exit code 101
```