### PR TITLE
Transcript trait

### DIFF
--- a/jolt-core/benches/grand_product.rs
+++ b/jolt-core/benches/grand_product.rs
@@ -10,7 +10,7 @@ use jolt_core::subprotocols::grand_product::{
 use jolt_core::subprotocols::grand_product_quarks::{
     QuarkGrandProduct, QuarkGrandProductConfig, QuarkHybridLayerDepth,
 };
-use jolt_core::utils::transcript::ProofTranscript;
+use jolt_core::utils::transcript::{DefaultTranscript, Transcript};
 use rand_chacha::ChaCha20Rng;
 use rand_core::{RngCore, SeedableRng};
 
@@ -96,7 +96,7 @@ fn benchmark_prove<PCS, F, G>(
         |b| {
             b.iter(|| {
                 // Prove the grand product
-                let mut transcript = ProofTranscript::new(b"test_transcript");
+                let mut transcript = DefaultTranscript::new(b"test_transcript");
                 let mut prover_accumulator: ProverOpeningAccumulator<F> =
                     ProverOpeningAccumulator::new();
                 let _proof: BatchedGrandProductProof<PCS> = grand_product
@@ -123,7 +123,7 @@ fn benchmark_verify<PCS, F, G>(
     let (leaves, setup, known_products) =
         setup_bench::<PCS, F>(config.num_layers, config.layer_size, config.percentage_ones);
 
-    let mut transcript = ProofTranscript::new(b"test_transcript");
+    let mut transcript = DefaultTranscript::new(b"test_transcript");
     let mut grand_product = G::construct_with_config(leaves, grand_products_config);
     let mut prover_accumulator: ProverOpeningAccumulator<F> = ProverOpeningAccumulator::new();
     let (proof, r_prover) = grand_product.prove_grand_product(
@@ -140,7 +140,7 @@ fn benchmark_verify<PCS, F, G>(
         |b| {
             b.iter(|| {
                 // Verify the grand product
-                transcript = ProofTranscript::new(b"test_transcript");
+                transcript = DefaultTranscript::new(b"test_transcript");
                 let mut verifier_accumulator: VerifierOpeningAccumulator<F, PCS> =
                     VerifierOpeningAccumulator::new();
                 let (_, r_verifier) = QuarkGrandProduct::verify_grand_product(

--- a/jolt-core/benches/grand_product.rs
+++ b/jolt-core/benches/grand_product.rs
@@ -96,7 +96,7 @@ fn benchmark_prove<PCS, F, G>(
         |b| {
             b.iter(|| {
                 // Prove the grand product
-                let mut transcript = DefaultTranscript::new(b"test_transcript");
+                let mut transcript = ProofTranscript::new(b"test_transcript");
                 let mut prover_accumulator: ProverOpeningAccumulator<F> =
                     ProverOpeningAccumulator::new();
                 let _proof: BatchedGrandProductProof<PCS> = grand_product
@@ -123,7 +123,7 @@ fn benchmark_verify<PCS, F, G>(
     let (leaves, setup, known_products) =
         setup_bench::<PCS, F>(config.num_layers, config.layer_size, config.percentage_ones);
 
-    let mut transcript = DefaultTranscript::new(b"test_transcript");
+    let mut transcript = ProofTranscript::new(b"test_transcript");
     let mut grand_product = G::construct_with_config(leaves, grand_products_config);
     let mut prover_accumulator: ProverOpeningAccumulator<F> = ProverOpeningAccumulator::new();
     let (proof, r_prover) = grand_product.prove_grand_product(
@@ -140,7 +140,7 @@ fn benchmark_verify<PCS, F, G>(
         |b| {
             b.iter(|| {
                 // Verify the grand product
-                transcript = DefaultTranscript::new(b"test_transcript");
+                transcript = ProofTranscript::new(b"test_transcript");
                 let mut verifier_accumulator: VerifierOpeningAccumulator<F, PCS> =
                     VerifierOpeningAccumulator::new();
                 let (_, r_verifier) = QuarkGrandProduct::verify_grand_product(

--- a/jolt-core/src/benches/bench.rs
+++ b/jolt-core/src/benches/bench.rs
@@ -6,6 +6,7 @@ use crate::poly::commitment::commitment_scheme::CommitmentScheme;
 use crate::poly::commitment::hyperkzg::HyperKZG;
 use crate::poly::commitment::hyrax::HyraxScheme;
 use crate::poly::commitment::zeromorph::Zeromorph;
+use crate::utils::transcript::{DefaultTranscript, Transcript};
 use ark_bn254::{Bn254, Fr, G1Projective};
 use serde::Serialize;
 
@@ -34,52 +35,71 @@ pub fn benchmarks(
 ) -> Vec<(tracing::Span, Box<dyn FnOnce()>)> {
     match pcs_type {
         PCSType::Hyrax => match bench_type {
-            BenchType::Sha2 => sha2::<Fr, HyraxScheme<G1Projective>>(),
-            BenchType::Sha3 => sha3::<Fr, HyraxScheme<G1Projective>>(),
-            BenchType::Sha2Chain => sha2chain::<Fr, HyraxScheme<G1Projective>>(),
-            BenchType::Fibonacci => fibonacci::<Fr, HyraxScheme<G1Projective>>(),
+            BenchType::Sha2 => {
+                sha2::<Fr, HyraxScheme<G1Projective, DefaultTranscript>, DefaultTranscript>()
+            }
+            BenchType::Sha3 => {
+                sha3::<Fr, HyraxScheme<G1Projective, DefaultTranscript>, DefaultTranscript>()
+            }
+            BenchType::Sha2Chain => {
+                sha2chain::<Fr, HyraxScheme<G1Projective, DefaultTranscript>, DefaultTranscript>()
+            }
+            BenchType::Fibonacci => {
+                fibonacci::<Fr, HyraxScheme<G1Projective, DefaultTranscript>, DefaultTranscript>()
+            }
             _ => panic!("BenchType does not have a mapping"),
         },
         PCSType::Zeromorph => match bench_type {
-            BenchType::Sha2 => sha2::<Fr, Zeromorph<Bn254>>(),
-            BenchType::Sha3 => sha3::<Fr, Zeromorph<Bn254>>(),
-            BenchType::Sha2Chain => sha2chain::<Fr, Zeromorph<Bn254>>(),
-            BenchType::Fibonacci => fibonacci::<Fr, Zeromorph<Bn254>>(),
+            BenchType::Sha2 => sha2::<Fr, Zeromorph<Bn254, DefaultTranscript>, DefaultTranscript>(),
+            BenchType::Sha3 => sha3::<Fr, Zeromorph<Bn254, DefaultTranscript>, DefaultTranscript>(),
+            BenchType::Sha2Chain => {
+                sha2chain::<Fr, Zeromorph<Bn254, DefaultTranscript>, DefaultTranscript>()
+            }
+            BenchType::Fibonacci => {
+                fibonacci::<Fr, Zeromorph<Bn254, DefaultTranscript>, DefaultTranscript>()
+            }
             _ => panic!("BenchType does not have a mapping"),
         },
         PCSType::HyperKZG => match bench_type {
-            BenchType::Sha2 => sha2::<Fr, HyperKZG<Bn254>>(),
-            BenchType::Sha3 => sha3::<Fr, HyperKZG<Bn254>>(),
-            BenchType::Sha2Chain => sha2chain::<Fr, HyperKZG<Bn254>>(),
-            BenchType::Fibonacci => fibonacci::<Fr, HyperKZG<Bn254>>(),
+            BenchType::Sha2 => sha2::<Fr, HyperKZG<Bn254, DefaultTranscript>, DefaultTranscript>(),
+            BenchType::Sha3 => sha3::<Fr, HyperKZG<Bn254, DefaultTranscript>, DefaultTranscript>(),
+            BenchType::Sha2Chain => {
+                sha2chain::<Fr, HyperKZG<Bn254, DefaultTranscript>, DefaultTranscript>()
+            }
+            BenchType::Fibonacci => {
+                fibonacci::<Fr, HyperKZG<Bn254, DefaultTranscript>, DefaultTranscript>()
+            }
             _ => panic!("BenchType does not have a mapping"),
         },
         _ => panic!("PCS Type does not have a mapping"),
     }
 }
 
-fn fibonacci<F, PCS>() -> Vec<(tracing::Span, Box<dyn FnOnce()>)>
+fn fibonacci<F, PCS, ProofTranscript>() -> Vec<(tracing::Span, Box<dyn FnOnce()>)>
 where
     F: JoltField,
-    PCS: CommitmentScheme<Field = F>,
+    PCS: CommitmentScheme<ProofTranscript, Field = F>,
+    ProofTranscript: Transcript,
 {
-    prove_example::<u32, PCS, F>("fibonacci-guest", &9u32)
+    prove_example::<u32, PCS, F, ProofTranscript>("fibonacci-guest", &9u32)
 }
 
-fn sha2<F, PCS>() -> Vec<(tracing::Span, Box<dyn FnOnce()>)>
+fn sha2<F, PCS, ProofTranscript>() -> Vec<(tracing::Span, Box<dyn FnOnce()>)>
 where
     F: JoltField,
-    PCS: CommitmentScheme<Field = F>,
+    PCS: CommitmentScheme<ProofTranscript, Field = F>,
+    ProofTranscript: Transcript,
 {
-    prove_example::<Vec<u8>, PCS, F>("sha2-guest", &vec![5u8; 2048])
+    prove_example::<Vec<u8>, PCS, F, ProofTranscript>("sha2-guest", &vec![5u8; 2048])
 }
 
-fn sha3<F, PCS>() -> Vec<(tracing::Span, Box<dyn FnOnce()>)>
+fn sha3<F, PCS, ProofTranscript>() -> Vec<(tracing::Span, Box<dyn FnOnce()>)>
 where
     F: JoltField,
-    PCS: CommitmentScheme<Field = F>,
+    PCS: CommitmentScheme<ProofTranscript, Field = F>,
+    ProofTranscript: Transcript,
 {
-    prove_example::<Vec<u8>, PCS, F>("sha3-guest", &vec![5u8; 2048])
+    prove_example::<Vec<u8>, PCS, F, ProofTranscript>("sha3-guest", &vec![5u8; 2048])
 }
 
 #[allow(dead_code)]
@@ -93,13 +113,14 @@ fn serialize_and_print_size(name: &str, item: &impl ark_serialize::CanonicalSeri
     println!("{:<30} : {:.3} MB", name, file_size_mb);
 }
 
-fn prove_example<T: Serialize, PCS, F>(
+fn prove_example<T: Serialize, PCS, F, ProofTranscript>(
     example_name: &str,
     input: &T,
 ) -> Vec<(tracing::Span, Box<dyn FnOnce()>)>
 where
     F: JoltField,
-    PCS: CommitmentScheme<Field = F>,
+    PCS: CommitmentScheme<ProofTranscript, Field = F>,
+    ProofTranscript: Transcript,
 {
     let mut tasks = Vec::new();
     let mut program = host::Program::new(example_name);
@@ -109,11 +130,15 @@ where
         let (bytecode, memory_init) = program.decode();
         let (io_device, trace) = program.trace();
 
-        let preprocessing: crate::jolt::vm::JoltPreprocessing<C, F, PCS> =
+        let preprocessing: crate::jolt::vm::JoltPreprocessing<C, F, PCS, ProofTranscript> =
             RV32IJoltVM::preprocess(bytecode.clone(), memory_init, 1 << 20, 1 << 20, 1 << 22);
 
         let (jolt_proof, jolt_commitments, _) =
-            <RV32IJoltVM as Jolt<_, PCS, C, M>>::prove(io_device, trace, preprocessing.clone());
+            <RV32IJoltVM as Jolt<_, PCS, C, M, ProofTranscript>>::prove(
+                io_device,
+                trace,
+                preprocessing.clone(),
+            );
 
         println!("Proof sizing:");
         serialize_and_print_size("jolt_commitments", &jolt_commitments);
@@ -146,10 +171,11 @@ where
     tasks
 }
 
-fn sha2chain<F, PCS>() -> Vec<(tracing::Span, Box<dyn FnOnce()>)>
+fn sha2chain<F, PCS, ProofTranscript>() -> Vec<(tracing::Span, Box<dyn FnOnce()>)>
 where
     F: JoltField,
-    PCS: CommitmentScheme<Field = F>,
+    PCS: CommitmentScheme<ProofTranscript, Field = F>,
+    ProofTranscript: Transcript,
 {
     let mut tasks = Vec::new();
     let mut program = host::Program::new("sha2-chain-guest");
@@ -160,11 +186,15 @@ where
         let (bytecode, memory_init) = program.decode();
         let (io_device, trace) = program.trace();
 
-        let preprocessing: crate::jolt::vm::JoltPreprocessing<C, F, PCS> =
+        let preprocessing: crate::jolt::vm::JoltPreprocessing<C, F, PCS, ProofTranscript> =
             RV32IJoltVM::preprocess(bytecode.clone(), memory_init, 1 << 20, 1 << 20, 1 << 22);
 
         let (jolt_proof, jolt_commitments, _) =
-            <RV32IJoltVM as Jolt<_, PCS, C, M>>::prove(io_device, trace, preprocessing.clone());
+            <RV32IJoltVM as Jolt<_, PCS, C, M, ProofTranscript>>::prove(
+                io_device,
+                trace,
+                preprocessing.clone(),
+            );
         let verification_result =
             RV32IJoltVM::verify(preprocessing, jolt_proof, jolt_commitments, None);
         assert!(

--- a/jolt-core/src/jolt/vm/bytecode.rs
+++ b/jolt-core/src/jolt/vm/bytecode.rs
@@ -20,12 +20,12 @@ use common::to_ram_address;
 
 use rayon::prelude::*;
 
+use super::{JoltPolynomials, JoltTraceStep};
+use crate::utils::transcript::Transcript;
 use crate::{
     lasso::memory_checking::{MemoryCheckingProof, MemoryCheckingProver, MemoryCheckingVerifier},
     poly::{dense_mlpoly::DensePolynomial, identity_poly::IdentityPolynomial},
 };
-
-use super::{JoltPolynomials, JoltTraceStep};
 
 #[derive(Default, CanonicalSerialize, CanonicalDeserialize)]
 pub struct BytecodeStuff<T: CanonicalSerialize + CanonicalDeserialize> {
@@ -59,7 +59,8 @@ pub type BytecodeOpenings<F: JoltField> = BytecodeStuff<F>;
 /// Note –– PCS: CommitmentScheme bound is not enforced.
 /// See issue #112792 <https://github.com/rust-lang/rust/issues/112792>.
 /// Adding #![feature(lazy_type_alias)] to the crate attributes seem to break
-pub type BytecodeCommitments<PCS: CommitmentScheme> = BytecodeStuff<PCS::Commitment>;
+pub type BytecodeCommitments<PCS: CommitmentScheme<ProofTranscript>, ProofTranscript: Transcript> =
+    BytecodeStuff<PCS::Commitment>;
 
 impl<F: JoltField, T: CanonicalSerialize + CanonicalDeserialize + Default>
     Initializable<T, BytecodePreprocessing<F>> for BytecodeStuff<T>
@@ -92,8 +93,8 @@ impl<T: CanonicalSerialize + CanonicalDeserialize> StructuredPolynomialData<T>
     }
 }
 
-pub type BytecodeProof<F, PCS> =
-    MemoryCheckingProof<F, PCS, BytecodeOpenings<F>, NoExogenousOpenings>;
+pub type BytecodeProof<F, PCS, ProofTranscript> =
+    MemoryCheckingProof<F, PCS, BytecodeOpenings<F>, NoExogenousOpenings, ProofTranscript>;
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct BytecodeRow {
@@ -290,7 +291,12 @@ impl<F: JoltField> BytecodePreprocessing<F> {
     }
 }
 
-impl<F: JoltField, PCS: CommitmentScheme<Field = F>> BytecodeProof<F, PCS> {
+impl<F, PCS, ProofTranscript> BytecodeProof<F, PCS, ProofTranscript>
+where
+    F: JoltField,
+    PCS: CommitmentScheme<ProofTranscript, Field = F>,
+    ProofTranscript: Transcript,
+{
     #[tracing::instrument(skip_all, name = "BytecodePolynomials::new")]
     pub fn generate_witness<InstructionSet: JoltInstructionSet>(
         preprocessing: &BytecodePreprocessing<F>,
@@ -469,14 +475,16 @@ impl<F: JoltField, PCS: CommitmentScheme<Field = F>> BytecodeProof<F, PCS> {
     }
 }
 
-impl<F, PCS> MemoryCheckingProver<F, PCS> for BytecodeProof<F, PCS>
+impl<F, PCS, ProofTranscript> MemoryCheckingProver<F, PCS, ProofTranscript>
+    for BytecodeProof<F, PCS, ProofTranscript>
 where
     F: JoltField,
-    PCS: CommitmentScheme<Field = F>,
+    PCS: CommitmentScheme<ProofTranscript, Field = F>,
+    ProofTranscript: Transcript,
 {
     type Polynomials = BytecodePolynomials<F>;
     type Openings = BytecodeOpenings<F>;
-    type Commitments = BytecodeCommitments<PCS>;
+    type Commitments = BytecodeCommitments<PCS, ProofTranscript>;
     type Preprocessing = BytecodePreprocessing<F>;
 
     // [virtual_address, elf_address, opcode, rd, rs1, rs2, imm, t]
@@ -596,10 +604,12 @@ where
     }
 }
 
-impl<F, PCS> MemoryCheckingVerifier<F, PCS> for BytecodeProof<F, PCS>
+impl<F, PCS, ProofTranscript> MemoryCheckingVerifier<F, PCS, ProofTranscript>
+    for BytecodeProof<F, PCS, ProofTranscript>
 where
     F: JoltField,
-    PCS: CommitmentScheme<Field = F>,
+    PCS: CommitmentScheme<ProofTranscript, Field = F>,
+    ProofTranscript: Transcript,
 {
     fn compute_verifier_openings(
         openings: &mut BytecodeOpenings<F>,
@@ -695,6 +705,7 @@ mod tests {
     use crate::{jolt::vm::rv32i_vm::RV32I, poly::commitment::hyrax::HyraxScheme};
 
     use super::*;
+    use crate::utils::transcript::DefaultTranscript;
     use ark_bn254::{Fr, G1Projective};
     use common::{
         constants::MEMORY_OPS_PER_INSTRUCTION,
@@ -757,21 +768,26 @@ mod tests {
         ];
 
         let preprocessing = BytecodePreprocessing::preprocess(program.clone());
-        let polys: BytecodePolynomials<Fr> =
-            BytecodeProof::<Fr, HyraxScheme<G1Projective>>::generate_witness::<RV32I>(
-                &preprocessing,
-                &mut trace,
-            );
+        let polys: BytecodePolynomials<Fr> = BytecodeProof::<
+            Fr,
+            HyraxScheme<G1Projective, DefaultTranscript>,
+            DefaultTranscript,
+        >::generate_witness::<RV32I>(
+            &preprocessing, &mut trace
+        );
 
         let (gamma, tau) = (&Fr::from(100), &Fr::from(35));
-        let (read_write_leaves, init_final_leaves) =
-            BytecodeProof::<Fr, HyraxScheme<G1Projective>>::compute_leaves(
-                &preprocessing,
-                &polys,
-                &JoltPolynomials::default(),
-                gamma,
-                tau,
-            );
+        let (read_write_leaves, init_final_leaves) = BytecodeProof::<
+            Fr,
+            HyraxScheme<G1Projective, DefaultTranscript>,
+            DefaultTranscript,
+        >::compute_leaves(
+            &preprocessing,
+            &polys,
+            &JoltPolynomials::default(),
+            gamma,
+            tau,
+        );
         let init_leaves = &init_final_leaves[0];
         let read_leaves = &read_write_leaves[0];
         let write_leaves = &read_write_leaves[1];
@@ -798,7 +814,9 @@ mod tests {
             BytecodeRow::new(to_ram_address(2), 8u64, 8u64, 8u64, 8u64, 8u64),
             BytecodeRow::new(to_ram_address(5), 0u64, 0u64, 0u64, 0u64, 0u64), // no_op: shouldn't exist in pgoram
         ];
-        BytecodeProof::<Fr, HyraxScheme<G1Projective>>::validate_bytecode(&program, &trace);
+        BytecodeProof::<Fr, HyraxScheme<G1Projective, DefaultTranscript>, DefaultTranscript>::validate_bytecode(
+            &program, &trace,
+        );
     }
 
     #[test]
@@ -814,6 +832,8 @@ mod tests {
             BytecodeRow::new(to_ram_address(3), 16u64, 16u64, 16u64, 16u64, 16u64),
             BytecodeRow::new(to_ram_address(2), 8u64, 8u64, 8u64, 8u64, 8u64),
         ];
-        BytecodeProof::<Fr, HyraxScheme<G1Projective>>::validate_bytecode(&program, &trace);
+        BytecodeProof::<Fr, HyraxScheme<G1Projective, DefaultTranscript>, DefaultTranscript>::validate_bytecode(
+            &program, &trace,
+        );
     }
 }

--- a/jolt-core/src/jolt/vm/instruction_lookups.rs
+++ b/jolt-core/src/jolt/vm/instruction_lookups.rs
@@ -579,7 +579,8 @@ where
         opening_accumulator: &mut ProverOpeningAccumulator<F>,
         transcript: &mut ProofTranscript,
     ) -> InstructionLookupsProof<C, M, F, PCS, InstructionSet, Subtables> {
-        transcript.append_protocol_name(Self::protocol_name());
+        let protocol_name = Self::protocol_name();
+        transcript.append_message(protocol_name);
 
         let trace_length = polynomials.instruction_lookups.dim[0].len();
         let r_eq = transcript.challenge_vector(trace_length.log_2());
@@ -662,7 +663,8 @@ where
         opening_accumulator: &mut VerifierOpeningAccumulator<F, PCS>,
         transcript: &mut ProofTranscript,
     ) -> Result<(), ProofVerifyError> {
-        transcript.append_protocol_name(Self::protocol_name());
+        let protocol_name = Self::protocol_name();
+        transcript.append_message(protocol_name);
 
         let r_eq = transcript.challenge_vector(proof.primary_sumcheck.num_rounds);
 

--- a/jolt-core/src/jolt/vm/instruction_lookups.rs
+++ b/jolt-core/src/jolt/vm/instruction_lookups.rs
@@ -7,6 +7,7 @@ use rayon::prelude::*;
 use std::marker::PhantomData;
 use tracing::trace_span;
 
+use super::{JoltCommitments, JoltPolynomials, JoltTraceStep};
 use crate::field::JoltField;
 use crate::jolt::instruction::{JoltInstructionSet, SubtableIndices};
 use crate::jolt::subtable::JoltSubtableSet;
@@ -16,6 +17,7 @@ use crate::lasso::memory_checking::{
 };
 use crate::poly::commitment::commitment_scheme::{BatchType, CommitShape, CommitmentScheme};
 use crate::utils::mul_0_1_optimized;
+use crate::utils::transcript::Transcript;
 use crate::{
     lasso::memory_checking::{MemoryCheckingProof, MemoryCheckingProver, MemoryCheckingVerifier},
     poly::{
@@ -28,11 +30,9 @@ use crate::{
     utils::{
         errors::ProofVerifyError,
         math::Math,
-        transcript::{AppendToTranscript, ProofTranscript},
+        transcript::{AppendToTranscript, DefaultTranscript},
     },
 };
-
-use super::{JoltCommitments, JoltPolynomials, JoltTraceStep};
 
 #[derive(Debug, Default, CanonicalSerialize, CanonicalDeserialize)]
 pub struct InstructionLookupStuff<T: CanonicalSerialize + CanonicalDeserialize> {
@@ -577,7 +577,7 @@ where
         polynomials: &'a JoltPolynomials<F>,
         preprocessing: &InstructionLookupsPreprocessing<C, F>,
         opening_accumulator: &mut ProverOpeningAccumulator<F>,
-        transcript: &mut ProofTranscript,
+        transcript: &mut DefaultTranscript,
     ) -> InstructionLookupsProof<C, M, F, PCS, InstructionSet, Subtables> {
         let protocol_name = Self::protocol_name();
         transcript.append_message(protocol_name);
@@ -661,7 +661,7 @@ where
         proof: InstructionLookupsProof<C, M, F, PCS, InstructionSet, Subtables>,
         commitments: &JoltCommitments<PCS>,
         opening_accumulator: &mut VerifierOpeningAccumulator<F, PCS>,
-        transcript: &mut ProofTranscript,
+        transcript: &mut DefaultTranscript,
     ) -> Result<(), ProofVerifyError> {
         let protocol_name = Self::protocol_name();
         transcript.append_message(protocol_name);
@@ -851,7 +851,7 @@ where
         flag_polys: &[DensePolynomial<F>],
         lookup_outputs_poly: &mut DensePolynomial<F>,
         degree: usize,
-        transcript: &mut ProofTranscript,
+        transcript: &mut DefaultTranscript,
     ) -> (SumcheckInstanceProof<F>, Vec<F>, Vec<F>, Vec<F>, F) {
         // Check all polys are the same size
         let poly_len = eq_poly.len();
@@ -1068,7 +1068,7 @@ where
 
     fn update_primary_sumcheck_transcript(
         round_uni_poly: UniPoly<F>,
-        transcript: &mut ProofTranscript,
+        transcript: &mut DefaultTranscript,
     ) -> F {
         round_uni_poly.compress().append_to_transcript(transcript);
 

--- a/jolt-core/src/jolt/vm/mod.rs
+++ b/jolt-core/src/jolt/vm/mod.rs
@@ -11,6 +11,7 @@ use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use common::constants::RAM_START_ADDRESS;
 use common::rv_trace::NUM_CIRCUIT_FLAGS;
 use serde::{Deserialize, Serialize};
+use std::marker::PhantomData;
 use strum::EnumCount;
 use timestamp_range_check::TimestampRangeCheckStuff;
 
@@ -31,7 +32,7 @@ use crate::poly::dense_mlpoly::DensePolynomial;
 use crate::r1cs::inputs::{ConstraintInput, R1CSPolynomials, R1CSProof, R1CSStuff};
 use crate::utils::errors::ProofVerifyError;
 use crate::utils::thread::drop_in_background_thread;
-use crate::utils::transcript::{AppendToTranscript, DefaultTranscript, Transcript};
+use crate::utils::transcript::{AppendToTranscript, Transcript};
 use common::{
     constants::MEMORY_OPS_PER_INSTRUCTION,
     rv_trace::{ELFInstruction, JoltDevice, MemoryOp},
@@ -49,10 +50,11 @@ use self::read_write_memory::{
 use super::instruction::JoltInstructionSet;
 
 #[derive(Clone)]
-pub struct JoltPreprocessing<const C: usize, F, PCS>
+pub struct JoltPreprocessing<const C: usize, F, PCS, ProofTranscript>
 where
     F: JoltField,
-    PCS: CommitmentScheme<Field = F>,
+    PCS: CommitmentScheme<ProofTranscript, Field = F>,
+    ProofTranscript: Transcript,
 {
     pub generators: PCS::Setup,
     pub instruction_lookups: InstructionLookupsPreprocessing<C, F>,
@@ -68,9 +70,13 @@ pub struct JoltTraceStep<InstructionSet: JoltInstructionSet> {
     pub circuit_flags: [bool; NUM_CIRCUIT_FLAGS],
 }
 
-pub struct ProverDebugInfo<F: JoltField> {
-    pub(crate) transcript: DefaultTranscript,
-    pub(crate) opening_accumulator: ProverOpeningAccumulator<F>,
+pub struct ProverDebugInfo<F, ProofTranscript>
+where
+    F: JoltField,
+    ProofTranscript: Transcript,
+{
+    pub(crate) transcript: ProofTranscript,
+    pub(crate) opening_accumulator: ProverOpeningAccumulator<F, ProofTranscript>,
 }
 
 impl<InstructionSet: JoltInstructionSet> JoltTraceStep<InstructionSet> {
@@ -99,21 +105,31 @@ impl<InstructionSet: JoltInstructionSet> JoltTraceStep<InstructionSet> {
 }
 
 #[derive(CanonicalSerialize, CanonicalDeserialize)]
-pub struct JoltProof<const C: usize, const M: usize, I, F, PCS, InstructionSet, Subtables>
-where
+pub struct JoltProof<
+    const C: usize,
+    const M: usize,
+    I,
+    F,
+    PCS,
+    InstructionSet,
+    Subtables,
+    ProofTranscript,
+> where
     I: ConstraintInput,
     F: JoltField,
-    PCS: CommitmentScheme<Field = F>,
+    PCS: CommitmentScheme<ProofTranscript, Field = F>,
     InstructionSet: JoltInstructionSet,
     Subtables: JoltSubtableSet<F>,
+    ProofTranscript: Transcript,
 {
     pub trace_length: usize,
     pub program_io: JoltDevice,
-    pub bytecode: BytecodeProof<F, PCS>,
-    pub read_write_memory: ReadWriteMemoryProof<F, PCS>,
-    pub instruction_lookups: InstructionLookupsProof<C, M, F, PCS, InstructionSet, Subtables>,
-    pub r1cs: UniformSpartanProof<C, I, F>,
-    pub opening_proof: ReducedOpeningProof<F, PCS>,
+    pub bytecode: BytecodeProof<F, PCS, ProofTranscript>,
+    pub read_write_memory: ReadWriteMemoryProof<F, PCS, ProofTranscript>,
+    pub instruction_lookups:
+        InstructionLookupsProof<C, M, F, PCS, InstructionSet, Subtables, ProofTranscript>,
+    pub r1cs: UniformSpartanProof<C, I, F, ProofTranscript>,
+    pub opening_proof: ReducedOpeningProof<F, PCS, ProofTranscript>,
 }
 
 #[derive(Default, CanonicalSerialize, CanonicalDeserialize)]
@@ -182,15 +198,17 @@ pub type JoltPolynomials<F: JoltField> = JoltStuff<DensePolynomial<F>>;
 /// See issue #112792 <https://github.com/rust-lang/rust/issues/112792>.
 /// Adding #![feature(lazy_type_alias)] to the crate attributes seem to break
 /// `alloy_sol_types`.
-pub type JoltCommitments<PCS: CommitmentScheme> = JoltStuff<PCS::Commitment>;
+pub type JoltCommitments<PCS: CommitmentScheme<ProofTranscript>, ProofTranscript: Transcript> =
+    JoltStuff<PCS::Commitment>;
 
 impl<
         const C: usize,
         T: CanonicalSerialize + CanonicalDeserialize + Default + Sync,
-        PCS: CommitmentScheme,
-    > Initializable<T, JoltPreprocessing<C, PCS::Field, PCS>> for JoltStuff<T>
+        PCS: CommitmentScheme<ProofTranscript>,
+        ProofTranscript: Transcript,
+    > Initializable<T, JoltPreprocessing<C, PCS::Field, PCS, ProofTranscript>> for JoltStuff<T>
 {
-    fn initialize(preprocessing: &JoltPreprocessing<C, PCS::Field, PCS>) -> Self {
+    fn initialize(preprocessing: &JoltPreprocessing<C, PCS::Field, PCS, ProofTranscript>) -> Self {
         Self {
             bytecode: BytecodeStuff::initialize(&preprocessing.bytecode),
             read_write_memory: ReadWriteMemoryStuff::initialize(&preprocessing.read_write_memory),
@@ -207,11 +225,15 @@ impl<
 
 impl<F: JoltField> JoltPolynomials<F> {
     #[tracing::instrument(skip_all, name = "JoltPolynomials::commit")]
-    pub fn commit<const C: usize, PCS: CommitmentScheme<Field = F>>(
+    pub fn commit<const C: usize, PCS, ProofTranscript>(
         &self,
-        preprocessing: &JoltPreprocessing<C, F, PCS>,
-    ) -> JoltCommitments<PCS> {
-        let mut commitments = JoltCommitments::<PCS>::initialize(preprocessing);
+        preprocessing: &JoltPreprocessing<C, F, PCS, ProofTranscript>,
+    ) -> JoltCommitments<PCS, ProofTranscript>
+    where
+        PCS: CommitmentScheme<ProofTranscript, Field = F>,
+        ProofTranscript: Transcript,
+    {
+        let mut commitments = JoltCommitments::<PCS, ProofTranscript>::initialize(preprocessing);
 
         let trace_polys = self.read_write_values();
         let trace_comitments =
@@ -241,7 +263,12 @@ impl<F: JoltField> JoltPolynomials<F> {
     }
 }
 
-pub trait Jolt<F: JoltField, PCS: CommitmentScheme<Field = F>, const C: usize, const M: usize> {
+pub trait Jolt<F, PCS, const C: usize, const M: usize, ProofTranscript>
+where
+    F: JoltField,
+    PCS: CommitmentScheme<ProofTranscript, Field = F>,
+    ProofTranscript: Transcript,
+{
     type InstructionSet: JoltInstructionSet;
     type Subtables: JoltSubtableSet<F>;
     type Constraints: R1CSConstraints<C, F>;
@@ -253,15 +280,17 @@ pub trait Jolt<F: JoltField, PCS: CommitmentScheme<Field = F>, const C: usize, c
         max_bytecode_size: usize,
         max_memory_address: usize,
         max_trace_length: usize,
-    ) -> JoltPreprocessing<C, F, PCS> {
-        let bytecode_commitment_shapes =
-            BytecodeProof::<F, PCS>::commit_shapes(max_bytecode_size, max_trace_length);
+    ) -> JoltPreprocessing<C, F, PCS, ProofTranscript> {
+        let bytecode_commitment_shapes = BytecodeProof::<F, PCS, ProofTranscript>::commit_shapes(
+            max_bytecode_size,
+            max_trace_length,
+        );
         let ram_commitment_shapes = ReadWriteMemoryPolynomials::<F>::commitment_shapes(
             max_memory_address,
             max_trace_length,
         );
         let timestamp_range_check_commitment_shapes =
-            TimestampValidityProof::<F, PCS>::commitment_shapes(max_trace_length);
+            TimestampValidityProof::<F, PCS, ProofTranscript>::commitment_shapes(max_trace_length);
 
         let instruction_lookups_commitment_shapes = InstructionLookupsProof::<
             C,
@@ -270,6 +299,7 @@ pub trait Jolt<F: JoltField, PCS: CommitmentScheme<Field = F>, const C: usize, c
             PCS,
             Self::InstructionSet,
             Self::Subtables,
+            ProofTranscript,
         >::commitment_shapes(max_trace_length);
 
         let instruction_lookups_preprocessing = InstructionLookupsPreprocessing::preprocess::<
@@ -316,7 +346,7 @@ pub trait Jolt<F: JoltField, PCS: CommitmentScheme<Field = F>, const C: usize, c
     fn prove(
         program_io: JoltDevice,
         mut trace: Vec<JoltTraceStep<Self::InstructionSet>>,
-        preprocessing: JoltPreprocessing<C, F, PCS>,
+        preprocessing: JoltPreprocessing<C, F, PCS, ProofTranscript>,
     ) -> (
         JoltProof<
             C,
@@ -326,9 +356,10 @@ pub trait Jolt<F: JoltField, PCS: CommitmentScheme<Field = F>, const C: usize, c
             PCS,
             Self::InstructionSet,
             Self::Subtables,
+            ProofTranscript,
         >,
-        JoltCommitments<PCS>,
-        Option<ProverDebugInfo<F>>,
+        JoltCommitments<PCS, ProofTranscript>,
+        Option<ProverDebugInfo<F, ProofTranscript>>,
     ) {
         let trace_length = trace.len();
         let padded_trace_length = trace_length.next_power_of_two();
@@ -336,19 +367,19 @@ pub trait Jolt<F: JoltField, PCS: CommitmentScheme<Field = F>, const C: usize, c
 
         JoltTraceStep::pad(&mut trace);
 
-        let mut transcript = DefaultTranscript::new(b"Jolt transcript");
+        let mut transcript = ProofTranscript::new(b"Jolt transcript");
         Self::fiat_shamir_preamble(&mut transcript, &program_io, trace_length);
 
-        let instruction_polynomials = InstructionLookupsProof::<
-            C,
-            M,
-            F,
-            PCS,
-            Self::InstructionSet,
-            Self::Subtables,
-        >::generate_witness(
-            &preprocessing.instruction_lookups, &trace
-        );
+        let instruction_polynomials =
+            InstructionLookupsProof::<
+                C,
+                M,
+                F,
+                PCS,
+                Self::InstructionSet,
+                Self::Subtables,
+                ProofTranscript,
+            >::generate_witness(&preprocessing.instruction_lookups, &trace);
 
         let load_store_flags = &instruction_polynomials.instruction_flags[5..10];
         let (memory_polynomials, read_timestamps) = ReadWriteMemoryPolynomials::generate_witness(
@@ -359,8 +390,17 @@ pub trait Jolt<F: JoltField, PCS: CommitmentScheme<Field = F>, const C: usize, c
         );
 
         let (bytecode_polynomials, range_check_polys) = rayon::join(
-            || BytecodeProof::<F, PCS>::generate_witness(&preprocessing.bytecode, &mut trace),
-            || TimestampValidityProof::<F, PCS>::generate_witness(&read_timestamps),
+            || {
+                BytecodeProof::<F, PCS, ProofTranscript>::generate_witness(
+                    &preprocessing.bytecode,
+                    &mut trace,
+                )
+            },
+            || {
+                TimestampValidityProof::<F, PCS, ProofTranscript>::generate_witness(
+                    &read_timestamps,
+                )
+            },
         );
 
         let r1cs_builder = Self::Constraints::construct_constraints(
@@ -371,6 +411,7 @@ pub trait Jolt<F: JoltField, PCS: CommitmentScheme<Field = F>, const C: usize, c
             C,
             <Self::Constraints as R1CSConstraints<C, F>>::Inputs,
             F,
+            ProofTranscript,
         >::setup(&r1cs_builder, padded_trace_length);
 
         let r1cs_polynomials = R1CSPolynomials::new::<
@@ -390,7 +431,7 @@ pub trait Jolt<F: JoltField, PCS: CommitmentScheme<Field = F>, const C: usize, c
 
         r1cs_builder.compute_aux(&mut jolt_polynomials);
 
-        let jolt_commitments = jolt_polynomials.commit::<C, PCS>(&preprocessing);
+        let jolt_commitments = jolt_polynomials.commit::<C, PCS, ProofTranscript>(&preprocessing);
 
         transcript.append_scalar(&spartan_key.vk_digest);
 
@@ -403,7 +444,8 @@ pub trait Jolt<F: JoltField, PCS: CommitmentScheme<Field = F>, const C: usize, c
             .iter()
             .for_each(|value| value.append_to_transcript(&mut transcript));
 
-        let mut opening_accumulator: ProverOpeningAccumulator<F> = ProverOpeningAccumulator::new();
+        let mut opening_accumulator: ProverOpeningAccumulator<F, ProofTranscript> =
+            ProverOpeningAccumulator::new();
 
         let bytecode_proof = BytecodeProof::prove_memory_checking(
             &preprocessing.generators,
@@ -435,6 +477,7 @@ pub trait Jolt<F: JoltField, PCS: CommitmentScheme<Field = F>, const C: usize, c
             C,
             <Self::Constraints as R1CSConstraints<C, F>>::Inputs,
             F,
+            ProofTranscript,
         >::prove::<PCS>(
             &r1cs_builder,
             &spartan_key,
@@ -472,7 +515,7 @@ pub trait Jolt<F: JoltField, PCS: CommitmentScheme<Field = F>, const C: usize, c
 
     #[tracing::instrument(skip_all)]
     fn verify(
-        mut preprocessing: JoltPreprocessing<C, F, PCS>,
+        mut preprocessing: JoltPreprocessing<C, F, PCS, ProofTranscript>,
         proof: JoltProof<
             C,
             M,
@@ -481,12 +524,13 @@ pub trait Jolt<F: JoltField, PCS: CommitmentScheme<Field = F>, const C: usize, c
             PCS,
             Self::InstructionSet,
             Self::Subtables,
+            ProofTranscript,
         >,
-        commitments: JoltCommitments<PCS>,
-        _debug_info: Option<ProverDebugInfo<F>>,
+        commitments: JoltCommitments<PCS, ProofTranscript>,
+        _debug_info: Option<ProverDebugInfo<F, ProofTranscript>>,
     ) -> Result<(), ProofVerifyError> {
-        let mut transcript = DefaultTranscript::new(b"Jolt transcript");
-        let mut opening_accumulator: VerifierOpeningAccumulator<F, PCS> =
+        let mut transcript = ProofTranscript::new(b"Jolt transcript");
+        let mut opening_accumulator: VerifierOpeningAccumulator<F, PCS, ProofTranscript> =
             VerifierOpeningAccumulator::new();
 
         #[cfg(test)]
@@ -502,12 +546,16 @@ pub trait Jolt<F: JoltField, PCS: CommitmentScheme<Field = F>, const C: usize, c
         let memory_start = RAM_START_ADDRESS - proof.program_io.memory_layout.ram_witness_offset;
         let r1cs_builder =
             Self::Constraints::construct_constraints(padded_trace_length, memory_start);
-        let spartan_key = spartan::UniformSpartanProof::setup(&r1cs_builder, padded_trace_length);
+        let spartan_key = spartan::UniformSpartanProof::<C, _, F, ProofTranscript>::setup(
+            &r1cs_builder,
+            padded_trace_length,
+        );
         transcript.append_scalar(&spartan_key.vk_digest);
 
         let r1cs_proof = R1CSProof {
             key: spartan_key,
             proof: proof.r1cs,
+            _marker: PhantomData,
         };
 
         commitments
@@ -566,10 +614,18 @@ pub trait Jolt<F: JoltField, PCS: CommitmentScheme<Field = F>, const C: usize, c
     fn verify_instruction_lookups<'a>(
         preprocessing: &InstructionLookupsPreprocessing<C, F>,
         generators: &PCS::Setup,
-        proof: InstructionLookupsProof<C, M, F, PCS, Self::InstructionSet, Self::Subtables>,
-        commitments: &'a JoltCommitments<PCS>,
-        opening_accumulator: &mut VerifierOpeningAccumulator<F, PCS>,
-        transcript: &mut DefaultTranscript,
+        proof: InstructionLookupsProof<
+            C,
+            M,
+            F,
+            PCS,
+            Self::InstructionSet,
+            Self::Subtables,
+            ProofTranscript,
+        >,
+        commitments: &'a JoltCommitments<PCS, ProofTranscript>,
+        opening_accumulator: &mut VerifierOpeningAccumulator<F, PCS, ProofTranscript>,
+        transcript: &mut ProofTranscript,
     ) -> Result<(), ProofVerifyError> {
         InstructionLookupsProof::verify(
             preprocessing,
@@ -585,10 +641,10 @@ pub trait Jolt<F: JoltField, PCS: CommitmentScheme<Field = F>, const C: usize, c
     fn verify_bytecode<'a>(
         preprocessing: &BytecodePreprocessing<F>,
         generators: &PCS::Setup,
-        proof: BytecodeProof<F, PCS>,
-        commitments: &'a JoltCommitments<PCS>,
-        opening_accumulator: &mut VerifierOpeningAccumulator<F, PCS>,
-        transcript: &mut DefaultTranscript,
+        proof: BytecodeProof<F, PCS, ProofTranscript>,
+        commitments: &'a JoltCommitments<PCS, ProofTranscript>,
+        opening_accumulator: &mut VerifierOpeningAccumulator<F, PCS, ProofTranscript>,
+        transcript: &mut ProofTranscript,
     ) -> Result<(), ProofVerifyError> {
         BytecodeProof::verify_memory_checking(
             preprocessing,
@@ -605,11 +661,11 @@ pub trait Jolt<F: JoltField, PCS: CommitmentScheme<Field = F>, const C: usize, c
     fn verify_memory<'a>(
         preprocessing: &mut ReadWriteMemoryPreprocessing,
         generators: &PCS::Setup,
-        proof: ReadWriteMemoryProof<F, PCS>,
-        commitment: &'a JoltCommitments<PCS>,
+        proof: ReadWriteMemoryProof<F, PCS, ProofTranscript>,
+        commitment: &'a JoltCommitments<PCS, ProofTranscript>,
         program_io: JoltDevice,
-        opening_accumulator: &mut VerifierOpeningAccumulator<F, PCS>,
-        transcript: &mut DefaultTranscript,
+        opening_accumulator: &mut VerifierOpeningAccumulator<F, PCS, ProofTranscript>,
+        transcript: &mut ProofTranscript,
     ) -> Result<(), ProofVerifyError> {
         assert!(program_io.inputs.len() <= program_io.memory_layout.max_input_size as usize);
         assert!(program_io.outputs.len() <= program_io.memory_layout.max_output_size as usize);
@@ -627,10 +683,15 @@ pub trait Jolt<F: JoltField, PCS: CommitmentScheme<Field = F>, const C: usize, c
 
     #[tracing::instrument(skip_all)]
     fn verify_r1cs<'a>(
-        proof: R1CSProof<C, <Self::Constraints as R1CSConstraints<C, F>>::Inputs, F>,
-        commitments: &'a JoltCommitments<PCS>,
-        opening_accumulator: &mut VerifierOpeningAccumulator<F, PCS>,
-        transcript: &mut DefaultTranscript,
+        proof: R1CSProof<
+            C,
+            <Self::Constraints as R1CSConstraints<C, F>>::Inputs,
+            F,
+            ProofTranscript,
+        >,
+        commitments: &'a JoltCommitments<PCS, ProofTranscript>,
+        opening_accumulator: &mut VerifierOpeningAccumulator<F, PCS, ProofTranscript>,
+        transcript: &mut ProofTranscript,
     ) -> Result<(), ProofVerifyError> {
         proof
             .verify(commitments, opening_accumulator, transcript)
@@ -638,7 +699,7 @@ pub trait Jolt<F: JoltField, PCS: CommitmentScheme<Field = F>, const C: usize, c
     }
 
     fn fiat_shamir_preamble(
-        transcript: &mut DefaultTranscript,
+        transcript: &mut ProofTranscript,
         program_io: &JoltDevice,
         trace_length: usize,
     ) {

--- a/jolt-core/src/jolt/vm/read_write_memory.rs
+++ b/jolt-core/src/jolt/vm/read_write_memory.rs
@@ -13,7 +13,10 @@ use std::marker::PhantomData;
 #[cfg(test)]
 use std::sync::{Arc, Mutex};
 
+use super::{timestamp_range_check::TimestampValidityProof, JoltCommitments};
+use super::{JoltPolynomials, JoltStuff, JoltTraceStep};
 use crate::poly::commitment::commitment_scheme::{BatchType, CommitShape, CommitmentScheme};
+use crate::utils::transcript::Transcript;
 use crate::{
     lasso::memory_checking::{
         MemoryCheckingProof, MemoryCheckingProver, MemoryCheckingVerifier, MultisetHashes,
@@ -22,7 +25,7 @@ use crate::{
         dense_mlpoly::DensePolynomial, eq_poly::EqPolynomial, identity_poly::IdentityPolynomial,
     },
     subprotocols::sumcheck::SumcheckInstanceProof,
-    utils::{errors::ProofVerifyError, math::Math, mul_0_optimized, transcript::ProofTranscript},
+    utils::{errors::ProofVerifyError, math::Math, mul_0_optimized, transcript::DefaultTranscript},
 };
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use common::constants::{
@@ -30,9 +33,6 @@ use common::constants::{
     RAM_OPS_PER_INSTRUCTION, RAM_START_ADDRESS, REGISTER_COUNT, REG_OPS_PER_INSTRUCTION,
 };
 use common::rv_trace::{JoltDevice, MemoryLayout, MemoryOp};
-
-use super::{timestamp_range_check::TimestampValidityProof, JoltCommitments};
-use super::{JoltPolynomials, JoltStuff, JoltTraceStep};
 
 #[derive(Clone)]
 pub struct ReadWriteMemoryPreprocessing {
@@ -1176,7 +1176,7 @@ where
         polynomials: &ReadWriteMemoryPolynomials<F>,
         program_io: &JoltDevice,
         opening_accumulator: &mut ProverOpeningAccumulator<F>,
-        transcript: &mut ProofTranscript,
+        transcript: &mut DefaultTranscript,
     ) -> Self {
         let memory_size = polynomials.v_final.len();
         let num_rounds = memory_size.log_2();
@@ -1261,7 +1261,7 @@ where
         preprocessing: &ReadWriteMemoryPreprocessing,
         commitment: &ReadWriteMemoryCommitments<PCS>,
         opening_accumulator: &mut VerifierOpeningAccumulator<F, PCS>,
-        transcript: &mut ProofTranscript,
+        transcript: &mut DefaultTranscript,
     ) -> Result<(), ProofVerifyError> {
         let r_eq = transcript.challenge_vector(proof.num_rounds);
 
@@ -1365,7 +1365,7 @@ where
         polynomials: &'a JoltPolynomials<F>,
         program_io: &JoltDevice,
         opening_accumulator: &mut ProverOpeningAccumulator<F>,
-        transcript: &mut ProofTranscript,
+        transcript: &mut DefaultTranscript,
     ) -> Self {
         let memory_checking_proof = ReadWriteMemoryProof::prove_memory_checking(
             generators,
@@ -1404,7 +1404,7 @@ where
         preprocessing: &ReadWriteMemoryPreprocessing,
         commitments: &JoltCommitments<PCS>,
         opening_accumulator: &mut VerifierOpeningAccumulator<F, PCS>,
-        transcript: &mut ProofTranscript,
+        transcript: &mut DefaultTranscript,
     ) -> Result<(), ProofVerifyError> {
         ReadWriteMemoryProof::verify_memory_checking(
             preprocessing,

--- a/jolt-core/src/jolt/vm/read_write_memory.rs
+++ b/jolt-core/src/jolt/vm/read_write_memory.rs
@@ -13,8 +13,6 @@ use std::marker::PhantomData;
 #[cfg(test)]
 use std::sync::{Arc, Mutex};
 
-use super::{timestamp_range_check::TimestampValidityProof, JoltCommitments};
-use super::{JoltPolynomials, JoltStuff, JoltTraceStep};
 use crate::poly::commitment::commitment_scheme::{BatchType, CommitShape, CommitmentScheme};
 use crate::utils::transcript::Transcript;
 use crate::{
@@ -25,7 +23,7 @@ use crate::{
         dense_mlpoly::DensePolynomial, eq_poly::EqPolynomial, identity_poly::IdentityPolynomial,
     },
     subprotocols::sumcheck::SumcheckInstanceProof,
-    utils::{errors::ProofVerifyError, math::Math, mul_0_optimized, transcript::DefaultTranscript},
+    utils::{errors::ProofVerifyError, math::Math, mul_0_optimized},
 };
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use common::constants::{
@@ -33,6 +31,9 @@ use common::constants::{
     RAM_OPS_PER_INSTRUCTION, RAM_START_ADDRESS, REGISTER_COUNT, REG_OPS_PER_INSTRUCTION,
 };
 use common::rv_trace::{JoltDevice, MemoryLayout, MemoryOp};
+
+use super::{timestamp_range_check::TimestampValidityProof, JoltCommitments};
+use super::{JoltPolynomials, JoltStuff, JoltTraceStep};
 
 #[derive(Clone)]
 pub struct ReadWriteMemoryPreprocessing {
@@ -179,7 +180,10 @@ pub type ReadWriteMemoryOpenings<F: JoltField> = ReadWriteMemoryStuff<F>;
 /// See issue #112792 <https://github.com/rust-lang/rust/issues/112792>.
 /// Adding #![feature(lazy_type_alias)] to the crate attributes seem to break
 /// `alloy_sol_types`.
-pub type ReadWriteMemoryCommitments<PCS: CommitmentScheme> = ReadWriteMemoryStuff<PCS::Commitment>;
+pub type ReadWriteMemoryCommitments<
+    PCS: CommitmentScheme<ProofTranscript>,
+    ProofTranscript: Transcript,
+> = ReadWriteMemoryStuff<PCS::Commitment>;
 
 impl<T: CanonicalSerialize + CanonicalDeserialize + Default>
     Initializable<T, ReadWriteMemoryPreprocessing> for ReadWriteMemoryStuff<T>
@@ -864,14 +868,16 @@ impl<F: JoltField> ReadWriteMemoryPolynomials<F> {
     }
 }
 
-impl<F, PCS> MemoryCheckingProver<F, PCS> for ReadWriteMemoryProof<F, PCS>
+impl<F, PCS, ProofTranscript> MemoryCheckingProver<F, PCS, ProofTranscript>
+    for ReadWriteMemoryProof<F, PCS, ProofTranscript>
 where
     F: JoltField,
-    PCS: CommitmentScheme<Field = F>,
+    PCS: CommitmentScheme<ProofTranscript, Field = F>,
+    ProofTranscript: Transcript,
 {
     type Polynomials = ReadWriteMemoryPolynomials<F>;
     type Openings = ReadWriteMemoryOpenings<F>;
-    type Commitments = ReadWriteMemoryCommitments<PCS>;
+    type Commitments = ReadWriteMemoryCommitments<PCS, ProofTranscript>;
     type Preprocessing = ReadWriteMemoryPreprocessing;
 
     type ExogenousOpenings = RegisterAddressOpenings<F>;
@@ -1036,10 +1042,12 @@ where
     }
 }
 
-impl<F, PCS> MemoryCheckingVerifier<F, PCS> for ReadWriteMemoryProof<F, PCS>
+impl<F, PCS, ProofTranscript> MemoryCheckingVerifier<F, PCS, ProofTranscript>
+    for ReadWriteMemoryProof<F, PCS, ProofTranscript>
 where
     F: JoltField,
-    PCS: CommitmentScheme<Field = F>,
+    PCS: CommitmentScheme<ProofTranscript, Field = F>,
+    ProofTranscript: Transcript,
 {
     fn compute_verifier_openings(
         openings: &mut Self::Openings,
@@ -1154,29 +1162,31 @@ where
 }
 
 #[derive(CanonicalSerialize, CanonicalDeserialize)]
-pub struct OutputSumcheckProof<F, PCS>
+pub struct OutputSumcheckProof<F, PCS, ProofTranscript>
 where
     F: JoltField,
-    PCS: CommitmentScheme<Field = F>,
+    PCS: CommitmentScheme<ProofTranscript, Field = F>,
+    ProofTranscript: Transcript,
 {
-    _pcs: PhantomData<PCS>,
+    _pcs: PhantomData<(PCS, ProofTranscript)>,
     num_rounds: usize,
     /// Sumcheck proof that v_final is equal to the program outputs at the relevant indices.
-    sumcheck_proof: SumcheckInstanceProof<F>,
+    sumcheck_proof: SumcheckInstanceProof<F, ProofTranscript>,
     /// Opening of v_final at the random point chosen over the course of sumcheck
     opening: F,
 }
 
-impl<F, PCS> OutputSumcheckProof<F, PCS>
+impl<F, PCS, ProofTranscript> OutputSumcheckProof<F, PCS, ProofTranscript>
 where
     F: JoltField,
-    PCS: CommitmentScheme<Field = F>,
+    PCS: CommitmentScheme<ProofTranscript, Field = F>,
+    ProofTranscript: Transcript,
 {
     fn prove_outputs(
         polynomials: &ReadWriteMemoryPolynomials<F>,
         program_io: &JoltDevice,
-        opening_accumulator: &mut ProverOpeningAccumulator<F>,
-        transcript: &mut DefaultTranscript,
+        opening_accumulator: &mut ProverOpeningAccumulator<F, ProofTranscript>,
+        transcript: &mut ProofTranscript,
     ) -> Self {
         let memory_size = polynomials.v_final.len();
         let num_rounds = memory_size.log_2();
@@ -1231,7 +1241,7 @@ where
         let output_check_fn = |vals: &[F]| -> F { vals[0] * vals[1] * (vals[2] - vals[3]) };
 
         let (sumcheck_proof, r_sumcheck, sumcheck_openings) =
-            SumcheckInstanceProof::<F>::prove_arbitrary::<_>(
+            SumcheckInstanceProof::<F, ProofTranscript>::prove_arbitrary::<_>(
                 &F::zero(),
                 num_rounds,
                 &mut sumcheck_polys,
@@ -1259,9 +1269,9 @@ where
     fn verify(
         proof: &Self,
         preprocessing: &ReadWriteMemoryPreprocessing,
-        commitment: &ReadWriteMemoryCommitments<PCS>,
-        opening_accumulator: &mut VerifierOpeningAccumulator<F, PCS>,
-        transcript: &mut DefaultTranscript,
+        commitment: &ReadWriteMemoryCommitments<PCS, ProofTranscript>,
+        opening_accumulator: &mut VerifierOpeningAccumulator<F, PCS, ProofTranscript>,
+        transcript: &mut ProofTranscript,
     ) -> Result<(), ProofVerifyError> {
         let r_eq = transcript.challenge_vector(proof.num_rounds);
 
@@ -1342,21 +1352,28 @@ where
 }
 
 #[derive(CanonicalSerialize, CanonicalDeserialize)]
-pub struct ReadWriteMemoryProof<F, PCS>
+pub struct ReadWriteMemoryProof<F, PCS, ProofTranscript>
 where
     F: JoltField,
-    PCS: CommitmentScheme<Field = F>,
+    PCS: CommitmentScheme<ProofTranscript, Field = F>,
+    ProofTranscript: Transcript,
 {
-    pub memory_checking_proof:
-        MemoryCheckingProof<F, PCS, ReadWriteMemoryOpenings<F>, RegisterAddressOpenings<F>>,
-    pub timestamp_validity_proof: TimestampValidityProof<F, PCS>,
-    pub output_proof: OutputSumcheckProof<F, PCS>,
+    pub memory_checking_proof: MemoryCheckingProof<
+        F,
+        PCS,
+        ReadWriteMemoryOpenings<F>,
+        RegisterAddressOpenings<F>,
+        ProofTranscript,
+    >,
+    pub timestamp_validity_proof: TimestampValidityProof<F, PCS, ProofTranscript>,
+    pub output_proof: OutputSumcheckProof<F, PCS, ProofTranscript>,
 }
 
-impl<F, PCS> ReadWriteMemoryProof<F, PCS>
+impl<F, PCS, ProofTranscript> ReadWriteMemoryProof<F, PCS, ProofTranscript>
 where
     F: JoltField,
-    PCS: CommitmentScheme<Field = F>,
+    PCS: CommitmentScheme<ProofTranscript, Field = F>,
+    ProofTranscript: Transcript,
 {
     #[tracing::instrument(skip_all, name = "ReadWriteMemoryProof::prove")]
     pub fn prove<'a>(
@@ -1364,8 +1381,8 @@ where
         preprocessing: &ReadWriteMemoryPreprocessing,
         polynomials: &'a JoltPolynomials<F>,
         program_io: &JoltDevice,
-        opening_accumulator: &mut ProverOpeningAccumulator<F>,
-        transcript: &mut DefaultTranscript,
+        opening_accumulator: &mut ProverOpeningAccumulator<F, ProofTranscript>,
+        transcript: &mut ProofTranscript,
     ) -> Self {
         let memory_checking_proof = ReadWriteMemoryProof::prove_memory_checking(
             generators,
@@ -1402,9 +1419,9 @@ where
         mut self,
         generators: &PCS::Setup,
         preprocessing: &ReadWriteMemoryPreprocessing,
-        commitments: &JoltCommitments<PCS>,
-        opening_accumulator: &mut VerifierOpeningAccumulator<F, PCS>,
-        transcript: &mut DefaultTranscript,
+        commitments: &JoltCommitments<PCS, ProofTranscript>,
+        opening_accumulator: &mut VerifierOpeningAccumulator<F, PCS, ProofTranscript>,
+        transcript: &mut ProofTranscript,
     ) -> Result<(), ProofVerifyError> {
         ReadWriteMemoryProof::verify_memory_checking(
             preprocessing,

--- a/jolt-core/src/jolt/vm/timestamp_range_check.rs
+++ b/jolt-core/src/jolt/vm/timestamp_range_check.rs
@@ -667,7 +667,8 @@ where
         let gamma: F = transcript.challenge_scalar();
         let tau: F = transcript.challenge_scalar();
 
-        transcript.append_protocol_name(Self::protocol_name());
+        let protocol_name = Self::protocol_name();
+        transcript.append_message(protocol_name);
 
         let (leaves, _) = TimestampValidityProof::<F, PCS>::compute_leaves(
             &NoPreprocessing,
@@ -714,7 +715,8 @@ where
         let gamma: F = transcript.challenge_scalar();
         let tau: F = transcript.challenge_scalar();
 
-        transcript.append_protocol_name(Self::protocol_name());
+        let protocol_name = Self::protocol_name();
+        transcript.append_message(protocol_name);
 
         // Multiset equality checks
         TimestampValidityProof::<F, PCS>::check_multiset_equality(

--- a/jolt-core/src/jolt/vm/timestamp_range_check.rs
+++ b/jolt-core/src/jolt/vm/timestamp_range_check.rs
@@ -16,7 +16,9 @@ use rayon::prelude::*;
 use std::collections::HashSet;
 use std::iter::zip;
 
+use super::{JoltCommitments, JoltPolynomials, JoltStuff};
 use crate::poly::commitment::commitment_scheme::{BatchType, CommitShape, CommitmentScheme};
+use crate::utils::transcript::Transcript;
 use crate::{
     lasso::memory_checking::{
         MemoryCheckingProof, MemoryCheckingProver, MemoryCheckingVerifier, MultisetHashes,
@@ -25,10 +27,8 @@ use crate::{
     poly::{
         dense_mlpoly::DensePolynomial, eq_poly::EqPolynomial, identity_poly::IdentityPolynomial,
     },
-    utils::{errors::ProofVerifyError, mul_0_1_optimized, transcript::ProofTranscript},
+    utils::{errors::ProofVerifyError, mul_0_1_optimized, transcript::DefaultTranscript},
 };
-
-use super::{JoltCommitments, JoltPolynomials, JoltStuff};
 
 #[derive(Default, CanonicalSerialize, CanonicalDeserialize)]
 pub struct TimestampRangeCheckStuff<T: CanonicalSerialize + CanonicalDeserialize + Sync> {
@@ -249,7 +249,7 @@ where
         _: &Self::Polynomials,
         _: &JoltPolynomials<F>,
         _: &mut ProverOpeningAccumulator<F>,
-        _: &mut ProofTranscript,
+        _: &mut DefaultTranscript,
     ) -> MemoryCheckingProof<F, PCS, Self::Openings, Self::ExogenousOpenings> {
         unimplemented!("Use TimestampValidityProof::prove instead");
     }
@@ -448,7 +448,7 @@ where
         _commitments: &Self::Commitments,
         _: &JoltCommitments<PCS>,
         _opening_accumulator: &mut VerifierOpeningAccumulator<F, PCS>,
-        _transcript: &mut ProofTranscript,
+        _transcript: &mut DefaultTranscript,
     ) -> Result<(), ProofVerifyError> {
         unimplemented!("Use TimestampValidityProof::verify instead");
     }
@@ -562,7 +562,7 @@ impl<F: JoltField, PCS: CommitmentScheme<Field = F>> BatchedGrandProduct<F, PCS>
     fn prove_grand_product(
         &mut self,
         _opening_accumulator: Option<&mut ProverOpeningAccumulator<F>>,
-        _transcript: &mut ProofTranscript,
+        _transcript: &mut DefaultTranscript,
         _setup: Option<&PCS::Setup>,
     ) -> (BatchedGrandProductProof<PCS>, Vec<F>) {
         unimplemented!("init/final grand products are batched with read/write grand products")
@@ -571,7 +571,7 @@ impl<F: JoltField, PCS: CommitmentScheme<Field = F>> BatchedGrandProduct<F, PCS>
         _proof: &BatchedGrandProductProof<PCS>,
         _claims: &Vec<F>,
         _opening_accumulator: Option<&mut VerifierOpeningAccumulator<F, PCS>>,
-        _transcript: &mut ProofTranscript,
+        _transcript: &mut DefaultTranscript,
         _setup: Option<&PCS::Setup>,
     ) -> (Vec<F>, Vec<F>) {
         unimplemented!("init/final grand products are batched with read/write grand products")
@@ -601,7 +601,7 @@ where
         polynomials: &'a TimestampRangeCheckPolynomials<F>,
         jolt_polynomials: &'a JoltPolynomials<F>,
         opening_accumulator: &mut ProverOpeningAccumulator<F>,
-        transcript: &mut ProofTranscript,
+        transcript: &mut DefaultTranscript,
     ) -> Self {
         let (batched_grand_product, multiset_hashes, r_grand_product) =
             TimestampValidityProof::prove_grand_products(
@@ -660,7 +660,7 @@ where
         polynomials: &TimestampRangeCheckPolynomials<F>,
         jolt_polynomials: &JoltPolynomials<F>,
         opening_accumulator: &mut ProverOpeningAccumulator<F>,
-        transcript: &mut ProofTranscript,
+        transcript: &mut DefaultTranscript,
         setup: &PCS::Setup,
     ) -> (BatchedGrandProductProof<PCS>, MultisetHashes<F>, Vec<F>) {
         // Fiat-Shamir randomness for multiset hashes
@@ -709,7 +709,7 @@ where
         generators: &PCS::Setup,
         commitments: &JoltCommitments<PCS>,
         opening_accumulator: &mut VerifierOpeningAccumulator<F, PCS>,
-        transcript: &mut ProofTranscript,
+        transcript: &mut DefaultTranscript,
     ) -> Result<(), ProofVerifyError> {
         // Fiat-Shamir randomness for multiset hashes
         let gamma: F = transcript.challenge_scalar();

--- a/jolt-core/src/lasso/memory_checking.rs
+++ b/jolt-core/src/lasso/memory_checking.rs
@@ -283,7 +283,8 @@ where
         let gamma: F = transcript.challenge_scalar();
         let tau: F = transcript.challenge_scalar();
 
-        transcript.append_protocol_name(Self::protocol_name());
+        let protocol_name = Self::protocol_name();
+        transcript.append_message(protocol_name);
 
         let (read_write_leaves, init_final_leaves) =
             Self::compute_leaves(preprocessing, polynomials, jolt_polynomials, &gamma, &tau);
@@ -520,7 +521,8 @@ where
         let gamma: F = transcript.challenge_scalar();
         let tau: F = transcript.challenge_scalar();
 
-        transcript.append_protocol_name(Self::protocol_name());
+        let protocol_name = Self::protocol_name();
+        transcript.append_message(protocol_name);
 
         Self::check_multiset_equality(preprocessing, &proof.multiset_hashes);
         proof.multiset_hashes.append_to_transcript(transcript);

--- a/jolt-core/src/lasso/memory_checking.rs
+++ b/jolt-core/src/lasso/memory_checking.rs
@@ -7,7 +7,7 @@ use crate::poly::eq_poly::EqPolynomial;
 use crate::poly::opening_proof::{ProverOpeningAccumulator, VerifierOpeningAccumulator};
 use crate::utils::errors::ProofVerifyError;
 use crate::utils::thread::drop_in_background_thread;
-use crate::utils::transcript::ProofTranscript;
+use crate::utils::transcript::{DefaultTranscript, Transcript};
 use crate::{
     poly::commitment::commitment_scheme::CommitmentScheme,
     subprotocols::grand_product::{
@@ -34,7 +34,7 @@ pub struct MultisetHashes<F: JoltField> {
 }
 
 impl<F: JoltField> MultisetHashes<F> {
-    pub fn append_to_transcript(&self, transcript: &mut ProofTranscript) {
+    pub fn append_to_transcript(&self, transcript: &mut DefaultTranscript) {
         transcript.append_scalars(&self.read_hashes);
         transcript.append_scalars(&self.write_hashes);
         transcript.append_scalars(&self.init_hashes);
@@ -227,7 +227,7 @@ where
         polynomials: &Self::Polynomials,
         jolt_polynomials: &JoltPolynomials<F>,
         opening_accumulator: &mut ProverOpeningAccumulator<F>,
-        transcript: &mut ProofTranscript,
+        transcript: &mut DefaultTranscript,
     ) -> MemoryCheckingProof<F, PCS, Self::Openings, Self::ExogenousOpenings> {
         let (
             read_write_grand_product,
@@ -270,7 +270,7 @@ where
         polynomials: &Self::Polynomials,
         jolt_polynomials: &JoltPolynomials<F>,
         opening_accumulator: &mut ProverOpeningAccumulator<F>,
-        transcript: &mut ProofTranscript,
+        transcript: &mut DefaultTranscript,
         pcs_setup: &PCS::Setup,
     ) -> (
         BatchedGrandProductProof<PCS>,
@@ -328,7 +328,7 @@ where
         jolt_polynomials: &JoltPolynomials<F>,
         r_read_write: &[F],
         r_init_final: &[F],
-        transcript: &mut ProofTranscript,
+        transcript: &mut DefaultTranscript,
     ) -> (Self::Openings, Self::ExogenousOpenings) {
         let mut openings = Self::Openings::initialize(preprocessing);
         let mut exogenous_openings = Self::ExogenousOpenings::default();
@@ -515,7 +515,7 @@ where
         commitments: &Self::Commitments,
         jolt_commitments: &JoltCommitments<PCS>,
         opening_accumulator: &mut VerifierOpeningAccumulator<F, PCS>,
-        transcript: &mut ProofTranscript,
+        transcript: &mut DefaultTranscript,
     ) -> Result<(), ProofVerifyError> {
         // Fiat-Shamir randomness for multiset hashes
         let gamma: F = transcript.challenge_scalar();

--- a/jolt-core/src/lasso/memory_checking.rs
+++ b/jolt-core/src/lasso/memory_checking.rs
@@ -7,7 +7,7 @@ use crate::poly::eq_poly::EqPolynomial;
 use crate::poly::opening_proof::{ProverOpeningAccumulator, VerifierOpeningAccumulator};
 use crate::utils::errors::ProofVerifyError;
 use crate::utils::thread::drop_in_background_thread;
-use crate::utils::transcript::{DefaultTranscript, Transcript};
+use crate::utils::transcript::Transcript;
 use crate::{
     poly::commitment::commitment_scheme::CommitmentScheme,
     subprotocols::grand_product::{
@@ -34,7 +34,10 @@ pub struct MultisetHashes<F: JoltField> {
 }
 
 impl<F: JoltField> MultisetHashes<F> {
-    pub fn append_to_transcript(&self, transcript: &mut DefaultTranscript) {
+    pub fn append_to_transcript<ProofTranscript: Transcript>(
+        &self,
+        transcript: &mut ProofTranscript,
+    ) {
         transcript.append_scalars(&self.read_hashes);
         transcript.append_scalars(&self.write_hashes);
         transcript.append_scalars(&self.init_hashes);
@@ -43,21 +46,22 @@ impl<F: JoltField> MultisetHashes<F> {
 }
 
 #[derive(CanonicalSerialize, CanonicalDeserialize)]
-pub struct MemoryCheckingProof<F, PCS, Openings, OtherOpenings>
+pub struct MemoryCheckingProof<F, PCS, Openings, OtherOpenings, ProofTranscript>
 where
     F: JoltField,
-    PCS: CommitmentScheme<Field = F>,
+    PCS: CommitmentScheme<ProofTranscript, Field = F>,
     Openings: StructuredPolynomialData<F> + Sync + CanonicalSerialize + CanonicalDeserialize,
     OtherOpenings: ExogenousOpenings<F> + Sync,
+    ProofTranscript: Transcript,
 {
     /// Read/write/init/final multiset hashes for each memory
     pub multiset_hashes: MultisetHashes<F>,
     /// The read and write grand products for every memory has the same size,
     /// so they can be batched.
-    pub read_write_grand_product: BatchedGrandProductProof<PCS>,
+    pub read_write_grand_product: BatchedGrandProductProof<PCS, ProofTranscript>,
     /// The init and final grand products for every memory has the same size,
     /// so they can be batched.
-    pub init_final_grand_product: BatchedGrandProductProof<PCS>,
+    pub init_final_grand_product: BatchedGrandProductProof<PCS, ProofTranscript>,
     /// The openings associated with the grand products.
     pub openings: Openings,
     pub exogenous_openings: OtherOpenings,
@@ -198,16 +202,17 @@ pub trait Initializable<T, Preprocessing>: StructuredPolynomialData<T> + Default
 // Empty struct to represent that no preprocessing data is used.
 pub struct NoPreprocessing;
 
-pub trait MemoryCheckingProver<F, PCS>
+pub trait MemoryCheckingProver<F, PCS, ProofTranscript>
 where
     F: JoltField,
-    PCS: CommitmentScheme<Field = F>,
+    PCS: CommitmentScheme<ProofTranscript, Field = F>,
+    ProofTranscript: Transcript,
     Self: Sync,
 {
-    type ReadWriteGrandProduct: BatchedGrandProduct<F, PCS> + Send + 'static =
-        BatchedDenseGrandProduct<F>;
-    type InitFinalGrandProduct: BatchedGrandProduct<F, PCS> + Send + 'static =
-        BatchedDenseGrandProduct<F>;
+    type ReadWriteGrandProduct: BatchedGrandProduct<F, PCS, ProofTranscript> + Send + 'static =
+        BatchedDenseGrandProduct<F, ProofTranscript>;
+    type InitFinalGrandProduct: BatchedGrandProduct<F, PCS, ProofTranscript> + Send + 'static =
+        BatchedDenseGrandProduct<F, ProofTranscript>;
 
     type Polynomials: StructuredPolynomialData<DensePolynomial<F>>;
     type Openings: StructuredPolynomialData<F> + Sync + Initializable<F, Self::Preprocessing>;
@@ -226,9 +231,9 @@ where
         preprocessing: &Self::Preprocessing,
         polynomials: &Self::Polynomials,
         jolt_polynomials: &JoltPolynomials<F>,
-        opening_accumulator: &mut ProverOpeningAccumulator<F>,
-        transcript: &mut DefaultTranscript,
-    ) -> MemoryCheckingProof<F, PCS, Self::Openings, Self::ExogenousOpenings> {
+        opening_accumulator: &mut ProverOpeningAccumulator<F, ProofTranscript>,
+        transcript: &mut ProofTranscript,
+    ) -> MemoryCheckingProof<F, PCS, Self::Openings, Self::ExogenousOpenings, ProofTranscript> {
         let (
             read_write_grand_product,
             init_final_grand_product,
@@ -269,12 +274,12 @@ where
         preprocessing: &Self::Preprocessing,
         polynomials: &Self::Polynomials,
         jolt_polynomials: &JoltPolynomials<F>,
-        opening_accumulator: &mut ProverOpeningAccumulator<F>,
-        transcript: &mut DefaultTranscript,
+        opening_accumulator: &mut ProverOpeningAccumulator<F, ProofTranscript>,
+        transcript: &mut ProofTranscript,
         pcs_setup: &PCS::Setup,
     ) -> (
-        BatchedGrandProductProof<PCS>,
-        BatchedGrandProductProof<PCS>,
+        BatchedGrandProductProof<PCS, ProofTranscript>,
+        BatchedGrandProductProof<PCS, ProofTranscript>,
         MultisetHashes<F>,
         Vec<F>,
         Vec<F>,
@@ -323,12 +328,12 @@ where
 
     fn compute_openings(
         preprocessing: &Self::Preprocessing,
-        opening_accumulator: &mut ProverOpeningAccumulator<F>,
+        opening_accumulator: &mut ProverOpeningAccumulator<F, ProofTranscript>,
         polynomials: &Self::Polynomials,
         jolt_polynomials: &JoltPolynomials<F>,
         r_read_write: &[F],
         r_init_final: &[F],
-        transcript: &mut DefaultTranscript,
+        transcript: &mut ProofTranscript,
     ) -> (Self::Openings, Self::ExogenousOpenings) {
         let mut openings = Self::Openings::initialize(preprocessing);
         let mut exogenous_openings = Self::ExogenousOpenings::default();
@@ -390,7 +395,11 @@ where
     fn read_write_grand_product(
         _preprocessing: &Self::Preprocessing,
         _polynomials: &Self::Polynomials,
-        read_write_leaves: <Self::ReadWriteGrandProduct as BatchedGrandProduct<F, PCS>>::Leaves,
+        read_write_leaves: <Self::ReadWriteGrandProduct as BatchedGrandProduct<
+            F,
+            PCS,
+            ProofTranscript,
+        >>::Leaves,
     ) -> (Self::ReadWriteGrandProduct, Vec<F>) {
         let batched_circuit = Self::ReadWriteGrandProduct::construct(read_write_leaves);
         let claims = batched_circuit.claims();
@@ -403,7 +412,11 @@ where
     fn init_final_grand_product(
         _preprocessing: &Self::Preprocessing,
         _polynomials: &Self::Polynomials,
-        init_final_leaves: <Self::InitFinalGrandProduct as BatchedGrandProduct<F, PCS>>::Leaves,
+        init_final_leaves: <Self::InitFinalGrandProduct as BatchedGrandProduct<
+            F,
+            PCS,
+            ProofTranscript,
+        >>::Leaves,
     ) -> (Self::InitFinalGrandProduct, Vec<F>) {
         let batched_circuit = Self::InitFinalGrandProduct::construct(init_final_leaves);
         let claims = batched_circuit.claims();
@@ -490,8 +503,8 @@ where
         gamma: &F,
         tau: &F,
     ) -> (
-        <Self::ReadWriteGrandProduct as BatchedGrandProduct<F, PCS>>::Leaves,
-        <Self::InitFinalGrandProduct as BatchedGrandProduct<F, PCS>>::Leaves,
+        <Self::ReadWriteGrandProduct as BatchedGrandProduct<F, PCS, ProofTranscript>>::Leaves,
+        <Self::InitFinalGrandProduct as BatchedGrandProduct<F, PCS, ProofTranscript>>::Leaves,
     );
 
     /// Computes the Reed-Solomon fingerprint (parametrized by `gamma` and `tau`) of the given memory `tuple`.
@@ -502,20 +515,28 @@ where
     fn protocol_name() -> &'static [u8];
 }
 
-pub trait MemoryCheckingVerifier<F, PCS>: MemoryCheckingProver<F, PCS>
+pub trait MemoryCheckingVerifier<F, PCS, ProofTranscript>:
+    MemoryCheckingProver<F, PCS, ProofTranscript>
 where
     F: JoltField,
-    PCS: CommitmentScheme<Field = F>,
+    PCS: CommitmentScheme<ProofTranscript, Field = F>,
+    ProofTranscript: Transcript,
 {
     /// Verifies a memory checking proof, given its associated polynomial `commitment`.
     fn verify_memory_checking(
         preprocessing: &Self::Preprocessing,
         pcs_setup: &PCS::Setup,
-        mut proof: MemoryCheckingProof<F, PCS, Self::Openings, Self::ExogenousOpenings>,
+        mut proof: MemoryCheckingProof<
+            F,
+            PCS,
+            Self::Openings,
+            Self::ExogenousOpenings,
+            ProofTranscript,
+        >,
         commitments: &Self::Commitments,
-        jolt_commitments: &JoltCommitments<PCS>,
-        opening_accumulator: &mut VerifierOpeningAccumulator<F, PCS>,
-        transcript: &mut DefaultTranscript,
+        jolt_commitments: &JoltCommitments<PCS, ProofTranscript>,
+        opening_accumulator: &mut VerifierOpeningAccumulator<F, PCS, ProofTranscript>,
+        transcript: &mut ProofTranscript,
     ) -> Result<(), ProofVerifyError> {
         // Fiat-Shamir randomness for multiset hashes
         let gamma: F = transcript.challenge_scalar();

--- a/jolt-core/src/lasso/surge.rs
+++ b/jolt-core/src/lasso/surge.rs
@@ -381,7 +381,8 @@ where
     ) -> (Self, Option<ProverDebugInfo<F>>) {
         let mut transcript = ProofTranscript::new(b"Surge transcript");
         let mut opening_accumulator: ProverOpeningAccumulator<F> = ProverOpeningAccumulator::new();
-        transcript.append_protocol_name(Self::protocol_name());
+        let protocol_name = Self::protocol_name();
+        transcript.append_message(protocol_name);
 
         let num_lookups = ops.len().next_power_of_two();
         let polynomials = Self::generate_witness(preprocessing, &ops);
@@ -490,7 +491,8 @@ where
             opening_accumulator.compare_to(debug_info.opening_accumulator, &generators);
         }
 
-        transcript.append_protocol_name(Self::protocol_name());
+        let protocol_name = Self::protocol_name();
+        transcript.append_message(protocol_name);
         let instruction = Instruction::default();
 
         let r_primary_sumcheck = transcript.challenge_vector(proof.primary_sumcheck.num_rounds);

--- a/jolt-core/src/lasso/surge.rs
+++ b/jolt-core/src/lasso/surge.rs
@@ -10,6 +10,10 @@ use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use rayon::iter::{IntoParallelIterator, IntoParallelRefIterator, ParallelIterator};
 use std::marker::{PhantomData, Sync};
 
+use super::memory_checking::{
+    Initializable, NoExogenousOpenings, StructuredPolynomialData, VerifierComputedOpening,
+};
+use crate::utils::transcript::Transcript;
 use crate::{
     jolt::instruction::JoltInstruction,
     lasso::memory_checking::{MemoryCheckingProof, MemoryCheckingProver, MemoryCheckingVerifier},
@@ -20,11 +24,9 @@ use crate::{
         identity_poly::IdentityPolynomial,
     },
     subprotocols::sumcheck::SumcheckInstanceProof,
-    utils::{errors::ProofVerifyError, math::Math, mul_0_1_optimized, transcript::ProofTranscript},
-};
-
-use super::memory_checking::{
-    Initializable, NoExogenousOpenings, StructuredPolynomialData, VerifierComputedOpening,
+    utils::{
+        errors::ProofVerifyError, math::Math, mul_0_1_optimized, transcript::DefaultTranscript,
+    },
 };
 
 #[derive(Default, CanonicalSerialize, CanonicalDeserialize)]
@@ -379,7 +381,7 @@ where
         generators: &PCS::Setup,
         ops: Vec<Instruction>,
     ) -> (Self, Option<ProverDebugInfo<F>>) {
-        let mut transcript = ProofTranscript::new(b"Surge transcript");
+        let mut transcript = DefaultTranscript::new(b"Surge transcript");
         let mut opening_accumulator: ProverOpeningAccumulator<F> = ProverOpeningAccumulator::new();
         let protocol_name = Self::protocol_name();
         transcript.append_message(protocol_name);
@@ -482,7 +484,7 @@ where
         proof: SurgeProof<F, PCS, Instruction, C, M>,
         _debug_info: Option<ProverDebugInfo<F>>,
     ) -> Result<(), ProofVerifyError> {
-        let mut transcript = ProofTranscript::new(b"Surge transcript");
+        let mut transcript = DefaultTranscript::new(b"Surge transcript");
         let mut opening_accumulator: VerifierOpeningAccumulator<F, PCS> =
             VerifierOpeningAccumulator::new();
         #[cfg(test)]

--- a/jolt-core/src/poly/commitment/binius.rs
+++ b/jolt-core/src/poly/commitment/binius.rs
@@ -5,17 +5,20 @@ use crate::poly::commitment::commitment_scheme::CommitShape;
 use crate::poly::commitment::commitment_scheme::CommitmentScheme;
 use crate::poly::dense_mlpoly::DensePolynomial;
 use crate::utils::errors::ProofVerifyError;
-use crate::utils::transcript::{AppendToTranscript, DefaultTranscript};
+use crate::utils::transcript::{AppendToTranscript, Transcript};
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
+use std::marker::PhantomData;
 
 #[derive(Clone)]
-pub struct Binius128Scheme {}
+pub struct Binius128Scheme<ProofTranscript: Transcript> {
+    _phantom: PhantomData<ProofTranscript>,
+}
 
 #[derive(Default, Debug, PartialEq, CanonicalSerialize, CanonicalDeserialize)]
 pub struct BiniusCommitment {}
 
 impl AppendToTranscript for BiniusCommitment {
-    fn append_to_transcript(&self, _transcript: &mut DefaultTranscript) {
+    fn append_to_transcript<ProofTranscript: Transcript>(&self, _transcript: &mut ProofTranscript) {
         todo!()
     }
 }
@@ -29,7 +32,9 @@ pub struct BiniusBatchedProof {}
 #[derive(Clone)]
 pub struct None {}
 
-impl CommitmentScheme for Binius128Scheme {
+impl<ProofTranscript: Transcript> CommitmentScheme<ProofTranscript>
+    for Binius128Scheme<ProofTranscript>
+{
     type Field = crate::field::binius::BiniusField<binius_field::BinaryField128bPolyval>;
     type Setup = None;
     type Commitment = BiniusCommitment;
@@ -56,7 +61,7 @@ impl CommitmentScheme for Binius128Scheme {
         _none: &Self::Setup,
         _poly: &DensePolynomial<Self::Field>,
         _opening_point: &[Self::Field],
-        _transcript: &mut DefaultTranscript,
+        _transcript: &mut ProofTranscript,
     ) -> Self::Proof {
         todo!()
     }
@@ -66,7 +71,7 @@ impl CommitmentScheme for Binius128Scheme {
         _opening_point: &[Self::Field],
         _openings: &[Self::Field],
         _batch_type: BatchType,
-        _transcript: &mut DefaultTranscript,
+        _transcript: &mut ProofTranscript,
     ) -> Self::BatchedProof {
         todo!()
     }
@@ -74,7 +79,7 @@ impl CommitmentScheme for Binius128Scheme {
     fn verify(
         _proof: &Self::Proof,
         _setup: &Self::Setup,
-        _transcript: &mut DefaultTranscript,
+        _transcript: &mut ProofTranscript,
         _opening_point: &[Self::Field],
         _opening: &Self::Field,
         _commitment: &Self::Commitment,
@@ -88,7 +93,7 @@ impl CommitmentScheme for Binius128Scheme {
         _opening_point: &[Self::Field],
         _openings: &[Self::Field],
         _commitments: &[&Self::Commitment],
-        _transcript: &mut DefaultTranscript,
+        _transcript: &mut ProofTranscript,
     ) -> Result<(), ProofVerifyError> {
         todo!()
     }

--- a/jolt-core/src/poly/commitment/binius.rs
+++ b/jolt-core/src/poly/commitment/binius.rs
@@ -5,7 +5,7 @@ use crate::poly::commitment::commitment_scheme::CommitShape;
 use crate::poly::commitment::commitment_scheme::CommitmentScheme;
 use crate::poly::dense_mlpoly::DensePolynomial;
 use crate::utils::errors::ProofVerifyError;
-use crate::utils::transcript::{AppendToTranscript, ProofTranscript};
+use crate::utils::transcript::{AppendToTranscript, DefaultTranscript};
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 
 #[derive(Clone)]
@@ -15,7 +15,7 @@ pub struct Binius128Scheme {}
 pub struct BiniusCommitment {}
 
 impl AppendToTranscript for BiniusCommitment {
-    fn append_to_transcript(&self, _transcript: &mut ProofTranscript) {
+    fn append_to_transcript(&self, _transcript: &mut DefaultTranscript) {
         todo!()
     }
 }
@@ -56,7 +56,7 @@ impl CommitmentScheme for Binius128Scheme {
         _none: &Self::Setup,
         _poly: &DensePolynomial<Self::Field>,
         _opening_point: &[Self::Field],
-        _transcript: &mut ProofTranscript,
+        _transcript: &mut DefaultTranscript,
     ) -> Self::Proof {
         todo!()
     }
@@ -66,7 +66,7 @@ impl CommitmentScheme for Binius128Scheme {
         _opening_point: &[Self::Field],
         _openings: &[Self::Field],
         _batch_type: BatchType,
-        _transcript: &mut ProofTranscript,
+        _transcript: &mut DefaultTranscript,
     ) -> Self::BatchedProof {
         todo!()
     }
@@ -74,7 +74,7 @@ impl CommitmentScheme for Binius128Scheme {
     fn verify(
         _proof: &Self::Proof,
         _setup: &Self::Setup,
-        _transcript: &mut ProofTranscript,
+        _transcript: &mut DefaultTranscript,
         _opening_point: &[Self::Field],
         _opening: &Self::Field,
         _commitment: &Self::Commitment,
@@ -88,7 +88,7 @@ impl CommitmentScheme for Binius128Scheme {
         _opening_point: &[Self::Field],
         _openings: &[Self::Field],
         _commitments: &[&Self::Commitment],
-        _transcript: &mut ProofTranscript,
+        _transcript: &mut DefaultTranscript,
     ) -> Result<(), ProofVerifyError> {
         todo!()
     }

--- a/jolt-core/src/poly/commitment/commitment_scheme.rs
+++ b/jolt-core/src/poly/commitment/commitment_scheme.rs
@@ -6,7 +6,7 @@ use crate::{
     poly::dense_mlpoly::DensePolynomial,
     utils::{
         errors::ProofVerifyError,
-        transcript::{AppendToTranscript, ProofTranscript},
+        transcript::{AppendToTranscript, DefaultTranscript},
     },
 };
 
@@ -86,7 +86,7 @@ pub trait CommitmentScheme: Clone + Sync + Send + 'static {
         setup: &Self::Setup,
         poly: &DensePolynomial<Self::Field>,
         opening_point: &[Self::Field], // point at which the polynomial is evaluated
-        transcript: &mut ProofTranscript,
+        transcript: &mut DefaultTranscript,
     ) -> Self::Proof;
     fn batch_prove(
         setup: &Self::Setup,
@@ -94,13 +94,13 @@ pub trait CommitmentScheme: Clone + Sync + Send + 'static {
         opening_point: &[Self::Field],
         openings: &[Self::Field],
         batch_type: BatchType,
-        transcript: &mut ProofTranscript,
+        transcript: &mut DefaultTranscript,
     ) -> Self::BatchedProof;
 
     fn verify(
         proof: &Self::Proof,
         setup: &Self::Setup,
-        transcript: &mut ProofTranscript,
+        transcript: &mut DefaultTranscript,
         opening_point: &[Self::Field], // point at which the polynomial is evaluated
         opening: &Self::Field,         // evaluation \widetilde{Z}(r)
         commitment: &Self::Commitment,
@@ -112,7 +112,7 @@ pub trait CommitmentScheme: Clone + Sync + Send + 'static {
         opening_point: &[Self::Field],
         openings: &[Self::Field],
         commitments: &[&Self::Commitment],
-        transcript: &mut ProofTranscript,
+        transcript: &mut DefaultTranscript,
     ) -> Result<(), ProofVerifyError>;
 
     fn protocol_name() -> &'static [u8];

--- a/jolt-core/src/poly/commitment/commitment_scheme.rs
+++ b/jolt-core/src/poly/commitment/commitment_scheme.rs
@@ -1,13 +1,11 @@
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use std::fmt::Debug;
 
+use crate::utils::transcript::Transcript;
 use crate::{
     field::JoltField,
     poly::dense_mlpoly::DensePolynomial,
-    utils::{
-        errors::ProofVerifyError,
-        transcript::{AppendToTranscript, DefaultTranscript},
-    },
+    utils::{errors::ProofVerifyError, transcript::AppendToTranscript},
 };
 
 #[derive(Clone, Debug)]
@@ -34,7 +32,7 @@ pub enum BatchType {
     GrandProduct,
 }
 
-pub trait CommitmentScheme: Clone + Sync + Send + 'static {
+pub trait CommitmentScheme<ProofTranscript: Transcript>: Clone + Sync + Send + 'static {
     type Field: JoltField + Sized;
     type Setup: Clone + Sync + Send;
     type Commitment: Default
@@ -86,7 +84,7 @@ pub trait CommitmentScheme: Clone + Sync + Send + 'static {
         setup: &Self::Setup,
         poly: &DensePolynomial<Self::Field>,
         opening_point: &[Self::Field], // point at which the polynomial is evaluated
-        transcript: &mut DefaultTranscript,
+        transcript: &mut ProofTranscript,
     ) -> Self::Proof;
     fn batch_prove(
         setup: &Self::Setup,
@@ -94,13 +92,13 @@ pub trait CommitmentScheme: Clone + Sync + Send + 'static {
         opening_point: &[Self::Field],
         openings: &[Self::Field],
         batch_type: BatchType,
-        transcript: &mut DefaultTranscript,
+        transcript: &mut ProofTranscript,
     ) -> Self::BatchedProof;
 
     fn verify(
         proof: &Self::Proof,
         setup: &Self::Setup,
-        transcript: &mut DefaultTranscript,
+        transcript: &mut ProofTranscript,
         opening_point: &[Self::Field], // point at which the polynomial is evaluated
         opening: &Self::Field,         // evaluation \widetilde{Z}(r)
         commitment: &Self::Commitment,
@@ -112,7 +110,7 @@ pub trait CommitmentScheme: Clone + Sync + Send + 'static {
         opening_point: &[Self::Field],
         openings: &[Self::Field],
         commitments: &[&Self::Commitment],
-        transcript: &mut DefaultTranscript,
+        transcript: &mut ProofTranscript,
     ) -> Result<(), ProofVerifyError>;
 
     fn protocol_name() -> &'static [u8];

--- a/jolt-core/src/poly/commitment/hyrax.rs
+++ b/jolt-core/src/poly/commitment/hyrax.rs
@@ -276,7 +276,8 @@ impl<F: JoltField, G: CurveGroup<ScalarField = F>> HyraxOpeningProof<G> {
         ratio: usize,
         transcript: &mut ProofTranscript,
     ) -> HyraxOpeningProof<G> {
-        transcript.append_protocol_name(Self::protocol_name());
+        let protocol_name = Self::protocol_name();
+        transcript.append_message(protocol_name);
 
         // assert vectors are of the right size
         assert_eq!(poly.get_num_vars(), opening_point.len());
@@ -303,7 +304,8 @@ impl<F: JoltField, G: CurveGroup<ScalarField = F>> HyraxOpeningProof<G> {
         commitment: &HyraxCommitment<G>,
         ratio: usize,
     ) -> Result<(), ProofVerifyError> {
-        transcript.append_protocol_name(Self::protocol_name());
+        let protocol_name = Self::protocol_name();
+        transcript.append_message(protocol_name);
 
         // compute L and R
         let (L_size, R_size) = matrix_dimensions(opening_point.len(), ratio);
@@ -371,7 +373,8 @@ impl<F: JoltField, G: CurveGroup<ScalarField = F>> BatchedHyraxOpeningProof<G> {
         batch_type: BatchType,
         transcript: &mut ProofTranscript,
     ) -> Self {
-        transcript.append_protocol_name(Self::protocol_name());
+        let protocol_name = Self::protocol_name();
+        transcript.append_message(protocol_name);
 
         // append the claimed evaluations to transcript
         transcript.append_scalars(openings);
@@ -455,7 +458,8 @@ impl<F: JoltField, G: CurveGroup<ScalarField = F>> BatchedHyraxOpeningProof<G> {
             )
         });
 
-        transcript.append_protocol_name(Self::protocol_name());
+        let protocol_name = Self::protocol_name();
+        transcript.append_message(protocol_name);
 
         // append the claimed evaluations to transcript
         transcript.append_scalars(openings);

--- a/jolt-core/src/poly/commitment/hyrax.rs
+++ b/jolt-core/src/poly/commitment/hyrax.rs
@@ -7,7 +7,7 @@ use crate::poly::dense_mlpoly::DensePolynomial;
 use crate::poly::eq_poly::EqPolynomial;
 use crate::utils::errors::ProofVerifyError;
 use crate::utils::math::Math;
-use crate::utils::transcript::{AppendToTranscript, DefaultTranscript, Transcript};
+use crate::utils::transcript::{AppendToTranscript, Transcript};
 use crate::utils::{compute_dotproduct, mul_0_1_optimized};
 use ark_ec::CurveGroup;
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
@@ -18,8 +18,8 @@ use tracing::trace_span;
 use crate::msm::VariableBaseMSM;
 
 #[derive(Clone)]
-pub struct HyraxScheme<G: CurveGroup> {
-    marker: PhantomData<G>,
+pub struct HyraxScheme<G: CurveGroup, ProofTranscript: Transcript> {
+    marker: PhantomData<(G, ProofTranscript)>,
 }
 
 const TRACE_LEN_R1CS_POLYS_BATCH_RATIO: usize = 64;
@@ -48,12 +48,14 @@ pub fn matrix_dimensions(num_vars: usize, ratio: usize) -> (usize, usize) {
     (col_size, row_size)
 }
 
-impl<F: JoltField, G: CurveGroup<ScalarField = F>> CommitmentScheme for HyraxScheme<G> {
+impl<F: JoltField, G: CurveGroup<ScalarField = F>, ProofTranscript: Transcript>
+    CommitmentScheme<ProofTranscript> for HyraxScheme<G, ProofTranscript>
+{
     type Field = G::ScalarField;
     type Setup = PedersenGenerators<G>;
     type Commitment = HyraxCommitment<G>;
-    type Proof = HyraxOpeningProof<G>;
-    type BatchedProof = BatchedHyraxOpeningProof<G>;
+    type Proof = HyraxOpeningProof<G, ProofTranscript>;
+    type BatchedProof = BatchedHyraxOpeningProof<G, ProofTranscript>;
 
     fn setup(shapes: &[CommitShape]) -> Self::Setup {
         let mut max_len: usize = 0;
@@ -86,7 +88,7 @@ impl<F: JoltField, G: CurveGroup<ScalarField = F>> CommitmentScheme for HyraxSch
         _setup: &Self::Setup,
         poly: &DensePolynomial<Self::Field>,
         opening_point: &[Self::Field],
-        transcript: &mut DefaultTranscript,
+        transcript: &mut ProofTranscript,
     ) -> Self::Proof {
         // Implicitly prove is "prove_single", with a ratio = 1
         HyraxOpeningProof::prove(poly, opening_point, 1, transcript)
@@ -97,7 +99,7 @@ impl<F: JoltField, G: CurveGroup<ScalarField = F>> CommitmentScheme for HyraxSch
         opening_point: &[Self::Field],
         openings: &[Self::Field],
         batch_type: BatchType,
-        transcript: &mut DefaultTranscript,
+        transcript: &mut ProofTranscript,
     ) -> Self::BatchedProof {
         BatchedHyraxOpeningProof::prove(
             polynomials,
@@ -143,7 +145,7 @@ impl<F: JoltField, G: CurveGroup<ScalarField = F>> CommitmentScheme for HyraxSch
     fn verify(
         proof: &Self::Proof,
         generators: &Self::Setup,
-        transcript: &mut DefaultTranscript,
+        transcript: &mut ProofTranscript,
         opening_point: &[Self::Field],
         opening: &Self::Field,
         commitment: &Self::Commitment,
@@ -166,7 +168,7 @@ impl<F: JoltField, G: CurveGroup<ScalarField = F>> CommitmentScheme for HyraxSch
         opening_point: &[Self::Field],
         openings: &[Self::Field],
         commitments: &[&Self::Commitment],
-        transcript: &mut DefaultTranscript,
+        transcript: &mut ProofTranscript,
     ) -> Result<(), ProofVerifyError> {
         BatchedHyraxOpeningProof::verify(
             batch_proof,
@@ -249,7 +251,7 @@ impl<F: JoltField, G: CurveGroup<ScalarField = F>> HyraxCommitment<G> {
 }
 
 impl<G: CurveGroup> AppendToTranscript for HyraxCommitment<G> {
-    fn append_to_transcript(&self, transcript: &mut DefaultTranscript) {
+    fn append_to_transcript<ProofTranscript: Transcript>(&self, transcript: &mut ProofTranscript) {
         transcript.append_message(b"poly_commitment_begin");
         for i in 0..self.row_commitments.len() {
             transcript.append_point(&self.row_commitments[i]);
@@ -259,12 +261,18 @@ impl<G: CurveGroup> AppendToTranscript for HyraxCommitment<G> {
 }
 
 #[derive(Debug, CanonicalSerialize, CanonicalDeserialize)]
-pub struct HyraxOpeningProof<G: CurveGroup> {
+pub struct HyraxOpeningProof<G: CurveGroup, ProofTranscript: Transcript> {
     pub vector_matrix_product: Vec<G::ScalarField>,
+    _marker: PhantomData<ProofTranscript>,
 }
 
 /// See Section 14.3 of Thaler's Proofs, Arguments, and Zero-Knowledge
-impl<F: JoltField, G: CurveGroup<ScalarField = F>> HyraxOpeningProof<G> {
+impl<F, G, ProofTranscript> HyraxOpeningProof<G, ProofTranscript>
+where
+    F: JoltField,
+    G: CurveGroup<ScalarField = F>,
+    ProofTranscript: Transcript,
+{
     fn protocol_name() -> &'static [u8] {
         b"Hyrax opening proof"
     }
@@ -274,8 +282,8 @@ impl<F: JoltField, G: CurveGroup<ScalarField = F>> HyraxOpeningProof<G> {
         poly: &DensePolynomial<G::ScalarField>,
         opening_point: &[G::ScalarField], // point at which the polynomial is evaluated
         ratio: usize,
-        transcript: &mut DefaultTranscript,
-    ) -> HyraxOpeningProof<G> {
+        transcript: &mut ProofTranscript,
+    ) -> HyraxOpeningProof<G, ProofTranscript> {
         let protocol_name = Self::protocol_name();
         transcript.append_message(protocol_name);
 
@@ -292,13 +300,14 @@ impl<F: JoltField, G: CurveGroup<ScalarField = F>> HyraxOpeningProof<G> {
 
         HyraxOpeningProof {
             vector_matrix_product,
+            _marker: PhantomData,
         }
     }
 
     pub fn verify(
         &self,
         pedersen_generators: &PedersenGenerators<G>,
-        transcript: &mut DefaultTranscript,
+        transcript: &mut ProofTranscript,
         opening_point: &[G::ScalarField], // point at which the polynomial is evaluated
         opening: &G::ScalarField,         // evaluation \widetilde{Z}(r)
         commitment: &HyraxCommitment<G>,
@@ -358,20 +367,23 @@ impl<F: JoltField, G: CurveGroup<ScalarField = F>> HyraxOpeningProof<G> {
 }
 
 #[derive(Debug, CanonicalSerialize, CanonicalDeserialize)]
-pub struct BatchedHyraxOpeningProof<G: CurveGroup> {
-    pub joint_proof: HyraxOpeningProof<G>,
+pub struct BatchedHyraxOpeningProof<G: CurveGroup, ProofTranscript: Transcript> {
+    pub joint_proof: HyraxOpeningProof<G, ProofTranscript>,
     pub ratio: usize,
+    _marker: PhantomData<ProofTranscript>,
 }
 
 /// See Section 16.1 of Thaler's Proofs, Arguments, and Zero-Knowledge
-impl<F: JoltField, G: CurveGroup<ScalarField = F>> BatchedHyraxOpeningProof<G> {
+impl<F: JoltField, G: CurveGroup<ScalarField = F>, ProofTranscript: Transcript>
+    BatchedHyraxOpeningProof<G, ProofTranscript>
+{
     #[tracing::instrument(skip_all, name = "BatchedHyraxOpeningProof::prove")]
     pub fn prove(
         polynomials: &[&DensePolynomial<G::ScalarField>],
         opening_point: &[G::ScalarField],
         openings: &[G::ScalarField],
         batch_type: BatchType,
-        transcript: &mut DefaultTranscript,
+        transcript: &mut ProofTranscript,
     ) -> Self {
         let protocol_name = Self::protocol_name();
         transcript.append_message(protocol_name);
@@ -434,7 +446,11 @@ impl<F: JoltField, G: CurveGroup<ScalarField = F>> BatchedHyraxOpeningProof<G> {
             transcript,
         );
 
-        Self { joint_proof, ratio }
+        Self {
+            joint_proof,
+            ratio,
+            _marker: PhantomData,
+        }
     }
 
     #[tracing::instrument(skip_all, name = "BatchedHyraxOpeningProof::verify")]
@@ -444,7 +460,7 @@ impl<F: JoltField, G: CurveGroup<ScalarField = F>> BatchedHyraxOpeningProof<G> {
         opening_point: &[G::ScalarField],
         openings: &[G::ScalarField],
         commitments: &[&HyraxCommitment<G>],
-        transcript: &mut DefaultTranscript,
+        transcript: &mut ProofTranscript,
     ) -> Result<(), ProofVerifyError> {
         assert_eq!(openings.len(), commitments.len());
         let (L_size, _R_size) = matrix_dimensions(opening_point.len(), self.ratio);
@@ -510,7 +526,7 @@ impl<F: JoltField, G: CurveGroup<ScalarField = F>> BatchedHyraxOpeningProof<G> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::utils::transcript::Transcript;
+    use crate::utils::transcript::{DefaultTranscript, Transcript};
     use ark_bn254::{Fr, G1Projective};
 
     #[test]

--- a/jolt-core/src/poly/commitment/mock.rs
+++ b/jolt-core/src/poly/commitment/mock.rs
@@ -2,16 +2,16 @@ use std::marker::PhantomData;
 
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 
+use super::commitment_scheme::{BatchType, CommitShape, CommitmentScheme};
+use crate::utils::transcript::Transcript;
 use crate::{
     field::JoltField,
     poly::dense_mlpoly::DensePolynomial,
     utils::{
         errors::ProofVerifyError,
-        transcript::{AppendToTranscript, ProofTranscript},
+        transcript::{AppendToTranscript, DefaultTranscript},
     },
 };
-
-use super::commitment_scheme::{BatchType, CommitShape, CommitmentScheme};
 
 #[derive(Clone)]
 pub struct MockCommitScheme<F: JoltField> {
@@ -24,7 +24,7 @@ pub struct MockCommitment<F: JoltField> {
 }
 
 impl<F: JoltField> AppendToTranscript for MockCommitment<F> {
-    fn append_to_transcript(&self, transcript: &mut ProofTranscript) {
+    fn append_to_transcript(&self, transcript: &mut DefaultTranscript) {
         transcript.append_message(b"mocker");
     }
 }
@@ -71,7 +71,7 @@ impl<F: JoltField> CommitmentScheme for MockCommitScheme<F> {
         _setup: &Self::Setup,
         _poly: &DensePolynomial<Self::Field>,
         opening_point: &[Self::Field],
-        _transcript: &mut ProofTranscript,
+        _transcript: &mut DefaultTranscript,
     ) -> Self::Proof {
         MockProof {
             opening_point: opening_point.to_owned(),
@@ -83,7 +83,7 @@ impl<F: JoltField> CommitmentScheme for MockCommitScheme<F> {
         opening_point: &[Self::Field],
         _openings: &[Self::Field],
         _batch_type: BatchType,
-        _transcript: &mut ProofTranscript,
+        _transcript: &mut DefaultTranscript,
     ) -> Self::BatchedProof {
         MockProof {
             opening_point: opening_point.to_owned(),
@@ -114,7 +114,7 @@ impl<F: JoltField> CommitmentScheme for MockCommitScheme<F> {
     fn verify(
         proof: &Self::Proof,
         _setup: &Self::Setup,
-        _transcript: &mut ProofTranscript,
+        _transcript: &mut DefaultTranscript,
         opening_point: &[Self::Field],
         opening: &Self::Field,
         commitment: &Self::Commitment,
@@ -131,7 +131,7 @@ impl<F: JoltField> CommitmentScheme for MockCommitScheme<F> {
         opening_point: &[Self::Field],
         openings: &[Self::Field],
         commitments: &[&Self::Commitment],
-        _transcript: &mut ProofTranscript,
+        _transcript: &mut DefaultTranscript,
     ) -> Result<(), ProofVerifyError> {
         assert_eq!(batch_proof.opening_point, opening_point);
         assert_eq!(openings.len(), commitments.len());

--- a/jolt-core/src/poly/commitment/zeromorph.rs
+++ b/jolt-core/src/poly/commitment/zeromorph.rs
@@ -258,7 +258,8 @@ where
         eval: &P::ScalarField,
         transcript: &mut ProofTranscript,
     ) -> Result<ZeromorphProof<P>, ProofVerifyError> {
-        transcript.append_protocol_name(Self::protocol_name());
+        let protocol_name = Self::protocol_name();
+        transcript.append_message(protocol_name);
 
         if pp.commit_pp.g1_powers().len() < poly.Z.len() {
             return Err(ProofVerifyError::KeyLengthError(
@@ -418,7 +419,8 @@ where
         proof: &ZeromorphProof<P>,
         transcript: &mut ProofTranscript,
     ) -> Result<(), ProofVerifyError> {
-        transcript.append_protocol_name(Self::protocol_name());
+        let protocol_name = Self::protocol_name();
+        transcript.append_message(protocol_name);
 
         let q_comms: Vec<P::G1> = proof.q_k_com.iter().map(|c| c.into_group()).collect();
         q_comms.iter().for_each(|c| transcript.append_point(c));

--- a/jolt-core/src/poly/unipoly.rs
+++ b/jolt-core/src/poly/unipoly.rs
@@ -4,7 +4,7 @@ use std::cmp::Ordering;
 use std::ops::{AddAssign, Index, IndexMut, Mul, MulAssign};
 
 use crate::utils::gaussian_elimination::gaussian_elimination;
-use crate::utils::transcript::{AppendToTranscript, ProofTranscript};
+use crate::utils::transcript::{AppendToTranscript, DefaultTranscript, Transcript};
 use ark_serialize::*;
 use rand_core::{CryptoRng, RngCore};
 use rayon::iter::{IntoParallelIterator, IntoParallelRefMutIterator, ParallelIterator};
@@ -252,7 +252,7 @@ impl<F: JoltField> CompressedUniPoly<F> {
 }
 
 impl<F: JoltField> AppendToTranscript for CompressedUniPoly<F> {
-    fn append_to_transcript(&self, transcript: &mut ProofTranscript) {
+    fn append_to_transcript(&self, transcript: &mut DefaultTranscript) {
         transcript.append_message(b"UniPoly_begin");
         for i in 0..self.coeffs_except_linear_term.len() {
             transcript.append_scalar(&self.coeffs_except_linear_term[i]);

--- a/jolt-core/src/poly/unipoly.rs
+++ b/jolt-core/src/poly/unipoly.rs
@@ -4,7 +4,7 @@ use std::cmp::Ordering;
 use std::ops::{AddAssign, Index, IndexMut, Mul, MulAssign};
 
 use crate::utils::gaussian_elimination::gaussian_elimination;
-use crate::utils::transcript::{AppendToTranscript, DefaultTranscript, Transcript};
+use crate::utils::transcript::{AppendToTranscript, Transcript};
 use ark_serialize::*;
 use rand_core::{CryptoRng, RngCore};
 use rayon::iter::{IntoParallelIterator, IntoParallelRefMutIterator, ParallelIterator};
@@ -252,7 +252,7 @@ impl<F: JoltField> CompressedUniPoly<F> {
 }
 
 impl<F: JoltField> AppendToTranscript for CompressedUniPoly<F> {
-    fn append_to_transcript(&self, transcript: &mut DefaultTranscript) {
+    fn append_to_transcript<ProofTranscript: Transcript>(&self, transcript: &mut ProofTranscript) {
         transcript.append_message(b"UniPoly_begin");
         for i in 0..self.coeffs_except_linear_term.len() {
             transcript.append_scalar(&self.coeffs_except_linear_term[i]);

--- a/jolt-core/src/r1cs/builder.rs
+++ b/jolt-core/src/r1cs/builder.rs
@@ -1,3 +1,10 @@
+use super::{
+    inputs::ConstraintInput,
+    key::{NonUniformR1CS, NonUniformR1CSConstraint, SparseEqualityItem},
+    ops::{Term, Variable, LC},
+    special_polys::SparsePolynomial,
+};
+use crate::utils::transcript::Transcript;
 use crate::{
     field::JoltField,
     jolt::vm::JoltPolynomials,
@@ -11,13 +18,6 @@ use crate::{
 };
 use rayon::prelude::*;
 use std::{collections::BTreeMap, marker::PhantomData};
-
-use super::{
-    inputs::ConstraintInput,
-    key::{NonUniformR1CS, NonUniformR1CSConstraint, SparseEqualityItem},
-    ops::{Term, Variable, LC},
-    special_polys::SparsePolynomial,
-};
 
 /// Constraints over a single row. Each variable points to a single item in Z and the corresponding coefficient.
 #[derive(Clone)]
@@ -636,7 +636,10 @@ impl<const C: usize, F: JoltField, I: ConstraintInput> CombinedUniformBuilder<C,
     }
 
     #[tracing::instrument(skip_all)]
-    pub fn compute_spartan_Az_Bz_Cz<PCS: CommitmentScheme<Field = F>>(
+    pub fn compute_spartan_Az_Bz_Cz<
+        PCS: CommitmentScheme<ProofTranscript, Field = F>,
+        ProofTranscript: Transcript,
+    >(
         &self,
         flattened_polynomials: &[&DensePolynomial<F>],
     ) -> (

--- a/jolt-core/src/r1cs/inputs.rs
+++ b/jolt-core/src/r1cs/inputs.rs
@@ -13,7 +13,7 @@ use crate::poly::commitment::commitment_scheme::CommitmentScheme;
 use crate::poly::dense_mlpoly::DensePolynomial;
 use crate::poly::opening_proof::VerifierOpeningAccumulator;
 use crate::utils::thread::unsafe_allocate_zero_vec;
-use crate::utils::transcript::ProofTranscript;
+use crate::utils::transcript::DefaultTranscript;
 
 use super::key::UniformSpartanKey;
 use super::spartan::{SpartanError, UniformSpartanProof};
@@ -224,7 +224,7 @@ impl<const C: usize, I: ConstraintInput, F: JoltField> R1CSProof<C, I, F> {
         &self,
         commitments: &JoltCommitments<PCS>,
         opening_accumulator: &mut VerifierOpeningAccumulator<F, PCS>,
-        transcript: &mut ProofTranscript,
+        transcript: &mut DefaultTranscript,
     ) -> Result<(), SpartanError> {
         self.proof
             .verify(&self.key, commitments, opening_accumulator, transcript)

--- a/jolt-core/src/r1cs/inputs.rs
+++ b/jolt-core/src/r1cs/inputs.rs
@@ -13,7 +13,7 @@ use crate::poly::commitment::commitment_scheme::CommitmentScheme;
 use crate::poly::dense_mlpoly::DensePolynomial;
 use crate::poly::opening_proof::VerifierOpeningAccumulator;
 use crate::utils::thread::unsafe_allocate_zero_vec;
-use crate::utils::transcript::DefaultTranscript;
+use crate::utils::transcript::Transcript;
 
 use super::key::UniformSpartanKey;
 use super::spartan::{SpartanError, UniformSpartanProof};
@@ -24,6 +24,7 @@ use ark_std::log2;
 use common::constants::RAM_OPS_PER_INSTRUCTION;
 use common::rv_trace::{CircuitFlags, NUM_CIRCUIT_FLAGS};
 use std::fmt::Debug;
+use std::marker::PhantomData;
 use strum::IntoEnumIterator;
 use strum_macros::EnumIter;
 
@@ -157,7 +158,8 @@ pub type R1CSOpenings<F: JoltField> = R1CSStuff<F>;
 /// See issue #112792 <https://github.com/rust-lang/rust/issues/112792>.
 /// Adding #![feature(lazy_type_alias)] to the crate attributes seem to break
 /// `alloy_sol_types`.
-pub type R1CSCommitments<PCS: CommitmentScheme> = R1CSStuff<PCS::Commitment>;
+pub type R1CSCommitments<PCS: CommitmentScheme<ProofTranscript>, ProofTranscript: Transcript> =
+    R1CSStuff<PCS::Commitment>;
 
 impl<F: JoltField> R1CSPolynomials<F> {
     pub fn new<
@@ -213,19 +215,27 @@ impl<F: JoltField> R1CSPolynomials<F> {
 }
 
 #[derive(CanonicalSerialize, CanonicalDeserialize)]
-pub struct R1CSProof<const C: usize, I: ConstraintInput, F: JoltField> {
+pub struct R1CSProof<const C: usize, I: ConstraintInput, F: JoltField, ProofTranscript: Transcript>
+{
     pub key: UniformSpartanKey<C, I, F>,
-    pub proof: UniformSpartanProof<C, I, F>,
+    pub proof: UniformSpartanProof<C, I, F, ProofTranscript>,
+    pub _marker: PhantomData<ProofTranscript>,
 }
 
-impl<const C: usize, I: ConstraintInput, F: JoltField> R1CSProof<C, I, F> {
+impl<const C: usize, I: ConstraintInput, F: JoltField, ProofTranscript: Transcript>
+    R1CSProof<C, I, F, ProofTranscript>
+{
     #[tracing::instrument(skip_all, name = "R1CSProof::verify")]
-    pub fn verify<PCS: CommitmentScheme<Field = F>>(
+    pub fn verify<PCS>(
         &self,
-        commitments: &JoltCommitments<PCS>,
-        opening_accumulator: &mut VerifierOpeningAccumulator<F, PCS>,
-        transcript: &mut DefaultTranscript,
-    ) -> Result<(), SpartanError> {
+        commitments: &JoltCommitments<PCS, ProofTranscript>,
+        opening_accumulator: &mut VerifierOpeningAccumulator<F, PCS, ProofTranscript>,
+        transcript: &mut ProofTranscript,
+    ) -> Result<(), SpartanError>
+    where
+        PCS: CommitmentScheme<ProofTranscript, Field = F>,
+        ProofTranscript: Transcript,
+    {
         self.proof
             .verify(&self.key, commitments, opening_accumulator, transcript)
     }

--- a/jolt-core/src/r1cs/spartan.rs
+++ b/jolt-core/src/r1cs/spartan.rs
@@ -12,7 +12,7 @@ use crate::r1cs::key::UniformSpartanKey;
 use crate::utils::math::Math;
 use crate::utils::thread::drop_in_background_thread;
 
-use crate::utils::transcript::ProofTranscript;
+use crate::utils::transcript::{DefaultTranscript, Transcript};
 use ark_serialize::CanonicalDeserialize;
 use ark_serialize::CanonicalSerialize;
 
@@ -93,7 +93,7 @@ impl<const C: usize, I: ConstraintInput, F: JoltField> UniformSpartanProof<C, I,
         key: &UniformSpartanKey<C, I, F>,
         polynomials: &JoltPolynomials<F>,
         opening_accumulator: &mut ProverOpeningAccumulator<F>,
-        transcript: &mut ProofTranscript,
+        transcript: &mut DefaultTranscript,
     ) -> Result<Self, SpartanError> {
         let flattened_polys: Vec<&DensePolynomial<F>> = I::flatten::<C>()
             .iter()
@@ -151,7 +151,7 @@ impl<const C: usize, I: ConstraintInput, F: JoltField> UniformSpartanProof<C, I,
             outer_sumcheck_claims[2],
             outer_sumcheck_claims[3],
         );
-        ProofTranscript::append_scalars(transcript, [claim_Az, claim_Bz, claim_Cz].as_slice());
+        DefaultTranscript::append_scalars(transcript, [claim_Az, claim_Bz, claim_Cz].as_slice());
 
         // inner sum-check
         let r_inner_sumcheck_RLC: F = transcript.challenge_scalar();
@@ -218,7 +218,7 @@ impl<const C: usize, I: ConstraintInput, F: JoltField> UniformSpartanProof<C, I,
         key: &UniformSpartanKey<C, I, F>,
         commitments: &JoltCommitments<PCS>,
         opening_accumulator: &mut VerifierOpeningAccumulator<F, PCS>,
-        transcript: &mut ProofTranscript,
+        transcript: &mut DefaultTranscript,
     ) -> Result<(), SpartanError> {
         let num_rounds_x = key.num_rows_total().log_2();
         let num_rounds_y = key.num_cols_total().log_2();

--- a/jolt-core/src/r1cs/spartan.rs
+++ b/jolt-core/src/r1cs/spartan.rs
@@ -12,7 +12,7 @@ use crate::r1cs::key::UniformSpartanKey;
 use crate::utils::math::Math;
 use crate::utils::thread::drop_in_background_thread;
 
-use crate::utils::transcript::{DefaultTranscript, Transcript};
+use crate::utils::transcript::Transcript;
 use ark_serialize::CanonicalDeserialize;
 use ark_serialize::CanonicalSerialize;
 
@@ -66,15 +66,26 @@ pub enum SpartanError {
 /// The proof is produced using Spartan's combination of the sum-check and
 /// the commitment to a vector viewed as a polynomial commitment
 #[derive(CanonicalSerialize, CanonicalDeserialize)]
-pub struct UniformSpartanProof<const C: usize, I: ConstraintInput, F: JoltField> {
+pub struct UniformSpartanProof<
+    const C: usize,
+    I: ConstraintInput,
+    F: JoltField,
+    ProofTranscript: Transcript,
+> {
     _inputs: PhantomData<I>,
-    pub(crate) outer_sumcheck_proof: SumcheckInstanceProof<F>,
+    pub(crate) outer_sumcheck_proof: SumcheckInstanceProof<F, ProofTranscript>,
     pub(crate) outer_sumcheck_claims: (F, F, F),
-    pub(crate) inner_sumcheck_proof: SumcheckInstanceProof<F>,
+    pub(crate) inner_sumcheck_proof: SumcheckInstanceProof<F, ProofTranscript>,
     pub(crate) claimed_witness_evals: Vec<F>,
+    _marker: PhantomData<ProofTranscript>,
 }
 
-impl<const C: usize, I: ConstraintInput, F: JoltField> UniformSpartanProof<C, I, F> {
+impl<const C: usize, I, F, ProofTranscript> UniformSpartanProof<C, I, F, ProofTranscript>
+where
+    I: ConstraintInput,
+    F: JoltField,
+    ProofTranscript: Transcript,
+{
     #[tracing::instrument(skip_all, name = "Spartan::setup")]
     pub fn setup(
         constraint_builder: &CombinedUniformBuilder<C, F, I>,
@@ -88,13 +99,16 @@ impl<const C: usize, I: ConstraintInput, F: JoltField> UniformSpartanProof<C, I,
     }
 
     #[tracing::instrument(skip_all, name = "Spartan::prove")]
-    pub fn prove<PCS: CommitmentScheme<Field = F>>(
+    pub fn prove<PCS>(
         constraint_builder: &CombinedUniformBuilder<C, F, I>,
         key: &UniformSpartanKey<C, I, F>,
         polynomials: &JoltPolynomials<F>,
-        opening_accumulator: &mut ProverOpeningAccumulator<F>,
-        transcript: &mut DefaultTranscript,
-    ) -> Result<Self, SpartanError> {
+        opening_accumulator: &mut ProverOpeningAccumulator<F, ProofTranscript>,
+        transcript: &mut ProofTranscript,
+    ) -> Result<Self, SpartanError>
+    where
+        PCS: CommitmentScheme<ProofTranscript, Field = F>,
+    {
         let flattened_polys: Vec<&DensePolynomial<F>> = I::flatten::<C>()
             .iter()
             .map(|var| var.get_ref(polynomials))
@@ -110,7 +124,7 @@ impl<const C: usize, I: ConstraintInput, F: JoltField> UniformSpartanProof<C, I,
         let mut poly_tau = DensePolynomial::new(EqPolynomial::evals(&tau));
 
         let (mut az, mut bz, mut cz) =
-            constraint_builder.compute_spartan_Az_Bz_Cz::<PCS>(&flattened_polys);
+            constraint_builder.compute_spartan_Az_Bz_Cz::<PCS, ProofTranscript>(&flattened_polys);
 
         let comb_func_outer = |eq: &F, az: &F, bz: &F, cz: &F| -> F {
             // Below is an optimized form of: eq * (Az * Bz - Cz)
@@ -151,7 +165,7 @@ impl<const C: usize, I: ConstraintInput, F: JoltField> UniformSpartanProof<C, I,
             outer_sumcheck_claims[2],
             outer_sumcheck_claims[3],
         );
-        DefaultTranscript::append_scalars(transcript, [claim_Az, claim_Bz, claim_Cz].as_slice());
+        ProofTranscript::append_scalars(transcript, [claim_Az, claim_Bz, claim_Cz].as_slice());
 
         // inner sum-check
         let r_inner_sumcheck_RLC: F = transcript.challenge_scalar();
@@ -209,17 +223,22 @@ impl<const C: usize, I: ConstraintInput, F: JoltField> UniformSpartanProof<C, I,
             outer_sumcheck_claims,
             inner_sumcheck_proof,
             claimed_witness_evals,
+            _marker: PhantomData,
         })
     }
 
     #[tracing::instrument(skip_all, name = "Spartan::verify")]
-    pub fn verify<PCS: CommitmentScheme<Field = F>>(
+    pub fn verify<PCS>(
         &self,
         key: &UniformSpartanKey<C, I, F>,
-        commitments: &JoltCommitments<PCS>,
-        opening_accumulator: &mut VerifierOpeningAccumulator<F, PCS>,
-        transcript: &mut DefaultTranscript,
-    ) -> Result<(), SpartanError> {
+        commitments: &JoltCommitments<PCS, ProofTranscript>,
+        opening_accumulator: &mut VerifierOpeningAccumulator<F, PCS, ProofTranscript>,
+        transcript: &mut ProofTranscript,
+    ) -> Result<(), SpartanError>
+    where
+        PCS: CommitmentScheme<ProofTranscript, Field = F>,
+        ProofTranscript: Transcript,
+    {
         let num_rounds_x = key.num_rows_total().log_2();
         let num_rounds_y = key.num_cols_total().log_2();
 

--- a/jolt-core/src/subprotocols/grand_product.rs
+++ b/jolt-core/src/subprotocols/grand_product.rs
@@ -7,26 +7,28 @@ use crate::poly::opening_proof::{ProverOpeningAccumulator, VerifierOpeningAccumu
 use crate::poly::{dense_mlpoly::DensePolynomial, unipoly::UniPoly};
 use crate::utils::math::Math;
 use crate::utils::thread::drop_in_background_thread;
-use crate::utils::transcript::{DefaultTranscript, Transcript};
+use crate::utils::transcript::Transcript;
 use ark_ff::Zero;
 use ark_serialize::*;
 use itertools::Itertools;
 use rayon::prelude::*;
+use std::marker::PhantomData;
 
 #[derive(CanonicalSerialize, CanonicalDeserialize)]
-pub struct BatchedGrandProductLayerProof<F: JoltField> {
-    pub proof: SumcheckInstanceProof<F>,
+pub struct BatchedGrandProductLayerProof<F: JoltField, ProofTranscript: Transcript> {
+    pub proof: SumcheckInstanceProof<F, ProofTranscript>,
     pub left_claims: Vec<F>,
     pub right_claims: Vec<F>,
+    _marker: PhantomData<ProofTranscript>,
 }
 
-impl<F: JoltField> BatchedGrandProductLayerProof<F> {
+impl<F: JoltField, ProofTranscript: Transcript> BatchedGrandProductLayerProof<F, ProofTranscript> {
     pub fn verify(
         &self,
         claim: F,
         num_rounds: usize,
         degree_bound: usize,
-        transcript: &mut DefaultTranscript,
+        transcript: &mut ProofTranscript,
     ) -> (F, Vec<F>) {
         self.proof
             .verify(claim, num_rounds, degree_bound, transcript)
@@ -35,12 +37,21 @@ impl<F: JoltField> BatchedGrandProductLayerProof<F> {
 }
 
 #[derive(CanonicalSerialize, CanonicalDeserialize)]
-pub struct BatchedGrandProductProof<PCS: CommitmentScheme> {
-    pub layers: Vec<BatchedGrandProductLayerProof<PCS::Field>>,
-    pub quark_proof: Option<QuarkGrandProductProof<PCS>>,
+pub struct BatchedGrandProductProof<PCS, ProofTranscript>
+where
+    PCS: CommitmentScheme<ProofTranscript>,
+    ProofTranscript: Transcript,
+{
+    pub layers: Vec<BatchedGrandProductLayerProof<PCS::Field, ProofTranscript>>,
+    pub quark_proof: Option<QuarkGrandProductProof<PCS, ProofTranscript>>,
 }
 
-pub trait BatchedGrandProduct<F: JoltField, PCS: CommitmentScheme<Field = F>>: Sized {
+pub trait BatchedGrandProduct<F, PCS, ProofTranscript>: Sized
+where
+    F: JoltField,
+    PCS: CommitmentScheme<ProofTranscript, Field = F>,
+    ProofTranscript: Transcript,
+{
     /// The bottom/input layer of the grand products
     type Leaves;
     type Config: Default + Clone + Copy;
@@ -58,16 +69,18 @@ pub trait BatchedGrandProduct<F: JoltField, PCS: CommitmentScheme<Field = F>>: S
     /// Returns an iterator over the layers of this batched grand product circuit.
     /// Each layer is mutable so that its polynomials can be bound over the course
     /// of proving.
-    fn layers(&'_ mut self) -> impl Iterator<Item = &'_ mut dyn BatchedGrandProductLayer<F>>;
+    fn layers(
+        &'_ mut self,
+    ) -> impl Iterator<Item = &'_ mut dyn BatchedGrandProductLayer<F, ProofTranscript>>;
 
     /// Computes a batched grand product proof, layer by layer.
     #[tracing::instrument(skip_all, name = "BatchedGrandProduct::prove_grand_product")]
     fn prove_grand_product(
         &mut self,
-        _opening_accumulator: Option<&mut ProverOpeningAccumulator<F>>,
-        transcript: &mut DefaultTranscript,
+        _opening_accumulator: Option<&mut ProverOpeningAccumulator<F, ProofTranscript>>,
+        transcript: &mut ProofTranscript,
         _setup: Option<&PCS::Setup>,
-    ) -> (BatchedGrandProductProof<PCS>, Vec<F>) {
+    ) -> (BatchedGrandProductProof<PCS, ProofTranscript>, Vec<F>) {
         let mut proof_layers = Vec::with_capacity(self.num_layers());
         let mut claims_to_verify = self.claims();
         let mut r_grand_product = Vec::new();
@@ -94,14 +107,14 @@ pub trait BatchedGrandProduct<F: JoltField, PCS: CommitmentScheme<Field = F>>: S
     /// This function may be overridden if the layer isn't just multiplication gates, e.g. in the
     /// case of `ToggledBatchedGrandProduct`.
     fn verify_sumcheck_claim(
-        layer_proofs: &[BatchedGrandProductLayerProof<F>],
+        layer_proofs: &[BatchedGrandProductLayerProof<F, ProofTranscript>],
         layer_index: usize,
         coeffs: &[F],
         sumcheck_claim: F,
         eq_eval: F,
         grand_product_claims: &mut Vec<F>,
         r_grand_product: &mut Vec<F>,
-        transcript: &mut DefaultTranscript,
+        transcript: &mut ProofTranscript,
     ) {
         let layer_proof = &layer_proofs[layer_index];
 
@@ -125,9 +138,9 @@ pub trait BatchedGrandProduct<F: JoltField, PCS: CommitmentScheme<Field = F>>: S
 
     /// Function used for layer sumchecks in the generic batch verifier as well as the quark layered sumcheck hybrid
     fn verify_layers(
-        proof_layers: &[BatchedGrandProductLayerProof<F>],
+        proof_layers: &[BatchedGrandProductLayerProof<F, ProofTranscript>],
         claims: &Vec<F>,
-        transcript: &mut DefaultTranscript,
+        transcript: &mut ProofTranscript,
         r_start: Vec<F>,
     ) -> (Vec<F>, Vec<F>) {
         let mut claims_to_verify = claims.to_owned();
@@ -188,10 +201,10 @@ pub trait BatchedGrandProduct<F: JoltField, PCS: CommitmentScheme<Field = F>>: S
 
     /// Verifies the given grand product proof.
     fn verify_grand_product(
-        proof: &BatchedGrandProductProof<PCS>,
+        proof: &BatchedGrandProductProof<PCS, ProofTranscript>,
         claims: &Vec<F>,
-        _opening_accumulator: Option<&mut VerifierOpeningAccumulator<F, PCS>>,
-        transcript: &mut DefaultTranscript,
+        _opening_accumulator: Option<&mut VerifierOpeningAccumulator<F, PCS, ProofTranscript>>,
+        transcript: &mut ProofTranscript,
         _setup: Option<&PCS::Setup>,
     ) -> (Vec<F>, Vec<F>) {
         // Pass the inputs to the layer verification function, by default we have no quarks and so we do not
@@ -201,14 +214,19 @@ pub trait BatchedGrandProduct<F: JoltField, PCS: CommitmentScheme<Field = F>>: S
     }
 }
 
-pub trait BatchedGrandProductLayer<F: JoltField>: BatchedCubicSumcheck<F> {
+pub trait BatchedGrandProductLayer<F, ProofTranscript>:
+    BatchedCubicSumcheck<F, ProofTranscript>
+where
+    F: JoltField,
+    ProofTranscript: Transcript,
+{
     /// Proves a single layer of a batched grand product circuit
     fn prove_layer(
         &mut self,
         claims: &mut Vec<F>,
         r_grand_product: &mut Vec<F>,
-        transcript: &mut DefaultTranscript,
-    ) -> BatchedGrandProductLayerProof<F> {
+        transcript: &mut ProofTranscript,
+    ) -> BatchedGrandProductLayerProof<F, ProofTranscript> {
         // produce a fresh set of coeffs
         let coeffs: Vec<F> = transcript.challenge_vector(claims.len());
         // produce a joint claim
@@ -251,6 +269,7 @@ pub trait BatchedGrandProductLayer<F: JoltField>: BatchedCubicSumcheck<F> {
             proof: sumcheck_proof,
             left_claims,
             right_claims,
+            _marker: PhantomData,
         }
     }
 }
@@ -266,23 +285,30 @@ pub type DenseGrandProductLayer<F> = Vec<F>;
 
 /// Represents a batch of `DenseGrandProductLayer`, all of the same length `layer_len`.
 #[derive(Debug, Clone)]
-pub struct BatchedDenseGrandProductLayer<F: JoltField> {
+pub struct BatchedDenseGrandProductLayer<F: JoltField, ProofTranscript: Transcript> {
     pub layers: Vec<DenseGrandProductLayer<F>>,
     pub layer_len: usize,
+    _marker: PhantomData<ProofTranscript>,
 }
 
-impl<F: JoltField> BatchedDenseGrandProductLayer<F> {
+impl<F: JoltField, ProofTranscript: Transcript> BatchedDenseGrandProductLayer<F, ProofTranscript> {
     pub fn new(values: Vec<Vec<F>>) -> Self {
         let layer_len = values[0].len();
         Self {
             layers: values,
             layer_len,
+            _marker: PhantomData,
         }
     }
 }
 
-impl<F: JoltField> BatchedGrandProductLayer<F> for BatchedDenseGrandProductLayer<F> {}
-impl<F: JoltField> BatchedCubicSumcheck<F> for BatchedDenseGrandProductLayer<F> {
+impl<F: JoltField, ProofTranscript: Transcript> BatchedGrandProductLayer<F, ProofTranscript>
+    for BatchedDenseGrandProductLayer<F, ProofTranscript>
+{
+}
+impl<F: JoltField, ProofTranscript: Transcript> BatchedCubicSumcheck<F, ProofTranscript>
+    for BatchedDenseGrandProductLayer<F, ProofTranscript>
+{
     fn num_rounds(&self) -> usize {
         self.layer_len.log_2() - 1
     }
@@ -416,12 +442,17 @@ impl<F: JoltField> BatchedCubicSumcheck<F> for BatchedDenseGrandProductLayer<F> 
 ///    / \   / \
 ///   o   o o   o  <- layers[layers.len() - 2]
 ///       ...
-pub struct BatchedDenseGrandProduct<F: JoltField> {
-    layers: Vec<BatchedDenseGrandProductLayer<F>>,
+pub struct BatchedDenseGrandProduct<F: JoltField, ProofTranscript: Transcript> {
+    layers: Vec<BatchedDenseGrandProductLayer<F, ProofTranscript>>,
+    _marker: PhantomData<ProofTranscript>,
 }
 
-impl<F: JoltField, PCS: CommitmentScheme<Field = F>> BatchedGrandProduct<F, PCS>
-    for BatchedDenseGrandProduct<F>
+impl<F, PCS, ProofTranscript> BatchedGrandProduct<F, PCS, ProofTranscript>
+    for BatchedDenseGrandProduct<F, ProofTranscript>
+where
+    F: JoltField,
+    PCS: CommitmentScheme<ProofTranscript, Field = F>,
+    ProofTranscript: Transcript,
 {
     type Leaves = Vec<Vec<F>>;
     type Config = ();
@@ -429,7 +460,8 @@ impl<F: JoltField, PCS: CommitmentScheme<Field = F>> BatchedGrandProduct<F, PCS>
     #[tracing::instrument(skip_all, name = "BatchedDenseGrandProduct::construct")]
     fn construct(leaves: Self::Leaves) -> Self {
         let num_layers = leaves[0].len().log_2();
-        let mut layers: Vec<BatchedDenseGrandProductLayer<F>> = Vec::with_capacity(num_layers);
+        let mut layers: Vec<BatchedDenseGrandProductLayer<F, ProofTranscript>> =
+            Vec::with_capacity(num_layers);
         layers.push(BatchedDenseGrandProductLayer::new(leaves));
 
         for i in 0..num_layers - 1 {
@@ -448,11 +480,14 @@ impl<F: JoltField, PCS: CommitmentScheme<Field = F>> BatchedGrandProduct<F, PCS>
             layers.push(BatchedDenseGrandProductLayer::new(new_layers));
         }
 
-        Self { layers }
+        Self {
+            layers,
+            _marker: PhantomData,
+        }
     }
     #[tracing::instrument(skip_all, name = "BatchedDenseGrandProduct::construct_with_config")]
     fn construct_with_config(leaves: Self::Leaves, _config: Self::Config) -> Self {
-        <Self as BatchedGrandProduct<F, PCS>>::construct(leaves)
+        <Self as BatchedGrandProduct<F, PCS, ProofTranscript>>::construct(leaves)
     }
 
     fn num_layers(&self) -> usize {
@@ -460,8 +495,11 @@ impl<F: JoltField, PCS: CommitmentScheme<Field = F>> BatchedGrandProduct<F, PCS>
     }
 
     fn claims(&self) -> Vec<F> {
-        let num_layers =
-            <BatchedDenseGrandProduct<F> as BatchedGrandProduct<F, PCS>>::num_layers(self);
+        let num_layers = <BatchedDenseGrandProduct<F, ProofTranscript> as BatchedGrandProduct<
+            F,
+            PCS,
+            ProofTranscript,
+        >>::num_layers(self);
         let last_layers = &self.layers[num_layers - 1];
         assert_eq!(last_layers.layer_len, 2);
         last_layers
@@ -471,10 +509,12 @@ impl<F: JoltField, PCS: CommitmentScheme<Field = F>> BatchedGrandProduct<F, PCS>
             .collect()
     }
 
-    fn layers(&'_ mut self) -> impl Iterator<Item = &'_ mut dyn BatchedGrandProductLayer<F>> {
+    fn layers(
+        &'_ mut self,
+    ) -> impl Iterator<Item = &'_ mut dyn BatchedGrandProductLayer<F, ProofTranscript>> {
         self.layers
             .iter_mut()
-            .map(|layer| layer as &mut dyn BatchedGrandProductLayer<F>)
+            .map(|layer| layer as &mut dyn BatchedGrandProductLayer<F, ProofTranscript>)
             .rev()
     }
 }
@@ -625,13 +665,19 @@ impl<F: JoltField> DynamicDensityGrandProductLayer<F> {
 /// size `layer_len`. Note that within a single batch, some layers may be represented by
 /// sparse vectors and others by dense vectors.
 #[derive(Debug, Clone)]
-pub struct BatchedSparseGrandProductLayer<F: JoltField> {
+pub struct BatchedSparseGrandProductLayer<F: JoltField, ProofTranscript: Transcript> {
     pub layer_len: usize,
     pub layers: Vec<DynamicDensityGrandProductLayer<F>>,
+    _marker: PhantomData<ProofTranscript>,
 }
 
-impl<F: JoltField> BatchedGrandProductLayer<F> for BatchedSparseGrandProductLayer<F> {}
-impl<F: JoltField> BatchedCubicSumcheck<F> for BatchedSparseGrandProductLayer<F> {
+impl<F: JoltField, ProofTranscript: Transcript> BatchedGrandProductLayer<F, ProofTranscript>
+    for BatchedSparseGrandProductLayer<F, ProofTranscript>
+{
+}
+impl<F: JoltField, ProofTranscript: Transcript> BatchedCubicSumcheck<F, ProofTranscript>
+    for BatchedSparseGrandProductLayer<F, ProofTranscript>
+{
     fn num_rounds(&self) -> usize {
         self.layer_len.log_2() - 1
     }
@@ -1056,7 +1102,7 @@ impl<F: JoltField> BatchedCubicSumcheck<F> for BatchedSparseGrandProductLayer<F>
 ///   o      o     o      o                          ↑
 ///  / \    / \   / \    / \    –––––––––––––––––––––––––––––––––––––––––––
 /// 🏴  o  🏳️ o  🏳️ o  🏴  o    toggle layer        ↓
-struct BatchedGrandProductToggleLayer<F: JoltField> {
+struct BatchedGrandProductToggleLayer<F: JoltField, ProofTranscript: Transcript> {
     /// The list of non-zero flag indices for each layer in the batch.
     flag_indices: Vec<Vec<usize>>,
     /// The list of non-zero flag values for each layer in the batch.
@@ -1065,9 +1111,10 @@ struct BatchedGrandProductToggleLayer<F: JoltField> {
     flag_values: Vec<Vec<F>>,
     fingerprints: Vec<Vec<F>>,
     layer_len: usize,
+    _marker: PhantomData<ProofTranscript>,
 }
 
-impl<F: JoltField> BatchedGrandProductToggleLayer<F> {
+impl<F: JoltField, ProofTranscript: Transcript> BatchedGrandProductToggleLayer<F, ProofTranscript> {
     fn new(flag_indices: Vec<Vec<usize>>, fingerprints: Vec<Vec<F>>) -> Self {
         let layer_len = fingerprints[0].len();
         Self {
@@ -1076,10 +1123,11 @@ impl<F: JoltField> BatchedGrandProductToggleLayer<F> {
             flag_values: vec![],
             fingerprints,
             layer_len,
+            _marker: PhantomData,
         }
     }
 
-    fn layer_output(&self) -> BatchedSparseGrandProductLayer<F> {
+    fn layer_output(&self) -> BatchedSparseGrandProductLayer<F, ProofTranscript> {
         let output_layers = self
             .fingerprints
             .par_iter()
@@ -1096,11 +1144,14 @@ impl<F: JoltField> BatchedGrandProductToggleLayer<F> {
         BatchedSparseGrandProductLayer {
             layer_len: self.layer_len,
             layers: output_layers,
+            _marker: PhantomData,
         }
     }
 }
 
-impl<F: JoltField> BatchedCubicSumcheck<F> for BatchedGrandProductToggleLayer<F> {
+impl<F: JoltField, ProofTranscript: Transcript> BatchedCubicSumcheck<F, ProofTranscript>
+    for BatchedGrandProductToggleLayer<F, ProofTranscript>
+{
     fn num_rounds(&self) -> usize {
         self.layer_len.log_2()
     }
@@ -1387,13 +1438,15 @@ impl<F: JoltField> BatchedCubicSumcheck<F> for BatchedGrandProductToggleLayer<F>
     }
 }
 
-impl<F: JoltField> BatchedGrandProductLayer<F> for BatchedGrandProductToggleLayer<F> {
+impl<F: JoltField, ProofTranscript: Transcript> BatchedGrandProductLayer<F, ProofTranscript>
+    for BatchedGrandProductToggleLayer<F, ProofTranscript>
+{
     fn prove_layer(
         &mut self,
         claims_to_verify: &mut Vec<F>,
         r_grand_product: &mut Vec<F>,
-        transcript: &mut DefaultTranscript,
-    ) -> BatchedGrandProductLayerProof<F> {
+        transcript: &mut ProofTranscript,
+    ) -> BatchedGrandProductLayerProof<F, ProofTranscript> {
         // produce a fresh set of coeffs
         let coeffs: Vec<F> = transcript.challenge_vector(claims_to_verify.len());
         // produce a joint claim
@@ -1425,17 +1478,23 @@ impl<F: JoltField> BatchedGrandProductLayer<F> for BatchedGrandProductToggleLaye
             proof: sumcheck_proof,
             left_claims,
             right_claims,
+            _marker: PhantomData,
         }
     }
 }
 
-pub struct ToggledBatchedGrandProduct<F: JoltField> {
-    toggle_layer: BatchedGrandProductToggleLayer<F>,
-    sparse_layers: Vec<BatchedSparseGrandProductLayer<F>>,
+pub struct ToggledBatchedGrandProduct<F: JoltField, ProofTranscript: Transcript> {
+    toggle_layer: BatchedGrandProductToggleLayer<F, ProofTranscript>,
+    sparse_layers: Vec<BatchedSparseGrandProductLayer<F, ProofTranscript>>,
+    _marker: PhantomData<ProofTranscript>,
 }
 
-impl<F: JoltField, PCS: CommitmentScheme<Field = F>> BatchedGrandProduct<F, PCS>
-    for ToggledBatchedGrandProduct<PCS::Field>
+impl<
+        F: JoltField,
+        PCS: CommitmentScheme<ProofTranscript, Field = F>,
+        ProofTranscript: Transcript,
+    > BatchedGrandProduct<F, PCS, ProofTranscript>
+    for ToggledBatchedGrandProduct<PCS::Field, ProofTranscript>
 {
     type Leaves = (Vec<Vec<usize>>, Vec<Vec<F>>); // (flags, fingerprints)
     type Config = ();
@@ -1446,7 +1505,8 @@ impl<F: JoltField, PCS: CommitmentScheme<Field = F>> BatchedGrandProduct<F, PCS>
         let num_layers = fingerprints[0].len().log_2();
 
         let toggle_layer = BatchedGrandProductToggleLayer::new(flags, fingerprints);
-        let mut layers: Vec<BatchedSparseGrandProductLayer<F>> = Vec::with_capacity(num_layers);
+        let mut layers: Vec<BatchedSparseGrandProductLayer<F, ProofTranscript>> =
+            Vec::with_capacity(num_layers);
         layers.push(toggle_layer.layer_output());
 
         for i in 0..num_layers - 1 {
@@ -1460,18 +1520,20 @@ impl<F: JoltField, PCS: CommitmentScheme<Field = F>> BatchedGrandProduct<F, PCS>
             layers.push(BatchedSparseGrandProductLayer {
                 layer_len: len,
                 layers: new_layers,
+                _marker: PhantomData,
             });
         }
 
         Self {
             toggle_layer,
             sparse_layers: layers,
+            _marker: PhantomData,
         }
     }
 
     #[tracing::instrument(skip_all, name = "ToggledBatchedGrandProduct::construct_with_config")]
     fn construct_with_config(leaves: Self::Leaves, _config: Self::Config) -> Self {
-        <Self as BatchedGrandProduct<F, PCS>>::construct(leaves)
+        <Self as BatchedGrandProduct<F, PCS, ProofTranscript>>::construct(leaves)
     }
 
     fn num_layers(&self) -> usize {
@@ -1479,7 +1541,8 @@ impl<F: JoltField, PCS: CommitmentScheme<Field = F>> BatchedGrandProduct<F, PCS>
     }
 
     fn claims(&self) -> Vec<F> {
-        let last_layers = &self.sparse_layers.last().unwrap();
+        let last_layers: &BatchedSparseGrandProductLayer<F, ProofTranscript> =
+            &self.sparse_layers.last().unwrap();
         let (left_claims, right_claims) = last_layers.final_claims();
         left_claims
             .iter()
@@ -1488,26 +1551,28 @@ impl<F: JoltField, PCS: CommitmentScheme<Field = F>> BatchedGrandProduct<F, PCS>
             .collect()
     }
 
-    fn layers(&'_ mut self) -> impl Iterator<Item = &'_ mut dyn BatchedGrandProductLayer<F>> {
-        [&mut self.toggle_layer as &mut dyn BatchedGrandProductLayer<F>]
+    fn layers(
+        &'_ mut self,
+    ) -> impl Iterator<Item = &'_ mut dyn BatchedGrandProductLayer<F, ProofTranscript>> {
+        [&mut self.toggle_layer as &mut dyn BatchedGrandProductLayer<F, ProofTranscript>]
             .into_iter()
             .chain(
                 self.sparse_layers
                     .iter_mut()
-                    .map(|layer| layer as &mut dyn BatchedGrandProductLayer<F>),
+                    .map(|layer| layer as &mut dyn BatchedGrandProductLayer<F, ProofTranscript>),
             )
             .rev()
     }
 
     fn verify_sumcheck_claim(
-        layer_proofs: &[BatchedGrandProductLayerProof<F>],
+        layer_proofs: &[BatchedGrandProductLayerProof<F, ProofTranscript>],
         layer_index: usize,
         coeffs: &[F],
         sumcheck_claim: F,
         eq_eval: F,
         grand_product_claims: &mut Vec<F>,
         r_grand_product: &mut Vec<F>,
-        transcript: &mut DefaultTranscript,
+        transcript: &mut ProofTranscript,
     ) {
         let layer_proof = &layer_proofs[layer_index];
         if layer_index != layer_proofs.len() - 1 {
@@ -1563,7 +1628,7 @@ impl<F: JoltField, PCS: CommitmentScheme<Field = F>> BatchedGrandProduct<F, PCS>
 mod grand_product_tests {
     use super::*;
     use crate::poly::commitment::zeromorph::Zeromorph;
-    use crate::utils::transcript::Transcript;
+    use crate::utils::transcript::{DefaultTranscript, Transcript};
     use ark_bn254::{Bn254, Fr};
     use ark_std::{test_rng, One};
     use rand_core::RngCore;
@@ -1581,23 +1646,26 @@ mod grand_product_tests {
         .take(BATCH_SIZE)
         .collect();
 
-        let mut batched_circuit = <BatchedDenseGrandProduct<Fr> as BatchedGrandProduct<
-            Fr,
-            Zeromorph<Bn254>,
-        >>::construct(leaves);
+        let mut batched_circuit =
+            <BatchedDenseGrandProduct<Fr, DefaultTranscript> as BatchedGrandProduct<
+                Fr,
+                Zeromorph<Bn254, DefaultTranscript>,
+                DefaultTranscript,
+            >>::construct(leaves);
         let mut transcript: DefaultTranscript = DefaultTranscript::new(b"test_transcript");
 
         // I love the rust type system
-        let claims =
-            <BatchedDenseGrandProduct<Fr> as BatchedGrandProduct<Fr, Zeromorph<Bn254>>>::claims(
-                &batched_circuit,
-            );
-        let (proof, r_prover) = <BatchedDenseGrandProduct<Fr> as BatchedGrandProduct<
+        let claims = <BatchedDenseGrandProduct<Fr, DefaultTranscript> as BatchedGrandProduct<
             Fr,
-            Zeromorph<Bn254>,
-        >>::prove_grand_product(
-            &mut batched_circuit, None, &mut transcript, None
-        );
+            Zeromorph<Bn254, DefaultTranscript>,
+            DefaultTranscript,
+        >>::claims(&batched_circuit);
+        let (proof, r_prover) =
+            <BatchedDenseGrandProduct<Fr, DefaultTranscript> as BatchedGrandProduct<
+                Fr,
+                Zeromorph<Bn254, DefaultTranscript>,
+                DefaultTranscript,
+            >>::prove_grand_product(&mut batched_circuit, None, &mut transcript, None);
 
         let mut transcript: DefaultTranscript = DefaultTranscript::new(b"test_transcript");
         let (_, r_verifier) = BatchedDenseGrandProduct::verify_grand_product(
@@ -1629,7 +1697,8 @@ mod grand_product_tests {
         })
         .take(BATCH_SIZE)
         .collect();
-        let mut batched_dense_layer = BatchedDenseGrandProductLayer::new(dense_layers.clone());
+        let mut batched_dense_layer =
+            BatchedDenseGrandProductLayer::<Fr, DefaultTranscript>::new(dense_layers.clone());
 
         let sparse_layers: Vec<DynamicDensityGrandProductLayer<Fr>> = dense_layers
             .iter()
@@ -1643,13 +1712,14 @@ mod grand_product_tests {
                 DynamicDensityGrandProductLayer::Sparse(sparse_layer)
             })
             .collect();
-        let mut batched_sparse_layer: BatchedSparseGrandProductLayer<Fr> =
+        let mut batched_sparse_layer: BatchedSparseGrandProductLayer<Fr, DefaultTranscript> =
             BatchedSparseGrandProductLayer {
                 layer_len: LAYER_SIZE,
                 layers: sparse_layers,
+                _marker: PhantomData,
             };
 
-        let condense = |sparse_layers: BatchedSparseGrandProductLayer<Fr>| {
+        let condense = |sparse_layers: BatchedSparseGrandProductLayer<Fr, DefaultTranscript>| {
             sparse_layers
                 .layers
                 .iter()
@@ -1731,10 +1801,12 @@ mod grand_product_tests {
         })
         .take(BATCH_SIZE)
         .collect();
-        let dense_layers: BatchedSparseGrandProductLayer<Fr> = BatchedSparseGrandProductLayer {
-            layer_len: LAYER_SIZE,
-            layers: dense_layers,
-        };
+        let dense_layers: BatchedSparseGrandProductLayer<Fr, DefaultTranscript> =
+            BatchedSparseGrandProductLayer {
+                layer_len: LAYER_SIZE,
+                layers: dense_layers,
+                _marker: PhantomData,
+            };
 
         let sparse_layers: Vec<DynamicDensityGrandProductLayer<Fr>> = dense_layers
             .layers
@@ -1753,10 +1825,12 @@ mod grand_product_tests {
                 DynamicDensityGrandProductLayer::Sparse(sparse_layer)
             })
             .collect();
-        let sparse_layers: BatchedSparseGrandProductLayer<Fr> = BatchedSparseGrandProductLayer {
-            layer_len: LAYER_SIZE,
-            layers: sparse_layers,
-        };
+        let sparse_layers: BatchedSparseGrandProductLayer<Fr, DefaultTranscript> =
+            BatchedSparseGrandProductLayer {
+                layer_len: LAYER_SIZE,
+                layers: sparse_layers,
+                _marker: PhantomData,
+            };
 
         let r_eq = std::iter::repeat_with(|| Fr::random(&mut rng))
             .take(LAYER_SIZE.log_2() - 1)

--- a/jolt-core/src/subprotocols/grand_product_quarks.rs
+++ b/jolt-core/src/subprotocols/grand_product_quarks.rs
@@ -14,20 +14,25 @@ use ark_serialize::*;
 use ark_std::{One, Zero};
 use itertools::Itertools;
 use rayon::prelude::*;
+use std::marker::PhantomData;
 use thiserror::Error;
 
 #[derive(CanonicalSerialize, CanonicalDeserialize)]
-pub struct QuarkGrandProductProof<PCS: CommitmentScheme> {
-    sumcheck_proof: SumcheckInstanceProof<PCS::Field>,
+pub struct QuarkGrandProductProof<
+    PCS: CommitmentScheme<ProofTranscript>,
+    ProofTranscript: Transcript,
+> {
+    sumcheck_proof: SumcheckInstanceProof<PCS::Field, ProofTranscript>,
     g_commitment: Vec<PCS::Commitment>,
     claimed_eval_g_r: Vec<PCS::Field>,
     claimed_eval_g_r_x: (Vec<PCS::Field>, Vec<PCS::Field>),
     helper_values: (Vec<PCS::Field>, Vec<PCS::Field>),
     num_vars: usize,
 }
-pub struct QuarkGrandProduct<F: JoltField> {
+pub struct QuarkGrandProduct<F: JoltField, ProofTranscript: Transcript> {
     polynomials: Vec<Vec<F>>,
-    base_layers: Vec<BatchedDenseGrandProductLayer<F>>,
+    base_layers: Vec<BatchedDenseGrandProductLayer<F, ProofTranscript>>,
+    _marker: PhantomData<ProofTranscript>,
 }
 
 #[derive(Clone, Copy, Debug, Default)]
@@ -56,8 +61,12 @@ pub struct QuarkGrandProductConfig {
     pub hybrid_layer_depth: QuarkHybridLayerDepth,
 }
 
-impl<F: JoltField, PCS: CommitmentScheme<Field = F>> BatchedGrandProduct<F, PCS>
-    for QuarkGrandProduct<F>
+impl<F, PCS, ProofTranscript> BatchedGrandProduct<F, PCS, ProofTranscript>
+    for QuarkGrandProduct<F, ProofTranscript>
+where
+    F: JoltField,
+    PCS: CommitmentScheme<ProofTranscript, Field = F>,
+    ProofTranscript: Transcript,
 {
     /// The bottom/input layer of the grand products
     type Leaves = Vec<Vec<F>>;
@@ -66,7 +75,7 @@ impl<F: JoltField, PCS: CommitmentScheme<Field = F>> BatchedGrandProduct<F, PCS>
     /// Constructs the grand product circuit(s) from `leaves`
     #[tracing::instrument(skip_all, name = "BatchedGrandProduct::construct")]
     fn construct(leaves: Self::Leaves) -> Self {
-        <Self as BatchedGrandProduct<F, PCS>>::construct_with_config(
+        <Self as BatchedGrandProduct<F, PCS, ProofTranscript>>::construct_with_config(
             leaves,
             QuarkGrandProductConfig::default(),
         )
@@ -84,8 +93,10 @@ impl<F: JoltField, PCS: CommitmentScheme<Field = F>> BatchedGrandProduct<F, PCS>
         };
 
         // Taken 1 to 1 from the code in the BatchedDenseGrandProductLayer implementation
-        let mut layers = Vec::<BatchedDenseGrandProductLayer<F>>::new();
-        layers.push(BatchedDenseGrandProductLayer::<F>::new(leaves));
+        let mut layers = Vec::<BatchedDenseGrandProductLayer<F, ProofTranscript>>::new();
+        layers.push(BatchedDenseGrandProductLayer::<F, ProofTranscript>::new(
+            leaves,
+        ));
 
         for i in 0..num_layers {
             let previous_layers = &layers[i];
@@ -108,6 +119,7 @@ impl<F: JoltField, PCS: CommitmentScheme<Field = F>> BatchedGrandProduct<F, PCS>
             return Self {
                 polynomials: Vec::<Vec<F>>::new(),
                 base_layers: layers,
+                _marker: PhantomData,
             };
         }
 
@@ -117,6 +129,7 @@ impl<F: JoltField, PCS: CommitmentScheme<Field = F>> BatchedGrandProduct<F, PCS>
         Self {
             polynomials: quark_polys,
             base_layers: layers,
+            _marker: PhantomData,
         }
     }
     /// The number of layers in the grand product, in this case it is the log of the quark layer size plus the gkr layer depth.
@@ -134,7 +147,9 @@ impl<F: JoltField, PCS: CommitmentScheme<Field = F>> BatchedGrandProduct<F, PCS>
     /// Each layer is mutable so that its polynomials can be bound over the course
     /// of proving.
     #[allow(unreachable_code)]
-    fn layers(&'_ mut self) -> impl Iterator<Item = &'_ mut dyn BatchedGrandProductLayer<F>> {
+    fn layers(
+        &'_ mut self,
+    ) -> impl Iterator<Item = &'_ mut dyn BatchedGrandProductLayer<F, ProofTranscript>> {
         panic!("We don't use the default prover and so we don't need the generic iterator");
         std::iter::empty()
     }
@@ -143,10 +158,10 @@ impl<F: JoltField, PCS: CommitmentScheme<Field = F>> BatchedGrandProduct<F, PCS>
     #[tracing::instrument(skip_all, name = "BatchedGrandProduct::prove_grand_product")]
     fn prove_grand_product(
         &mut self,
-        opening_accumulator: Option<&mut ProverOpeningAccumulator<F>>,
-        transcript: &mut DefaultTranscript,
+        opening_accumulator: Option<&mut ProverOpeningAccumulator<F, ProofTranscript>>,
+        transcript: &mut ProofTranscript,
         setup: Option<&PCS::Setup>,
-    ) -> (BatchedGrandProductProof<PCS>, Vec<F>) {
+    ) -> (BatchedGrandProductProof<PCS, ProofTranscript>, Vec<F>) {
         let mut proof_layers = Vec::with_capacity(self.base_layers.len());
 
         // For proofs of polynomials of size less than 16 we support these with no quark proof
@@ -154,7 +169,7 @@ impl<F: JoltField, PCS: CommitmentScheme<Field = F>> BatchedGrandProduct<F, PCS>
             // When doing the quark hybrid proof, we first prove the grand product of a layer of a polynomial which is 4 layers deep in the tree
             // of a standard layered sumcheck grand product, then we use the sumcheck layers to prove via gkr layers that the random point opened
             // by the quark proof is in fact the folded result of the base layer.
-            let (quark, random, claims) = QuarkGrandProductProof::<PCS>::prove(
+            let (quark, random, claims) = QuarkGrandProductProof::<PCS, ProofTranscript>::prove(
                 &self.polynomials,
                 opening_accumulator.unwrap(),
                 transcript,
@@ -165,7 +180,11 @@ impl<F: JoltField, PCS: CommitmentScheme<Field = F>> BatchedGrandProduct<F, PCS>
             (
                 None,
                 Vec::<F>::new(),
-                <QuarkGrandProduct<F> as BatchedGrandProduct<F, PCS>>::claims(self),
+                <QuarkGrandProduct<F, ProofTranscript> as BatchedGrandProduct<
+                    F,
+                    PCS,
+                    ProofTranscript,
+                >>::claims(self),
             )
         };
 
@@ -185,10 +204,10 @@ impl<F: JoltField, PCS: CommitmentScheme<Field = F>> BatchedGrandProduct<F, PCS>
     /// Verifies the given grand product proof.
     #[tracing::instrument(skip_all, name = "BatchedGrandProduct::verify_grand_product")]
     fn verify_grand_product(
-        proof: &BatchedGrandProductProof<PCS>,
+        proof: &BatchedGrandProductProof<PCS, ProofTranscript>,
         claims: &Vec<F>,
-        opening_accumulator: Option<&mut VerifierOpeningAccumulator<F, PCS>>,
-        transcript: &mut DefaultTranscript,
+        opening_accumulator: Option<&mut VerifierOpeningAccumulator<F, PCS, ProofTranscript>>,
+        transcript: &mut ProofTranscript,
         _setup: Option<&PCS::Setup>,
     ) -> (Vec<F>, Vec<F>) {
         // Here we must also support the case where the number of layers is very small
@@ -207,11 +226,12 @@ impl<F: JoltField, PCS: CommitmentScheme<Field = F>> BatchedGrandProduct<F, PCS>
             }
         };
 
-        let (sumcheck_claims, sumcheck_r) = <Self as BatchedGrandProduct<F, PCS>>::verify_layers(
-            &proof.layers,
-            &v_points,
-            transcript,
-            rand,
+        let (sumcheck_claims, sumcheck_r) = <Self as BatchedGrandProduct<
+            F,
+            PCS,
+            ProofTranscript,
+        >>::verify_layers(
+            &proof.layers, &v_points, transcript, rand
         );
 
         (sumcheck_claims, sumcheck_r)
@@ -231,7 +251,11 @@ pub enum QuarkError {
     InvalidBinding,
 }
 
-impl<PCS: CommitmentScheme> QuarkGrandProductProof<PCS> {
+impl<PCS, ProofTranscript> QuarkGrandProductProof<PCS, ProofTranscript>
+where
+    PCS: CommitmentScheme<ProofTranscript>,
+    ProofTranscript: Transcript,
+{
     /// Computes a grand product proof using the Section 5 technique from Quarks Paper
     /// First - Extends the evals of v to create an f poly, then commits to it and evals
     /// Then - Constructs a g poly and preforms sumcheck proof that sum == 0
@@ -239,8 +263,8 @@ impl<PCS: CommitmentScheme> QuarkGrandProductProof<PCS> {
     /// Returns a random point and evaluation to be verified by the caller (which our hybrid prover does with GKR)
     fn prove(
         leaves: &[Vec<PCS::Field>],
-        opening_accumulator: &mut ProverOpeningAccumulator<PCS::Field>,
-        transcript: &mut DefaultTranscript,
+        opening_accumulator: &mut ProverOpeningAccumulator<PCS::Field, ProofTranscript>,
+        transcript: &mut ProofTranscript,
         setup: &PCS::Setup,
     ) -> (Self, Vec<PCS::Field>, Vec<PCS::Field>) {
         let v_length = leaves[0].len();
@@ -253,7 +277,7 @@ impl<PCS: CommitmentScheme> QuarkGrandProductProof<PCS> {
 
         for v in leaves.iter() {
             let v_polynomial = DensePolynomial::<PCS::Field>::new(v.to_vec());
-            let (f_1_r, f_r_0, f_r_1, p) = v_into_f::<PCS>(&v_polynomial);
+            let (f_1_r, f_r_0, f_r_1, p) = v_into_f::<PCS, ProofTranscript>(&v_polynomial);
             v_polys.push(v_polynomial);
             g_polys.push(f_1_r.clone());
             sumcheck_polys.push(f_1_r);
@@ -272,14 +296,14 @@ impl<PCS: CommitmentScheme> QuarkGrandProductProof<PCS> {
         // Now we do the sumcheck using the prove arbitrary
         // First instantiate our polynomials
         let tau: Vec<PCS::Field> = transcript.challenge_vector(v_variables);
-        let evals: DensePolynomial<<PCS as CommitmentScheme>::Field> =
+        let evals: DensePolynomial<<PCS as CommitmentScheme<ProofTranscript>>::Field> =
             DensePolynomial::new(EqPolynomial::evals(&tau));
         //We add evals as the second to last polynomial in the sumcheck
         sumcheck_polys.push(evals);
 
         // Next we calculate the polynomial equal to 1 at all points but 1,1,1...,0
         let challenge_sum = vec![PCS::Field::one(); v_variables];
-        let eq_sum: DensePolynomial<<PCS as CommitmentScheme>::Field> =
+        let eq_sum: DensePolynomial<<PCS as CommitmentScheme<ProofTranscript>>::Field> =
             DensePolynomial::new(EqPolynomial::evals(&challenge_sum));
         //We add evals as the last polynomial in the sumcheck
         sumcheck_polys.push(eq_sum);
@@ -312,14 +336,15 @@ impl<PCS: CommitmentScheme> QuarkGrandProductProof<PCS> {
         // Now run the sumcheck in arbitrary mode
         // Note - We use the final randomness from binding all variables (x) as the source random for the openings so the verifier can
         //        check that the base layer is the same as is committed too.
-        let (sumcheck_proof, x, _) = SumcheckInstanceProof::<PCS::Field>::prove_arbitrary::<_>(
-            &rlc_claims,
-            v_variables,
-            &mut sumcheck_polys,
-            output_check_fn,
-            3,
-            transcript,
-        );
+        let (sumcheck_proof, x, _) =
+            SumcheckInstanceProof::<PCS::Field, ProofTranscript>::prove_arbitrary::<_>(
+                &rlc_claims,
+                v_variables,
+                &mut sumcheck_polys,
+                output_check_fn,
+                3,
+                transcript,
+            );
 
         let borrowed: Vec<&DensePolynomial<PCS::Field>> = g_polys.iter().collect();
         let chis_r = EqPolynomial::evals(&x);
@@ -344,10 +369,15 @@ impl<PCS: CommitmentScheme> QuarkGrandProductProof<PCS> {
         // Therefore we do a line reduced opening on g(r', 0) and g(r', 1)e();
         let mut r_prime = vec![PCS::Field::zero(); x.len() - 1];
         r_prime.clone_from_slice(&x[1..x.len()]);
-        let claimed_eval_g_r_x =
-            open_and_prove::<PCS>(&r_prime, &g_polys, opening_accumulator, transcript);
+        let claimed_eval_g_r_x = open_and_prove::<PCS, ProofTranscript>(
+            &r_prime,
+            &g_polys,
+            opening_accumulator,
+            transcript,
+        );
         // next we need to make a claim about h(r', 0) and h(r', 1) so we use our line reduction to make one claim
-        let ((r_t, h_r_t), helper_values) = line_reduce::<PCS>(&r_prime, &v_polys, transcript);
+        let ((r_t, h_r_t), helper_values) =
+            line_reduce::<PCS, ProofTranscript>(&r_prime, &v_polys, transcript);
 
         let num_vars = v_variables;
 
@@ -370,8 +400,8 @@ impl<PCS: CommitmentScheme> QuarkGrandProductProof<PCS> {
     fn verify(
         &self,
         claims: &[PCS::Field],
-        opening_accumulator: &mut VerifierOpeningAccumulator<PCS::Field, PCS>,
-        transcript: &mut DefaultTranscript,
+        opening_accumulator: &mut VerifierOpeningAccumulator<PCS::Field, PCS, ProofTranscript>,
+        transcript: &mut ProofTranscript,
         n_rounds: usize,
     ) -> Result<(Vec<PCS::Field>, Vec<PCS::Field>), QuarkError> {
         // First we append the claimed values for the commitment and the product
@@ -412,7 +442,7 @@ impl<PCS: CommitmentScheme> QuarkGrandProductProof<PCS> {
             transcript,
         );
         // Next do the line reduction verification of g(r', 0) and g(r', 1)
-        line_reduce_opening_verify::<PCS>(
+        line_reduce_opening_verify::<PCS, ProofTranscript>(
             &self.claimed_eval_g_r_x,
             &r_prime,
             &borrowed_g,
@@ -477,14 +507,18 @@ impl<PCS: CommitmentScheme> QuarkGrandProductProof<PCS> {
 
 // Computes slices of f for the sumcheck
 #[allow(clippy::type_complexity)]
-fn v_into_f<PCS: CommitmentScheme>(
+fn v_into_f<PCS, ProofTranscript>(
     v: &DensePolynomial<PCS::Field>,
 ) -> (
     DensePolynomial<PCS::Field>,
     DensePolynomial<PCS::Field>,
     DensePolynomial<PCS::Field>,
     PCS::Field,
-) {
+)
+where
+    PCS: CommitmentScheme<ProofTranscript>,
+    ProofTranscript: Transcript,
+{
     let v_length = v.len();
     let mut f_evals = vec![PCS::Field::zero(); 2 * v_length];
     let (evals, _) = v.split_evals(v.len());
@@ -528,15 +562,15 @@ fn v_into_f<PCS: CommitmentScheme>(
 //        (or vice versa) as implicitly defining the line t*f(0r) + (t-1)f(1r) and so the evals data alone
 //        is sufficient to calculate the claimed line, then we sample a random value r_star and do an opening proof
 //        on (r_star - 1) * f(0r) + r_star * f(1r) in the commitment to f.
-fn open_and_prove<PCS: CommitmentScheme>(
+fn open_and_prove<PCS: CommitmentScheme<ProofTranscript>, ProofTranscript: Transcript>(
     r: &[PCS::Field],
     f_polys: &[DensePolynomial<PCS::Field>],
-    opening_accumulator: &mut ProverOpeningAccumulator<PCS::Field>,
-    transcript: &mut DefaultTranscript,
+    opening_accumulator: &mut ProverOpeningAccumulator<PCS::Field, ProofTranscript>,
+    transcript: &mut ProofTranscript,
 ) -> (Vec<PCS::Field>, Vec<PCS::Field>) {
     // Do the line reduction protocol
     let ((r_star, openings_star), (openings_0, openings_1)) =
-        line_reduce::<PCS>(r, f_polys, transcript);
+        line_reduce::<PCS, ProofTranscript>(r, f_polys, transcript);
     opening_accumulator.append(
         &f_polys.iter().collect::<Vec<_>>(),
         DensePolynomial::new(EqPolynomial::evals(&r_star)),
@@ -551,10 +585,10 @@ fn open_and_prove<PCS: CommitmentScheme>(
 #[allow(clippy::type_complexity)]
 /// Calculates the r0 r1 values and writes their evaluation to the transcript before calculating r star and
 /// the opening of this, but does not prove the opening as that is left to the calling function
-fn line_reduce<PCS: CommitmentScheme>(
+fn line_reduce<PCS: CommitmentScheme<ProofTranscript>, ProofTranscript: Transcript>(
     r: &[PCS::Field],
     f_polys: &[DensePolynomial<PCS::Field>],
-    transcript: &mut DefaultTranscript,
+    transcript: &mut ProofTranscript,
 ) -> (
     (Vec<PCS::Field>, Vec<PCS::Field>),
     (Vec<PCS::Field>, Vec<PCS::Field>),
@@ -604,12 +638,15 @@ fn line_reduce<PCS: CommitmentScheme>(
 }
 
 /// Does the counterpart of the open_and_prove by computing an r_star vector point and then validating this opening
-fn line_reduce_opening_verify<PCS: CommitmentScheme>(
+fn line_reduce_opening_verify<
+    PCS: CommitmentScheme<ProofTranscript>,
+    ProofTranscript: Transcript,
+>(
     data: &(Vec<PCS::Field>, Vec<PCS::Field>),
     r: &[PCS::Field],
     commitments: &[&PCS::Commitment],
-    opening_accumulator: &mut VerifierOpeningAccumulator<PCS::Field, PCS>,
-    transcript: &mut DefaultTranscript,
+    opening_accumulator: &mut VerifierOpeningAccumulator<PCS::Field, PCS, ProofTranscript>,
+    transcript: &mut ProofTranscript,
 ) {
     // First compute the line reduction and points
     let (r_star, claimed) = line_reduce_verify(&(data.0.clone(), data.1.clone()), r, transcript);
@@ -623,10 +660,10 @@ fn line_reduce_opening_verify<PCS: CommitmentScheme>(
     );
 }
 
-fn line_reduce_verify<F: JoltField>(
+fn line_reduce_verify<F: JoltField, ProofTranscript: Transcript>(
     data: &(Vec<F>, Vec<F>),
     r: &[F],
-    transcript: &mut DefaultTranscript,
+    transcript: &mut ProofTranscript,
 ) -> (Vec<F>, Vec<F>) {
     // To get our random we first append the openings data
     transcript.append_scalars(&data.0);
@@ -674,16 +711,18 @@ mod quark_grand_product_tests {
         let srs = ZeromorphSRS::<Bn254>::setup(&mut rng, 1 << 9);
         let setup = srs.trim(1 << 9);
 
-        let mut prover_accumulator: ProverOpeningAccumulator<Fr> = ProverOpeningAccumulator::new();
-        let mut verifier_accumulator: VerifierOpeningAccumulator<Fr, Zeromorph<Bn254>> =
-            VerifierOpeningAccumulator::new();
+        let mut prover_accumulator: ProverOpeningAccumulator<Fr, DefaultTranscript> =
+            ProverOpeningAccumulator::new();
+        let mut verifier_accumulator: VerifierOpeningAccumulator<
+            Fr,
+            Zeromorph<Bn254, DefaultTranscript>,
+            DefaultTranscript,
+        > = VerifierOpeningAccumulator::new();
 
-        let (proof, _, _) = QuarkGrandProductProof::<Zeromorph<Bn254>>::prove(
-            &v,
-            &mut prover_accumulator,
-            &mut transcript,
-            &setup,
-        );
+        let (proof, _, _) = QuarkGrandProductProof::<
+            Zeromorph<Bn254, DefaultTranscript>,
+            DefaultTranscript,
+        >::prove(&v, &mut prover_accumulator, &mut transcript, &setup);
         let batched_proof = prover_accumulator.reduce_and_prove(&setup, &mut transcript);
 
         // Note resetting the transcript is important
@@ -720,15 +759,24 @@ mod quark_grand_product_tests {
         let srs = ZeromorphSRS::<Bn254>::setup(&mut rng, 1 << 9);
         let setup = srs.trim(1 << 9);
 
-        let mut prover_accumulator: ProverOpeningAccumulator<Fr> = ProverOpeningAccumulator::new();
-        let mut verifier_accumulator: VerifierOpeningAccumulator<Fr, Zeromorph<Bn254>> =
-            VerifierOpeningAccumulator::new();
-
-        let mut hybrid_grand_product = <QuarkGrandProduct<Fr> as BatchedGrandProduct<
+        let mut prover_accumulator: ProverOpeningAccumulator<Fr, DefaultTranscript> =
+            ProverOpeningAccumulator::new();
+        let mut verifier_accumulator: VerifierOpeningAccumulator<
             Fr,
-            Zeromorph<Bn254>,
-        >>::construct_with_config(v, config);
-        let proof: BatchedGrandProductProof<Zeromorph<Bn254>> = hybrid_grand_product
+            Zeromorph<Bn254, DefaultTranscript>,
+            DefaultTranscript,
+        > = VerifierOpeningAccumulator::new();
+
+        let mut hybrid_grand_product =
+            <QuarkGrandProduct<Fr, DefaultTranscript> as BatchedGrandProduct<
+                Fr,
+                Zeromorph<Bn254, DefaultTranscript>,
+                DefaultTranscript,
+            >>::construct_with_config(v, config);
+        let proof: BatchedGrandProductProof<
+            Zeromorph<Bn254, DefaultTranscript>,
+            DefaultTranscript,
+        > = hybrid_grand_product
             .prove_grand_product(Some(&mut prover_accumulator), &mut transcript, Some(&setup))
             .0;
         let batched_proof = prover_accumulator.reduce_and_prove(&setup, &mut transcript);

--- a/jolt-core/src/subprotocols/sumcheck.rs
+++ b/jolt-core/src/subprotocols/sumcheck.rs
@@ -8,7 +8,7 @@ use crate::r1cs::special_polys::{SparsePolynomial, SparseTripleIterator};
 use crate::utils::errors::ProofVerifyError;
 use crate::utils::mul_0_optimized;
 use crate::utils::thread::drop_in_background_thread;
-use crate::utils::transcript::{AppendToTranscript, ProofTranscript};
+use crate::utils::transcript::{AppendToTranscript, DefaultTranscript, Transcript};
 use ark_serialize::*;
 use rayon::prelude::*;
 
@@ -30,7 +30,7 @@ pub trait BatchedCubicSumcheck<F: JoltField>: Sync {
         claim: &F,
         coeffs: &[F],
         eq_poly: &mut DensePolynomial<F>,
-        transcript: &mut ProofTranscript,
+        transcript: &mut DefaultTranscript,
     ) -> (SumcheckInstanceProof<F>, Vec<F>, (Vec<F>, Vec<F>)) {
         debug_assert_eq!(eq_poly.get_num_vars(), self.num_rounds());
 
@@ -84,7 +84,7 @@ impl<F: JoltField> SumcheckInstanceProof<F> {
         polys: &mut Vec<DensePolynomial<F>>,
         comb_func: Func,
         combined_degree: usize,
-        transcript: &mut ProofTranscript,
+        transcript: &mut DefaultTranscript,
     ) -> (Self, Vec<F>, Vec<F>)
     where
         Func: Fn(&[F]) -> F + std::marker::Sync,
@@ -257,7 +257,7 @@ impl<F: JoltField> SumcheckInstanceProof<F> {
         poly_B: &mut SparsePolynomial<F>,
         poly_C: &mut SparsePolynomial<F>,
         comb_func: Func,
-        transcript: &mut ProofTranscript,
+        transcript: &mut DefaultTranscript,
     ) -> (Self, Vec<F>, Vec<F>)
     where
         Func: Fn(&F, &F, &F, &F) -> F + Sync,
@@ -327,7 +327,7 @@ impl<F: JoltField> SumcheckInstanceProof<F> {
         num_rounds: usize,
         poly_A: &mut DensePolynomial<F>,
         witness_polynomials: &[&DensePolynomial<F>],
-        transcript: &mut ProofTranscript,
+        transcript: &mut DefaultTranscript,
     ) -> (Self, Vec<F>, Vec<F>) {
         let mut r: Vec<F> = Vec::with_capacity(num_rounds);
         let mut polys: Vec<CompressedUniPoly<F>> = Vec::with_capacity(num_rounds);
@@ -520,7 +520,7 @@ impl<F: JoltField> SumcheckInstanceProof<F> {
         claim: F,
         num_rounds: usize,
         degree_bound: usize,
-        transcript: &mut ProofTranscript,
+        transcript: &mut DefaultTranscript,
     ) -> Result<(F, Vec<F>), ProofVerifyError> {
         let mut e = claim;
         let mut r: Vec<F> = Vec::new();

--- a/jolt-core/src/utils/sol_types.rs
+++ b/jolt-core/src/utils/sol_types.rs
@@ -9,6 +9,7 @@ use crate::r1cs::spartan::UniformSpartanProof;
 use crate::subprotocols::grand_product::BatchedGrandProductLayerProof;
 use crate::subprotocols::grand_product::BatchedGrandProductProof;
 use crate::subprotocols::sumcheck::SumcheckInstanceProof;
+use crate::utils::transcript::Transcript;
 use alloy_primitives::U256;
 use alloy_sol_types::sol;
 use ark_bn254::FrConfig;
@@ -130,7 +131,9 @@ impl Into<VK> for &HyperKZGVerifierKey<Bn254> {
     }
 }
 
-impl<F: JoltField> Into<SumcheckProof> for &SumcheckInstanceProof<F> {
+impl<F: JoltField, ProofTranscript: Transcript> Into<SumcheckProof>
+    for &SumcheckInstanceProof<F, ProofTranscript>
+{
     fn into(self) -> SumcheckProof {
         let mut compressed_polys = vec![];
 
@@ -156,8 +159,8 @@ pub fn into_uint256<F: JoltField>(from: F) -> U256 {
 }
 
 const C: usize = 4;
-impl Into<SpartanProof>
-    for &UniformSpartanProof<C, JoltR1CSInputs, Fp<MontBackend<FrConfig, 4>, 4>>
+impl<ProofTranscript: Transcript> Into<SpartanProof>
+    for &UniformSpartanProof<C, JoltR1CSInputs, Fp<MontBackend<FrConfig, 4>, 4>, ProofTranscript>
 {
     fn into(self) -> SpartanProof {
         let claimed_evals = self
@@ -177,7 +180,9 @@ impl Into<SpartanProof>
     }
 }
 
-impl<F: JoltField> Into<GKRLayer> for BatchedGrandProductLayerProof<F> {
+impl<F: JoltField, ProofTranscript: Transcript> Into<GKRLayer>
+    for BatchedGrandProductLayerProof<F, ProofTranscript>
+{
     fn into(self) -> GKRLayer {
         let left = self.left_claims.into_iter().map(into_uint256).collect();
         let right = self.right_claims.into_iter().map(into_uint256).collect();
@@ -189,7 +194,9 @@ impl<F: JoltField> Into<GKRLayer> for BatchedGrandProductLayerProof<F> {
     }
 }
 
-impl Into<GrandProductProof> for BatchedGrandProductProof<HyperKZG<Bn254>> {
+impl<ProofTranscript: Transcript> Into<GrandProductProof>
+    for BatchedGrandProductProof<HyperKZG<Bn254, ProofTranscript>, ProofTranscript>
+{
     fn into(self) -> GrandProductProof {
         let layers: Vec<GKRLayer> = self.layers.into_iter().map(|i| i.into()).collect();
         assert!(self.quark_proof.is_none(), "Quarks are unsupported");

--- a/jolt-core/src/utils/transcript.rs
+++ b/jolt-core/src/utils/transcript.rs
@@ -90,10 +90,6 @@ impl ProofTranscript {
         self.update_state(hasher.finalize().into());
     }
 
-    pub fn append_protocol_name(&mut self, protocol_name: &'static [u8]) {
-        self.append_message(protocol_name);
-    }
-
     pub fn append_scalar<F: JoltField>(&mut self, scalar: &F) {
         let mut buf = vec![];
         scalar.serialize_uncompressed(&mut buf).unwrap();


### PR DESCRIPTION
ProofTranscript is now a type parameter everywhere. 

This is necessary for in-circuit Jolt verification (Keccak is very expensive in R1CS), also for anyone who might want to use their own transcript implementation. 

