### PR TITLE
 Fix hyphenation in "left-hand side" in sparse-constraint-systems.md  

### DIFF
--- a/book/src/how/sparse-constraint-systems.md
+++ b/book/src/how/sparse-constraint-systems.md
@@ -27,7 +27,7 @@ Here, one should think of $z$ as an execution trace for the VM, i.e., a list of 
 that happened at each and every cycle of VM. In Jolt, there are under 100 entries of $z$ per cycle
 (though as we add pre-compiles this number might grow).
 
-We modify each constraint by multiplying the left hand side by the binary flag $b_j$, i.e., 
+We modify each constraint by multiplying the left-hand side by the binary flag $b_j$, i.e., 
 $$b_j \cdot \left(\langle a_i, z \rangle \cdot \langle b_i, z \rangle  - \langle c_i, z \rangle \right) = 0.$$
 
 Now, for any cycle where this pre-compile is not executed, the prover can simply assign any variables 
@@ -68,6 +68,6 @@ and has other benefits.
 
 We call this technique (fast proving for) "sparse constraint systems". Note that the term sparse here
 does not refer to there being the sparsity of the R1CS constraint matrices themselves, 
-but rather to almost all of the left hand sides of the constraints being $0$
+but rather to almost all of the left-hand sides of the constraints being $0$
 when the constraints are evaluated on the valid witness vector $z$.
 


### PR DESCRIPTION
This pull request corrects two instances of improper hyphenation in the file `sparse-constraint-systems.md`. The term **"left hand side"** has been updated to **"left-hand side"** to follow standard grammatical rules for compound adjectives.  

## Changes Made  
- Updated "left hand side" to "left-hand side" in two locations:  
  1. Line 27: Explanation of constraint modification.  
  2. Line 68: Discussion of sparsity in constraint systems.  

## Checklist Before Merging  
- [x] Grammar and style corrected for clarity and consistency.  
- [x] No breaking changes introduced.  
- [x] Verified that these changes align with the repository's contributing guidelines.  
