### PR TITLE
Update attributes.rs

### DIFF
--- a/common/src/attributes.rs
+++ b/common/src/attributes.rs
@@ -13,7 +13,7 @@ pub struct Attributes {
     pub max_output_size: u64,
 }
 
-pub fn parse_attributes(attr: &Vec<NestedMeta>) -> Attributes {
+pub fn parse_attributes(attr: &[NestedMeta]) -> Attributes {
     let mut attributes = HashMap::<_, u64>::new();
     let mut wasm = false;
 


### PR DESCRIPTION
Using &[NestedMeta] instead of Vec<NestedMeta> in the function signature can be a better choice, as ownership of the vector is not required