### PR TITLE
Draft: Implement streaming version of `BytecodePolynomials`

### DIFF
--- a/jolt-core/src/benches/bench.rs
+++ b/jolt-core/src/benches/bench.rs
@@ -2,7 +2,7 @@ use crate::field::JoltField;
 use crate::host;
 use crate::jolt::vm::rv32i_vm::{RV32IJoltVM, C, M};
 use crate::jolt::vm::Jolt;
-use crate::poly::commitment::commitment_scheme::CommitmentScheme;
+use crate::poly::commitment::commitment_scheme::StreamingCommitmentScheme;
 use crate::poly::commitment::hyperkzg::HyperKZG;
 use crate::poly::commitment::hyrax::HyraxScheme;
 use crate::poly::commitment::zeromorph::Zeromorph;
@@ -61,7 +61,7 @@ pub fn benchmarks(
 fn fibonacci<F, PCS>() -> Vec<(tracing::Span, Box<dyn FnOnce()>)>
 where
     F: JoltField,
-    PCS: CommitmentScheme<Field = F>,
+    PCS: StreamingCommitmentScheme<Field = F>,
 {
     prove_example::<u32, PCS, F>("fibonacci-guest", &9u32)
 }
@@ -69,7 +69,7 @@ where
 fn sha2<F, PCS>() -> Vec<(tracing::Span, Box<dyn FnOnce()>)>
 where
     F: JoltField,
-    PCS: CommitmentScheme<Field = F>,
+    PCS: StreamingCommitmentScheme<Field = F>,
 {
     prove_example::<Vec<u8>, PCS, F>("sha2-guest", &vec![5u8; 2048])
 }
@@ -77,7 +77,7 @@ where
 fn sha3<F, PCS>() -> Vec<(tracing::Span, Box<dyn FnOnce()>)>
 where
     F: JoltField,
-    PCS: CommitmentScheme<Field = F>,
+    PCS: StreamingCommitmentScheme<Field = F>,
 {
     prove_example::<Vec<u8>, PCS, F>("sha3-guest", &vec![5u8; 2048])
 }
@@ -99,7 +99,7 @@ fn prove_example<T: Serialize, PCS, F>(
 ) -> Vec<(tracing::Span, Box<dyn FnOnce()>)>
 where
     F: JoltField,
-    PCS: CommitmentScheme<Field = F>,
+    PCS: StreamingCommitmentScheme<Field = F>,
 {
     let mut tasks = Vec::new();
     let mut program = host::Program::new(example_name);
@@ -149,7 +149,7 @@ where
 fn sha2chain<F, PCS>() -> Vec<(tracing::Span, Box<dyn FnOnce()>)>
 where
     F: JoltField,
-    PCS: CommitmentScheme<Field = F>,
+    PCS: StreamingCommitmentScheme<Field = F>,
 {
     let mut tasks = Vec::new();
     let mut program = host::Program::new("sha2-chain-guest");

--- a/jolt-core/src/field/mod.rs
+++ b/jolt-core/src/field/mod.rs
@@ -48,6 +48,9 @@ pub trait JoltField:
     fn to_u64(&self) -> Option<u64> {
         unimplemented!("conversion to u64 not implemented");
     }
+    fn from_usize(val: usize) -> Option<Self> {
+        Self::from_u64(val as u64)
+    }
 }
 
 pub trait OptimizedMul<Rhs, Output>: Sized + Mul<Rhs, Output = Output> {

--- a/jolt-core/src/jolt/vm/bytecode.rs
+++ b/jolt-core/src/jolt/vm/bytecode.rs
@@ -589,15 +589,15 @@ impl<F: JoltField, PCS: CommitmentScheme<Field = F>> BytecodeProof<F, PCS> {
 }
 
 // TODO: Use BytecodeStuff? XXX
-pub struct StreamingBytecodeCommitment<C: StreamingCommitmentScheme> {
-    a_read_write: C::State,
-    v_read_write: [C::State; 6],
-    t_read: C::State,
+pub struct StreamingBytecodeCommitment<'a, C: StreamingCommitmentScheme> {
+    a_read_write: C::State<'a>,
+    v_read_write: [C::State<'a>; 6],
+    t_read: C::State<'a>,
 }
 
-impl<C: StreamingCommitmentScheme> StreamingBytecodeCommitment<C> {
+impl<'a, C: StreamingCommitmentScheme> StreamingBytecodeCommitment<'a, C> {
     /// Initialize a streaming computation of a commitment.
-    pub fn initialize(size: usize, setup: &C::Setup, batch_type: &BatchType) -> Self {
+    pub fn initialize(size: usize, setup: &'a C::Setup, batch_type: &BatchType) -> Self {
         let a_read_write = C::initialize(size, setup, batch_type);
         let v_read_write = std::array::from_fn(|_| a_read_write.clone());
         let t_read = a_read_write.clone();

--- a/jolt-core/src/jolt/vm/mod.rs
+++ b/jolt-core/src/jolt/vm/mod.rs
@@ -5,6 +5,7 @@ use crate::field::JoltField;
 use crate::poly::opening_proof::{
     ProverOpeningAccumulator, ReducedOpeningProof, VerifierOpeningAccumulator,
 };
+use crate::r1cs::inputs::StreamingR1CSCommitment;
 use crate::r1cs::constraints::R1CSConstraints;
 use crate::r1cs::spartan::{self, UniformSpartanProof};
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
@@ -34,7 +35,7 @@ use crate::lasso::memory_checking::{
 };
 use crate::poly::commitment::commitment_scheme::{BatchType, CommitmentScheme, StreamingCommitmentScheme};
 use crate::poly::dense_mlpoly::DensePolynomial;
-use crate::r1cs::inputs::{ConstraintInput, R1CSPolynomials, R1CSProof, R1CSStuff};
+use crate::r1cs::inputs::{ConstraintInput, R1CSPolynomials, R1CSProof, R1CSStuff, StreamingR1CSPolynomials};
 use crate::utils::errors::ProofVerifyError;
 use crate::utils::thread::drop_in_background_thread;
 use crate::utils::transcript::{AppendToTranscript, ProofTranscript};
@@ -396,6 +397,18 @@ pub trait Jolt<F: JoltField, PCS: StreamingCommitmentScheme<Field = F>, const C:
             });
         let bytecode_commitments = StreamingBytecodeCommitment::finalize(streaming_trace_commitments);
 
+        let streaming_r1cs_polynomials = StreamingR1CSPolynomials::<F>::new::<
+            C,
+            M,
+            Self::InstructionSet,
+            <Self::Constraints as R1CSConstraints<C, F>>::Inputs,
+        >(&trace2);
+        let r1cs_commitments = StreamingR1CSCommitment::<C, PCS>::initialize(&streaming_r1cs_polynomials, &preprocessing.generators, &BatchType::Big);
+        let r1cs_commitments = streaming_r1cs_polynomials.fold(r1cs_commitments, |state, step| {
+            StreamingR1CSCommitment::process(state, &step)
+        });
+        let r1cs_commitments = StreamingR1CSCommitment::finalize(r1cs_commitments);
+
         let mut jolt_polynomials = JoltPolynomials {
             bytecode: bytecode_polynomials,
             read_write_memory: memory_polynomials,
@@ -417,6 +430,9 @@ pub trait Jolt<F: JoltField, PCS: StreamingCommitmentScheme<Field = F>, const C:
         assert_eq!(bytecode_commitments[5], jolt_commitments.bytecode.v_read_write[3]);
         assert_eq!(bytecode_commitments[6], jolt_commitments.bytecode.v_read_write[4]);
         assert_eq!(bytecode_commitments[7], jolt_commitments.bytecode.v_read_write[5]);
+        assert_eq!(r1cs_commitments.0, jolt_commitments.r1cs.chunks_x);
+        assert_eq!(r1cs_commitments.1, jolt_commitments.r1cs.chunks_y);
+        assert_eq!(r1cs_commitments.2, jolt_commitments.r1cs.circuit_flags);
 
         transcript.append_scalar(&spartan_key.vk_digest);
 

--- a/jolt-core/src/jolt/vm/rv32i_vm.rs
+++ b/jolt-core/src/jolt/vm/rv32i_vm.rs
@@ -36,7 +36,7 @@ use crate::jolt::subtable::{
     truncate_overflow::TruncateOverflowSubtable, xor::XorSubtable, JoltSubtableSet, LassoSubtable,
     SubtableId,
 };
-use crate::poly::commitment::commitment_scheme::CommitmentScheme;
+use crate::poly::commitment::commitment_scheme::StreamingCommitmentScheme;
 
 /// Generates an enum out of a list of JoltInstruction types. All JoltInstruction methods
 /// are callable on the enum type via enum_dispatch.
@@ -176,7 +176,7 @@ pub const M: usize = 1 << 16;
 impl<F, PCS> Jolt<F, PCS, C, M> for RV32IJoltVM
 where
     F: JoltField,
-    PCS: CommitmentScheme<Field = F>,
+    PCS: StreamingCommitmentScheme<Field = F>,
 {
     type InstructionSet = RV32I;
     type Subtables = RV32ISubtables<F>;

--- a/jolt-core/src/poly/commitment/binius.rs
+++ b/jolt-core/src/poly/commitment/binius.rs
@@ -11,7 +11,7 @@ use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 #[derive(Clone)]
 pub struct Binius128Scheme {}
 
-#[derive(Default, Debug, PartialEq, CanonicalSerialize, CanonicalDeserialize)]
+#[derive(Default, Debug, PartialEq, Eq, CanonicalSerialize, CanonicalDeserialize)]
 pub struct BiniusCommitment {}
 
 impl AppendToTranscript for BiniusCommitment {

--- a/jolt-core/src/poly/commitment/commitment_scheme.rs
+++ b/jolt-core/src/poly/commitment/commitment_scheme.rs
@@ -39,6 +39,7 @@ pub trait CommitmentScheme: Clone + Sync + Send + 'static {
     type Setup: Clone + Sync + Send;
     type Commitment: Default
         + Debug
+        + Eq
         + Sync
         + Send
         + PartialEq
@@ -116,4 +117,12 @@ pub trait CommitmentScheme: Clone + Sync + Send + 'static {
     ) -> Result<(), ProofVerifyError>;
 
     fn protocol_name() -> &'static [u8];
+}
+
+pub trait StreamingCommitmentScheme: CommitmentScheme {
+    type State;
+
+    fn initialize(size: usize, setup: &Self::Setup, batch_type: &BatchType) -> Self::State;
+    fn process(state: Self::State, eval: Self::Field) -> Self::State;
+    fn finalize(state: Self::State) -> Self::Commitment;
 }

--- a/jolt-core/src/poly/commitment/commitment_scheme.rs
+++ b/jolt-core/src/poly/commitment/commitment_scheme.rs
@@ -120,9 +120,9 @@ pub trait CommitmentScheme: Clone + Sync + Send + 'static {
 }
 
 pub trait StreamingCommitmentScheme: CommitmentScheme {
-    type State: Clone + Debug;
+    type State<'a>: Clone + Debug;
 
-    fn initialize(size: usize, setup: &Self::Setup, batch_type: &BatchType) -> Self::State;
-    fn process(state: Self::State, eval: Self::Field) -> Self::State;
-    fn finalize(state: Self::State) -> Self::Commitment;
+    fn initialize<'a>(size: usize, setup: &'a Self::Setup, batch_type: &BatchType) -> Self::State<'a>;
+    fn process<'a>(state: Self::State<'a>, eval: Self::Field) -> Self::State<'a>;
+    fn finalize<'a>(state: Self::State<'a>) -> Self::Commitment;
 }

--- a/jolt-core/src/poly/commitment/commitment_scheme.rs
+++ b/jolt-core/src/poly/commitment/commitment_scheme.rs
@@ -120,7 +120,7 @@ pub trait CommitmentScheme: Clone + Sync + Send + 'static {
 }
 
 pub trait StreamingCommitmentScheme: CommitmentScheme {
-    type State;
+    type State: Clone + Debug;
 
     fn initialize(size: usize, setup: &Self::Setup, batch_type: &BatchType) -> Self::State;
     fn process(state: Self::State, eval: Self::Field) -> Self::State;

--- a/jolt-core/src/poly/commitment/hyperkzg.rs
+++ b/jolt-core/src/poly/commitment/hyperkzg.rs
@@ -8,9 +8,8 @@
 //! (2) HyperKZG is specialized to use KZG as the univariate commitment scheme, so it includes several optimizations (both during the transformation of multilinear-to-univariate claims
 //! and within the KZG commitment scheme implementation itself).
 use super::{
-    commitment_scheme::{BatchType, CommitmentScheme},
-    kzg,
-    kzg::{KZGProverKey, KZGVerifierKey, UnivariateKZG},
+    commitment_scheme::{BatchType, CommitmentScheme, StreamingCommitmentScheme},
+    kzg::{self, KZGProverKey, KZGVerifierKey, UnivariateKZG},
 };
 use crate::field;
 use crate::poly::commitment::commitment_scheme::CommitShape;
@@ -59,7 +58,7 @@ pub struct HyperKZGVerifierKey<P: Pairing> {
     pub kzg_vk: KZGVerifierKey<P>,
 }
 
-#[derive(Debug, PartialEq, CanonicalSerialize, CanonicalDeserialize)]
+#[derive(Debug, Eq, PartialEq, CanonicalSerialize, CanonicalDeserialize)]
 pub struct HyperKZGCommitment<P: Pairing>(pub P::G1Affine);
 
 impl<P: Pairing> Default for HyperKZGCommitment<P> {
@@ -643,6 +642,23 @@ where
 
     fn protocol_name() -> &'static [u8] {
         b"hyperkzg"
+    }
+}
+
+impl<P: Pairing> StreamingCommitmentScheme for HyperKZG<P>
+where
+    <P as Pairing>::ScalarField: field::JoltField,
+{
+    type State = ();
+
+    fn initialize(size: usize, setup: &Self::Setup, batch_type: &BatchType) -> Self::State {
+        todo!()
+    }
+    fn process(state: Self::State, eval: Self::Field) -> Self::State {
+        todo!()
+    }
+    fn finalize(state: Self::State) -> Self::Commitment {
+        todo!()
     }
 }
 

--- a/jolt-core/src/poly/commitment/hyrax.rs
+++ b/jolt-core/src/poly/commitment/hyrax.rs
@@ -182,6 +182,7 @@ impl<F: JoltField, G: CurveGroup<ScalarField = F>> CommitmentScheme for HyraxSch
     }
 }
 
