### PR TITLE
Spartan-Binius

### DIFF
--- a/jolt-core/src/benches/bench.rs
+++ b/jolt-core/src/benches/bench.rs
@@ -99,7 +99,7 @@ where
 fn spartan(binius: bool) -> Vec<(tracing::Span, Box<dyn FnOnce()>)> {
     const LOG_LEN: usize = 28;
     const LEN: usize = 1 << LOG_LEN;
-    const SPARSITY: f64 = 0.35; // pct non-zeros
+    const SPARSITY: f64 = 0.2; // pct non-zeros
 
     let bz: Vec<u64> = vec![1; LEN];
     let mut az: Vec<u64> = Vec::new();

--- a/jolt-core/src/jolt/vm/mod.rs
+++ b/jolt-core/src/jolt/vm/mod.rs
@@ -4,6 +4,7 @@ use crate::field::JoltField;
 use crate::r1cs::builder::CombinedUniformBuilder;
 use crate::r1cs::jolt_constraints::{construct_jolt_constraints, JoltIn};
 use crate::r1cs::spartan::{self, UniformSpartanProof};
+use crate::subprotocols::sumcheck::CurveSpartanSumcheckBackend;
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use ark_std::log2;
 use common::constants::RAM_START_ADDRESS;
@@ -398,7 +399,7 @@ pub trait Jolt<F: JoltField, PCS: CommitmentScheme<Field = F>, const C: usize, c
 
         drop_in_background_thread(jolt_polynomials);
 
-        let spartan_proof = UniformSpartanProof::<F, PCS>::prove_precommitted(
+        let spartan_proof = UniformSpartanProof::<F, PCS>::prove_precommitted::<_, CurveSpartanSumcheckBackend>(
             &preprocessing.generators,
             r1cs_builder,
             &spartan_key,

--- a/jolt-core/src/poly/commitment/mod.rs
+++ b/jolt-core/src/poly/commitment/mod.rs
@@ -5,6 +5,4 @@ pub mod hyrax;
 pub mod kzg;
 pub mod pedersen;
 pub mod zeromorph;
-
-#[cfg(test)]
 pub mod mock;

--- a/jolt-core/src/poly/dense_mlpoly.rs
+++ b/jolt-core/src/poly/dense_mlpoly.rs
@@ -213,6 +213,7 @@ impl<F: JoltField> DensePolynomial<F> {
         self.len = n;
     }
 
+    #[tracing::instrument(skip_all)]
     pub fn bound_poly_var_bot_01_optimized(&mut self, r: &F) {
         let n = self.len() / 2;
         let mut new_z = unsafe_allocate_zero_vec(n);

--- a/jolt-core/src/r1cs/special_polys.rs
+++ b/jolt-core/src/r1cs/special_polys.rs
@@ -292,26 +292,37 @@ impl<'a, F: JoltField> SparseTripleIterator<'a, F> {
             let dense_range_end = range.0;
 
             if a_sparse_i < a.Z.len() && a.Z[a_sparse_i].1 < dense_range_end {
-                let inner_span = tracing::span!(tracing::Level::DEBUG, "a");
-                let inner_enter = inner_span.enter();
-                let _enter = span.enter();
                 let a_start = a_sparse_i;
-                // Scan over a until the corresponding dense index is out of range
-                while a_sparse_i < a.Z.len() && a.Z[a_sparse_i].1 < dense_range_end {
-                    a_sparse_i += 1;
+                // Use binary search to find the first index where the dense index is out of range
+                let mut left = a_sparse_i;
+                let mut right = a.Z.len();
+                while left < right {
+                    let mid = (left + right) / 2;
+                    if a.Z[mid].1 < dense_range_end {
+                        left = mid + 1;
+                    } else {
+                        right = mid;
+                    }
                 }
+                a_sparse_i = left;
 
                 a_chunks[chunk_index - 1] = &a.Z[a_start..a_sparse_i];
             }
 
             if c_sparse_i < c.Z.len() && c.Z[c_sparse_i].1 < dense_range_end {
-                let inner_span = tracing::span!(tracing::Level::DEBUG, "c");
-                let inner_enter = inner_span.enter();
                 let c_start = c_sparse_i;
-                // Scan over c until the corresponding dense index is out of range
-                while c_sparse_i < c.Z.len() && c.Z[c_sparse_i].1 < dense_range_end {
-                    c_sparse_i += 1;
+                // Use binary search to find the first index where the dense index is out of range
+                let mut left = c_sparse_i;
+                let mut right = c.Z.len();
+                while left < right {
+                    let mid = (left + right) / 2;
+                    if c.Z[mid].1 < dense_range_end {
+                        left = mid + 1;
+                    } else {
+                        right = mid;
+                    }
                 }
+                c_sparse_i = left;
 
                 c_chunks[chunk_index - 1] = &c.Z[c_start..c_sparse_i];
             }

--- a/jolt-core/src/r1cs/special_polys.rs
+++ b/jolt-core/src/r1cs/special_polys.rs
@@ -215,7 +215,6 @@ impl<F: JoltField> SparsePolynomial<F> {
         }
     }
 
-    #[cfg(test)]
     #[tracing::instrument(skip_all)]
     pub fn to_dense(self) -> DensePolynomial<F> {
         use crate::utils::{math::Math, thread::unsafe_allocate_zero_vec};
@@ -293,6 +292,9 @@ impl<'a, F: JoltField> SparseTripleIterator<'a, F> {
             let dense_range_end = range.0;
 
             if a_sparse_i < a.Z.len() && a.Z[a_sparse_i].1 < dense_range_end {
+                let inner_span = tracing::span!(tracing::Level::DEBUG, "a");
+                let inner_enter = inner_span.enter();
+                let _enter = span.enter();
                 let a_start = a_sparse_i;
                 // Scan over a until the corresponding dense index is out of range
                 while a_sparse_i < a.Z.len() && a.Z[a_sparse_i].1 < dense_range_end {
@@ -303,6 +305,8 @@ impl<'a, F: JoltField> SparseTripleIterator<'a, F> {
             }
 
             if c_sparse_i < c.Z.len() && c.Z[c_sparse_i].1 < dense_range_end {
+                let inner_span = tracing::span!(tracing::Level::DEBUG, "c");
+                let inner_enter = inner_span.enter();
                 let c_start = c_sparse_i;
                 // Scan over c until the corresponding dense index is out of range
                 while c_sparse_i < c.Z.len() && c.Z[c_sparse_i].1 < dense_range_end {

--- a/jolt-core/src/subprotocols/sumcheck.rs
+++ b/jolt-core/src/subprotocols/sumcheck.rs
@@ -440,16 +440,10 @@ impl<F: JoltField /*+ ark_ff::PrimeField */> SpartanSumcheckBackend<F> for Curve
             claim_per_round = poly.evaluate(&r_i);
 
             // bound all tables to the verifier's challenege
-            rayon::join(
-                || poly_eq.bound_poly_var_bot_01_optimized(&r_i),
-                || rayon::join(
-                    || poly_A.bound_poly_var_bot_par(&r_i),
-                    || rayon::join(
-                        || poly_B.bound_poly_var_bot_par(&r_i),
-                        || poly_C.bound_poly_var_bot_par(&r_i)
-                    )
-                )
-            );
+            poly_eq.bound_poly_var_bot_01_optimized(&r_i);
+            poly_A.bound_poly_var_bot_par(&r_i);
+            poly_B.bound_poly_var_bot_par(&r_i);
+            poly_C.bound_poly_var_bot_par(&r_i);
         }
 
         assert_eq!(poly_eq.len(), 1);
@@ -800,11 +794,6 @@ impl<F: JoltField> SpartanSumcheckBackend<F> for BiniusSpartanSumcheckBackend {
         let mut poly_z = DensePolynomial::new(flat_z);
         assert_eq!(poly_A.len(), poly_z.len());
 
-        // let comb_func = |inputs: &[F]| -> F {
-        //     debug_assert_eq!(inputs.len(), 2);
-        //     inputs[0].mul_0_optimized(inputs[1])
-        // };
-
         let mut r: Vec<F> = Vec::new();
         let mut compressed_polys: Vec<CompressedUniPoly<F>> = Vec::new();
 
@@ -836,7 +825,6 @@ impl<F: JoltField> SpartanSumcheckBackend<F> for BiniusSpartanSumcheckBackend {
                     }
                 );
 
-            // println!("evals: {eval_points:?}");
             let round_uni_poly = UniPoly::from_evals(&vec![eval_points.0, eval_points.1, eval_points.2]);
             round_uni_poly.append_to_transcript(transcript);
             let r_j = transcript.challenge_scalar();

--- a/jolt-core/src/subprotocols/sumcheck.rs
+++ b/jolt-core/src/subprotocols/sumcheck.rs
@@ -440,10 +440,16 @@ impl<F: JoltField /*+ ark_ff::PrimeField */> SpartanSumcheckBackend<F> for Curve
             claim_per_round = poly.evaluate(&r_i);
 
             // bound all tables to the verifier's challenege
-            poly_eq.bound_poly_var_bot_01_optimized(&r_i);
-            poly_A.bound_poly_var_bot_par(&r_i);
-            poly_B.bound_poly_var_bot_par(&r_i);
-            poly_C.bound_poly_var_bot_par(&r_i);
+            rayon::join(
+                || poly_eq.bound_poly_var_bot_01_optimized(&r_i),
+                || rayon::join(
+                    || poly_A.bound_poly_var_bot_par(&r_i),
+                    || rayon::join(
+                        || poly_B.bound_poly_var_bot_par(&r_i),
+                        || poly_C.bound_poly_var_bot_par(&r_i)
+                    )
+                )
+            );
         }
 
         assert_eq!(poly_eq.len(), 1);


### PR DESCRIPTION
Spartan-Binius implemented for the 128b Polyval field. At this point it performs at roughly 2x the speed of `ark_ff::Bn254`.

Remaining low hanging fruit
* eq polynomial optimizations
* reduce the number of evaluation points
* count the post-bind chunk size for `SparsePolynomials` more efficiently