### PR TITLE
chore: replace lazy_static with LazyLock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1832,7 +1832,6 @@ dependencies = [
  "iai-callgrind",
  "indicatif",
  "itertools 0.10.5",
- "lazy_static",
  "memory-stats",
  "num-integer",
  "postcard",

--- a/jolt-core/Cargo.toml
+++ b/jolt-core/Cargo.toml
@@ -32,7 +32,6 @@ clap = { version = "4.3.10", features = ["derive"] }
 enum_dispatch = "0.3.12"
 fixedbitset = "0.5.0"
 itertools = "0.10.0"
-lazy_static = "1.4.0"
 num-integer = "0.1.45"
 postcard = { version = "1.0.8", default-features = false, features = [
     "use-std",

--- a/jolt-core/src/jolt/vm/rv32i_vm.rs
+++ b/jolt-core/src/jolt/vm/rv32i_vm.rs
@@ -254,14 +254,12 @@ mod tests {
     use crate::poly::commitment::mock::MockCommitScheme;
     use crate::poly::commitment::zeromorph::Zeromorph;
     use crate::utils::transcript::{KeccakTranscript, Transcript};
-    use std::sync::Mutex;
+    use std::sync::{LazyLock, Mutex};
     use strum::{EnumCount, IntoEnumIterator};
 
     // If multiple tests try to read the same trace artifacts simultaneously, they will fail
-    lazy_static::lazy_static! {
-        static ref FIB_FILE_LOCK: Mutex<()> = Mutex::new(());
-        static ref SHA3_FILE_LOCK: Mutex<()> = Mutex::new(());
-    }
+    static FIB_FILE_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
+    static SHA3_FILE_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
 
     fn test_instruction_set_subtables<PCS, ProofTranscript>()
     where

--- a/jolt-core/src/utils/profiling.rs
+++ b/jolt-core/src/utils/profiling.rs
@@ -1,18 +1,14 @@
 #[cfg(not(target_arch = "wasm32"))]
 use memory_stats::memory_stats;
-use std::{collections::HashMap, sync::Mutex};
+use std::{
+    collections::HashMap,
+    sync::{LazyLock, Mutex},
+};
 
-lazy_static::lazy_static! {
-    static ref MEMORY_USAGE_MAP: Mutex<HashMap<&'static str, f64>> = {
-        let m = HashMap::new();
-        Mutex::new(m)
-    };
-
-    static ref MEMORY_DELTA_MAP: Mutex<HashMap<&'static str, f64>> = {
-        let m = HashMap::new();
-        Mutex::new(m)
-    };
-}
+static MEMORY_USAGE_MAP: LazyLock<Mutex<HashMap<&'static str, f64>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+static MEMORY_DELTA_MAP: LazyLock<Mutex<HashMap<&'static str, f64>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
 
 #[cfg(not(target_arch = "wasm32"))]
 pub fn start_memory_tracing_span(label: &'static str) {

--- a/jolt-evm-verifier/script/Cargo.lock
+++ b/jolt-evm-verifier/script/Cargo.lock
@@ -1573,7 +1573,6 @@ dependencies = [
  "getrandom 0.2.15",
  "indicatif",
  "itertools 0.10.5",
- "lazy_static",
  "memory-stats",
  "num-integer",
  "postcard",


### PR DESCRIPTION
`LazyLock` does the same thing but is built-in as of Rust 1.80.0.