### PR TITLE
Adds an onchain compatible transcript and removes Merlin

### DIFF
--- a/jolt-core/Cargo.toml
+++ b/jolt-core/Cargo.toml
@@ -29,7 +29,6 @@ ark-serialize = { version = "0.4.2", default-features = false, features = [
 ark-std = { version = "0.4.0" }
 binius-field = { git = "https://gitlab.com/UlvetannaOSS/binius", package = "binius_field"}
 clap = { version = "4.3.10", features = ["derive"] }
-digest = "0.8.1"
 enum_dispatch = "0.3.12"
 fixedbitset = "0.5.0"
 itertools = "0.10.0"
@@ -45,7 +44,7 @@ rand_core = { version = "0.6.4", default-features = false }
 rayon = { version = "^1.8.0", optional = true }
 rgb = "0.8.37"
 serde = { version = "1.0.*", default-features = false }
-sha3 = "0.8.2"
+sha3 = "0.10.8"
 smallvec = "1.13.1"
 strum = "0.25.0"
 strum_macros = "0.25.2"

--- a/jolt-core/src/jolt/vm/bytecode.rs
+++ b/jolt-core/src/jolt/vm/bytecode.rs
@@ -350,15 +350,14 @@ pub struct BytecodeCommitment<C: CommitmentScheme> {
 }
 
 impl<C: CommitmentScheme> AppendToTranscript for BytecodeCommitment<C> {
-    fn append_to_transcript(&self, label: &'static [u8], transcript: &mut ProofTranscript) {
-        transcript.append_protocol_name(label);
+    fn append_to_transcript(&self, transcript: &mut ProofTranscript) {
+        transcript.append_protocol_name(b"Bytecode Commitments");
 
         for commitment in &self.trace_commitments {
-            commitment.append_to_transcript(b"trace", transcript);
+            commitment.append_to_transcript(transcript);
         }
 
-        self.t_final_commitment
-            .append_to_transcript(b"final", transcript);
+        self.t_final_commitment.append_to_transcript(transcript);
     }
 }
 

--- a/jolt-core/src/jolt/vm/instruction_lookups.rs
+++ b/jolt-core/src/jolt/vm/instruction_lookups.rs
@@ -617,7 +617,7 @@ where
     }
 
     fn protocol_name() -> &'static [u8] {
-        b"Instruction lookups memory checking"
+        b"Instruction lookups check"
     }
 }
 

--- a/jolt-core/src/jolt/vm/instruction_lookups.rs
+++ b/jolt-core/src/jolt/vm/instruction_lookups.rs
@@ -79,15 +79,15 @@ pub struct InstructionCommitment<C: CommitmentScheme> {
 }
 
 impl<C: CommitmentScheme> AppendToTranscript for InstructionCommitment<C> {
-    fn append_to_transcript(&self, label: &'static [u8], transcript: &mut ProofTranscript) {
-        transcript.append_message(label, b"InstructionCommitment_begin");
+    fn append_to_transcript(&self, transcript: &mut ProofTranscript) {
+        transcript.append_message(b"InstructionCommitment_begin");
         for commitment in &self.trace_commitment {
-            commitment.append_to_transcript(b"trace_commitment", transcript);
+            commitment.append_to_transcript(transcript);
         }
         for commitment in &self.final_commitment {
-            commitment.append_to_transcript(b"final_commitment", transcript);
+            commitment.append_to_transcript(transcript);
         }
-        transcript.append_message(label, b"InstructionCommitment_end");
+        transcript.append_message(b"InstructionCommitment_end");
     }
 }
 
@@ -817,7 +817,7 @@ where
         transcript.append_protocol_name(Self::protocol_name());
 
         let trace_length = polynomials.dim[0].len();
-        let r_eq = transcript.challenge_vector(b"Jolt instruction lookups", trace_length.log_2());
+        let r_eq = transcript.challenge_vector(trace_length.log_2());
 
         let eq_evals: Vec<F> = EqPolynomial::evals(&r_eq);
         let mut eq_poly = DensePolynomial::new(eq_evals);
@@ -876,10 +876,7 @@ where
     ) -> Result<(), ProofVerifyError> {
         transcript.append_protocol_name(Self::protocol_name());
 
-        let r_eq = transcript.challenge_vector(
-            b"Jolt instruction lookups",
-            proof.primary_sumcheck.num_rounds,
-        );
+        let r_eq = transcript.challenge_vector(proof.primary_sumcheck.num_rounds);
 
         // TODO: compartmentalize all primary sumcheck logic
         let (claim_last, r_primary_sumcheck) = proof.primary_sumcheck.sumcheck_proof.verify(
@@ -1264,9 +1261,9 @@ where
         round_uni_poly: UniPoly<F>,
         transcript: &mut ProofTranscript,
     ) -> F {
-        round_uni_poly.append_to_transcript(b"poly", transcript);
+        round_uni_poly.append_to_transcript(transcript);
 
-        transcript.challenge_scalar::<F>(b"challenge_nextround")
+        transcript.challenge_scalar::<F>()
     }
 
     /// Combines the subtable values given by `vals` and the flag values given by `flags`.

--- a/jolt-core/src/jolt/vm/mod.rs
+++ b/jolt-core/src/jolt/vm/mod.rs
@@ -125,17 +125,11 @@ pub struct JoltCommitments<PCS: CommitmentScheme> {
 
 impl<PCS: CommitmentScheme> JoltCommitments<PCS> {
     fn append_to_transcript(&self, transcript: &mut ProofTranscript) {
-        self.bytecode.append_to_transcript(b"bytecode", transcript);
-        self.read_write_memory
-            .append_to_transcript(b"read_write_memory", transcript);
-        self.timestamp_range_check
-            .append_to_transcript(b"timestamp_range_check", transcript);
-        self.instruction_lookups
-            .append_to_transcript(b"instruction_lookups", transcript);
-        self.r1cs
-            .as_ref()
-            .unwrap()
-            .append_to_transcript(b"r1cs", transcript);
+        self.bytecode.append_to_transcript(transcript);
+        self.read_write_memory.append_to_transcript(transcript);
+        self.timestamp_range_check.append_to_transcript(transcript);
+        self.instruction_lookups.append_to_transcript(transcript);
+        self.r1cs.as_ref().unwrap().append_to_transcript(transcript);
     }
 }
 
@@ -375,7 +369,7 @@ pub trait Jolt<F: JoltField, PCS: CommitmentScheme<Field = F>, const C: usize, c
             padded_trace_length,
         );
 
-        transcript.append_scalar(b"spartan key", &spartan_key.vk_digest);
+        transcript.append_scalar(&spartan_key.vk_digest);
 
         jolt_commitments.r1cs = Some(r1cs_commitments);
         jolt_commitments.append_to_transcript(&mut transcript);
@@ -439,7 +433,7 @@ pub trait Jolt<F: JoltField, PCS: CommitmentScheme<Field = F>, const C: usize, c
         Self::fiat_shamir_preamble(&mut transcript, &proof.program_io, proof.trace_length);
 
         // append the digest of vk (which includes R1CS matrices) and the RelaxedR1CSInstance to the transcript
-        transcript.append_scalar(b"spartan key", &proof.r1cs.key.vk_digest);
+        transcript.append_scalar(&proof.r1cs.key.vk_digest);
 
         commitments.append_to_transcript(&mut transcript);
 
@@ -688,16 +682,16 @@ pub trait Jolt<F: JoltField, PCS: CommitmentScheme<Field = F>, const C: usize, c
         program_io: &JoltDevice,
         trace_length: usize,
     ) {
-        transcript.append_u64(b"Unpadded trace length", trace_length as u64);
-        transcript.append_u64(b"C", C as u64);
-        transcript.append_u64(b"M", M as u64);
-        transcript.append_u64(b"# instructions", Self::InstructionSet::COUNT as u64);
-        transcript.append_u64(b"# subtables", Self::Subtables::COUNT as u64);
-        transcript.append_u64(b"Max input size", program_io.memory_layout.max_input_size);
-        transcript.append_u64(b"Max output size", program_io.memory_layout.max_output_size);
-        transcript.append_bytes(b"Program inputs", &program_io.inputs);
-        transcript.append_bytes(b"Program outputs", &program_io.outputs);
-        transcript.append_u64(b"Program panic", program_io.panic as u64);
+        transcript.append_u64(trace_length as u64);
+        transcript.append_u64(C as u64);
+        transcript.append_u64(M as u64);
+        transcript.append_u64(Self::InstructionSet::COUNT as u64);
+        transcript.append_u64(Self::Subtables::COUNT as u64);
+        transcript.append_u64(program_io.memory_layout.max_input_size);
+        transcript.append_u64(program_io.memory_layout.max_output_size);
+        transcript.append_bytes(&program_io.inputs);
+        transcript.append_bytes(&program_io.outputs);
+        transcript.append_u64(program_io.panic as u64);
     }
 }
 

