### PR TITLE
Reorder R1CS constraints

### DIFF
--- a/jolt-core/Cargo.toml
+++ b/jolt-core/Cargo.toml
@@ -105,8 +105,10 @@ default = [
     "ark-ff/asm",
     "host",
     "rayon",
+    "reorder",
 ]
 host = ["dep:reqwest", "dep:tokio"]
+reorder = []
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 memory-stats = "1.0.0"

--- a/jolt-core/src/jolt/vm/mod.rs
+++ b/jolt-core/src/jolt/vm/mod.rs
@@ -378,6 +378,7 @@ where
         let padded_trace_length = trace_length.next_power_of_two();
         println!("Trace length: {}", trace_length);
 
+        // TODO(JP): Drop padding on number of steps
         JoltTraceStep::pad(&mut trace);
 
         let mut transcript = ProofTranscript::new(b"Jolt transcript");

--- a/jolt-core/src/r1cs/builder.rs
+++ b/jolt-core/src/r1cs/builder.rs
@@ -580,12 +580,12 @@ impl<const C: usize, F: JoltField, I: ConstraintInput> CombinedUniformBuilder<C,
         let num_constraints =
             self.uniform_builder.constraints.len() + self.offset_equality_constraints.len();
         num_constraints.next_power_of_two()
-     }
+    }
 
     /// Total number of rows used across all repeated constraints. Not padded to nearest power of two.
     pub(super) fn constraint_rows(&self) -> usize {
         if cfg!(feature = "reorder") {
-            return self.uniform_repeat * self.padded_rows_per_step()
+            return self.uniform_repeat * self.padded_rows_per_step();
         }
 
         self.offset_eq_constraint_rows() + self.uniform_repeat_constraint_rows()
@@ -816,7 +816,7 @@ impl<const C: usize, F: JoltField, I: ConstraintInput> CombinedUniformBuilder<C,
             #[cfg(test)]
             self.assert_valid(flattened_polynomials, &az_poly, &bz_poly, &cz_poly);
 
-            return (az_poly, bz_poly, cz_poly)
+            return (az_poly, bz_poly, cz_poly);
         }
 
         let uniform_constraint_rows = self.uniform_repeat_constraint_rows();

--- a/jolt-core/src/r1cs/key.rs
+++ b/jolt-core/src/r1cs/key.rs
@@ -25,6 +25,7 @@ pub struct UniformSpartanKey<const C: usize, I: ConstraintInput, F: JoltField> {
     pub offset_eq_r1cs: NonUniformR1CS<F>,
 
     /// Number of constraints across all steps padded to nearest power of 2
+    // TODO: #[not(cfg(feature = "reorder"))]
     pub num_cons_total: usize,
 
     /// Number of steps padded to the nearest power of 2
@@ -112,6 +113,11 @@ impl<F: JoltField> NonUniformR1CS<F> {
 
         (eq_constants, condition_constants)
     }
+
+    /// Unpadded number of non-uniform constraints.
+    fn num_constraints(&self) -> usize {
+        self.constraints.len()
+    }
 }
 
 /// Represents a single constraint row where the variables are either from the current step (offset = false)
@@ -138,8 +144,9 @@ impl<const C: usize, F: JoltField, I: ConstraintInput> UniformSpartanKey<C, I, F
         let uniform_r1cs = constraint_builder.materialize_uniform();
         let offset_eq_r1cs = constraint_builder.materialize_offset_eq();
 
+        // TODO: #[not(cfg(feature = "reorder"))]
         let total_rows = constraint_builder.constraint_rows().next_power_of_two();
-        let num_steps = constraint_builder.uniform_repeat().next_power_of_two();
+        let num_steps = constraint_builder.uniform_repeat().next_power_of_two(); // TODO(JP): Number of steps no longer need to be padded.
 
         let vk_digest = Self::digest(&uniform_r1cs, &offset_eq_r1cs, num_steps);
 
@@ -147,6 +154,7 @@ impl<const C: usize, F: JoltField, I: ConstraintInput> UniformSpartanKey<C, I, F
             _inputs: PhantomData,
             uniform_r1cs,
             offset_eq_r1cs,
+            // TODO: #[not(cfg(feature = "reorder"))]
             num_cons_total: total_rows,
             num_steps,
             vk_digest,
@@ -167,8 +175,23 @@ impl<const C: usize, F: JoltField, I: ConstraintInput> UniformSpartanKey<C, I, F
         2 * self.num_vars_total()
     }
 
