### PR TITLE
doc: fix grammar Update binius.md

### DIFF
--- a/book/src/background/binius.md
+++ b/book/src/background/binius.md
@@ -1,7 +1,7 @@
 # Binius
 [Binius](https://eprint.iacr.org/2023/1784.pdf) was written by Ben Diamond and Jim Posen of Irreducible (fka Ulvetanna). It's a new commitment scheme that allows Jolt to use smaller fields more efficiently. 
 
-The Binius paper also gives a number of sum-check-based polynomial IOPs for to be combined with the commitment scheme. For Jolt's purposes, these will yield extremely efficient protocols for proving hash evaluations with various standard hash functions like Keccak (important for recursing Jolt-with-Binius-commitment), and for the RISC-V addition and multiplication operations. 
+The Binius paper also gives a number of sum-check-based polynomial IOPs to be combined with the commitment scheme. For Jolt's purposes, these will yield extremely efficient protocols for proving hash evaluations with various standard hash functions like Keccak (important for recursing Jolt-with-Binius-commitment), and for the RISC-V addition and multiplication operations. 
 
 Here is a brief summary of changes that will occur in Jolt in order to incorporate the Binius commitment scheme:
 


### PR DESCRIPTION
<img width="904" alt="Снимок экрана 2024-12-08 в 18 01 44" src="https://github.com/user-attachments/assets/d84d01ff-ac7e-4f68-a0f1-719b1c41bf7a">

The phrase "for to be combined" is incorrect. This phrase looks more correct:

"The Binius paper also gives a number of sum-check-based polynomial IOPs to be combined with the commitment scheme."

This adjustment removes the unnecessary "for," making the sentence grammatically correct.