### PR TITLE
Adds compressed polys to transcript instead normal ones

### DIFF
--- a/jolt-core/src/jolt/vm/instruction_lookups.rs
+++ b/jolt-core/src/jolt/vm/instruction_lookups.rs
@@ -1261,7 +1261,7 @@ where
         round_uni_poly: UniPoly<F>,
         transcript: &mut ProofTranscript,
     ) -> F {
-        round_uni_poly.append_to_transcript(transcript);
+        round_uni_poly.compress().append_to_transcript(transcript);
 
         transcript.challenge_scalar::<F>()
     }

--- a/jolt-core/src/poly/unipoly.rs
+++ b/jolt-core/src/poly/unipoly.rs
@@ -234,6 +234,16 @@ impl<F: JoltField> AppendToTranscript for UniPoly<F> {
     }
 }
 
+impl<F: JoltField> AppendToTranscript for CompressedUniPoly<F> {
+    fn append_to_transcript(&self, transcript: &mut ProofTranscript) {
+        transcript.append_message(b"UniPoly_begin");
+        for i in 0..self.coeffs_except_linear_term.len() {
+            transcript.append_scalar(&self.coeffs_except_linear_term[i]);
+        }
+        transcript.append_message(b"UniPoly_end");
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/jolt-core/src/subprotocols/sumcheck.rs
+++ b/jolt-core/src/subprotocols/sumcheck.rs
@@ -40,8 +40,9 @@ pub trait BatchedCubicSumcheck<F: JoltField>: Sync {
 
         for _round in 0..self.num_rounds() {
             let cubic_poly = self.compute_cubic(coeffs, eq_poly, previous_claim);
+            let compressed_poly = cubic_poly.compress();
             // append the prover's message to the transcript
-            cubic_poly.append_to_transcript(transcript);
+            compressed_poly.append_to_transcript(transcript);
             //derive the verifier's challenge for the next round
             let r_j = transcript.challenge_scalar();
 
@@ -50,7 +51,7 @@ pub trait BatchedCubicSumcheck<F: JoltField>: Sync {
             self.bind(eq_poly, &r_j);
 
             previous_claim = cubic_poly.evaluate(&r_j);
-            cubic_polys.push(cubic_poly.compress());
+            cubic_polys.push(compressed_poly);
         }
 
         debug_assert_eq!(eq_poly.len(), 1);
@@ -156,9 +157,10 @@ impl<F: JoltField> SumcheckInstanceProof<F> {
                 });
 
             let round_uni_poly = UniPoly::from_evals(&eval_points);
+            let round_compressed_poly = round_uni_poly.compress();
 
             // append the prover's message to the transcript
-            round_uni_poly.append_to_transcript(transcript);
+            round_compressed_poly.append_to_transcript(transcript);
             let r_j = transcript.challenge_scalar();
             r.push(r_j);
 
@@ -166,7 +168,7 @@ impl<F: JoltField> SumcheckInstanceProof<F> {
             polys
                 .par_iter_mut()
                 .for_each(|poly| poly.bound_poly_var_top(&r_j));
-            compressed_polys.push(round_uni_poly.compress());
+            compressed_polys.push(round_compressed_poly);
         }
 
         let final_evals = polys.iter().map(|poly| poly[0]).collect();
@@ -282,13 +284,15 @@ impl<F: JoltField> SumcheckInstanceProof<F> {
                 UniPoly::from_evals(&evals)
             };
 
+            let compressed_poly = poly.compress();
+
             // append the prover's message to the transcript
-            poly.append_to_transcript(transcript);
+            compressed_poly.append_to_transcript(transcript);
 
             //derive the verifier's challenge for the next round
             let r_i = transcript.challenge_scalar();
             r.push(r_i);
-            polys.push(poly.compress());
+            polys.push(compressed_poly);
 
             // Set up next round
             claim_per_round = poly.evaluate(&r_i);
@@ -370,13 +374,14 @@ impl<F: JoltField> SumcheckInstanceProof<F> {
             UniPoly::from_evals(&evals)
         };
 
+        let compressed_poly = poly.compress();
         // append the prover's message to the transcript
-        poly.append_to_transcript(transcript);
+        compressed_poly.append_to_transcript(transcript);
 
         //derive the verifier's challenge for the next round
         let r_i: F = transcript.challenge_scalar();
         r.push(r_i);
-        polys.push(poly.compress());
+        polys.push(compressed_poly);
 
         // Set up next round
         claim_per_round = poly.evaluate(&r_i);
@@ -417,14 +422,15 @@ impl<F: JoltField> SumcheckInstanceProof<F> {
                 UniPoly::from_evals(&evals)
             };
 
+            let compressed_poly = poly.compress();
             // append the prover's message to the transcript
-            poly.append_to_transcript(transcript);
+            compressed_poly.append_to_transcript(transcript);
 
             //derive the verifier's challenge for the next round
             let r_i: F = transcript.challenge_scalar();
 
             r.push(r_i);
-            polys.push(poly.compress());
+            polys.push(compressed_poly);
 
             // Set up next round
             claim_per_round = poly.evaluate(&r_i);
@@ -528,7 +534,7 @@ impl<F: JoltField> SumcheckInstanceProof<F> {
             assert_eq!(poly.eval_at_zero() + poly.eval_at_one(), e);
 
             // append the prover's message to the transcript
-            poly.append_to_transcript(transcript);
+            self.compressed_polys[i].append_to_transcript(transcript);
 
             //derive the verifier's challenge for the next round
             let r_i = transcript.challenge_scalar();


### PR DESCRIPTION
We were computing compressed polys but not using them to reduce the committed transcript length despite that appearing to be their purpose.