--- a/jolt-core/src/jolt/vm/read_write_memory.rs
+++ b/jolt-core/src/jolt/vm/read_write_memory.rs
@@ -964,16 +964,14 @@ pub struct MemoryCommitment<C: CommitmentScheme> {
 }
 
 impl<C: CommitmentScheme> AppendToTranscript for MemoryCommitment<C> {
-    fn append_to_transcript(&self, label: &'static [u8], transcript: &mut ProofTranscript) {
-        transcript.append_message(label, b"MemoryCommitment_begin");
+    fn append_to_transcript(&self, transcript: &mut ProofTranscript) {
+        transcript.append_message(b"MemoryCommitment_begin");
         for commitment in &self.trace_commitments {
-            commitment.append_to_transcript(b"trace_commit", transcript);
+            commitment.append_to_transcript(transcript);
         }
-        self.v_final_commitment
-            .append_to_transcript(b"v_final_commit", transcript);
-        self.t_final_commitment
-            .append_to_transcript(b"t_final_commit", transcript);
-        transcript.append_message(label, b"MemoryCommitment_end");
+        self.v_final_commitment.append_to_transcript(transcript);
+        self.t_final_commitment.append_to_transcript(transcript);
+        transcript.append_message(b"MemoryCommitment_end");
     }
 }
 
@@ -1510,7 +1508,7 @@ where
         transcript: &mut ProofTranscript,
     ) -> Self {
         let num_rounds = polynomials.memory_size.log_2();
-        let r_eq = transcript.challenge_vector(b"output_sumcheck", num_rounds);
+        let r_eq = transcript.challenge_vector(num_rounds);
         let eq: DensePolynomial<F> = DensePolynomial::new(EqPolynomial::evals(&r_eq));
 
         let io_witness_range: Vec<_> = (0..polynomials.memory_size as u64)
@@ -1588,7 +1586,7 @@ where
         commitment: &MemoryCommitment<C>,
         transcript: &mut ProofTranscript,
     ) -> Result<(), ProofVerifyError> {
-        let r_eq = transcript.challenge_vector(b"output_sumcheck", proof.num_rounds);
+        let r_eq = transcript.challenge_vector(proof.num_rounds);
 
         let (sumcheck_claim, r_sumcheck) =
             proof

--- a/jolt-core/src/jolt/vm/timestamp_range_check.rs
+++ b/jolt-core/src/jolt/vm/timestamp_range_check.rs
@@ -172,12 +172,12 @@ pub struct RangeCheckCommitment<C: CommitmentScheme> {
 }
 
 impl<C: CommitmentScheme> AppendToTranscript for RangeCheckCommitment<C> {
-    fn append_to_transcript(&self, label: &'static [u8], transcript: &mut ProofTranscript) {
-        transcript.append_message(label, b"RangeCheckCommitment_begin");
+    fn append_to_transcript(&self, transcript: &mut ProofTranscript) {
+        transcript.append_message(b"RangeCheckCommitment_begin");
         for commitment in &self.commitments {
-            commitment.append_to_transcript(b"range", transcript);
+            commitment.append_to_transcript(transcript);
         }
-        transcript.append_message(label, b"RangeCheckCommitment_end");
+        transcript.append_message(b"RangeCheckCommitment_end");
     }
 }
 
@@ -680,8 +680,8 @@ where
         setup: &C::Setup,
     ) -> (BatchedGrandProductProof<C>, MultisetHashes<F>, Vec<F>) {
         // Fiat-Shamir randomness for multiset hashes
-        let gamma: F = transcript.challenge_scalar(b"Memory checking gamma");
-        let tau: F = transcript.challenge_scalar(b"Memory checking tau");
+        let gamma: F = transcript.challenge_scalar();
+        let tau: F = transcript.challenge_scalar();
 
         transcript.append_protocol_name(Self::protocol_name());
 
@@ -719,8 +719,8 @@ where
         transcript: &mut ProofTranscript,
     ) -> Result<(), ProofVerifyError> {
         // Fiat-Shamir randomness for multiset hashes
-        let gamma: F = transcript.challenge_scalar(b"Memory checking gamma");
-        let tau: F = transcript.challenge_scalar(b"Memory checking tau");
+        let gamma: F = transcript.challenge_scalar();
+        let tau: F = transcript.challenge_scalar();
 
         transcript.append_protocol_name(Self::protocol_name());
 

--- a/jolt-core/src/jolt/vm/timestamp_range_check.rs
+++ b/jolt-core/src/jolt/vm/timestamp_range_check.rs
@@ -453,7 +453,7 @@ where
     }
 
     fn protocol_name() -> &'static [u8] {
-        b"Timestamp validity proof memory checking"
+        b"Timestamp Validity Proof"
     }
 }
 