+#[derive(Clone, Debug)]
 pub struct HyraxSchemeState<G: CurveGroup> {
     row_commitments: Vec<G>,
     generators: Vec<<G as CurveGroup>::Affine>,

--- a/jolt-core/src/poly/commitment/hyrax.rs
+++ b/jolt-core/src/poly/commitment/hyrax.rs
@@ -192,9 +192,9 @@ pub struct HyraxSchemeState<G: CurveGroup> {
 }
 
 impl<F: JoltField, G: CurveGroup<ScalarField = F>> StreamingCommitmentScheme for HyraxScheme<G> {
-    type State = HyraxSchemeState<G>;
+    type State<'a> = HyraxSchemeState<G>;
 
-    fn initialize(n: usize, generators: &Self::Setup, batch_type: &BatchType) -> Self::State {
+    fn initialize<'a>(n: usize, generators: &'a Self::Setup, batch_type: &BatchType) -> Self::State<'a> {
         let ell = n.log_2();
 
         let ratio = batch_type_to_ratio(batch_type);
@@ -216,7 +216,7 @@ impl<F: JoltField, G: CurveGroup<ScalarField = F>> StreamingCommitmentScheme for
         }
     }
 
-    fn process(mut state: Self::State, eval: Self::Field) -> Self::State {
+    fn process<'a>(mut state: Self::State<'a>, eval: Self::Field) -> Self::State<'a> {
         state.current_row.push(eval);
 
         if state.current_row.len() == state.R_size {
@@ -228,7 +228,7 @@ impl<F: JoltField, G: CurveGroup<ScalarField = F>> StreamingCommitmentScheme for
 
         state
     }
