### PR TITLE
Fix typos 

### DIFF
--- a/book/src/future/proof-size-breakdown.md
+++ b/book/src/future/proof-size-breakdown.md
@@ -47,7 +47,7 @@ and one attests to the validity of initialization of memory plus a final pass ov
 The reason we do not run these grand products "together as one big grand product" is they are 
 each potentially of different sizes,
 and it is annoying (though possible) to "batch prove" differently-sized grand products together.
-However, a relatively easy way to get down to 3 grand prodcuts is to set the memory size
+However, a relatively easy way to get down to 3 grand products is to set the memory size
 in each of the three categories above to equal the number of reads/writes. This simply involves 
 padding the memory with zeros to make it equal in size to 
 the number of reads/writes into the memory (i.e., NUM_CYCLES). Doing this will not substantially increase

--- a/jolt-core/src/jolt/instruction/remu.rs
+++ b/jolt-core/src/jolt/instruction/remu.rs
@@ -9,7 +9,7 @@ use crate::jolt::instruction::{
     JoltInstruction,
 };
 
-/// Perform unsigned divison and return remainder
+/// Perform unsigned division and return remainder
 pub struct REMUInstruction<const WORD_SIZE: usize>;
 
 impl<const WORD_SIZE: usize> VirtualInstructionSequence for REMUInstruction<WORD_SIZE> {


### PR DESCRIPTION
# Fix Typos in Documentation and Code Comments

## Description

This pull request fixes minor typos in the following files:

1. **Documentation (`proof-size-breakdown.md`)**:
   - Corrected "prodcuts" → "products".

2. **Code Comment (`remu.rs`)**:
   - Fixed the typo in the comment:
     - "divison" → "division".

These are editorial changes that do not impact functionality.

## Changes Made

### File: `book/src/future/proof-size-breakdown.md`
- Fixed "prodcuts" to "products".

### File: `jolt-core/src/jolt/instruction/remu.rs`
- Corrected a comment typo: "divison" → "division".

## Checklist
- [x] Documentation is typo-free.
- [x] Code comments are clear and grammatically correct.
- [x] No functional changes were made to the codebase.

## Additional Notes
These changes are small but help improve the quality of the documentation and code readability.
