### PR TITLE
Fix Minor Typo in Comment Update SpartanVerifier.sol

### DIFF
--- a/jolt-evm-verifier/src/subprotocols/SpartanVerifier.sol
+++ b/jolt-evm-verifier/src/subprotocols/SpartanVerifier.sol
@@ -78,7 +78,7 @@ contract SpartanVerifier is HyperKZG {
         Fr claim_inner_join =
             claim_Az + r_inner_sumcheck_RLC * claim_Bz + r_inner_sumcheck_RLC * r_inner_sumcheck_RLC * claim_Cz;
 
-        // Validate the the inner sumcheck
+        // Validate the inner sumcheck
         (Fr claim_inner, Fr[] memory r_y) =
             SumcheckVerifier.verify_sumcheck(transcript, proof.inner, claim_inner_join, log_cols, 2);
         // The n prefix is key.uniform_r1cs.num_vars.next_power_of_two().log_2() + 1; and in our system it's initialized to 8


### PR DESCRIPTION
### Description:
This update addresses a minor typo in the comments of the `SpartanVerifier` contract. Specifically, the comment contained the phrase "the the inner sumcheck," which was corrected to "the inner sumcheck."

<img width="394" alt="Снимок экрана 2024-12-01 в 13 56 14" src="https://github.com/user-attachments/assets/62596a3a-f44f-4d5e-903a-080fea690063">

While this is a small change, maintaining clear and precise comments is crucial for code readability and understanding. Typos, even in comments, can create confusion, especially for other developers reviewing the code or collaborating on future changes. By fixing this, we ensure that the documentation remains professional and accurate.