-    fn finalize(state: Self::State) -> Self::Commitment {
+    fn finalize<'a>(state: Self::State<'a>) -> Self::Commitment {
         assert_eq!(state.current_row.len(), 0, "Incorrect number of elements processed.");
         assert_eq!(state.row_commitments.len(), state.L_size, "Incorrect number of elements processed.");
 

--- a/jolt-core/src/poly/commitment/zeromorph.rs
+++ b/jolt-core/src/poly/commitment/zeromorph.rs
@@ -25,7 +25,7 @@ use tracing::trace_span;
 use rayon::prelude::*;
 
 use super::{
-    commitment_scheme::{BatchType, CommitShape, CommitmentScheme},
+    commitment_scheme::{BatchType, CommitShape, CommitmentScheme, StreamingCommitmentScheme},
     kzg::{KZGProverKey, KZGVerifierKey, UnivariateKZG, SRS},
 };
 
@@ -64,7 +64,7 @@ pub struct ZeromorphVerifierKey<P: Pairing> {
     pub tau_N_max_sub_2_N: P::G2Affine,
 }
 
-#[derive(Debug, PartialEq, CanonicalSerialize, CanonicalDeserialize)]
+#[derive(Debug, Eq, PartialEq, CanonicalSerialize, CanonicalDeserialize)]
 pub struct ZeromorphCommitment<P: Pairing>(P::G1Affine);
 
 impl<P: Pairing> Default for ZeromorphCommitment<P> {
@@ -609,6 +609,23 @@ where
 
     fn protocol_name() -> &'static [u8] {
         b"zeromorph"
+    }
+}
+
+impl<P: Pairing> StreamingCommitmentScheme for Zeromorph<P>
+where
+    <P as Pairing>::ScalarField: field::JoltField,
+{
+    type State = ();
+
+    fn initialize(size: usize, setup: &Self::Setup, batch_type: &BatchType) -> Self::State {
+        todo!()
+    }
+    fn process(state: Self::State, eval: Self::Field) -> Self::State {
+        todo!()
+    }
+    fn finalize(state: Self::State) -> Self::Commitment {
+        todo!()
     }
 }
 

