### PR TITLE
The Return of the King

### DIFF
--- a/jolt-core/src/poly/eq_poly.rs
+++ b/jolt-core/src/poly/eq_poly.rs
@@ -101,33 +101,6 @@ impl<F: JoltField> EqPolynomial<F> {
     }
 }
 
-/* This MLE is 1 if y = x + 1 for x in the range [0... 2^l-2].
-That is, it ignores the case where x is all 1s, outputting 0.
-Assumes x and y are provided big-endian. */
-pub fn eq_plus_one<F: JoltField>(x: &[F], y: &[F], l: usize) -> F {
-    let one = F::one();
-
-    /* If y+1 = x, then the two bit vectors are of the following form.
-        Let k be the longest suffix of 1s in x.
-        In y, those k bits are 0.
-        Then, the next bit in x is 0 and the next bit in y is 1.
-        The remaining higher bits are the same in x and y.
-    */
-    (0..l)
-        .into_par_iter()
-        .map(|k| {
-            let lower_bits_product = (0..k)
-                .map(|i| x[l - 1 - i] * (F::one() - y[l - 1 - i]))
-                .product::<F>();
-            let kth_bit_product = (F::one() - x[l - 1 - k]) * y[l - 1 - k];
-            let higher_bits_product = ((k + 1)..l)
-                .map(|i| x[l - 1 - i] * y[l - 1 - i] + (one - x[l - 1 - i]) * (one - y[l - 1 - i]))
-                .product::<F>();
-            lower_bits_product * kth_bit_product * higher_bits_product
-        })
-        .sum()
-}
-
 impl<F: JoltField> EqPlusOnePolynomial<F> {
     pub fn new(x: Vec<F>) -> Self {
         EqPlusOnePolynomial { x }

--- a/jolt-core/src/poly/eq_poly.rs
+++ b/jolt-core/src/poly/eq_poly.rs
@@ -128,7 +128,7 @@ pub fn eq_plus_one<F: JoltField>(x: &[F], y: &[F], l: usize) -> F {
         .sum()
 }
 
-impl <F: JoltField> EqPlusOnePolynomial<F> {
+impl<F: JoltField> EqPlusOnePolynomial<F> {
     pub fn new(x: Vec<F>) -> Self {
         EqPlusOnePolynomial { x }
     }
@@ -137,8 +137,8 @@ impl <F: JoltField> EqPlusOnePolynomial<F> {
     That is, it ignores the case where x is all 1s, outputting 0.
     Assumes x and y are provided big-endian. */
     pub fn evaluate(&self, y: &[F]) -> F {
-        let l = self.x.len(); 
-        let x = &self.x; 
+        let l = self.x.len();
+        let x = &self.x;
         assert!(y.len() == l);
         let one = F::from_u64(1_u64);
 
@@ -156,17 +156,18 @@ impl <F: JoltField> EqPlusOnePolynomial<F> {
                     .product::<F>();
                 let kth_bit_product = (F::one() - x[l - 1 - k]) * y[l - 1 - k];
                 let higher_bits_product = ((k + 1)..l)
-                    .map(|i| x[l - 1 - i] * y[l - 1 - i] + (one - x[l - 1 - i]) * (one - y[l - 1 - i]))
+                    .map(|i| {
+                        x[l - 1 - i] * y[l - 1 - i] + (one - x[l - 1 - i]) * (one - y[l - 1 - i])
+                    })
                     .product::<F>();
                 lower_bits_product * kth_bit_product * higher_bits_product
             })
             .sum()
-    }   
-
+    }
 
     #[tracing::instrument(skip_all, "EqPlusOnePolynomial::evals")]
     pub fn evals(r: &[F]) -> Vec<F> {
-        let ell = r.len(); 
+        let ell = r.len();
         let mut eq_evals: Vec<F> = vec![F::one(); ell.pow2()];
         let mut eq_plus_one_evals: Vec<F> = vec![F::zero(); ell.pow2()];
 
@@ -179,28 +180,35 @@ impl <F: JoltField> EqPlusOnePolynomial<F> {
 
             let mut selected: Vec<_> = eq_evals.par_iter_mut().step_by(step).collect();
 
-            selected.par_chunks_mut(2).enumerate().for_each(|(_j, chunk)| {
-                let (x, y) = chunk.split_at_mut(1);
-                let x = &mut x[0];
-                let y = &mut y[0];
-                **y = **x * r[i - 1];
-                **x *= (F::one() - r[i - 1]);
-            });
+            selected
+                .par_chunks_mut(2)
+                .enumerate()
+                .for_each(|(_j, chunk)| {
+                    let (x, y) = chunk.split_at_mut(1);
+                    let x = &mut x[0];
+                    let y = &mut y[0];
+                    **y = **x * r[i - 1];
+                    **x *= (F::one() - r[i - 1]);
+                });
         };
 
-        for i in 0..ell { // i indicates the LENGTH of the prefix of r for which the eq_table is calculated
+        for i in 0..ell {
+            // i indicates the LENGTH of the prefix of r for which the eq_table is calculated
             eq_evals_helper(&mut eq_evals, r, i);
 
-            let step = 1 << (ell - i); 
+            let step = 1 << (ell - i);
             let half_step = step / 2;
 
-            let r_lower_product = (F::one()-r[i]) * 
-                r.iter().skip(i + 1).copied().product::<F>();
+            let r_lower_product = (F::one() - r[i]) * r.iter().skip(i + 1).copied().product::<F>();
 
-            eq_plus_one_evals.par_iter_mut().enumerate().skip(half_step).step_by(step).for_each(|(index, v)| {
-                *v = eq_evals[index-half_step] * r_lower_product;
-            });
-
+            eq_plus_one_evals
+                .par_iter_mut()
+                .enumerate()
+                .skip(half_step)
+                .step_by(step)
+                .for_each(|(index, v)| {
+                    *v = eq_evals[index - half_step] * r_lower_product;
+                });
         }
         eq_plus_one_evals
     }

--- a/jolt-core/src/poly/eq_poly.rs
+++ b/jolt-core/src/poly/eq_poly.rs
@@ -7,6 +7,10 @@ pub struct EqPolynomial<F> {
     r: Vec<F>,
 }
 
+pub struct EqPlusOnePolynomial<F> {
+    x: Vec<F>,
+}
+
 const PARALLEL_THRESHOLD: usize = 16;
 
 impl<F: JoltField> EqPolynomial<F> {
@@ -122,4 +126,81 @@ pub fn eq_plus_one<F: JoltField>(x: &[F], y: &[F], l: usize) -> F {
             lower_bits_product * kth_bit_product * higher_bits_product
         })
         .sum()
+}
+
+impl <F: JoltField> EqPlusOnePolynomial<F> {
+    pub fn new(x: Vec<F>) -> Self {
+        EqPlusOnePolynomial { x }
+    }
+
+    /* This MLE is 1 if y = x + 1 for x in the range [0... 2^l-2].
+    That is, it ignores the case where x is all 1s, outputting 0.
+    Assumes x and y are provided big-endian. */
+    pub fn evaluate(&self, y: &[F]) -> F {
+        let l = self.x.len(); 
+        let x = &self.x; 
+        assert!(y.len() == l);
+        let one = F::from_u64(1_u64);
+
+        /* If y+1 = x, then the two bit vectors are of the following form.
+            Let k be the longest suffix of 1s in x.
+            In y, those k bits are 0.
+            Then, the next bit in x is 0 and the next bit in y is 1.
+            The remaining higher bits are the same in x and y.
+        */
+        (0..l)
+            .into_par_iter()
+            .map(|k| {
+                let lower_bits_product = (0..k)
+                    .map(|i| x[l - 1 - i] * (F::one() - y[l - 1 - i]))
+                    .product::<F>();
+                let kth_bit_product = (F::one() - x[l - 1 - k]) * y[l - 1 - k];
+                let higher_bits_product = ((k + 1)..l)
+                    .map(|i| x[l - 1 - i] * y[l - 1 - i] + (one - x[l - 1 - i]) * (one - y[l - 1 - i]))
+                    .product::<F>();
+                lower_bits_product * kth_bit_product * higher_bits_product
+            })
+            .sum()
+    }   
+
+
+    pub fn evals(r: &[F]) -> Vec<F> {
+        let ell = r.len(); 
+        let mut eq_evals: Vec<F> = vec![F::one(); ell.pow2()];
+        let mut eq_plus_one_evals: Vec<F> = vec![F::zero(); ell.pow2()];
+
+        let eq_evals_helper = |eq_evals: &mut Vec<F>, r: &[F], i: usize| {
+            if i == 0 {
+                return;
+            }
+            let ell = r.len();
+            let step = 1 << (ell - i); // step = (full / size)/2
+
+            let mut selected: Vec<_> = eq_evals.par_iter_mut().step_by(step).collect();
+
+            selected.par_chunks_mut(2).enumerate().for_each(|(_j, chunk)| {
+                let (x, y) = chunk.split_at_mut(1);
+                let x = &mut x[0];
+                let y = &mut y[0];
+                **y = **x * r[i - 1];
+                **x = **x * (F::one() - r[i - 1]);
+            });
+        };
+
+        for i in 0..ell { // i indicates the LENGTH of the prefix of r for which the eq_table is calculated
+            eq_evals_helper(&mut eq_evals, r, i);
+
+            let step = 1 << (ell - i); 
+            let half_step = step / 2;
+
+            let r_lower_product = (F::one()-r[i]) * 
+                r.iter().skip(i + 1).map(|&x| x).product::<F>();
+
+            eq_plus_one_evals.par_iter_mut().enumerate().skip(half_step).step_by(step).for_each(|(index, v)| {
+                *v = eq_evals[index-half_step] * r_lower_product;
+            });
+
+        }
+        eq_plus_one_evals
+    }
 }

--- a/jolt-core/src/poly/eq_poly.rs
+++ b/jolt-core/src/poly/eq_poly.rs
@@ -164,6 +164,7 @@ impl <F: JoltField> EqPlusOnePolynomial<F> {
     }   
 
 
+    #[tracing::instrument(skip_all, "EqPlusOnePolynomial::evals")]
     pub fn evals(r: &[F]) -> Vec<F> {
         let ell = r.len(); 
         let mut eq_evals: Vec<F> = vec![F::one(); ell.pow2()];

--- a/jolt-core/src/poly/eq_poly.rs
+++ b/jolt-core/src/poly/eq_poly.rs
@@ -184,7 +184,7 @@ impl <F: JoltField> EqPlusOnePolynomial<F> {
                 let x = &mut x[0];
                 let y = &mut y[0];
                 **y = **x * r[i - 1];
-                **x = **x * (F::one() - r[i - 1]);
+                **x *= (F::one() - r[i - 1]);
             });
         };
 
@@ -195,7 +195,7 @@ impl <F: JoltField> EqPlusOnePolynomial<F> {
             let half_step = step / 2;
 
             let r_lower_product = (F::one()-r[i]) * 
-                r.iter().skip(i + 1).map(|&x| x).product::<F>();
+                r.iter().skip(i + 1).copied().product::<F>();
 
             eq_plus_one_evals.par_iter_mut().enumerate().skip(half_step).step_by(step).for_each(|(index, v)| {
                 *v = eq_evals[index-half_step] * r_lower_product;

--- a/jolt-core/src/poly/eq_poly.rs
+++ b/jolt-core/src/poly/eq_poly.rs
@@ -188,7 +188,7 @@ impl<F: JoltField> EqPlusOnePolynomial<F> {
                     let x = &mut x[0];
                     let y = &mut y[0];
                     **y = **x * r[i - 1];
-                    **x *= (F::one() - r[i - 1]);
+                    **x *= F::one() - r[i - 1];
                 });
         };
 

--- a/jolt-core/src/r1cs/constraints.rs
+++ b/jolt-core/src/r1cs/constraints.rs
@@ -266,5 +266,6 @@ impl<const C: usize, F: JoltField> R1CSConstraints<C, F> for JoltRV32IMConstrain
         );
 
         vec![pc_constraint, virtual_sequence_constraint]
+        // vec![]
     }
 }

