### PR TITLE
onchain-verifier: measuring gas usage for grand product argument

### DIFF
--- a/jolt-evm-verifier/foundry.toml
+++ b/jolt-evm-verifier/foundry.toml
@@ -6,5 +6,4 @@ optimizer = true
 optimizer-runs = 1000
 via_ir = true
 
-
 # See more config options https://github.com/foundry-rs/foundry/blob/master/crates/config/README.md#all-options

--- a/jolt-evm-verifier/src/reference/JoltVerifier.sol
+++ b/jolt-evm-verifier/src/reference/JoltVerifier.sol
@@ -112,11 +112,11 @@ library GrandProductArgument {
         return (newClaims, newRGrandProduct);
     }
 
-    function verify(
-        Jolt.BatchedGrandProductProof memory proof,
-        Fr[] memory claims,
-        Transcript memory transcript
-    ) public pure returns (Fr[] memory) {
+    function verify(Jolt.BatchedGrandProductProof memory proof, Fr[] memory claims, Transcript memory transcript)
+        public
+        pure
+        returns (Fr[] memory)
+    {
         Fr[] memory rGrandProduct = new Fr[](0);
 
         for (uint256 i = 0; i < proof.layers.length; i++) {

--- a/jolt-evm-verifier/src/reference/JoltVerifier.sol
+++ b/jolt-evm-verifier/src/reference/JoltVerifier.sol
@@ -2,7 +2,6 @@
 
 pragma solidity >=0.8.21;
 
-import {IVerifier} from "../interfaces/IVerifier.sol";
 import {Transcript, FiatShamirTranscript} from "../subprotocols/FiatShamirTranscript.sol";
 import {Fr, FrLib, sub, MODULUS} from "./Fr.sol";
 import {Jolt} from "./JoltTypes.sol";
@@ -13,7 +12,7 @@ import "forge-std/console.sol";
 error GrandProductArgumentFailed();
 error SumcheckFailed();
 
-contract JoltVerifier is IVerifier {
+library GrandProductArgument {
     using FiatShamirTranscript for Transcript;
 
     function verifySumcheckLayer(
@@ -113,12 +112,13 @@ contract JoltVerifier is IVerifier {
         return (newClaims, newRGrandProduct);
     }
 
-    function verifyGrandProduct(
+    function verify(
         Jolt.BatchedGrandProductProof memory proof,
         Fr[] memory claims,
         Transcript memory transcript
-    ) external pure returns (Fr[] memory) {
+    ) public pure returns (Fr[] memory) {
         Fr[] memory rGrandProduct = new Fr[](0);
+
         for (uint256 i = 0; i < proof.layers.length; i++) {
             //get coeffs
             uint256[] memory loaded = transcript.challenge_scalars(claims.length, MODULUS);

--- a/jolt-evm-verifier/test/GrandProductArgumentGasWrapper.sol
+++ b/jolt-evm-verifier/test/GrandProductArgumentGasWrapper.sol
@@ -15,6 +15,7 @@ error SumcheckFailed();
 
 contract GrandProductArgumentGasWrapper is TestBase {
     using FiatShamirTranscript for Transcript;
+
     bool private enableLogging = vm.envOr("BENCHMARK_LOGGING", false);
 
     function conditionalLog(string memory message) internal view {
@@ -29,7 +30,6 @@ contract GrandProductArgumentGasWrapper is TestBase {
         }
     }
 
-
     function verifySumcheckLayer(
         Jolt.BatchedGrandProductLayerProof memory layer,
         Transcript memory transcript,
@@ -40,11 +40,9 @@ contract GrandProductArgumentGasWrapper is TestBase {
         return GrandProductArgument.verifySumcheckLayer(layer, transcript, claim, degree_bound, num_rounds);
     }
 
-
     function buildEqEval(Fr[] memory rGrandProduct, Fr[] memory rSumcheck) public pure returns (Fr eqEval) {
         return GrandProductArgument.buildEqEval(rGrandProduct, rSumcheck);
     }
-
 
     function verifySumcheckClaim(
         Jolt.BatchedGrandProductLayerProof[] memory layerProofs,
@@ -56,16 +54,18 @@ contract GrandProductArgumentGasWrapper is TestBase {
         Fr[] memory rGrandProduct,
         Transcript memory transcript
     ) public pure returns (Fr[] memory newClaims, Fr[] memory newRGrandProduct) {
-        return GrandProductArgument.verifySumcheckClaim(layerProofs, layerIndex, coeffs, sumcheckClaim, eqEval, claims, rGrandProduct, transcript);
+        return GrandProductArgument.verifySumcheckClaim(
+            layerProofs, layerIndex, coeffs, sumcheckClaim, eqEval, claims, rGrandProduct, transcript
+        );
     }
 
-    function verify(
-        Jolt.BatchedGrandProductProof memory proof,
-        Fr[] memory claims,
-        Transcript memory transcript
-    ) external view returns (Fr[] memory) {
+    function verify(Jolt.BatchedGrandProductProof memory proof, Fr[] memory claims, Transcript memory transcript)
+        external
+        view
+        returns (Fr[] memory)
+    {
         Fr[] memory rGrandProduct = new Fr[](0);
-        uint gasUsed = gasleft();
+        uint256 gasUsed = gasleft();
 
         for (uint256 i = 0; i < proof.layers.length; i++) {
             conditionalLog("[grand-product] round:", i);

--- a/jolt-evm-verifier/test/GrandProductArgumentGasWrapper.sol
+++ b/jolt-evm-verifier/test/GrandProductArgumentGasWrapper.sol
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.21;
+
+import {Jolt} from "../src/reference/JoltTypes.sol";
+import {Fr, FrLib, sub, MODULUS} from "../src/reference/Fr.sol";
+import {Transcript, FiatShamirTranscript} from "../src/subprotocols/FiatShamirTranscript.sol";
+import {UniPoly, UniPolyLib} from "../src/reference/UniPoly.sol";
+import {GrandProductArgument} from "../src/reference/JoltVerifier.sol";
+import {TestBase} from "./base/TestBase.sol";
+
+import "forge-std/console.sol";
+
+error GrandProductArgumentFailed();
+error SumcheckFailed();
+
+contract GrandProductArgumentGasWrapper is TestBase {
+    using FiatShamirTranscript for Transcript;
+    bool private enableLogging = vm.envBool("BENCHMARK_LOGGING");
+
+    function conditionalLog(string memory message) internal view {
+        if (enableLogging) {
+            console.log(message);
+        }
+    }
+
+    function conditionalLog(string memory message, uint256 value) internal view {
+        if (enableLogging) {
+            console.log(message, value);
+        }
+    }
+
+
+    function verifySumcheckLayer(
+        Jolt.BatchedGrandProductLayerProof memory layer,
+        Transcript memory transcript,
+        Fr claim,
+        uint256 degree_bound,
+        uint256 num_rounds
+    ) public pure returns (Fr, Fr[] memory) {
+        return GrandProductArgument.verifySumcheckLayer(layer, transcript, claim, degree_bound, num_rounds);
+    }
+
+
+    function buildEqEval(Fr[] memory rGrandProduct, Fr[] memory rSumcheck) public pure returns (Fr eqEval) {
+        return GrandProductArgument.buildEqEval(rGrandProduct, rSumcheck);
+    }
+
+
+    function verifySumcheckClaim(
+        Jolt.BatchedGrandProductLayerProof[] memory layerProofs,
+        uint256 layerIndex,
+        Fr[] memory coeffs,
+        Fr sumcheckClaim,
+        Fr eqEval,
+        Fr[] memory claims,
+        Fr[] memory rGrandProduct,
+        Transcript memory transcript
+    ) public pure returns (Fr[] memory newClaims, Fr[] memory newRGrandProduct) {
+        return GrandProductArgument.verifySumcheckClaim(layerProofs, layerIndex, coeffs, sumcheckClaim, eqEval, claims, rGrandProduct, transcript);
+    }
+
+    function verify(
+        Jolt.BatchedGrandProductProof memory proof,
+        Fr[] memory claims,
+        Transcript memory transcript
+    ) external view returns (Fr[] memory) {
+        Fr[] memory rGrandProduct = new Fr[](0);
+        uint gasUsed = gasleft();
+
+        for (uint256 i = 0; i < proof.layers.length; i++) {
+            conditionalLog("[grand-product] round:", i);
+            //get coeffs
+            uint256[] memory loaded = transcript.challenge_scalars(claims.length, MODULUS);
+            Fr[] memory coeffs;
+            // TODO - hard convert should be removed when the transcript gets better Fr native typed support.
+            assembly {
+                coeffs := loaded
+            }
+
+            //create a joined claim
+            Fr joined_claim = Fr.wrap(0);
+            for (uint256 k = 0; k < claims.length; k++) {
+                joined_claim = joined_claim + (claims[k] * coeffs[k]);
+            }
+
+            if (
+                claims.length != proof.layers[i].leftClaims.length
+                    || claims.length != proof.layers[i].rightClaims.length
+            ) {
+                revert GrandProductArgumentFailed();
+            }
+
+            gasUsed = gasleft();
+            // verify sumcheck and get rSumcheck
+            (Fr sumcheckClaim, Fr[] memory rSumcheck) =
+                verifySumcheckLayer(proof.layers[i], transcript, joined_claim, 3, i);
+            gasUsed -= gasleft();
+            conditionalLog("[grand-product] verifySumcheckLayer gas usage:", gasUsed);
+
+            if (rSumcheck.length != rGrandProduct.length) {
+                revert GrandProductArgumentFailed();
+            }
+
+            // Append the right and left claims to the transcript
+            for (uint256 l = 0; l < proof.layers[l].leftClaims.length; l++) {
+                transcript.append_scalar(Fr.unwrap(proof.layers[i].leftClaims[l]));
+                transcript.append_scalar(Fr.unwrap(proof.layers[i].rightClaims[l]));
+            }
+
+            gasUsed = gasleft();
+            Fr eqEval = buildEqEval(rGrandProduct, rSumcheck);
+            gasUsed -= gasleft();
+            conditionalLog("[grand-product] buildEqEval gas usage:", gasUsed);
+
+            rGrandProduct = new Fr[](rSumcheck.length);
+            for (uint256 l = 0; l < rSumcheck.length; l++) {
+                rGrandProduct[l] = rSumcheck[rSumcheck.length - 1 - l];
+            }
+
+            gasUsed = gasleft();
+            (claims, rGrandProduct) =
+                verifySumcheckClaim(proof.layers, i, coeffs, sumcheckClaim, eqEval, claims, rGrandProduct, transcript);
+            gasUsed -= gasleft();
+            conditionalLog("[grand-product] verifySumcheckClaim gas usage:", gasUsed);
+        }
+
+        return rGrandProduct;
+    }
+}

--- a/jolt-evm-verifier/test/GrandProductArgumentGasWrapper.sol
+++ b/jolt-evm-verifier/test/GrandProductArgumentGasWrapper.sol
@@ -15,7 +15,7 @@ error SumcheckFailed();
 
 contract GrandProductArgumentGasWrapper is TestBase {
     using FiatShamirTranscript for Transcript;
-    bool private enableLogging = vm.envBool("BENCHMARK_LOGGING");
+    bool private enableLogging = vm.envOr("BENCHMARK_LOGGING", false);
 
     function conditionalLog(string memory message) internal view {
         if (enableLogging) {

--- a/jolt-evm-verifier/test/base/TestBaseJolt.sol
+++ b/jolt-evm-verifier/test/base/TestBaseJolt.sol
@@ -3,22 +3,25 @@
 pragma solidity ^0.8.21;
 
 import {TestBase} from "./TestBase.sol";
-import {IVerifier} from "../../src/interfaces/IVerifier.sol";
 import {Jolt} from "../../src/reference/JoltTypes.sol";
-import {JoltVerifier} from "../../src/reference/JoltVerifier.sol";
+import {GrandProductArgument} from "../../src/reference/JoltVerifier.sol";
 import {Transcript, FiatShamirTranscript} from "../../src/subprotocols/FiatShamirTranscript.sol";
-import {Fr} from "../../src/reference/Fr.sol";
+import {Fr, FrLib, MODULUS} from "../../src/reference/Fr.sol";
+import {UniPoly, UniPolyLib} from "../../src/reference/UniPoly.sol";
+import {GrandProductArgumentGasWrapper} from "../GrandProductArgumentGasWrapper.sol";
 
 import "forge-std/console.sol";
 
-contract TestBaseJolt is TestBase {
-    IVerifier public verifier;
+error GrandProductArgumentFailed();
+error SumcheckFailed();
+
+contract TestGrandProduct is TestBase {
+    using FiatShamirTranscript for Transcript;
+
 
     function testValidGrandProductProof() public {
         // Inits the transcript with the same string label as the rust code
         Transcript memory transcript = FiatShamirTranscript.new_transcript("test_transcript", 4);
-
-        verifier = IVerifier(address(new JoltVerifier()));
 
         (Jolt.BatchedGrandProductProof memory proof, uint256[] memory claims, uint256[] memory r) = getProofData();
 
@@ -27,10 +30,26 @@ contract TestBaseJolt is TestBase {
             claims_fr := claims
         }
 
-        Fr[] memory verifierRGrandProduct = verifier.verifyGrandProduct(proof, claims_fr, transcript);
+        Fr[] memory verifierRGrandProduct = GrandProductArgument.verify(proof, claims_fr, transcript);
 
         for (uint256 i = 0; i < verifierRGrandProduct.length; i++) {
             assertTrue(r[i] == Fr.unwrap(verifierRGrandProduct[i]));
         }
+    }
+
+    function testGasGrandProductVerify() public {
+        Transcript memory transcript = FiatShamirTranscript.new_transcript("test_transcript", 4);
+
+        (Jolt.BatchedGrandProductProof memory proof, uint256[] memory claims_fr,) = getProofData();
+
+        Fr[] memory claims;
+        assembly ("memory-safe") {
+            claims := claims_fr
+        }
+
+        GrandProductArgumentGasWrapper wrapper = new GrandProductArgumentGasWrapper();
+
+        wrapper.verify(proof, claims, transcript);
+
     }
 }

--- a/jolt-evm-verifier/test/base/TestBaseJolt.sol
+++ b/jolt-evm-verifier/test/base/TestBaseJolt.sol
@@ -18,7 +18,6 @@ error SumcheckFailed();
 contract TestGrandProduct is TestBase {
     using FiatShamirTranscript for Transcript;
 
-
     function testValidGrandProductProof() public {
         // Inits the transcript with the same string label as the rust code
         Transcript memory transcript = FiatShamirTranscript.new_transcript("test_transcript", 4);
@@ -50,6 +49,5 @@ contract TestGrandProduct is TestBase {
         GrandProductArgumentGasWrapper wrapper = new GrandProductArgumentGasWrapper();
 
         wrapper.verify(proof, claims, transcript);
-
     }
 }


### PR DESCRIPTION
I got some troubles using foundry's `gas-report` to work with the code with internal functions, but will continue to investigate. 

 For now this is a new test that outputs some gas benchmarks for the internal functions of the verifier when `BENCHMARK_LOGGING=true` using a wrapper around the grand product argument library

You can run the gas report with `BENCHMARK_LOGGING=true forge test --via-ir --ffi -vv --match-test testGasGrandProductVerify`

I don't think it's the best, so would love some ideas on how to make it better!