### PR TITLE
fix: make sure the proper nightly version is used

### DIFF
--- a/book/src/usage/install.md
+++ b/book/src/usage/install.md
@@ -1,6 +1,6 @@
 # Installing
 Start by installing the `jolt` command line tool.
 ```
-cargo +nightly install --git https://github.com/a16z/jolt --force --bins jolt
+cargo +nightly-2024-09-30 install --git https://github.com/a16z/jolt --force --bins jolt
 ```
 

--- a/book/src/usage/quickstart.md
+++ b/book/src/usage/quickstart.md
@@ -2,7 +2,7 @@
 ## Installing
 Start by installing the `jolt` command line tool.
 ```
-cargo +nightly install --git https://github.com/a16z/jolt --force --bins jolt
+cargo +nightly-2024-09-30 install --git https://github.com/a16z/jolt --force --bins jolt
 ```
 
 ## Creating a Project


### PR DESCRIPTION
Use the correct nightly version (required by `binius`) when installing `jolt` binary.

Relates to https://github.com/a16z/jolt/issues/508