### PR TITLE
Properly uses compression in sumcheck verifier

### DIFF
--- a/jolt-core/src/poly/unipoly.rs
+++ b/jolt-core/src/poly/unipoly.rs
@@ -222,15 +222,27 @@ impl<F: JoltField> CompressedUniPoly<F> {
         assert_eq!(self.coeffs_except_linear_term.len() + 1, coeffs.len());
         UniPoly { coeffs }
     }
-}
 
-impl<F: JoltField> AppendToTranscript for UniPoly<F> {
-    fn append_to_transcript(&self, transcript: &mut ProofTranscript) {
-        transcript.append_message(b"UniPoly_begin");
-        for i in 0..self.coeffs.len() {
-            transcript.append_scalar(&self.coeffs[i]);
+    // In the verifier we do not have to check that f(0) + f(1) = hint as we can just
+    // recover the linear term assuming the prover did it right, then eval the poly
+    pub fn eval_from_hint(&self, hint: &F, x: &F) -> F {
+        let mut linear_term =
+            *hint - self.coeffs_except_linear_term[0] - self.coeffs_except_linear_term[0];
+        for i in 1..self.coeffs_except_linear_term.len() {
+            linear_term -= self.coeffs_except_linear_term[i];
         }
-        transcript.append_message(b"UniPoly_end");
+
+        let mut running_point = *x;
+        let mut running_sum = self.coeffs_except_linear_term[0] + *x * linear_term;
+        for i in 1..self.coeffs_except_linear_term.len() {
+            running_point = running_point * x;
+            running_sum += self.coeffs_except_linear_term[i] * running_point;
+        }
+        running_sum
+    }
+
+    pub fn degree(&self) -> usize {
+        self.coeffs_except_linear_term.len()
     }
 }
 

--- a/jolt-core/src/subprotocols/sumcheck.rs
+++ b/jolt-core/src/subprotocols/sumcheck.rs
@@ -520,18 +520,13 @@ impl<F: JoltField> SumcheckInstanceProof<F> {
         // verify that there is a univariate polynomial for each round
         assert_eq!(self.compressed_polys.len(), num_rounds);
         for i in 0..self.compressed_polys.len() {
-            let poly = self.compressed_polys[i].decompress(&e);
-
             // verify degree bound
-            if poly.degree() != degree_bound {
+            if self.compressed_polys[i].degree() != degree_bound {
                 return Err(ProofVerifyError::InvalidInputLength(
                     degree_bound,
-                    poly.degree(),
+                    self.compressed_polys[i].degree(),
                 ));
             }
-
-            // check if G_k(0) + G_k(1) = e
-            assert_eq!(poly.eval_at_zero() + poly.eval_at_one(), e);
 
             // append the prover's message to the transcript
             self.compressed_polys[i].append_to_transcript(transcript);
@@ -541,8 +536,8 @@ impl<F: JoltField> SumcheckInstanceProof<F> {
 
             r.push(r_i);
 
-            // evaluate the claimed degree-ell polynomial at r_i
-            e = poly.evaluate(&r_i);
+            // evaluate the claimed degree-ell polynomial at r_i using the hint
+            e = self.compressed_polys[i].eval_from_hint(&e, &r_i);
         }
 
         Ok((e, r))


### PR DESCRIPTION
The compressed sumcheck uni polys are calculated as f(0) + f(1) = hint, currently we decompress, check this relationship and then evaluate, however because we decompress using this relation the check can never fail. Instead we should be taking advantage of the compression by computing the linear term implicitly the evaluating, as we do in this PR. 