--- a/jolt-core/src/poly/commitment/zeromorph.rs
+++ b/jolt-core/src/poly/commitment/zeromorph.rs
@@ -616,15 +616,15 @@ impl<P: Pairing> StreamingCommitmentScheme for Zeromorph<P>
 where
     <P as Pairing>::ScalarField: field::JoltField,
 {
-    type State = ();
+    type State<'a> = ();
 
-    fn initialize(size: usize, setup: &Self::Setup, batch_type: &BatchType) -> Self::State {
+    fn initialize<'a>(size: usize, setup: &'a Self::Setup, batch_type: &BatchType) -> Self::State<'a> {
         todo!()
     }
-    fn process(state: Self::State, eval: Self::Field) -> Self::State {
+    fn process<'a>(state: Self::State<'a>, eval: Self::Field) -> Self::State<'a> {
         todo!()
     }
-    fn finalize(state: Self::State) -> Self::Commitment {
+    fn finalize<'a>(state: Self::State<'a>) -> Self::Commitment {
         todo!()
     }
 }

--- a/jolt-core/src/utils/mod.rs
+++ b/jolt-core/src/utils/mod.rs
@@ -10,6 +10,7 @@ pub mod instruction_utils;
 pub mod math;
 pub mod profiling;
 pub mod sol_types;