@@ -831,6 +831,6 @@ where
     }
 
     fn protocol_name() -> &'static [u8] {
-        b"Timestamp validity proof memory checking"
+        b"Timestamp Validity Proof"
     }
 }

--- a/jolt-core/src/lasso/memory_checking.rs
+++ b/jolt-core/src/lasso/memory_checking.rs
@@ -35,10 +35,10 @@ pub struct MultisetHashes<F: JoltField> {
 
 impl<F: JoltField> MultisetHashes<F> {
     pub fn append_to_transcript(&self, transcript: &mut ProofTranscript) {
-        transcript.append_scalars(b"Read multiset hashes", &self.read_hashes);
-        transcript.append_scalars(b"Write multiset hashes", &self.write_hashes);
-        transcript.append_scalars(b"Init multiset hashes", &self.init_hashes);
-        transcript.append_scalars(b"Final multiset hashes", &self.final_hashes);
+        transcript.append_scalars(&self.read_hashes);
+        transcript.append_scalars(&self.write_hashes);
+        transcript.append_scalars(&self.init_hashes);
+        transcript.append_scalars(&self.final_hashes);
     }
 }
 
@@ -160,8 +160,8 @@ where
         Vec<F>,
     ) {
         // Fiat-Shamir randomness for multiset hashes
-        let gamma: F = transcript.challenge_scalar(b"Memory checking gamma");
-        let tau: F = transcript.challenge_scalar(b"Memory checking tau");
+        let gamma: F = transcript.challenge_scalar();
+        let tau: F = transcript.challenge_scalar();
 
         transcript.append_protocol_name(Self::protocol_name());
 
@@ -333,8 +333,8 @@ where
         transcript: &mut ProofTranscript,
     ) -> Result<(), ProofVerifyError> {
         // Fiat-Shamir randomness for multiset hashes
-        let gamma: F = transcript.challenge_scalar(b"Memory checking gamma");
-        let tau: F = transcript.challenge_scalar(b"Memory checking tau");
+        let gamma: F = transcript.challenge_scalar();
+        let tau: F = transcript.challenge_scalar();
 
         transcript.append_protocol_name(Self::protocol_name());
 

--- a/jolt-core/src/lasso/surge.rs
+++ b/jolt-core/src/lasso/surge.rs
@@ -383,7 +383,7 @@ where
     }
 
     fn protocol_name() -> &'static [u8] {
-        b"Surge memory checking"
+        b"SurgeMemCheck"
     }
 }
 

--- a/jolt-core/src/lasso/surge.rs
+++ b/jolt-core/src/lasso/surge.rs
@@ -579,11 +579,11 @@ where
         // TODO(sragss): Commit some of this stuff to transcript?
 
         // Primary sumcheck
-        let r_primary_sumcheck = transcript.challenge_vector(b"primary_sumcheck", num_rounds);
+        let r_primary_sumcheck = transcript.challenge_vector(num_rounds);
         let eq: DensePolynomial<F> = DensePolynomial::new(EqPolynomial::evals(&r_primary_sumcheck));
         let sumcheck_claim: F = Self::compute_primary_sumcheck_claim(&polynomials, &eq);
 
-        transcript.append_scalar(b"sumcheck_claim", &sumcheck_claim);
+        transcript.append_scalar(&sumcheck_claim);
         let mut combined_sumcheck_polys = polynomials.E_polys.clone();
         combined_sumcheck_polys.push(eq);
 
@@ -638,13 +638,9 @@ where
         transcript.append_protocol_name(Self::protocol_name());
         let instruction = Instruction::default();
 
-        let r_primary_sumcheck =
-            transcript.challenge_vector(b"primary_sumcheck", proof.primary_sumcheck.num_rounds);
+        let r_primary_sumcheck = transcript.challenge_vector(proof.primary_sumcheck.num_rounds);
 
