### PR TITLE
Optimize memory-checking openings for 0s and 1s

### DIFF
--- a/jolt-core/src/jolt/vm/timestamp_range_check.rs
+++ b/jolt-core/src/jolt/vm/timestamp_range_check.rs
@@ -636,7 +636,7 @@ where
                     .zip(timestamp_openings.openings_mut().into_par_iter()),
             )
             .for_each(|(poly, opening)| {
-                let claim = poly.evaluate_at_chi(&chis);
+                let claim = poly.evaluate_at_chi_low_optimized(&chis);
                 *opening = claim;
             });
 

--- a/jolt-core/src/lasso/memory_checking.rs
+++ b/jolt-core/src/lasso/memory_checking.rs
@@ -362,7 +362,7 @@ where
                     .zip_eq(exogenous_openings.openings_mut().into_par_iter()),
             )
             .for_each(|(poly, opening)| {
-                let claim = poly.evaluate_at_chi(&eq_read_write);
+                let claim = poly.evaluate_at_chi_low_optimized(&eq_read_write);
                 *opening = claim;
             });
 
@@ -387,7 +387,7 @@ where
             .par_iter()
             .zip_eq(openings.init_final_values_mut().into_par_iter())
             .for_each(|(poly, opening)| {
-                let claim = poly.evaluate_at_chi(&eq_init_final);
+                let claim = poly.evaluate_at_chi_low_optimized(&eq_init_final);
                 *opening = claim;
             });
 


### PR DESCRIPTION
this probably slipped through when I was working on https://github.com/a16z/jolt/pull/453