### PR TITLE
Use SplitEqPolynomial in Spartan cubic sumcheck

### DIFF
--- a/jolt-core/src/subprotocols/sparse_grand_product.rs
+++ b/jolt-core/src/subprotocols/sparse_grand_product.rs
@@ -135,7 +135,7 @@ impl<F: JoltField> BatchedGrandProductToggleLayer<F> {
             .enumerate()
             .map(|(batch_index, fingerprints)| {
                 let flag_indices = &self.flag_indices[batch_index / 2];
-                let mut sparse_coeffs = vec![];
+                let mut sparse_coeffs = Vec::with_capacity(self.layer_len);
                 for i in flag_indices {
                     sparse_coeffs
                         .push((batch_index * self.layer_len / 2 + i, fingerprints[*i]).into());


### PR DESCRIPTION
Uses the Dao-Thaler EQ optimization in the first Spartan sumcheck. 

This PR also includes some changes to hopefully fix the weird behavior (seemingly introduced by https://github.com/a16z/jolt/pull/481) where `SparseInterleavedPolynomial::layer_output` and `BatchedGrandProductToggleLayer::layer_output` are sometimes an order of magnitude or more slower than usual