--- a/jolt-core/src/r1cs/constraints.rs
+++ b/jolt-core/src/r1cs/constraints.rs
@@ -266,6 +266,5 @@ impl<const C: usize, F: JoltField> R1CSConstraints<C, F> for JoltRV32IMConstrain
         );
 
         vec![pc_constraint, virtual_sequence_constraint]
-        // vec![]
     }
 }

--- a/jolt-core/src/r1cs/key.rs
+++ b/jolt-core/src/r1cs/key.rs
@@ -260,8 +260,16 @@ impl<const C: usize, F: JoltField, I: ConstraintInput> UniformSpartanKey<C, I, F
     }
 
     /// (Verifier) Evaluates the full expanded witness vector at 'r' using evaluations of segments.
-    #[tracing::instrument(skip_all, name = "UniformSpartanKey::evaluate_z_mle_with_segment_evals")]
-    pub fn evaluate_z_mle_with_segment_evals(&self, segment_evals: &[F], r: &[F], with_const: bool) -> F {
+    #[tracing::instrument(
+        skip_all,
+        name = "UniformSpartanKey::evaluate_z_mle_with_segment_evals"
+    )]
+    pub fn evaluate_z_mle_with_segment_evals(
+        &self,
+        segment_evals: &[F],
+        r: &[F],
+        with_const: bool,
+    ) -> F {
         assert_eq!(self.uniform_r1cs.num_vars, segment_evals.len());
         assert_eq!(r.len(), self.num_vars_uniform_padded().log_2() + 1);
 
@@ -271,9 +279,9 @@ impl<const C: usize, F: JoltField, I: ConstraintInput> UniformSpartanKey<C, I, F
         let var_and_const_bits = var_bits + 1;
 
         let r_const = r[0];
-        let r_var= &r[1..var_bits + 1];
+        let r_var = &r[1..var_bits + 1];
 
-        let eq_ry_var= EqPolynomial::evals(r_var);
+        let eq_ry_var = EqPolynomial::evals(r_var);
         let eval_variables: F = (0..self.uniform_r1cs.num_vars)
             .map(|var_index| eq_ry_var[var_index] * segment_evals[var_index])
             .sum();

--- a/jolt-core/src/r1cs/key.rs
+++ b/jolt-core/src/r1cs/key.rs
@@ -14,8 +14,6 @@ use sha3::Digest;
 
 use crate::utils::math::Math;
 
-use rayon::prelude::*;
-
 #[derive(CanonicalSerialize, CanonicalDeserialize)]
 pub struct UniformSpartanKey<const C: usize, I: ConstraintInput, F: JoltField> {
     _inputs: PhantomData<I>,

--- a/jolt-core/src/r1cs/key.rs
+++ b/jolt-core/src/r1cs/key.rs
@@ -5,7 +5,7 @@ use sha3::Sha3_256;
 
 use crate::{
     field::JoltField,
-    poly::eq_poly::{EqPolynomial, EqPlusOnePolynomial},
+    poly::eq_poly::EqPolynomial,
     utils::{index_to_field_bitvector, mul_0_1_optimized, thread::unsafe_allocate_zero_vec},
 };
 

--- a/jolt-core/src/r1cs/key.rs
+++ b/jolt-core/src/r1cs/key.rs
@@ -298,7 +298,6 @@ impl<const C: usize, F: JoltField, I: ConstraintInput> UniformSpartanKey<C, I, F
     pub fn evaluate_matrix_mle_full(
         &self,
         rx_constr: &[F],
-        rx_step: &[F],
         ry_var: &[F],
         r_non_uni: &F,
     ) -> (F, F, F) {

--- a/jolt-core/src/r1cs/spartan.rs
+++ b/jolt-core/src/r1cs/spartan.rs
@@ -266,8 +266,8 @@ where
         assert_eq!(bind_z_ry_var.len(), eq_plus_one_rx_step.len());
 
         let mut shift_sumcheck_polys = vec![
-            MultilinearPolynomial::LargeScalars(DensePolynomial::new(bind_z_ry_var)),
-            MultilinearPolynomial::LargeScalars(DensePolynomial::new(eq_plus_one_rx_step)),
+            MultilinearPolynomial::from(bind_z_ry_var),
+            MultilinearPolynomial::from(eq_plus_one_rx_step),
         ];
 
         let shift_sumcheck_claim = (0..1 << num_rounds_shift_sumcheck)

--- a/jolt-core/src/r1cs/spartan.rs
+++ b/jolt-core/src/r1cs/spartan.rs
@@ -173,8 +173,9 @@ where
 
         let (rx_step, rx_constr) = outer_sumcheck_r.split_at(num_steps_bits);
 
-        let eq_rx_step = EqPolynomial::evals(rx_step);
-        let eq_plus_one_rx_step = EqPlusOnePolynomial::evals(rx_step);
+        let (eq_rx_step, eq_plus_one_rx_step) = EqPlusOnePolynomial::evals(rx_step, None);
+        let (eq_rx_step_r2, eq_plus_one_rx_step_r2) =
+            EqPlusOnePolynomial::evals(rx_step, F::montgomery_r2());
 
         /* Compute the two polynomials provided as input to the second sumcheck:
            - poly_ABC: A(r_x, y_var || rx_step), A_shift(..) at all variables y_var
@@ -198,15 +199,9 @@ where
             .par_iter()
             .zip(bind_z.par_iter_mut().zip(bind_shift_z.par_iter_mut()))
             .for_each(|(poly, (eval, eval_shifted))| {
-                let result = (0..poly.original_len())
-                    .into_par_iter()
-                    .map(|t| {
-                        let coeff = poly.get_coeff(t);
-                        (coeff * eq_rx_step[t], coeff * eq_plus_one_rx_step[t])
-                    })
-                    .reduce(|| (F::zero(), F::zero()), |a, b| (a.0 + b.0, a.1 + b.1));
-
-                (*eval, *eval_shifted) = (result.0, result.1);
+                *eval = poly.dot_product(Some(&eq_rx_step), Some(&eq_rx_step_r2));
+                *eval_shifted =
+                    poly.dot_product(Some(&eq_plus_one_rx_step), Some(&eq_plus_one_rx_step_r2));
             });
 
         bind_z[num_vars_padded] = F::one();
@@ -248,6 +243,7 @@ where
 
         let ry_var = inner_sumcheck_r[1..].to_vec();
         let eq_ry_var = EqPolynomial::evals(&ry_var);
+        let eq_ry_var_r2 = EqPolynomial::evals_with_r2(&ry_var);
 
         let mut bind_z_ry_var: Vec<F> = Vec::with_capacity(num_steps_padded);
 
@@ -259,7 +255,7 @@ where
                 flattened_polys
                     .iter()
                     .enumerate()
-                    .map(|(i, poly)| poly.get_coeff(t) * eq_ry_var[i])
+                    .map(|(i, poly)| poly.scale_coeff(t, eq_ry_var[i], eq_ry_var_r2[i]))
                     .sum()
             })
             .collect_into_vec(&mut bind_z_ry_var);

--- a/jolt-core/src/r1cs/spartan.rs
+++ b/jolt-core/src/r1cs/spartan.rs
@@ -8,8 +8,6 @@ use crate::field::JoltField;
 use crate::jolt::vm::JoltCommitments;
 use crate::jolt::vm::JoltPolynomials;
 use crate::poly::commitment::commitment_scheme::CommitmentScheme;
-use crate::poly::multilinear_polynomial::BindingOrder;
-use crate::poly::multilinear_polynomial::PolynomialBinding;
 use crate::poly::multilinear_polynomial::MultilinearPolynomial;
 use crate::poly::multilinear_polynomial::PolynomialEvaluation;
 use crate::poly::opening_proof::ProverOpeningAccumulator;
@@ -32,7 +30,6 @@ use crate::{
 
 use super::builder::CombinedUniformBuilder;
 use super::inputs::ConstraintInput;
-use super::key::Coeff;
 
 #[derive(Clone, Debug, Eq, PartialEq, Error)]
 pub enum SpartanError {
@@ -416,7 +413,7 @@ where
         let y_prime = [ry_var.clone(), rx_step.to_owned()].concat();
         let eval_z = key.evaluate_z_mle(&self.claimed_witness_evals, &y_prime, true);
 
-        let (eval_a, eval_b, eval_c) = key.evaluate_matrix_mle_full(&rx_constr, &rx_step, &ry_var, &r_non_uni);
+        let (eval_a, eval_b, eval_c) = key.evaluate_matrix_mle_full(rx_constr, rx_step, &ry_var, &r_non_uni);
 
         let left_expected = eval_a
             + inner_sumcheck_RLC * eval_b

--- a/jolt-core/src/r1cs/spartan.rs
+++ b/jolt-core/src/r1cs/spartan.rs
@@ -1,6 +1,8 @@
 #![allow(clippy::len_without_is_empty)]
 
 use std::marker::PhantomData;
+use tracing::{span, Level}; 
+use rayon::prelude::*;
 
 use crate::field::JoltField;
 use crate::jolt::vm::JoltCommitments;
@@ -22,7 +24,7 @@ use ark_serialize::CanonicalSerialize;
 use thiserror::Error;
 
 use crate::{
-    poly::{dense_mlpoly::DensePolynomial, eq_poly::EqPolynomial},
+    poly::{dense_mlpoly::DensePolynomial, eq_poly::{EqPolynomial, EqPlusOnePolynomial}},
     subprotocols::sumcheck::SumcheckInstanceProof,
 };
 
@@ -78,7 +80,10 @@ pub struct UniformSpartanProof<
     pub(crate) outer_sumcheck_proof: SumcheckInstanceProof<F, ProofTranscript>,
     pub(crate) outer_sumcheck_claims: (F, F, F),
     pub(crate) inner_sumcheck_proof: SumcheckInstanceProof<F, ProofTranscript>,
+    pub(crate) shift_sumcheck_proof: SumcheckInstanceProof<F, ProofTranscript>,
+    pub(crate) shift_sumcheck_claim: F,
     pub(crate) claimed_witness_evals: Vec<F>,
+    pub(crate) claimed_witness_evals_shift_sumcheck: Vec<F>,
     _marker: PhantomData<ProofTranscript>,
 }
 
@@ -119,7 +124,7 @@ where
         let num_rounds_x = key.num_rows_bits();
         let num_rounds_y = key.num_cols_total().log_2();
 
-        // outer sum-check
+        /* Sumcheck 1: Outer sumcheck */
         let tau = (0..num_rounds_x)
             .map(|_i| transcript.challenge_scalar())
             .collect::<Vec<F>>();
@@ -144,41 +149,178 @@ where
             outer_sumcheck_claims[1],
             outer_sumcheck_claims[2],
         );
+        
+        /* Sumcheck 2: Inner sumcheck */
+        /*
+            sumcheck claim:  
+         */
 
-        // inner sum-check
-        let r_inner_sumcheck_RLC: F = transcript.challenge_scalar();
+        let num_steps_padded = constraint_builder.uniform_repeat().next_power_of_two();
+        let num_steps_bits = num_steps_padded.ilog2() as usize;
+
+        let inner_sumcheck_RLC: F = transcript.challenge_scalar();
         let claim_inner_joint = claim_Az
-            + r_inner_sumcheck_RLC * claim_Bz
-            + r_inner_sumcheck_RLC * r_inner_sumcheck_RLC * claim_Cz;
+            + inner_sumcheck_RLC * claim_Bz
+            + inner_sumcheck_RLC * inner_sumcheck_RLC * claim_Cz;
 
         // this is the polynomial extended from the vector r_A * A(r_x, y) + r_B * B(r_x, y) + r_C * C(r_x, y) for all y
+        let num_vars_padded = key.num_vars_uniform_padded();
         let num_constr_bits = constraint_builder.padded_rows_per_step().ilog2() as usize;
-        let (rx_ts, rx_con) = outer_sumcheck_r.split_at(outer_sumcheck_r.len() - num_constr_bits);
-        let mut poly_ABC =
-            DensePolynomial::new(key.evaluate_r1cs_mle_rlc(rx_con, rx_ts, r_inner_sumcheck_RLC));
+        let num_step_bits = outer_sumcheck_r.len() - num_constr_bits;
+
+        let (rx_step, rx_con) = outer_sumcheck_r.split_at(num_step_bits);
+
+        let eq_rx_step = EqPolynomial::evals(rx_step);
+
+        let mut eq_plus_one_rx_step  = vec![];
+        let span = span!(Level::INFO, "evals_eq_plus_one");
+        {
+            eq_plus_one_rx_step = EqPlusOnePolynomial::evals(rx_step);
+        }
+
+        // A(rx_con || rx_step, y_var || rx_step) evaluated at each y_var
+        let poly_ABC = DensePolynomial::new(
+            key.evaluate_r1cs_mle_rlc(rx_con, rx_step, inner_sumcheck_RLC)
+        );
+
+        let mut evals: Vec<F> = Vec::with_capacity(num_vars_padded * 2);
+        let mut evals_shifted: Vec<F> = Vec::with_capacity(num_vars_padded * 2);
+
+        let span = span!(Level::INFO, "evals_z");
+        {
+        evals = flattened_polys
+            .iter()
+            .map(|poly| {
+                (0..poly.original_len())
+                    .into_iter()
+                    .map(|t| {
+                        poly.get_coeff(t) *  eq_rx_step[t]
+                    })
+                    .sum()
+            })
+            .collect();
+        evals.resize(evals.len().next_power_of_two(), F::zero());
+        evals.push(F::one()); // Constant
+        evals.resize(evals.len().next_power_of_two(), F::zero());
+        }
+
+
+        let span = span!(Level::INFO, "evals_z");
+        {
+        evals_shifted = flattened_polys
+            .iter()
+            .map(|poly| {
+                (0..poly.original_len())
+                .into_iter()
+                .map(|t| {
+                        poly.get_coeff(t) * eq_plus_one_rx_step[t] 
+                    })
+                    .sum()
+            })
+            .collect();
+        evals_shifted.resize(evals.len(), F::zero());
+        }
+
+        let poly_z = DensePolynomial::new(evals.into_iter().chain(evals_shifted.into_iter()).collect());
+        assert_eq!(poly_z.len(), poly_ABC.len());
+
+        let num_rounds = poly_ABC.len().log_2();
+        
+        let mut polys = vec![
+            MultilinearPolynomial::LargeScalars(poly_ABC), 
+            MultilinearPolynomial::LargeScalars(poly_z)
+        ]; 
+
+        let comb_func = |poly_evals: &[F]| -> F {
+            assert_eq!(poly_evals.len(), 2);
+            poly_evals[0] * poly_evals[1]
+        };
 
         let (inner_sumcheck_proof, inner_sumcheck_r, _claims_inner) =
-            SumcheckInstanceProof::prove_spartan_quadratic(
+            SumcheckInstanceProof::prove_arbitrary(
                 &claim_inner_joint, // r_A * v_A + r_B * v_B + r_C * v_C
-                num_rounds_y,
-                &mut poly_ABC, // r_A * A(r_x, y) + r_B * B(r_x, y) + r_C * C(r_x, y) for all y
-                &flattened_polys,
+                num_rounds,
+                &mut polys, // r_A * A(r_x, y) + r_B * B(r_x, y) + r_C * C(r_x, y) for all y
+                comb_func,
+                2,
                 transcript,
             );
-        drop_in_background_thread(poly_ABC);
+        drop_in_background_thread(polys);
 
-        // Requires 'r_col_segment_bits' to index the (const, segment). Within that segment we index the step using 'r_col_step'
-        let r_col_segment_bits = key.uniform_r1cs.num_vars.next_power_of_two().log_2() + 1;
-        let r_col_step = &inner_sumcheck_r[r_col_segment_bits..];
+        let r_y_var = inner_sumcheck_r[1..].to_vec();
+        assert_eq!(r_y_var.len(), key.num_vars_uniform_padded().log_2() + 1);
+
+        let eq_ry_var = EqPolynomial::evals(&r_y_var);
+
+        /*  Sumcheck 3: the shift sumcheck */
+
+        /*  Binding 2: evaluating z on r_y_var
+            TODO(arasuarun): this might lead to inefficient memory paging 
+            as we access each poly in flattened_poly num_steps_padded-many times.
+        */ 
+        let mut evals_z_r_y_var: Vec<F> = Vec::with_capacity(num_steps_padded);
+
+        let span = span!(Level::INFO, "evals_z_r_y_var");
+        {
+        let _enter = span.enter();
+        evals_z_r_y_var = (0..constraint_builder.uniform_repeat())
+            .into_par_iter()
+            .map(|t| {
+                flattened_polys
+                    .par_iter()
+                    .enumerate()
+                    .map(|(i, poly)| {
+                        poly.get_coeff(t) * eq_ry_var[i]
+                    })
+                    .sum()
+            })
+            .collect();
+        }
+
+        let num_rounds_shift_sumcheck = num_steps_bits; 
+        assert_eq!(evals_z_r_y_var.len(), 1 << num_rounds_shift_sumcheck); 
+        let mut shift_sumcheck_polys = vec![
+            MultilinearPolynomial::LargeScalars(DensePolynomial::new(evals_z_r_y_var)),
+            MultilinearPolynomial::LargeScalars(DensePolynomial::new(eq_plus_one_rx_step)),
+        ];
+
+        let shift_sumcheck_claim = (0..1 << num_rounds_shift_sumcheck) 
+            .into_par_iter()
+            .map(|i| {
+                let params: Vec<F> = shift_sumcheck_polys.iter().map(|poly| poly.get_coeff(i)).collect();
+                comb_func(&params)
+            })
+            .reduce(|| F::zero(), |acc, x| acc + x);
+
+        let (shift_sumcheck_proof, shift_sumcheck_r, shift_sumcheck_claims) =
+            SumcheckInstanceProof::prove_arbitrary(
+                &shift_sumcheck_claim, 
+                num_rounds_shift_sumcheck, 
+                &mut shift_sumcheck_polys, 
+                comb_func, 
+                2, 
+                transcript);
+        drop_in_background_thread(shift_sumcheck_polys);
 
         let (claimed_witness_evals, chis) =
-            MultilinearPolynomial::batch_evaluate(&flattened_polys, r_col_step);
+            MultilinearPolynomial::batch_evaluate(&flattened_polys, rx_step);
 
         opening_accumulator.append(
             &flattened_polys,
             DensePolynomial::new(chis),
-            r_col_step.to_vec(),
+            rx_step.to_vec(),
             &claimed_witness_evals,
+            transcript,
+        );
+
+        let (claimed_witness_evals_shift_sumcheck, chis2) =
+            MultilinearPolynomial::batch_evaluate(&flattened_polys, &shift_sumcheck_r);
+
+        opening_accumulator.append(
+            &flattened_polys,
+            DensePolynomial::new(chis2),
+            shift_sumcheck_r.to_vec(),
+            &claimed_witness_evals_shift_sumcheck,
             transcript,
         );
 
@@ -193,7 +335,10 @@ where
             outer_sumcheck_proof,
             outer_sumcheck_claims,
             inner_sumcheck_proof,
+            shift_sumcheck_proof,
+            shift_sumcheck_claim,
             claimed_witness_evals,
+            claimed_witness_evals_shift_sumcheck,
             _marker: PhantomData,
         })
     }
