### PR TITLE
Fix typos in documentation

### DIFF
--- a/book/src/future/folding.md
+++ b/book/src/future/folding.md
@@ -21,7 +21,7 @@ and the details will be fully fleshed out in an upcoming e-print.</LI>
 </OL>
 
 Note that this plan does not require "non-uniform folding". The fact that there are many different primitive RISC-V 
-instructions is handled by "monolithic Jolt". Folding is merely applied to accumluate many copies of the same claim,
+instructions is handled by "monolithic Jolt". Folding is merely applied to accumulate many copies of the same claim,
 namely that a Jolt proof (minus any HyperKZG evaluation proof) was correctly verified. 
 
 # Space cost estimates

--- a/book/src/future/proof-size-breakdown.md
+++ b/book/src/future/proof-size-breakdown.md
@@ -6,7 +6,7 @@ Here is the breakdown of contributors to proof size:
 
 <OL>
 <LI> In Jolt, we commit to about 250 polynomials and produce just one HyperKZG evaluation proof. 
-  It's one group element (about 32 bytes) per commitment, and an evaluation proof is a couple of dozen group group elements.
+  It's one group element (about 32 bytes) per commitment, and an evaluation proof is a couple of dozen group elements.
   So this is about 9 KBs total. 
 
   With some engineering headaches we could go below 9 KBs by committing to some of the 250 polynomials as a single, larger


### PR DESCRIPTION
## Changes Made

### In `book/src/future/folding.md`:
- Fixed spelling: "accumluate" → "accumulate"

### In `book/src/future/proof-size-breakdown.md`:
- Fixed duplicate word: "group group" → "group"