### PR TITLE
fix: update broken link architecture.md

### DIFF
--- a/book/src/how/architecture.md
+++ b/book/src/how/architecture.md
@@ -25,7 +25,7 @@ To handle reads/writes to RAM (and registers) Jolt uses a memory checking argume
 
 ### R1CS constraints
 
-To handle the "fetch" part of the fetch-decode-execute loop, there is a minimal R1CS instance (about 60 constraints per cycle of the RISC-V VM). These constraints handle program counter (PC) updates and serves as the "glue" enforcing consistency between polynomials used in the components below. Jolt uses [Spartan](https://eprint.iacr.org/2019/550), optimized for the highly-structured nature of the constraint system (e.g., the R1CS constraint matrices are block-diagonal with blocks of size only about 60 x 80). This is implemented in [jolt-core/src/r1cs](../../../jolt-core/src/r1cs/).
+To handle the "fetch" part of the fetch-decode-execute loop, there is a minimal R1CS instance (about 60 constraints per cycle of the RISC-V VM). These constraints handle program counter (PC) updates and serves as the "glue" enforcing consistency between polynomials used in the components below. Jolt uses [Spartan](https://eprint.iacr.org/2019/550), optimized for the highly-structured nature of the constraint system (e.g., the R1CS constraint matrices are block-diagonal with blocks of size only about 60 x 80). This is implemented in [jolt-core/src/r1cs](https://github.com/a16z/jolt/tree/main/jolt-core/src/r1cs).
 
 *For more details: [R1CS constraints](./r1cs_constraints.md)*
 


### PR DESCRIPTION
Hi! I replaced the broken link in `architecture.md` with the correct link pointing to `jolt-core/src/r1cs/`
![image](https://github.com/user-attachments/assets/581c031c-a8c3-4bca-a4f8-9cb219cfcb5a)
![image](https://github.com/user-attachments/assets/966674ac-2884-4d32-8c7f-64f409777f24)