+    // TODO: #[not(cfg(feature = "reorder"))]
     pub fn num_rows_total(&self) -> usize {
         self.num_cons_total
+    }
+
+    /// Padded number of constraint rows per step.
+    // #[cfg(feature = "reorder")]
+    pub fn padded_row_constraint_per_step(&self) -> usize {
+        // JP: This is redundant with `padded_rows_per_step`. Can we reuse that instead?
+        (self.uniform_r1cs.num_rows + self.offset_eq_r1cs.num_constraints()).next_power_of_two()
+    }
+
+    /// Number of bits needed for all rows.
+    // #[cfg(feature = "reorder")]
+    pub fn num_rows_bits(&self) -> usize {
+        let row_count = self.num_steps * self.padded_row_constraint_per_step();
+        row_count.next_power_of_two().log_2()
     }
 
     /// Evaluates A(r_x, y) + r_rlc * B(r_x, y) + r_rlc^2 * C(r_x, y) where r_x = r_constr || r_step for all y.
@@ -213,9 +236,9 @@ impl<const C: usize, F: JoltField, I: ConstraintInput> UniformSpartanKey<C, I, F
             };
 
         let (eq_constants, condition_constants) = self.offset_eq_r1cs.constants();
-        let sm_a_r = compute_repeated(&self.uniform_r1cs.a, Some(eq_constants));
-        let sm_b_r = compute_repeated(&self.uniform_r1cs.b, Some(condition_constants));
-        let sm_c_r = compute_repeated(&self.uniform_r1cs.c, None);
+        let sm_a_r = compute_repeated(&self.uniform_r1cs.a, Some(eq_constants)); // V var entries
+        let sm_b_r = compute_repeated(&self.uniform_r1cs.b, Some(condition_constants)); // V var entries
+        let sm_c_r = compute_repeated(&self.uniform_r1cs.c, None); // V var entries
 
         let r_rlc_sq = r_rlc.square();
         let sm_rlc = sm_a_r
@@ -306,18 +329,28 @@ impl<const C: usize, F: JoltField, I: ConstraintInput> UniformSpartanKey<C, I, F
 
     /// Evaluates A(r), B(r), C(r) efficiently using their small uniform representations.
     #[tracing::instrument(skip_all, name = "UniformSpartanKey::evaluate_r1cs_matrix_mles")]
