### PR TITLE
docs: grammar fix Update batched-openings.md

### DIFF
--- a/book/src/background/batched-openings.md
+++ b/book/src/background/batched-openings.md
@@ -1,4 +1,4 @@
 # Batched Openings
-At the end of the sumcheck protocol, the verifier must evaluate many multilinear polynomials at a single point. For polynomials which the verifier cannot compute on their own, they depend on the verification of a PCS opening proof provided by the prover. To save on verifier costs, all polynomials opened at the same point can be combined to a single opening proof.
+At the end of the sumcheck protocol, the verifier must evaluate many multilinear polynomials at a single point. For polynomials which the verifier cannot compute on its own, they depend on the verification of a PCS opening proof provided by the prover. To save on verifier costs, all polynomials opened at the same point can be combined to a single opening proof.
 
 The best reading on the subject can be found in **Section 16.1** of the [Textbook](https://people.cs.georgetown.edu/jthaler/ProofsArgsAndZK.pdf).


### PR DESCRIPTION
<img width="888" alt="Снимок экрана 2024-12-08 в 17 59 00" src="https://github.com/user-attachments/assets/2a28be33-3fc8-40ac-b250-ac03f7c060d5">

The phrase "on their own" replaced with "**on its own**" to match the singular subject "verifier."