### PR TITLE
Fix typos

### DIFF
--- a/jolt-evm-verifier/src/subprotocols/FiatShamirTranscript.sol
+++ b/jolt-evm-verifier/src/subprotocols/FiatShamirTranscript.sol
@@ -89,7 +89,7 @@ library FiatShamirTranscript {
         ///      of stepping
     }
 
-    /// We append a point of a N/pN x N/pN where p is less than 2^256 and the point is encoded as (32 bytes, 32 bytes)
+    /// We append a point of an N/pN x N/pN where p is less than 2^256 and the point is encoded as (32 bytes, 32 bytes)
     /// On eth mainnet this will be a point on the bn256 pairing curve which there is a precompile for
     /// WARN - This function assumes that the caller has done the mod to ensure the top bits are zero for x and y
     /// @param transcript The transcript we are hashing the value into

--- a/jolt-evm-verifier/src/subprotocols/HyperKZG.sol
+++ b/jolt-evm-verifier/src/subprotocols/HyperKZG.sol
@@ -164,7 +164,7 @@ contract HyperKZG {
             accumulated_q = q * accumulated_q;
         }
 
-        // Finally we do a MSM to get the value of the the left hand side
+        // Finally we do an MSM to get the value of the the left hand side
         // NOTE - This is gas inefficient and grows with log of the proof size so we might want
         //        to move to a pippenger window algo with much smaller MSMs which we might save gas on.
         // Our first value is the c_x c_y as this would be the first entry of com in rust.


### PR DESCRIPTION
This pull request corrects typos in two files:

1. **FiatShamirTranscript.sol**: Corrected the use of the article "a" to "an" in the comment.
2. **HyperKZG.sol**: Corrected the use of the article "a" to "an" in the comment.
