### PR TITLE
fix: refactor check for provable functions in wasm build process

### DIFF
--- a/src/build_wasm.rs
+++ b/src/build_wasm.rs
@@ -270,7 +270,6 @@ pub fn build_wasm() {
     println!("Building the project with wasm-pack...");
     let functions = extract_provable_functions();
     let function_names: Vec<String> = functions.iter().map(|f| f.func_name.clone()).collect();
-    println!("Found {:?}", function_names);
     let is_std = is_std().expect("Failed to check if std feature is enabled");
     for function in functions {
         preprocess_and_save(&function.func_name, &function.attributes, is_std)


### PR DESCRIPTION
Changes:
- Simplified the attribute checking logic in `is_provable`
- Now correctly identifies attributes with the structure `jolt::provable`

While the previous implementation built wasm correctly, the index.html demo was broken. The demo described in the docs will now work as expected.