+pub mod streaming;
 pub mod thread;
 pub mod transcript;
 

--- a/jolt-core/src/utils/streaming.rs
+++ b/jolt-core/src/utils/streaming.rs
@@ -1,0 +1,52 @@
+/// An iterator that maps over the values of `iter` with `f`, which modifies its accumulated state.
+pub struct MapState<S, I, F> {
+    state: S,
+    iter: I,
+    f: F,
+}
+
+pub fn map_state<B, S, I, F>(initial_state: S, iter: I, f: F) -> MapState<S, I, F>
+where
+    I: Iterator,
+    F: FnMut(&mut S, I::Item) -> B,
+{
+    MapState::new(initial_state, iter, f)
+}
+
+impl<S, I, F> MapState<S, I, F> {
+    fn new<B>(initial_state: S, iter: I, f: F) -> Self
+    where
+        I: Iterator,
+        F: FnMut(&mut S, I::Item) -> B,
+    {
+        MapState {
+            state: initial_state,
+            iter,
+            f,
+        }
+    }
+
+    /// Return the accumulated state.
+    /// Note that this **does not** collect the rest of the iterator.
+    fn finalize(self) -> S {
+        self.state
+    }
+}
+
+impl<B, S, I, F> Iterator for MapState<S, I, F>
+where
+    I: Iterator,
+    F: FnMut(&mut S, I::Item) -> B,
+{
+    type Item = B;
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        self.iter.next().map(|x| (self.f)(&mut self.state, x))
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.iter.size_hint()
+    }
+}


### PR DESCRIPTION
@moodlezoup @sragss, I've started implementing a streaming version of `BytecodePolynomials`. I want to make sure we're on the right track before we start migrating the code to use this streaming behavior. 

I created the `MapState` iterator since the stream mutates `final_cts` as it processes the trace. It seems like this should exist in the standard library, but I couldn't find anything that accomplishes this. One limitation of this is that `final_cts` can't be read until the stream is consumed. I'm not sure if this is feasible with how the code uses `final_cts`. If not, we may need to do an additional pass upfront that computes `final_cts`. 