### PR TITLE
fix: trait methods without implementations must end with a semicolon

### DIFF
--- a/common/src/serializable.rs
+++ b/common/src/serializable.rs
@@ -29,7 +29,7 @@ where
 
     fn deserialize_from_file(path: &Path) -> Result<Self, std::io::Error>
     where
-        Self: Sized,
+        Self: Sized;
     {
         let mut file = File::open(path)?;
         let mut contents = String::new();


### PR DESCRIPTION
In the `Serializable` trait, in the declaration of the `deserialize_from_file` method, a semicolon is missing after the `where Self: Sized` clause.

P.S. In Rust, trait methods without implementations must end with a semicolon.