### PR TITLE
chore: Update toolchain to nightly-2024-09-30

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2024-08-01"
+channel = "nightly-2024-09-30"
 targets = ["riscv32im-unknown-none-elf"]


### PR DESCRIPTION
This aligns the toolchain with Binius's [rust-toolchain](https://gitlab.com/IrreducibleOSS/binius/-/blob/main/rust-toolchain.toml?ref_type=heads)

By updating the toolchain, we solve the following error on the starter project:
```
cargo run --release
   Compiling ark-bn254 v0.4.0
   Compiling binius_field v0.1.0 (https://gitlab.com/UlvetannaOSS/binius#33eab8c9)
error[E0658]: use of unstable library feature 'iter_repeat_n'
   --> /Users/user/.cargo/git/checkouts/binius-073c6a8ffd019076/33eab8c/crates/field/src/packed.rs:225:76
    |
225 |             self.iter().skip(block_idx * block_len).take(block_len).flat_map(|elem| iter::repeat_n(elem, repeat))
    |                                                                                     ^^^^^^^^^^^^^^
    |
    = note: see issue #104434 <https://github.com/rust-lang/rust/issues/104434> for more information
    = help: add `#![feature(iter_repeat_n)]` to the crate attributes to enable
    = note: this compiler was built on 2024-07-31; consider upgrading it if it is out of date

For more information about this error, try `rustc --explain E0658`.
error: could not compile `binius_field` (lib) due to 1 previous error
```

The toolchain update solves an incompatibility between the nightly compiler version in use by Jolt and the use of `iter::repeat_n` that was introduced [three days ago in Binius]( https://gitlab.com/IrreducibleOSS/binius/-/commit/0c8c49b5cf7145949d5cbd4a237cda736c0dd1d3#18e5709a6ae23c4c65ba91824c951600b7bb4def_185_225).

This fixes #508. I will open a separate PR in [a16z/rust](https://github.com/a16z/rust) for the CI pipeline