-    pub fn evaluate_r1cs_matrix_mles(&self, r: &[F]) -> (F, F, F) {
-        let total_rows_bits = self.num_rows_total().log_2();
-        let total_cols_bits = self.num_cols_total().log_2();
-        let steps_bits: usize = self.num_steps.log_2();
-        let constraint_rows_bits = (self.uniform_r1cs.num_rows + 1).next_power_of_two().log_2();
-        let uniform_cols_bits = self.uniform_r1cs.num_vars.next_power_of_two().log_2();
-        assert_eq!(r.len(), total_rows_bits + total_cols_bits);
-        assert_eq!(total_rows_bits - steps_bits, constraint_rows_bits);
+    pub fn evaluate_r1cs_matrix_mles(&self, r_row: &[F], r_col: &[F]) -> (F, F, F) {
+        let (total_cols_bits, steps_bits, constraint_rows_bits, r_row_constr, r_row_step) = if cfg!(feature = "reorder") {
+            let total_rows_bits = r_row.len();
+            let total_cols_bits = r_col.len();
+            let constraint_rows_bits = self.padded_row_constraint_per_step().log_2();
+            let steps_bits: usize = total_rows_bits - constraint_rows_bits;
+            let (r_row_step, r_row_constr) = r_row.split_at(total_rows_bits - constraint_rows_bits); // TMP
+            (total_cols_bits, steps_bits, constraint_rows_bits, r_row_constr, r_row_step)
+        } else {
+            let total_rows_bits = self.num_rows_total().log_2();
+            let total_cols_bits = self.num_cols_total().log_2();
+            let steps_bits: usize = self.num_steps.log_2();
+            let constraint_rows_bits = (self.uniform_r1cs.num_rows + 1).next_power_of_two().log_2();
+            assert_eq!(r_row.len(), total_rows_bits);
+            assert_eq!(r_col.len(), total_cols_bits);
+            assert_eq!(total_rows_bits - steps_bits, constraint_rows_bits);
 
-        // Deconstruct 'r' into representitive bits
-        let (r_row, r_col) = r.split_at(total_rows_bits);
-        let (r_row_constr, r_row_step) = r_row.split_at(constraint_rows_bits);
+            // Deconstruct 'r' into representitive bits
+            let (r_row_constr, r_row_step) = r_row.split_at(constraint_rows_bits);
+            (total_cols_bits, steps_bits, constraint_rows_bits, r_row_constr, r_row_step)
+        };
+        let uniform_cols_bits = self.uniform_r1cs.num_vars.next_power_of_two().log_2();
         let (r_col_var, r_col_step) = r_col.split_at(uniform_cols_bits + 1);
         assert_eq!(r_row_step.len(), r_col_step.len());
 

--- a/jolt-core/src/r1cs/key.rs
+++ b/jolt-core/src/r1cs/key.rs
@@ -330,26 +330,41 @@ impl<const C: usize, F: JoltField, I: ConstraintInput> UniformSpartanKey<C, I, F
     /// Evaluates A(r), B(r), C(r) efficiently using their small uniform representations.
     #[tracing::instrument(skip_all, name = "UniformSpartanKey::evaluate_r1cs_matrix_mles")]
     pub fn evaluate_r1cs_matrix_mles(&self, r_row: &[F], r_col: &[F]) -> (F, F, F) {
-        let (total_cols_bits, steps_bits, constraint_rows_bits, r_row_constr, r_row_step) = if cfg!(feature = "reorder") {
-            let total_rows_bits = r_row.len();
-            let total_cols_bits = r_col.len();
-            let constraint_rows_bits = self.padded_row_constraint_per_step().log_2();
-            let steps_bits: usize = total_rows_bits - constraint_rows_bits;
-            let (r_row_step, r_row_constr) = r_row.split_at(total_rows_bits - constraint_rows_bits); // TMP
-            (total_cols_bits, steps_bits, constraint_rows_bits, r_row_constr, r_row_step)
-        } else {
-            let total_rows_bits = self.num_rows_total().log_2();
-            let total_cols_bits = self.num_cols_total().log_2();
-            let steps_bits: usize = self.num_steps.log_2();
-            let constraint_rows_bits = (self.uniform_r1cs.num_rows + 1).next_power_of_two().log_2();
-            assert_eq!(r_row.len(), total_rows_bits);
-            assert_eq!(r_col.len(), total_cols_bits);
-            assert_eq!(total_rows_bits - steps_bits, constraint_rows_bits);
+        let (total_cols_bits, steps_bits, constraint_rows_bits, r_row_constr, r_row_step) =
+            if cfg!(feature = "reorder") {
+                let total_rows_bits = r_row.len();
+                let total_cols_bits = r_col.len();
+                let constraint_rows_bits = self.padded_row_constraint_per_step().log_2();
+                let steps_bits: usize = total_rows_bits - constraint_rows_bits;
+                let (r_row_step, r_row_constr) =
+                    r_row.split_at(total_rows_bits - constraint_rows_bits); // TMP
+                (
+                    total_cols_bits,
+                    steps_bits,
+                    constraint_rows_bits,
+                    r_row_constr,
+                    r_row_step,
+                )
+            } else {
+                let total_rows_bits = self.num_rows_total().log_2();
+                let total_cols_bits = self.num_cols_total().log_2();
+                let steps_bits: usize = self.num_steps.log_2();
+                let constraint_rows_bits =
+                    (self.uniform_r1cs.num_rows + 1).next_power_of_two().log_2();
+                assert_eq!(r_row.len(), total_rows_bits);
+                assert_eq!(r_col.len(), total_cols_bits);
+                assert_eq!(total_rows_bits - steps_bits, constraint_rows_bits);
 
-            // Deconstruct 'r' into representitive bits
-            let (r_row_constr, r_row_step) = r_row.split_at(constraint_rows_bits);
-            (total_cols_bits, steps_bits, constraint_rows_bits, r_row_constr, r_row_step)
-        };
+                // Deconstruct 'r' into representitive bits
+                let (r_row_constr, r_row_step) = r_row.split_at(constraint_rows_bits);
+                (
+                    total_cols_bits,
+                    steps_bits,
+                    constraint_rows_bits,
+                    r_row_constr,
+                    r_row_step,
+                )
+            };
         let uniform_cols_bits = self.uniform_r1cs.num_vars.next_power_of_two().log_2();
         let (r_col_var, r_col_step) = r_col.split_at(uniform_cols_bits + 1);
         assert_eq!(r_row_step.len(), r_col_step.len());

--- a/jolt-core/src/r1cs/ops.rs
+++ b/jolt-core/src/r1cs/ops.rs
@@ -108,6 +108,23 @@ impl LC {
         result
     }
 
+    // JP: Why does `evaluate` exist?
+    pub fn evaluate_row<F: JoltField>(
+        &self,
+        flattened_polynomials: &[&DensePolynomial<F>],
+        row: usize,
+    ) -> F {
+        self.terms()
+            .iter()
+            .map(|term| match term.0 {
+                Variable::Input(var_index) | Variable::Auxiliary(var_index) => {
+                    F::from_i64(term.1).mul_01_optimized(flattened_polynomials[var_index][row])
+                }
+                Variable::Constant => F::from_i64(term.1),
+            })
+            .sum()
+    }
+
     pub fn evaluate_batch<F: JoltField>(
         &self,
         flattened_polynomials: &[&DensePolynomial<F>],

--- a/jolt-core/src/r1cs/spartan.rs
+++ b/jolt-core/src/r1cs/spartan.rs
@@ -162,7 +162,8 @@ where
         // this is the polynomial extended from the vector r_A * A(r_x, y) + r_B * B(r_x, y) + r_C * C(r_x, y) for all y
         let (rx_con, rx_ts) = if cfg!(feature = "reorder") {
             let num_constr_bits = constraint_builder.padded_rows_per_step().ilog2() as usize;
-            let (rx_ts, rx_con) = outer_sumcheck_r.split_at(outer_sumcheck_r.len() - num_constr_bits);
+            let (rx_ts, rx_con) =
+                outer_sumcheck_r.split_at(outer_sumcheck_r.len() - num_constr_bits);
             (rx_con, rx_ts)
         } else {
             let num_steps_bits = constraint_builder

--- a/jolt-core/src/r1cs/spartan.rs
+++ b/jolt-core/src/r1cs/spartan.rs
@@ -115,7 +115,11 @@ where
             .map(|var| var.get_ref(polynomials))
             .collect();
 
-        let num_rounds_x = key.num_rows_total().log_2();
+        let num_rounds_x = if cfg!(feature = "reorder") {
+            key.num_rows_bits()
+        } else {
+            key.num_rows_total().log_2()
+        };
         let num_rounds_y = key.num_cols_total().log_2();
 
         // outer sum-check
@@ -156,12 +160,19 @@ where
             + r_inner_sumcheck_RLC * r_inner_sumcheck_RLC * claim_Cz;
 
         // this is the polynomial extended from the vector r_A * A(r_x, y) + r_B * B(r_x, y) + r_C * C(r_x, y) for all y
-        let num_steps_bits = constraint_builder
-            .uniform_repeat()
-            .next_power_of_two()
-            .ilog2();
-        let (rx_con, rx_ts) =
-            outer_sumcheck_r.split_at(outer_sumcheck_r.len() - num_steps_bits as usize);
+        let (rx_con, rx_ts) = if cfg!(feature = "reorder") {
+            let num_constr_bits = constraint_builder.padded_rows_per_step().ilog2() as usize;
+            let (rx_ts, rx_con) = outer_sumcheck_r.split_at(outer_sumcheck_r.len() - num_constr_bits);
+            (rx_con, rx_ts)
+        } else {
+            let num_steps_bits = constraint_builder
+                .uniform_repeat()
+                .next_power_of_two()
+                .ilog2();
+            let (rx_con, rx_ts) =
+                outer_sumcheck_r.split_at(outer_sumcheck_r.len() - num_steps_bits as usize);
+            (rx_con, rx_ts)
+        };
         let mut poly_ABC =
             DensePolynomial::new(key.evaluate_r1cs_mle_rlc(rx_con, rx_ts, r_inner_sumcheck_RLC));
 
@@ -221,7 +232,11 @@ where
         PCS: CommitmentScheme<ProofTranscript, Field = F>,
         ProofTranscript: Transcript,
     {
-        let num_rounds_x = key.num_rows_total().log_2();
+        let num_rounds_x = if cfg!(feature = "reorder") {
+            key.num_rows_bits()
+        } else {
+            key.num_rows_total().log_2()
+        };
         let num_rounds_y = key.num_cols_total().log_2();
 
         // outer sum-check
@@ -271,8 +286,7 @@ where
         let eval_Z = key.evaluate_z_mle(&self.claimed_witness_evals, &inner_sumcheck_r);
 
         let r_y = inner_sumcheck_r.clone();
-        let r = [r_x, r_y].concat();
-        let (eval_a, eval_b, eval_c) = key.evaluate_r1cs_matrix_mles(&r);
+        let (eval_a, eval_b, eval_c) = key.evaluate_r1cs_matrix_mles(&r_x, &r_y);
 
         let left_expected = eval_a
             + r_inner_sumcheck_RLC * eval_b


### PR DESCRIPTION
This adds the flag `"reorder"` which reorders R1CS constraints so that all constraint rows for a given step are next to each other. This is necessary for streaming to minimize memory usage. 



This material is based upon work supported by the Defense Advanced Research Projects Agency (DARPA) under Contract No. HR001120C0085. Any opinions, findings, conclusions, or recommendations expressed in this material are those of the author(s) and do not necessarily reflect the views of the Defense Advanced Research Projects Agency (DARPA). Distribution Statement "A" (Approved for Public Release, Distribution Unlimited).