@@ -210,7 +355,7 @@ where
         PCS: CommitmentScheme<ProofTranscript, Field = F>,
         ProofTranscript: Transcript,
     {
-        let num_rounds_x = key.num_rows_bits();
+        let num_rounds_x = key.num_rows_total().log_2();
         let num_rounds_y = key.num_cols_total().log_2();
 
         // outer sum-check
@@ -218,17 +363,17 @@ where
             .map(|_i| transcript.challenge_scalar())
             .collect::<Vec<F>>();
 
-        let (claim_outer_final, r_x) = self
+        let (claim_outer_final, outer_sumcheck_r) = self
             .outer_sumcheck_proof
             .verify(F::zero(), num_rounds_x, 3, transcript)
             .map_err(|_| SpartanError::InvalidOuterSumcheckProof)?;
 
         // Outer sumcheck is bound from the top, reverse the fiat shamir randomness
-        let r_x: Vec<F> = r_x.into_iter().rev().collect();
+        let outer_sumcheck_r: Vec<F> = outer_sumcheck_r.into_iter().rev().collect();
 
         // verify claim_outer_final
         let (claim_Az, claim_Bz, claim_Cz) = self.outer_sumcheck_claims;
-        let taus_bound_rx = EqPolynomial::new(tau).evaluate(&r_x);
+        let taus_bound_rx = EqPolynomial::new(tau).evaluate(&outer_sumcheck_r);
         let claim_outer_final_expected = taus_bound_rx * (claim_Az * claim_Bz - claim_Cz);
         if claim_outer_final != claim_outer_final_expected {
             return Err(SpartanError::InvalidOuterSumcheckClaim);
@@ -244,30 +389,58 @@ where
         );
 
         // inner sum-check
-        let r_inner_sumcheck_RLC: F = transcript.challenge_scalar();
+        let inner_sumcheck_RLC: F = transcript.challenge_scalar();
         let claim_inner_joint = self.outer_sumcheck_claims.0
-            + r_inner_sumcheck_RLC * self.outer_sumcheck_claims.1
-            + r_inner_sumcheck_RLC * r_inner_sumcheck_RLC * self.outer_sumcheck_claims.2;
+            + inner_sumcheck_RLC * self.outer_sumcheck_claims.1
+            + inner_sumcheck_RLC * inner_sumcheck_RLC * self.outer_sumcheck_claims.2;
 
+        let num_rounds = (2 * key.num_vars_uniform_padded()).log_2() + 1; // +1 for cross-step
         let (claim_inner_final, inner_sumcheck_r) = self
             .inner_sumcheck_proof
-            .verify(claim_inner_joint, num_rounds_y, 2, transcript)
+            .verify(claim_inner_joint, num_rounds, 2, transcript) 
             .map_err(|_| SpartanError::InvalidInnerSumcheckProof)?;
 
-        // n_prefix = n_segments + 1
-        let n_prefix = key.uniform_r1cs.num_vars.next_power_of_two().log_2() + 1;
+        // let inner_sumcheck_r: Vec<F> = inner_sumcheck_r.into_iter().rev().collect();
 
-        let eval_Z = key.evaluate_z_mle(&self.claimed_witness_evals, &inner_sumcheck_r);
+        let n_constraint_bits_uniform = key.uniform_r1cs.num_rows.next_power_of_two().log_2();
+        let num_step_bits = key.num_steps.log_2();
+        let outer_sumcheck_r_step = &outer_sumcheck_r[..num_step_bits];
+        
+        let r_choice = inner_sumcheck_r[0]; 
+        let r_y_var = inner_sumcheck_r[1..].to_vec();
+        let y_prime = [r_y_var.clone(), outer_sumcheck_r_step.to_owned()].concat();
+        let eval_z = key.evaluate_z_mle(&self.claimed_witness_evals, &y_prime, true);
 
-        let r_y = inner_sumcheck_r.clone();
-        let (eval_a, eval_b, eval_c) = key.evaluate_r1cs_matrix_mles(&r_x, &r_y);
+        let r = [outer_sumcheck_r.clone(), y_prime].concat();
+        let (eval_a, eval_b, eval_c) = key.evaluate_r1cs_matrix_mles(&r, &r_choice);
 
         let left_expected = eval_a
-            + r_inner_sumcheck_RLC * eval_b
-            + r_inner_sumcheck_RLC * r_inner_sumcheck_RLC * eval_c;
-        let right_expected = eval_Z;
+            + inner_sumcheck_RLC * eval_b
+            + inner_sumcheck_RLC * inner_sumcheck_RLC * eval_c;
+        let right_expected = 
+            (F::one() - r_choice) * eval_z + 
+            r_choice * self.shift_sumcheck_claim; 
+
         let claim_inner_final_expected = left_expected * right_expected;
+
+        assert_eq!(claim_inner_final, claim_inner_final_expected);
         if claim_inner_final != claim_inner_final_expected {
+            return Err(SpartanError::InvalidInnerSumcheckClaim);
+        }
+
+        let num_steps_bits = outer_sumcheck_r_step.len();
+        let num_rounds_shift_sumcheck = num_steps_bits;
+        let (claim_shift_final, shift_sumcheck_r) = self
+            .shift_sumcheck_proof
+            .verify(self.shift_sumcheck_claim, num_rounds_shift_sumcheck, 2, transcript) 
+            .map_err(|_| SpartanError::InvalidInnerSumcheckProof)?;
+
+        let y_prime_shift_sumcheck = [r_y_var, shift_sumcheck_r.to_owned()].concat(); 
+        let eval_z_shift_sumcheck = key.evaluate_z_mle(&self.claimed_witness_evals_shift_sumcheck, &y_prime_shift_sumcheck, false);
+        let eq_plus_one_shift_sumcheck = EqPlusOnePolynomial::new(outer_sumcheck_r_step.to_vec()).evaluate(&shift_sumcheck_r);
+        let claim_shift_sumcheck_expected = eval_z_shift_sumcheck * eq_plus_one_shift_sumcheck; 
+        assert_eq!(claim_shift_final, claim_shift_sumcheck_expected);
+        if claim_shift_final != claim_shift_sumcheck_expected {
             return Err(SpartanError::InvalidInnerSumcheckClaim);
         }
 
@@ -275,11 +448,19 @@ where
             .iter()
             .map(|var| var.get_ref(commitments))
             .collect();
-        let r_y_point = &inner_sumcheck_r[n_prefix..];
+
+        let r_y_point = outer_sumcheck_r_step; 
         opening_accumulator.append(
             &flattened_commitments,
             r_y_point.to_vec(),
             &self.claimed_witness_evals.iter().collect::<Vec<_>>(),
+            transcript,
+        );
+
+        opening_accumulator.append(
+            &flattened_commitments,
+            shift_sumcheck_r.to_vec(),
+            &self.claimed_witness_evals_shift_sumcheck.iter().collect::<Vec<_>>(),
             transcript,
         );
 

--- a/jolt-core/src/r1cs/spartan.rs
+++ b/jolt-core/src/r1cs/spartan.rs
@@ -249,7 +249,7 @@ where
         let span = span!(Level::INFO, "bind_z_ry_var");
         let _guard = span.enter();
         let num_steps_unpadded = constraint_builder.uniform_repeat();
-        (0..num_steps_unpadded) // unpadded number of steps is sufficient 
+        (0..num_steps_unpadded) // unpadded number of steps is sufficient
             .into_par_iter()
             .map(|t| {
                 flattened_polys
@@ -381,11 +381,11 @@ where
         );
 
         /* Sumcheck 2: Inner sumcheck
-            - claim is an RLC of claims_Az, Bz, Cz
-            where claim_Az = \sum_{y_var} A(rx, y_var || rx_step) * z(y_var || rx_step)
-                                + A_shift(..) * z_shift(..)
-            - verifying it involves computing each term with randomness ry_var 
-         */
+           - claim is an RLC of claims_Az, Bz, Cz
+           where claim_Az = \sum_{y_var} A(rx, y_var || rx_step) * z(y_var || rx_step)
+                               + A_shift(..) * z_shift(..)
+           - verifying it involves computing each term with randomness ry_var
+        */
         let inner_sumcheck_RLC: F = transcript.challenge_scalar();
         let claim_inner_joint = self.outer_sumcheck_claims.0
             + inner_sumcheck_RLC * self.outer_sumcheck_claims.1
@@ -403,7 +403,8 @@ where
 
         let r_non_uni = inner_sumcheck_r[0];
         let ry_var = inner_sumcheck_r[1..].to_vec();
-        let eval_z = key.evaluate_z_mle_with_segment_evals(&self.claimed_witness_evals, &ry_var, true);
+        let eval_z =
+            key.evaluate_z_mle_with_segment_evals(&self.claimed_witness_evals, &ry_var, true);
 
         let (eval_a, eval_b, eval_c) = key.evaluate_matrix_mle_full(rx_constr, &ry_var, &r_non_uni);
 

--- a/jolt-core/src/subprotocols/sumcheck.rs
+++ b/jolt-core/src/subprotocols/sumcheck.rs
@@ -108,6 +108,18 @@ impl<F: JoltField, ProofTranscript: Transcript> SumcheckInstanceProof<F, ProofTr
         let mut r: Vec<F> = Vec::new();
         let mut compressed_polys: Vec<CompressedUniPoly<F>> = Vec::new();
 
+        #[cfg(test)]
+        {
+            let total_evals = 1 << num_rounds;
+            let mut sum = F::zero();
+            for i in 0..total_evals {
+                let params: Vec<F> = polys.iter().map(|poly| poly.get_coeff(i)).collect();
+                sum += comb_func(&params);
+            }
+            assert_eq!(&sum, claim, "Sumcheck claim is wrong");
+        }
+
+
         for _round in 0..num_rounds {
             // Vector storing evaluations of combined polynomials g(x) = P_0(x) * ... P_{num_polys} (x)
             // for points {0, ..., |g(x)|}

--- a/jolt-core/src/subprotocols/sumcheck.rs
+++ b/jolt-core/src/subprotocols/sumcheck.rs
@@ -119,7 +119,6 @@ impl<F: JoltField, ProofTranscript: Transcript> SumcheckInstanceProof<F, ProofTr
             assert_eq!(&sum, claim, "Sumcheck claim is wrong");
         }
 
-
         for _round in 0..num_rounds {
             // Vector storing evaluations of combined polynomials g(x) = P_0(x) * ... P_{num_polys} (x)
             // for points {0, ..., |g(x)|}


### PR DESCRIPTION
Optimization crushing the second Spartan sumcheck. Instead of the inner sumcheck with `a * b` rounds where `a = num_vars_padded` and `b = num_steps_padded`, we now perform two sumchecks of `a` rounds and `b` rounds, respectively. 

There's a lot to document. I'm making the PR for now to unblock @moodlezoup's other optimizations. 

Edit: The below change is no longer needed. The optimization works with the trace as is. 
~~A *major* change in the code that we should discuss before merging:~~ 
- ~~There was an issue with how the cross-step (also called "non-uniform" constraints) were handled for the last step. Now, the changes in this PR assume that all witness elements belonging to the last step are 0, so the step is effectively ignored. This requires some changes to the trace polynomials (in `builder.rs`).~~
- ~~In particular, this means that if a program runs for *exactly* a power of 2 number of steps, we'd still need to pad it to the next power of 2. I don't think this is an issue for now but might pop up if we're sharding programs later for folding.~~

How ready is the PR? It's good enough to build on but needs cleanup before merging into main. 
- Needs code cleanup like variable names and so on (especially in `key.rs`). 
- I don't think there are any major wasteful clones. 
- Needs a sweep to see which parts can be parallelized better. Particularly a loop in the prover function that possibly runs into some of the old paging issues we faced before.

Also need to test with flamegraphs to make sure we're seeing the right performance improvements in the prover's sumchecks. 

Update: Performance improvement on Macbook M3.

| Trace Len | on Main  | with Opt | % improvement |
|-----------|------:|------------:|------:|
| 350k      |  1.3s |        1.0s |   23% |
| 1.3m      |  5.5s |        3.8s |   31% |
| 2.6m      | 10.5s |        7.7s |   27% |
| 10m       |   87s |         31s |   66% |

At 10m, total Jolt prove time sees a 33% improvement. 
