### PR TITLE
fix(jolt-core): Fixes DIVU and REMU sequence_output

### DIFF
--- a/jolt-core/src/jolt/instruction/divu.rs
+++ b/jolt-core/src/jolt/instruction/divu.rs
@@ -228,7 +228,15 @@ impl<const WORD_SIZE: usize> VirtualInstructionSequence for DIVUInstruction<WORD
     }
 
     fn sequence_output(x: u64, y: u64) -> u64 {
-        x / y
+        if y == 0 {
+            match WORD_SIZE {
+                32 => u32::MAX as u64,
+                64 => u64::MAX,
+                _ => panic!("Unsupported WORD_SIZE: {}", WORD_SIZE),
+            }
+        } else {
+            x / y
+        }
     }
 }
 
@@ -238,7 +246,7 @@ mod test {
     use crate::{jolt::instruction::JoltInstruction, jolt_virtual_sequence_test};
 
     #[test]
-    fn div_virtual_sequence_32() {
+    fn divu_virtual_sequence_32() {
         jolt_virtual_sequence_test!(DIVUInstruction::<32>, RV32IM::DIVU);
     }
 }

--- a/jolt-core/src/jolt/instruction/remu.rs
+++ b/jolt-core/src/jolt/instruction/remu.rs
@@ -215,8 +215,12 @@ impl<const WORD_SIZE: usize> VirtualInstructionSequence for REMUInstruction<WORD
         } else {
             x / y
         };
-         
-        if y == 0 { x } else { x - quotient * y }
+
+        if y == 0 {
+            x
+        } else {
+            x - quotient * y
+        }
     }
 }
 

--- a/jolt-core/src/jolt/instruction/remu.rs
+++ b/jolt-core/src/jolt/instruction/remu.rs
@@ -206,20 +206,14 @@ impl<const WORD_SIZE: usize> VirtualInstructionSequence for REMUInstruction<WORD
     }
 
     fn sequence_output(x: u64, y: u64) -> u64 {
-        let quotient = if y == 0 {
-            match WORD_SIZE {
-                32 => u32::MAX as u64,
-                64 => u64::MAX,
-                _ => panic!("Unsupported WORD_SIZE: {}", WORD_SIZE),
-            }
-        } else {
-            x / y
-        };
-
         if y == 0 {
             x
         } else {
-            x - quotient * y
+            match WORD_SIZE {
+                32 => (x as u32 % y as u32) as u64,
+                64 => x % y,
+                _ => panic!("Unsupported WORD_SIZE: {}", WORD_SIZE),
+            }
         }
     }
 }

--- a/jolt-core/src/jolt/instruction/remu.rs
+++ b/jolt-core/src/jolt/instruction/remu.rs
@@ -206,11 +206,17 @@ impl<const WORD_SIZE: usize> VirtualInstructionSequence for REMUInstruction<WORD
     }
 
     fn sequence_output(x: u64, y: u64) -> u64 {
-        match WORD_SIZE {
-            32 => (x as u32 % y as u32) as u64,
-            64 => x % y,
-            _ => panic!("Unsupported WORD_SIZE: {}", WORD_SIZE),
-        }
+        let quotient = if y == 0 {
+            match WORD_SIZE {
+                32 => u32::MAX as u64,
+                64 => u64::MAX,
+                _ => panic!("Unsupported WORD_SIZE: {}", WORD_SIZE),
+            }
+        } else {
+            x / y
+        };
+         
+        if y == 0 { x } else { x - quotient * y }
     }
 }
 


### PR DESCRIPTION
We return the correct output from sequence output when the divisor is zero, for divu and remu.

Should fix #499 