### PR TITLE
Fix bug in default jolt fibonacci template

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -241,5 +241,5 @@ const GUEST_MAIN: &str = r#"#![cfg_attr(feature = "guest", no_std)]
 #![no_main]
 
 #[allow(unused_imports)]
-use fibonacci_guest::*;
+use guest::*;
 "#;


### PR DESCRIPTION
This import is broken in the file generated by jolt new [project] and the project fails to build as a result. I noticed this while doing the quickstart. Sorry if this was fixed already and has to do with an old version of Jolt on my computer.