### PR TITLE
fix: WASM build failures because of binius

### DIFF
--- a/jolt-core/Cargo.toml
+++ b/jolt-core/Cargo.toml
@@ -27,7 +27,6 @@ ark-serialize = { version = "0.4.2", default-features = false, features = [
     "derive",
 ] }
 ark-std = { version = "0.4.0" }
-binius-field = { git = "https://gitlab.com/UlvetannaOSS/binius", package = "binius_field" }
 clap = { version = "4.3.10", features = ["derive"] }
 enum_dispatch = "0.3.12"
 fixedbitset = "0.5.0"
@@ -66,7 +65,7 @@ indicatif = "0.17.8"
 common = { path = "../common" }
 tracer = { path = "../tracer" }
 bincode = "1.3.3"
-bytemuck = "1.15.0"
+bytemuck = "1.19.0"
 hex = "0.4.3"
 tokio = { version = "1.38.0", optional = true }
 alloy-primitives = "0.7.6"
@@ -111,6 +110,7 @@ host = ["dep:reqwest", "dep:tokio"]
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 memory-stats = "1.0.0"
 tokio = { version = "1.38.0", optional = true, features = ["rt-multi-thread"] }
+binius-field = { git = "https://gitlab.com/UlvetannaOSS/binius", package = "binius_field" }
 
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/jolt-core/src/field/mod.rs
+++ b/jolt-core/src/field/mod.rs
@@ -91,4 +91,5 @@ where
 }
 
 pub mod ark;
+#[cfg(not(target_arch = "wasm32"))]
 pub mod binius;

--- a/src/build_wasm.rs
+++ b/src/build_wasm.rs
@@ -53,8 +53,9 @@ fn preprocess_and_save(func_name: &str, attributes: &Attributes, is_std: bool) -
 }
 
 fn extract_provable_functions() -> Vec<FunctionAttributes> {
-    let content = fs::read_to_string("guest/src/lib.rs").expect("Unable to read file");
-    let syntax: syn::File = syn::parse_file(&content).expect("Unable to parse file");
+    let guest_path = Path::new("guest/src/lib.rs");
+    let content = fs::read_to_string(guest_path).expect(&format!("Unable to read file: {:?}", guest_path));
+    let syntax: syn::File = syn::parse_file(&content).expect(&format!("Unable to parse file: {:?}", guest_path));
 
     syntax
         .items

--- a/src/build_wasm.rs
+++ b/src/build_wasm.rs
@@ -54,8 +54,10 @@ fn preprocess_and_save(func_name: &str, attributes: &Attributes, is_std: bool) -
 
 fn extract_provable_functions() -> Vec<FunctionAttributes> {
     let guest_path = Path::new("guest/src/lib.rs");
-    let content = fs::read_to_string(guest_path).expect(&format!("Unable to read file: {:?}", guest_path));
-    let syntax: syn::File = syn::parse_file(&content).expect(&format!("Unable to parse file: {:?}", guest_path));
+    let content = fs::read_to_string(guest_path)
+        .unwrap_or_else(|_| panic!("Unable to read file: {:?}", guest_path));
+    let syntax: syn::File = syn::parse_file(&content)
+        .unwrap_or_else(|_| panic!("Unable to parse file: {:?}", guest_path));
 
     syntax
         .items


### PR DESCRIPTION
Our dependency https://gitlab.com/IrreducibleOSS/binius uses tracing-profile and causes wasm builds to fail. 

Fixed by skipping binius for wasm. Will file another issue for that. 

fixes #472