### PR TITLE
Strip RISC-V binary

### DIFF
--- a/jolt-core/src/host/mod.rs
+++ b/jolt-core/src/host/mod.rs
@@ -114,6 +114,10 @@ impl Program {
                 "passes=lower-atomic",
                 "-C",
                 "panic=abort",
+                "-C",
+                "strip=symbols",
+                "-C",
+                "opt-level=z",
             ];
 
             let toolchain = if self.std {


### PR DESCRIPTION
This dramatically reduces the produced RISC-V binary size (for small programs about 4x). 

E.g. the fibonacci guest binary goes from 27KB down to 6KB.