-        transcript.append_scalar(
-            b"sumcheck_claim",
-            &proof.primary_sumcheck.claimed_evaluation,
-        );
+        transcript.append_scalar(&proof.primary_sumcheck.claimed_evaluation);
         let primary_sumcheck_poly_degree = instruction.g_poly_degree(C) + 1;
         let (claim_last, r_z) = proof.primary_sumcheck.sumcheck_proof.verify(
             proof.primary_sumcheck.claimed_evaluation,

--- a/jolt-core/src/poly/commitment/binius.rs
+++ b/jolt-core/src/poly/commitment/binius.rs
@@ -15,7 +15,7 @@ pub struct Binius128Scheme {}
 pub struct BiniusCommitment {}
 
 impl AppendToTranscript for BiniusCommitment {
-    fn append_to_transcript(&self, _label: &[u8], _transcript: &mut ProofTranscript) {
+    fn append_to_transcript(&self, _transcript: &mut ProofTranscript) {
         todo!()
     }
 }

--- a/jolt-core/src/poly/commitment/hyrax.rs
+++ b/jolt-core/src/poly/commitment/hyrax.rs
@@ -215,12 +215,12 @@ impl<F: JoltField, G: CurveGroup<ScalarField = F>> HyraxCommitment<G> {
 }
 
 impl<G: CurveGroup> AppendToTranscript for HyraxCommitment<G> {
-    fn append_to_transcript(&self, label: &'static [u8], transcript: &mut ProofTranscript) {
-        transcript.append_message(label, b"poly_commitment_begin");
+    fn append_to_transcript(&self, transcript: &mut ProofTranscript) {
+        transcript.append_message(b"poly_commitment_begin");
         for i in 0..self.row_commitments.len() {
-            transcript.append_point(b"poly_commitment_share", &self.row_commitments[i]);
+            transcript.append_point(&self.row_commitments[i]);
         }
-        transcript.append_message(label, b"poly_commitment_end");
+        transcript.append_message(b"poly_commitment_end");
     }
 }
 
@@ -340,10 +340,9 @@ impl<F: JoltField, G: CurveGroup<ScalarField = F>> BatchedHyraxOpeningProof<G> {
         transcript.append_protocol_name(Self::protocol_name());
 
         // append the claimed evaluations to transcript
-        transcript.append_scalars(b"evals_ops_val", openings);
+        transcript.append_scalars(openings);
 
-        let rlc_coefficients: Vec<_> =
-            transcript.challenge_vector(b"challenge_combine_n_to_one", polynomials.len());
+        let rlc_coefficients: Vec<_> = transcript.challenge_vector(polynomials.len());
 
         let _span = trace_span!("Compute RLC of polynomials");
         let _enter = _span.enter();
@@ -425,10 +424,9 @@ impl<F: JoltField, G: CurveGroup<ScalarField = F>> BatchedHyraxOpeningProof<G> {
         transcript.append_protocol_name(Self::protocol_name());
 
         // append the claimed evaluations to transcript
-        transcript.append_scalars(b"evals_ops_val", openings);
+        transcript.append_scalars(openings);
 
-        let rlc_coefficients: Vec<_> =
-            transcript.challenge_vector(b"challenge_combine_n_to_one", openings.len());
+        let rlc_coefficients: Vec<_> = transcript.challenge_vector(openings.len());
 
         let rlc_eval = compute_dotproduct(&rlc_coefficients, openings);
 

--- a/jolt-core/src/poly/commitment/mock.rs
+++ b/jolt-core/src/poly/commitment/mock.rs
@@ -24,8 +24,8 @@ pub struct MockCommitment<F: JoltField> {
 }
 
 impl<F: JoltField> AppendToTranscript for MockCommitment<F> {
-    fn append_to_transcript(&self, label: &'static [u8], transcript: &mut ProofTranscript) {
-        transcript.append_message(label, b"mocker");
+    fn append_to_transcript(&self, transcript: &mut ProofTranscript) {
+        transcript.append_message(b"mocker");
     }
 }
 

--- a/jolt-core/src/poly/unipoly.rs
+++ b/jolt-core/src/poly/unipoly.rs
@@ -225,12 +225,12 @@ impl<F: JoltField> CompressedUniPoly<F> {
 }
 
 impl<F: JoltField> AppendToTranscript for UniPoly<F> {
-    fn append_to_transcript(&self, label: &'static [u8], transcript: &mut ProofTranscript) {
-        transcript.append_message(label, b"UniPoly_begin");
+    fn append_to_transcript(&self, transcript: &mut ProofTranscript) {
+        transcript.append_message(b"UniPoly_begin");
         for i in 0..self.coeffs.len() {
-            transcript.append_scalar(b"coeff", &self.coeffs[i]);
+            transcript.append_scalar(&self.coeffs[i]);
         }
-        transcript.append_message(label, b"UniPoly_end");
+        transcript.append_message(b"UniPoly_end");
     }
 }
 

--- a/jolt-core/src/r1cs/inputs.rs
+++ b/jolt-core/src/r1cs/inputs.rs
@@ -179,21 +179,21 @@ pub struct R1CSCommitment<C: CommitmentScheme> {
 }
 
 impl<C: CommitmentScheme> AppendToTranscript for R1CSCommitment<C> {
-    fn append_to_transcript(&self, label: &'static [u8], transcript: &mut ProofTranscript) {
-        transcript.append_message(label, b"R1CSCommitment_begin");
+    fn append_to_transcript(&self, transcript: &mut ProofTranscript) {
+        transcript.append_message(b"R1CSCommitment_begin");
         for commitment in &self.io {
-            commitment.append_to_transcript(b"io", transcript);
+            commitment.append_to_transcript(transcript);
         }
         for commitment in &self.aux {
-            commitment.append_to_transcript(b"aux", transcript);
+            commitment.append_to_transcript(transcript);
         }
         for commitment in &self.chunks {
-            commitment.append_to_transcript(b"chunks_s", transcript);
+            commitment.append_to_transcript(transcript);
         }
         for commitment in &self.circuit_flags {
-            commitment.append_to_transcript(b"circuit_flags", transcript);
+            commitment.append_to_transcript(transcript);
         }
-        transcript.append_message(label, b"R1CSCommitment_end");
+        transcript.append_message(b"R1CSCommitment_end");
     }
 }
 

--- a/jolt-core/src/r1cs/key.rs
+++ b/jolt-core/src/r1cs/key.rs
@@ -9,7 +9,7 @@ use crate::{
 };
 
 use super::{builder::CombinedUniformBuilder, ops::ConstraintInput};
-use digest::Digest;
+use sha3::Digest;
 
 use crate::utils::math::Math;
 
@@ -369,7 +369,7 @@ impl<F: JoltField> UniformSpartanKey<F> {
         hash_bytes.extend(offset_eq_bytes);
         hash_bytes.extend(num_steps.to_be_bytes().to_vec());
         let mut hasher = Sha3_256::new();
-        hasher.input(hash_bytes);
+        hasher.update(hash_bytes);
 
         let map_to_field = |digest: &[u8]| -> F {
             let bv = (0..250).map(|i| {
@@ -389,7 +389,7 @@ impl<F: JoltField> UniformSpartanKey<F> {
             }
             digest
         };
-        map_to_field(&hasher.result())
+        map_to_field(&hasher.finalize())
     }
 }
 

--- a/jolt-core/src/r1cs/spartan.rs
+++ b/jolt-core/src/r1cs/spartan.rs
@@ -186,7 +186,7 @@ impl<F: JoltField, C: CommitmentScheme<Field = F>> UniformSpartanProof<F, C> {
 
         // outer sum-check
         let tau = (0..num_rounds_x)
-            .map(|_i| transcript.challenge_scalar(b"t"))
+            .map(|_i| transcript.challenge_scalar())
             .collect::<Vec<F>>();
         let mut poly_tau = DensePolynomial::new(EqPolynomial::evals(&tau));
 
@@ -257,14 +257,10 @@ impl<F: JoltField, C: CommitmentScheme<Field = F>> UniformSpartanProof<F, C> {
             outer_sumcheck_claims[2],
             outer_sumcheck_claims[3],
         );
-        ProofTranscript::append_scalars(
-            transcript,
-            b"claims_outer",
-            [claim_Az, claim_Bz, claim_Cz].as_slice(),
-        );
+        ProofTranscript::append_scalars(transcript, [claim_Az, claim_Bz, claim_Cz].as_slice());
 
         // inner sum-check
-        let r_inner_sumcheck_RLC: F = transcript.challenge_scalar(b"r");
+        let r_inner_sumcheck_RLC: F = transcript.challenge_scalar();
         let claim_inner_joint = claim_Az
             + r_inner_sumcheck_RLC * claim_Bz
             + r_inner_sumcheck_RLC * r_inner_sumcheck_RLC * claim_Cz;
@@ -338,7 +334,7 @@ impl<F: JoltField, C: CommitmentScheme<Field = F>> UniformSpartanProof<F, C> {
 
         // outer sum-check
         let tau = (0..num_rounds_x)
-            .map(|_i| transcript.challenge_scalar(b"t"))
+            .map(|_i| transcript.challenge_scalar())
             .collect::<Vec<F>>();
 
         let (claim_outer_final, r_x) = self
@@ -355,7 +351,6 @@ impl<F: JoltField, C: CommitmentScheme<Field = F>> UniformSpartanProof<F, C> {
         }
 
         transcript.append_scalars(
-            b"claims_outer",
             [
                 self.outer_sumcheck_claims.0,
                 self.outer_sumcheck_claims.1,
@@ -365,7 +360,7 @@ impl<F: JoltField, C: CommitmentScheme<Field = F>> UniformSpartanProof<F, C> {
         );
 
         // inner sum-check
-        let r_inner_sumcheck_RLC: F = transcript.challenge_scalar(b"r");
+        let r_inner_sumcheck_RLC: F = transcript.challenge_scalar();
         let claim_inner_joint = self.outer_sumcheck_claims.0
             + r_inner_sumcheck_RLC * self.outer_sumcheck_claims.1
             + r_inner_sumcheck_RLC * r_inner_sumcheck_RLC * self.outer_sumcheck_claims.2;

--- a/jolt-core/src/subprotocols/grand_product.rs
+++ b/jolt-core/src/subprotocols/grand_product.rs
@@ -104,7 +104,7 @@ pub trait BatchedGrandProduct<F: JoltField, C: CommitmentScheme<Field = F>>: Siz
         assert_eq!(expected_sumcheck_claim, sumcheck_claim);
 
         // produce a random challenge to condense two claims into a single claim
-        let r_layer = transcript.challenge_scalar(b"challenge_r_layer");
+        let r_layer = transcript.challenge_scalar();
 
         *grand_product_claims = layer_proof
             .left_claims
@@ -132,8 +132,7 @@ pub trait BatchedGrandProduct<F: JoltField, C: CommitmentScheme<Field = F>>: Siz
 
         for (layer_index, layer_proof) in proof_layers.iter().enumerate() {
             // produce a fresh set of coeffs
-            let coeffs: Vec<F> =
-                transcript.challenge_vector(b"rand_coeffs_next_layer", claims_to_verify.len());
+            let coeffs: Vec<F> = transcript.challenge_vector(claims_to_verify.len());
             // produce a joint claim
             let claim = claims_to_verify
                 .iter()
@@ -151,8 +150,8 @@ pub trait BatchedGrandProduct<F: JoltField, C: CommitmentScheme<Field = F>>: Siz
                 .iter()
                 .zip(layer_proof.right_claims.iter())
             {
-                transcript.append_scalar(b"sumcheck left claim", left);
-                transcript.append_scalar(b"sumcheck right claim", right);
+                transcript.append_scalar(left);
+                transcript.append_scalar(right);
             }
 
             assert_eq!(r_grand_product.len(), r_sumcheck.len());
@@ -203,7 +202,7 @@ pub trait BatchedGrandProductLayer<F: JoltField>: BatchedCubicSumcheck<F> {
         transcript: &mut ProofTranscript,
     ) -> BatchedGrandProductLayerProof<F> {
         // produce a fresh set of coeffs
-        let coeffs: Vec<F> = transcript.challenge_vector(b"rand_coeffs_next_layer", claims.len());
+        let coeffs: Vec<F> = transcript.challenge_vector(claims.len());
         // produce a joint claim
         let claim = claims
             .iter()
@@ -220,8 +219,8 @@ pub trait BatchedGrandProductLayer<F: JoltField>: BatchedCubicSumcheck<F> {
 
         let (left_claims, right_claims) = sumcheck_claims;
         for (left, right) in left_claims.iter().zip(right_claims.iter()) {
-            transcript.append_scalar(b"sumcheck left claim", left);
-            transcript.append_scalar(b"sumcheck right claim", right);
+            transcript.append_scalar(left);
+            transcript.append_scalar(right);
         }
 
         r_sumcheck
@@ -230,7 +229,7 @@ pub trait BatchedGrandProductLayer<F: JoltField>: BatchedCubicSumcheck<F> {
             .collect_into_vec(r_grand_product);
 
         // produce a random challenge to condense two claims into a single claim
-        let r_layer = transcript.challenge_scalar(b"challenge_r_layer");
+        let r_layer = transcript.challenge_scalar();
 
         *claims = left_claims
             .iter()
@@ -1382,8 +1381,7 @@ impl<F: JoltField> BatchedGrandProductLayer<F> for BatchedGrandProductToggleLaye
         transcript: &mut ProofTranscript,
     ) -> BatchedGrandProductLayerProof<F> {
         // produce a fresh set of coeffs
-        let coeffs: Vec<F> =
-            transcript.challenge_vector(b"rand_coeffs_next_layer", claims_to_verify.len());
+        let coeffs: Vec<F> = transcript.challenge_vector(claims_to_verify.len());
         // produce a joint claim
         let claim = claims_to_verify
             .iter()
@@ -1400,8 +1398,8 @@ impl<F: JoltField> BatchedGrandProductLayer<F> for BatchedGrandProductToggleLaye
 
         let (left_claims, right_claims) = sumcheck_claims;
         for (left, right) in left_claims.iter().zip(right_claims.iter()) {
-            transcript.append_scalar(b"sumcheck left claim", left);
-            transcript.append_scalar(b"sumcheck right claim", right);
+            transcript.append_scalar(left);
+            transcript.append_scalar(right);
         }
 
         r_sumcheck
@@ -1503,7 +1501,7 @@ impl<F: JoltField, C: CommitmentScheme<Field = F>> BatchedGrandProduct<F, C>
             assert_eq!(expected_sumcheck_claim, sumcheck_claim);
 
             // produce a random challenge to condense two claims into a single claim
-            let r_layer = transcript.challenge_scalar(b"challenge_r_layer");
+            let r_layer = transcript.challenge_scalar();
 
             *grand_product_claims = layer_proof
                 .left_claims

--- a/jolt-core/src/subprotocols/sumcheck.rs
+++ b/jolt-core/src/subprotocols/sumcheck.rs
@@ -41,9 +41,9 @@ pub trait BatchedCubicSumcheck<F: JoltField>: Sync {
         for _round in 0..self.num_rounds() {
             let cubic_poly = self.compute_cubic(coeffs, eq_poly, previous_claim);
             // append the prover's message to the transcript
-            cubic_poly.append_to_transcript(b"poly", transcript);
+            cubic_poly.append_to_transcript(transcript);
             //derive the verifier's challenge for the next round
-            let r_j = transcript.challenge_scalar(b"challenge_nextround");
+            let r_j = transcript.challenge_scalar();
 
             r.push(r_j);
             // bind polynomials to verifier's challenge
@@ -158,8 +158,8 @@ impl<F: JoltField> SumcheckInstanceProof<F> {
             let round_uni_poly = UniPoly::from_evals(&eval_points);
 
             // append the prover's message to the transcript
-            round_uni_poly.append_to_transcript(b"poly", transcript);
-            let r_j = transcript.challenge_scalar(b"challenge_nextround");
+            round_uni_poly.append_to_transcript(transcript);
+            let r_j = transcript.challenge_scalar();
             r.push(r_j);
 
             // bound all tables to the verifier's challenege
@@ -268,10 +268,10 @@ impl<F: JoltField> SumcheckInstanceProof<F> {
             };
 
             // append the prover's message to the transcript
-            poly.append_to_transcript(b"poly", transcript);
+            poly.append_to_transcript(transcript);
 
             //derive the verifier's challenge for the next round
-            let r_i = transcript.challenge_scalar(b"challenge_nextround");
+            let r_i = transcript.challenge_scalar();
             r.push(r_i);
             polys.push(poly.compress());
 
@@ -361,10 +361,10 @@ impl<F: JoltField> SumcheckInstanceProof<F> {
         };
 
         // append the prover's message to the transcript
-        poly.append_to_transcript(b"poly", transcript);
+        poly.append_to_transcript(transcript);
 
         //derive the verifier's challenge for the next round
-        let r_i: F = transcript.challenge_scalar(b"challenge_nextround");
+        let r_i: F = transcript.challenge_scalar();
         r.push(r_i);
         polys.push(poly.compress());
 
@@ -408,10 +408,10 @@ impl<F: JoltField> SumcheckInstanceProof<F> {
             };
 
             // append the prover's message to the transcript
-            poly.append_to_transcript(b"poly", transcript);
+            poly.append_to_transcript(transcript);
 
             //derive the verifier's challenge for the next round
-            let r_i: F = transcript.challenge_scalar(b"challenge_nextround");
+            let r_i: F = transcript.challenge_scalar();
 
             r.push(r_i);
             polys.push(poly.compress());
@@ -518,10 +518,10 @@ impl<F: JoltField> SumcheckInstanceProof<F> {
             assert_eq!(poly.eval_at_zero() + poly.eval_at_one(), e);
 
             // append the prover's message to the transcript
-            poly.append_to_transcript(b"poly", transcript);
+            poly.append_to_transcript(transcript);
 
             //derive the verifier's challenge for the next round
-            let r_i = transcript.challenge_scalar(b"challenge_nextround");
+            let r_i = transcript.challenge_scalar();
 
             r.push(r_i);
 

--- a/jolt-core/src/utils/transcript.rs
+++ b/jolt-core/src/utils/transcript.rs
@@ -34,7 +34,7 @@ impl ProofTranscript {
         // Note we add the extra memory here to improve the ease of eth integrations
         Keccak256::new()
             .chain_update(self.state)
-            .chain_update([0_u8; 24])
+            .chain_update([0_u8; 28])
             .chain_update(self.n_rounds.to_le_bytes())
     }
 

--- a/jolt-core/src/utils/transcript.rs
+++ b/jolt-core/src/utils/transcript.rs
@@ -1,29 +1,59 @@
 use crate::field::JoltField;
 use ark_ec::CurveGroup;
-use merlin::Transcript;
+use sha3::{Digest, Keccak256};
 
 #[derive(Clone)]
 pub struct ProofTranscript {
-    inner: Transcript,
+    // Ethereum compatible 256 bit running state
+    state: [u8; 32],
+    // We append an ordinal to each invoke of the hash
+    n_rounds: u32,
 }
 
 impl ProofTranscript {
     pub fn new(label: &'static [u8]) -> Self {
+        // Hash in the label
+        let mut hasher = Keccak256::new();
+        hasher.update(label);
+        let out = hasher.finalize();
+
         Self {
-            inner: Transcript::new(label),
+            state: out.into(),
+            n_rounds: 0,
         }
     }
 
+    /// Gives the hasher object with the running seed and index added
+    /// To load hash you must call finalize, after appending u8 vectors
+    fn hasher(&self) -> Keccak256 {
+        // Note we add the extra memory here to improve the ease of eth integrations
+        Keccak256::new()
+            .chain_update(self.state)
+            .chain_update([0_u8; 24])
+            .chain_update(self.n_rounds.to_le_bytes())
+    }
+
     pub fn append_message(&mut self, label: &'static [u8], msg: &'static [u8]) {
-        self.inner.append_message(label, msg);
+        // Instantiate hasher add our seed, position and msg
+        let hasher = self.hasher().chain_update(label).chain_update(msg);
+        self.state = hasher.finalize().into();
+        self.n_rounds += 1;
     }
 
     pub fn append_bytes(&mut self, label: &'static [u8], bytes: &[u8]) {
-        self.inner.append_message(label, bytes);
+        // Add the message and label
+        let hasher = self.hasher().chain_update(label).chain_update(bytes);
+        self.state = hasher.finalize().into();
+        self.n_rounds += 1;
     }
 
     pub fn append_u64(&mut self, label: &'static [u8], x: u64) {
-        self.inner.append_u64(label, x);
+        let hasher = self
+            .hasher()
+            .chain_update(label)
+            .chain_update(x.to_le_bytes());
+        self.state = hasher.finalize().into();
+        self.n_rounds += 1;
     }
 
     pub fn append_protocol_name(&mut self, protocol_name: &'static [u8]) {
@@ -33,7 +63,7 @@ impl ProofTranscript {
     pub fn append_scalar<F: JoltField>(&mut self, label: &'static [u8], scalar: &F) {
         let mut buf = vec![];
         scalar.serialize_compressed(&mut buf).unwrap();
-        self.inner.append_message(label, &buf);
+        self.append_bytes(label, &buf);
     }
 
     pub fn append_scalars<F: JoltField>(&mut self, label: &'static [u8], scalars: &[F]) {
@@ -41,13 +71,13 @@ impl ProofTranscript {
         for item in scalars.iter() {
             self.append_scalar(label, item);
         }
-        self.inner.append_message(label, b"end_append_vector");
+        self.append_message(label, b"end_append_vector");
     }
 
     pub fn append_point<G: CurveGroup>(&mut self, label: &'static [u8], point: &G) {
         let mut buf = vec![];
         point.serialize_compressed(&mut buf).unwrap();
-        self.inner.append_message(label, &buf);
+        self.append_bytes(label, &buf);
     }
 
     pub fn append_points<G: CurveGroup>(&mut self, label: &'static [u8], points: &[G]) {
@@ -55,12 +85,12 @@ impl ProofTranscript {
         for item in points.iter() {
             self.append_point(label, item);
         }
-        self.inner.append_message(label, b"end_append_vector");
+        self.append_message(label, b"end_append_vector");
     }
 
     pub fn challenge_scalar<F: JoltField>(&mut self, label: &'static [u8]) -> F {
         let mut buf = vec![0u8; F::NUM_BYTES];
-        self.inner.challenge_bytes(label, &mut buf);
+        self.challenge_bytes(label, &mut buf);
         F::from_bytes(&buf)
     }
 
@@ -82,6 +112,32 @@ impl ProofTranscript {
             q_powers[i] = q_powers[i - 1] * q;
         }
         q_powers
+    }
+
+    // Loads arbitrary byte lengths using ceil(out/32) invocations of 32 byte randoms
+    // Discards top bits when the size is less than 32 bytes
+    fn challenge_bytes(&mut self, label: &'static [u8], out: &mut [u8]) {
+        let mut remaining_len = out.len();
+        let mut start = 0;
+        while remaining_len > 32 {
+            self.challenge_bytes32(label, &mut out[start..start + 32]);
+            start += 32;
+            remaining_len -= 32;
+        }
+        // We load a full 32 byte random region
+        let mut full_rand = vec![0_u8; 32];
+        self.challenge_bytes32(label, &mut full_rand);
+        // Then only clone the first bits of this random region to perfectly fill out
+        out[start..start + remaining_len].clone_from_slice(&full_rand[0..remaining_len]);
+    }
+
+    // Loads exactly 32 bytes from the transcript by hashing the seed with the round constant
+    fn challenge_bytes32(&mut self, label: &'static [u8], out: &mut [u8]) {
+        assert_eq!(32, out.len());
+        let rand: [u8; 32] = self.hasher().chain_update(label).finalize().into();
+        out.clone_from_slice(rand.as_slice());
+        self.state = rand;
+        self.n_rounds += 1;
     }
 }
 

--- a/jolt-core/src/utils/transcript.rs
+++ b/jolt-core/src/utils/transcript.rs
@@ -33,80 +33,73 @@ impl ProofTranscript {
             .chain_update(self.n_rounds.to_le_bytes())
     }
 
-    pub fn append_message(&mut self, label: &'static [u8], msg: &'static [u8]) {
+    pub fn append_message(&mut self, msg: &'static [u8]) {
         // Instantiate hasher add our seed, position and msg
-        let hasher = self.hasher().chain_update(label).chain_update(msg);
+        let hasher = self.hasher().chain_update(msg);
         self.state = hasher.finalize().into();
         self.n_rounds += 1;
     }
 
-    pub fn append_bytes(&mut self, label: &'static [u8], bytes: &[u8]) {
+    pub fn append_bytes(&mut self, bytes: &[u8]) {
         // Add the message and label
-        let hasher = self.hasher().chain_update(label).chain_update(bytes);
+        let hasher = self.hasher().chain_update(bytes);
         self.state = hasher.finalize().into();
         self.n_rounds += 1;
     }
 
-    pub fn append_u64(&mut self, label: &'static [u8], x: u64) {
-        let hasher = self
-            .hasher()
-            .chain_update(label)
-            .chain_update(x.to_le_bytes());
+    pub fn append_u64(&mut self, x: u64) {
+        let hasher = self.hasher().chain_update(x.to_le_bytes());
         self.state = hasher.finalize().into();
         self.n_rounds += 1;
     }
 
     pub fn append_protocol_name(&mut self, protocol_name: &'static [u8]) {
-        self.append_message(b"protocol-name", protocol_name);
+        self.append_message(protocol_name);
     }
 
-    pub fn append_scalar<F: JoltField>(&mut self, label: &'static [u8], scalar: &F) {
+    pub fn append_scalar<F: JoltField>(&mut self, scalar: &F) {
         let mut buf = vec![];
         scalar.serialize_compressed(&mut buf).unwrap();
-        self.append_bytes(label, &buf);
+        self.append_bytes(&buf);
     }
 
-    pub fn append_scalars<F: JoltField>(&mut self, label: &'static [u8], scalars: &[F]) {
-        self.append_message(label, b"begin_append_vector");
+    pub fn append_scalars<F: JoltField>(&mut self, scalars: &[F]) {
+        self.append_message(b"begin_append_vector");
         for item in scalars.iter() {
-            self.append_scalar(label, item);
+            self.append_scalar(item);
         }
-        self.append_message(label, b"end_append_vector");
+        self.append_message(b"end_append_vector");
     }
 
-    pub fn append_point<G: CurveGroup>(&mut self, label: &'static [u8], point: &G) {
+    pub fn append_point<G: CurveGroup>(&mut self, point: &G) {
         let mut buf = vec![];
         point.serialize_compressed(&mut buf).unwrap();
-        self.append_bytes(label, &buf);
+        self.append_bytes(&buf);
     }
 
-    pub fn append_points<G: CurveGroup>(&mut self, label: &'static [u8], points: &[G]) {
-        self.append_message(label, b"begin_append_vector");
+    pub fn append_points<G: CurveGroup>(&mut self, points: &[G]) {
+        self.append_message(b"begin_append_vector");
         for item in points.iter() {
-            self.append_point(label, item);
+            self.append_point(item);
         }
-        self.append_message(label, b"end_append_vector");
+        self.append_message(b"end_append_vector");
     }
 
-    pub fn challenge_scalar<F: JoltField>(&mut self, label: &'static [u8]) -> F {
+    pub fn challenge_scalar<F: JoltField>(&mut self) -> F {
         let mut buf = vec![0u8; F::NUM_BYTES];
-        self.challenge_bytes(label, &mut buf);
+        self.challenge_bytes(&mut buf);
         F::from_bytes(&buf)
     }
 
-    pub fn challenge_vector<F: JoltField>(&mut self, label: &'static [u8], len: usize) -> Vec<F> {
+    pub fn challenge_vector<F: JoltField>(&mut self, len: usize) -> Vec<F> {
         (0..len)
-            .map(|_i| self.challenge_scalar(label))
+            .map(|_i| self.challenge_scalar())
             .collect::<Vec<F>>()
     }
 
     // Compute powers of scalar q : (1, q, q^2, ..., q^(len-1))
-    pub fn challenge_scalar_powers<F: JoltField>(
-        &mut self,
-        label: &'static [u8],
-        len: usize,
-    ) -> Vec<F> {
-        let q: F = self.challenge_scalar(label);
+    pub fn challenge_scalar_powers<F: JoltField>(&mut self, len: usize) -> Vec<F> {
+        let q: F = self.challenge_scalar();
         let mut q_powers = vec![F::one(); len];
         for i in 1..len {
             q_powers[i] = q_powers[i - 1] * q;
@@ -116,25 +109,25 @@ impl ProofTranscript {
 
     // Loads arbitrary byte lengths using ceil(out/32) invocations of 32 byte randoms
     // Discards top bits when the size is less than 32 bytes
-    fn challenge_bytes(&mut self, label: &'static [u8], out: &mut [u8]) {
+    fn challenge_bytes(&mut self, out: &mut [u8]) {
         let mut remaining_len = out.len();
         let mut start = 0;
         while remaining_len > 32 {
-            self.challenge_bytes32(label, &mut out[start..start + 32]);
+            self.challenge_bytes32(&mut out[start..start + 32]);
             start += 32;
             remaining_len -= 32;
         }
         // We load a full 32 byte random region
         let mut full_rand = vec![0_u8; 32];
-        self.challenge_bytes32(label, &mut full_rand);
+        self.challenge_bytes32(&mut full_rand);
         // Then only clone the first bits of this random region to perfectly fill out
         out[start..start + remaining_len].clone_from_slice(&full_rand[0..remaining_len]);
     }
 
     // Loads exactly 32 bytes from the transcript by hashing the seed with the round constant
-    fn challenge_bytes32(&mut self, label: &'static [u8], out: &mut [u8]) {
+    fn challenge_bytes32(&mut self, out: &mut [u8]) {
         assert_eq!(32, out.len());
-        let rand: [u8; 32] = self.hasher().chain_update(label).finalize().into();
+        let rand: [u8; 32] = self.hasher().finalize().into();
         out.clone_from_slice(rand.as_slice());
         self.state = rand;
         self.n_rounds += 1;
@@ -142,5 +135,5 @@ impl ProofTranscript {
 }
 
 pub trait AppendToTranscript {
-    fn append_to_transcript(&self, label: &'static [u8], transcript: &mut ProofTranscript);
+    fn append_to_transcript(&self, transcript: &mut ProofTranscript);
 }


### PR DESCRIPTION
Change list:

1. Replaces the Merlin transcript which uses keccack1600 permutations with a transcript which we define for jolt and which uses keccack256. This transcript squeezes all inputs into 32bytes with an action counter. It doesn't abstract over the hasher object to support snark friendly recursion hashes, but this would be only a small change.
2. Removes Merlin from our dependency graph
3. Because we removed Merlin we bump the sha3 version to be modern as opposed to the 5 year old current import, and make small interface changes in key.rs and perdersen.rs
4. Most labels are removed in favor of the increasing index which is hashed into each step.

There is no performance change.