### PR TITLE
fix: add deserialize function and change types to RV32IHyraxProof in wasm-related code

### DIFF
--- a/jolt-core/src/jolt/vm/rv32i_vm.rs
+++ b/jolt-core/src/jolt/vm/rv32i_vm.rs
@@ -204,6 +204,19 @@ impl RV32IHyraxProof {
         let file = File::open(path.into())?;
         Ok(RV32IHyraxProof::deserialize_compressed(file)?)
     }
+
+    /// Serializes the proof to a byte vector
+    pub fn serialize_to_bytes(&self) -> Result<Vec<u8>> {
+        let mut buffer = Vec::new();
+        self.serialize_compressed(&mut buffer)?;
+        Ok(buffer)
+    }
+
+    /// Deserializes a proof from a byte vector
+    pub fn deserialize_from_bytes(bytes: &[u8]) -> Result<Self> {
+        let cursor = std::io::Cursor::new(bytes);
+        Ok(RV32IHyraxProof::deserialize_compressed(cursor)?)
+    }
 }
 
 // ==================== TEST ====================

--- a/jolt-sdk/macros/src/lib.rs
+++ b/jolt-sdk/macros/src/lib.rs
@@ -537,10 +537,10 @@ impl MacroBuilder {
             #[wasm_bindgen]
             #[cfg(all(target_arch = "wasm32", not(feature = "guest")))]
             pub fn #verify_wasm_fn_name(preprocessing_data: &[u8], proof_bytes: &[u8]) -> bool {
-                use jolt::{Jolt, Proof, RV32IJoltVM};
+                use jolt::{Jolt, RV32IHyraxProof, RV32IJoltVM};
 
                 let decoded_preprocessing_data: DecodedData = deserialize_from_bin(preprocessing_data).unwrap();
-                let proof = Proof::deserialize_from_bytes(proof_bytes).unwrap();
+                let proof = RV32IHyraxProof::deserialize_from_bytes(proof_bytes).unwrap();
 
                 let preprocessing = RV32IJoltVM::preprocess(
                     decoded_preprocessing_data.bytecode,


### PR DESCRIPTION
- added serialize_to_bytes and deserialize_from_bytes methods to RV32IHyraxProof.
- modified imports to include RV32IHyraxProof in wasm.
- updated deserialization logic in verify_wasm_fn_name to use RV32IHyraxProof::deserialize_from_bytes.