### PR TITLE
Fix grammar and remove duplicate words

### DIFF
--- a/jolt-evm-verifier/README.md
+++ b/jolt-evm-verifier/README.md
@@ -1,6 +1,6 @@
 # Jolt EVM Verifier
 
-This packages implements a verifier for the Jolt prover which can run in the EVM. 
+This package implements a verifier for the Jolt prover which can run in the EVM. 
 
 ## *WARNING THIS PACKAGE IS NEITHER COMPLETE NOR REVIEWED FOR SECURITY. DO NOT USE IN PRODUCTION.*
 

--- a/jolt-evm-verifier/src/subprotocols/HyperKZG.sol
+++ b/jolt-evm-verifier/src/subprotocols/HyperKZG.sol
@@ -20,7 +20,7 @@ contract HyperKZG {
     using FrLib for Fr;
 
     // These are initialized using the trusted setup values. NOTE - You must negate the point
-    // VK_g2 in order to have the checks pass, unlike the the rust which checks e(L, VK_G2) =
+    // VK_g2 in order to have the checks pass, unlike the rust which checks e(L, VK_G2) =
     // e(R, VK_Beta_G2) we use a precompile which checks e(L,-VK_G2)e(R, VK_Beta_G2) = 1
     uint256 immutable VK_g1_x;
     uint256 immutable VK_g1_y;
@@ -164,7 +164,7 @@ contract HyperKZG {
             accumulated_q = q * accumulated_q;
         }
 
-        // Finally we do a MSM to get the value of the the left hand side
+        // Finally we do a MSM to get the value of the left hand side
         // NOTE - This is gas inefficient and grows with log of the proof size so we might want
         //        to move to a pippenger window algo with much smaller MSMs which we might save gas on.
         // Our first value is the c_x c_y as this would be the first entry of com in rust.


### PR DESCRIPTION


## Changes Made

### In `jolt-evm-verifier/README.md`:
- Changed "packages" to "package"
- Old: `This packages implements a verifier`
- New: `This package implements a verifier`

### In `jolt-evm-verifier/src/subprotocols/HyperKZG.sol`:
- Removed duplicate word "the" in comments
- Old: `// Finally we do a MSM to get the value of the the left hand side`
- New: `// Finally we do a MSM to get the value of the left hand side`

## Reason for Changes
1. Grammar fix: "This package" is the correct singular form since we're referring to a single package/module. This improves readability and maintains proper English grammar.

2. Removed duplicate word: The word "the" was accidentally duplicated in the comment. This is a simple typo fix that improves code documentation clarity.

## Impact
These changes are documentation-only fixes and do not affect any functionality. They improve the readability and professionalism of the codebase.