### PR TITLE
Shout d=1

### DIFF
--- a/jolt-core/src/benches/bench.rs
+++ b/jolt-core/src/benches/bench.rs
@@ -5,8 +5,12 @@ use crate::jolt::vm::Jolt;
 use crate::poly::commitment::commitment_scheme::CommitmentScheme;
 use crate::poly::commitment::hyperkzg::HyperKZG;
 use crate::poly::commitment::zeromorph::Zeromorph;
+use crate::subprotocols::shout::ShoutProof;
+use crate::utils::math::Math;
 use crate::utils::transcript::{KeccakTranscript, Transcript};
 use ark_bn254::{Bn254, Fr};
+use ark_std::test_rng;
+use rand_core::RngCore;
 use serde::Serialize;
 
 #[derive(Debug, Copy, Clone, clap::ValueEnum)]
@@ -21,6 +25,7 @@ pub enum BenchType {
     Sha2,
     Sha3,
     Sha2Chain,
+    Shout,
 }
 
 #[allow(unreachable_patterns)] // good errors on new BenchTypes
@@ -41,6 +46,7 @@ pub fn benchmarks(
             BenchType::Fibonacci => {
                 fibonacci::<Fr, Zeromorph<Bn254, KeccakTranscript>, KeccakTranscript>()
             }
+            BenchType::Shout => shout::<Fr, Zeromorph<Bn254, KeccakTranscript>, KeccakTranscript>(),
             _ => panic!("BenchType does not have a mapping"),
         },
         PCSType::HyperKZG => match bench_type {
@@ -52,10 +58,52 @@ pub fn benchmarks(
             BenchType::Fibonacci => {
                 fibonacci::<Fr, HyperKZG<Bn254, KeccakTranscript>, KeccakTranscript>()
             }
+            BenchType::Shout => shout::<Fr, Zeromorph<Bn254, KeccakTranscript>, KeccakTranscript>(),
             _ => panic!("BenchType does not have a mapping"),
         },
         _ => panic!("PCS Type does not have a mapping"),
     }
+}
+
+fn shout<F, PCS, ProofTranscript>() -> Vec<(tracing::Span, Box<dyn FnOnce()>)>
+where
+    F: JoltField,
+    PCS: CommitmentScheme<ProofTranscript, Field = F>,
+    ProofTranscript: Transcript,
+{
+    let small_value_lookup_tables = F::compute_lookup_tables();
+    F::initialize_lookup_tables(small_value_lookup_tables);
+
+    let mut tasks = Vec::new();
+
+    const TABLE_SIZE: usize = 64;
+    const NUM_LOOKUPS: usize = 1 << 20;
+
+    let mut rng = test_rng();
+
+    let lookup_table: Vec<F> = (0..TABLE_SIZE).map(|_| F::random(&mut rng)).collect();
+    let read_addresses: Vec<usize> = (0..NUM_LOOKUPS)
+        .map(|_| rng.next_u32() as usize % TABLE_SIZE)
+        .collect();
+
+    let mut prover_transcript = KeccakTranscript::new(b"test_transcript");
+    let r_cycle: Vec<F> = prover_transcript.challenge_vector(NUM_LOOKUPS.log_2());
+
+    let task = move || {
+        let _proof = ShoutProof::prove(
+            lookup_table,
+            read_addresses,
+            &r_cycle,
+            &mut prover_transcript,
+        );
+    };
+
+    tasks.push((
+        tracing::info_span!("Shout d=1"),
+        Box::new(task) as Box<dyn FnOnce()>,
+    ));
+
+    tasks
 }
 
 fn fibonacci<F, PCS, ProofTranscript>() -> Vec<(tracing::Span, Box<dyn FnOnce()>)>

--- a/jolt-core/src/jolt/vm/read_write_memory.rs
+++ b/jolt-core/src/jolt/vm/read_write_memory.rs
@@ -4,7 +4,7 @@ use crate::lasso::memory_checking::{
     ExogenousOpenings, Initializable, StructuredPolynomialData, VerifierComputedOpening,
 };
 use crate::poly::compact_polynomial::{CompactPolynomial, SmallScalar};
-use crate::poly::multilinear_polynomial::MultilinearPolynomial;
+use crate::poly::multilinear_polynomial::{MultilinearPolynomial, PolynomialEvaluation};
 use crate::poly::opening_proof::{ProverOpeningAccumulator, VerifierOpeningAccumulator};
 use crate::utils::thread::unsafe_allocate_zero_vec;
 use rayon::prelude::*;

--- a/jolt-core/src/lasso/surge.rs
+++ b/jolt-core/src/lasso/surge.rs
@@ -4,7 +4,7 @@ use crate::{
     poly::{
         commitment::commitment_scheme::BatchType,
         compact_polynomial::{CompactPolynomial, SmallScalar},
-        multilinear_polynomial::MultilinearPolynomial,
+        multilinear_polynomial::{MultilinearPolynomial, PolynomialEvaluation},
         opening_proof::{ProverOpeningAccumulator, VerifierOpeningAccumulator},
     },
 };

--- a/jolt-core/src/poly/identity_poly.rs
+++ b/jolt-core/src/poly/identity_poly.rs
@@ -2,20 +2,120 @@ use crate::field::JoltField;
 
 use crate::utils::math::Math;
 
-pub struct IdentityPolynomial {
-    size_point: usize,
+use super::multilinear_polynomial::{BindingOrder, PolynomialBinding, PolynomialEvaluation};
+
+pub struct IdentityPolynomial<F: JoltField> {
+    num_vars: usize,
+    num_bound_vars: usize,
+    bound_value: F,
 }
 
-impl IdentityPolynomial {
-    pub fn new(size_point: usize) -> Self {
-        IdentityPolynomial { size_point }
+impl<F: JoltField> IdentityPolynomial<F> {
+    pub fn new(num_vars: usize) -> Self {
+        IdentityPolynomial {
+            num_vars,
+            num_bound_vars: 0,
+            bound_value: F::zero(),
+        }
+    }
+}
+
+impl<F: JoltField> PolynomialBinding<F> for IdentityPolynomial<F> {
+    fn is_bound(&self) -> bool {
+        self.num_bound_vars != 0
     }
 
-    pub fn evaluate<F: JoltField>(&self, r: &[F]) -> F {
+    fn bind(&mut self, r: F, order: BindingOrder) {
+        debug_assert!(self.num_bound_vars < self.num_vars);
+        debug_assert_eq!(
+            order,
+            BindingOrder::LowToHigh,
+            "IdentityPolynomial only supports low-to-high binding"
+        );
+
+        self.bound_value += F::from_u32(1u32 << self.num_bound_vars) * r;
+        self.num_bound_vars += 1;
+    }
+
+    fn final_sumcheck_claim(&self) -> F {
+        debug_assert_eq!(self.num_vars, self.num_bound_vars);
+        self.bound_value
+    }
+}
+
+impl<F: JoltField> PolynomialEvaluation<F> for IdentityPolynomial<F> {
+    fn evaluate(&self, r: &[F]) -> F {
         let len = r.len();
-        assert_eq!(len, self.size_point);
+        assert_eq!(len, self.num_vars);
         (0..len)
             .map(|i| F::from_u64((len - i - 1).pow2() as u64) * r[i])
             .sum()
+    }
+
+    fn batch_evaluate(polys: &[&Self], r: &[F]) -> (Vec<F>, Vec<F>) {
+        todo!()
+    }
+
+    fn sumcheck_evals(&self, index: usize, degree: usize, order: BindingOrder) -> Vec<F> {
+        debug_assert!(degree > 0);
+        debug_assert!(index < self.num_vars.pow2() / 2);
+        debug_assert_eq!(
+            order,
+            BindingOrder::LowToHigh,
+            "IdentityPolynomial only supports low-to-high binding"
+        );
+
+        let mut evals = vec![F::zero(); degree];
+        evals[0] = self.bound_value + F::from_u64((index as u64) << (1 + self.num_bound_vars));
+        let m = F::from_u32(1 << self.num_bound_vars);
+        let mut eval = evals[0] + m;
+        for i in 1..degree {
+            eval += m;
+            evals[i] = eval;
+        }
+        evals
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::poly::multilinear_polynomial::MultilinearPolynomial;
+
+    use super::*;
+    use ark_bn254::Fr;
+    use ark_std::test_rng;
+
+    #[test]
+    fn identity_poly() {
+        const NUM_VARS: usize = 10;
+
+        let mut rng = test_rng();
+        let mut identity_poly: IdentityPolynomial<Fr> = IdentityPolynomial::new(NUM_VARS);
+        let mut reference_poly: MultilinearPolynomial<Fr> =
+            MultilinearPolynomial::from((0..(1 << NUM_VARS)).map(|i| i as u32).collect::<Vec<_>>());
+
+        for j in 0..reference_poly.len() / 2 {
+            let identity_poly_evals = identity_poly.sumcheck_evals(j, 3, BindingOrder::LowToHigh);
+            let reference_poly_evals = reference_poly.sumcheck_evals(j, 3, BindingOrder::LowToHigh);
+            assert_eq!(identity_poly_evals, reference_poly_evals);
+        }
+
+        for _ in 0..NUM_VARS {
+            let r = Fr::random(&mut rng);
+            identity_poly.bind(r, BindingOrder::LowToHigh);
+            reference_poly.bind(r, BindingOrder::LowToHigh);
+            for j in 0..reference_poly.len() / 2 {
+                let identity_poly_evals =
+                    identity_poly.sumcheck_evals(j, 3, BindingOrder::LowToHigh);
+                let reference_poly_evals =
+                    reference_poly.sumcheck_evals(j, 3, BindingOrder::LowToHigh);
+                assert_eq!(identity_poly_evals, reference_poly_evals);
+            }
+        }
+
+        assert_eq!(
+            identity_poly.final_sumcheck_claim(),
+            reference_poly.final_sumcheck_claim()
+        );
     }
 }

--- a/jolt-core/src/poly/identity_poly.rs
+++ b/jolt-core/src/poly/identity_poly.rs
@@ -37,6 +37,11 @@ impl<F: JoltField> PolynomialBinding<F> for IdentityPolynomial<F> {
         self.num_bound_vars += 1;
     }
 
+    fn bind_parallel(&mut self, r: F, order: BindingOrder) {
+        // Binding is constant time, no parallelism necessary
+        self.bind(r, order);
+    }
+
     fn final_sumcheck_claim(&self) -> F {
         debug_assert_eq!(self.num_vars, self.num_bound_vars);
         self.bound_value

--- a/jolt-core/src/poly/identity_poly.rs
+++ b/jolt-core/src/poly/identity_poly.rs
@@ -57,8 +57,8 @@ impl<F: JoltField> PolynomialEvaluation<F> for IdentityPolynomial<F> {
             .sum()
     }
 
-    fn batch_evaluate(polys: &[&Self], r: &[F]) -> (Vec<F>, Vec<F>) {
-        todo!()
+    fn batch_evaluate(_polys: &[&Self], _r: &[F]) -> (Vec<F>, Vec<F>) {
+        unimplemented!("Currently unused")
     }
 
     fn sumcheck_evals(&self, index: usize, degree: usize, order: BindingOrder) -> Vec<F> {

--- a/jolt-core/src/poly/multilinear_polynomial.rs
+++ b/jolt-core/src/poly/multilinear_polynomial.rs
@@ -28,6 +28,7 @@ pub enum MultilinearPolynomial<F: JoltField> {
 }
 
 /// The order in which polynomial variables are bound in sumcheck
+#[derive(Debug, PartialEq)]
 pub enum BindingOrder {
     LowToHigh,
     HighToLow,

--- a/jolt-core/src/subprotocols/mod.rs
+++ b/jolt-core/src/subprotocols/mod.rs
@@ -2,6 +2,7 @@
 
 pub mod grand_product;
 pub mod grand_product_quarks;
+pub mod shout;
 pub mod sparse_grand_product;
 pub mod sumcheck;
 

--- a/jolt-core/src/subprotocols/shout.rs
+++ b/jolt-core/src/subprotocols/shout.rs
@@ -122,8 +122,8 @@ impl<F: JoltField, ProofTranscript: Transcript> ShoutProof<F, ProofTranscript> {
 
             // Bind polynomials
             rayon::join(
-                || ra.bind(r_j, BindingOrder::LowToHigh),
-                || val.bind(r_j, BindingOrder::LowToHigh),
+                || ra.bind_parallel(r_j, BindingOrder::LowToHigh),
+                || val.bind_parallel(r_j, BindingOrder::LowToHigh),
             );
         }
 
@@ -240,8 +240,8 @@ pub fn prove_core_shout_piop<F: JoltField, ProofTranscript: Transcript>(
 
         // Bind polynomials
         rayon::join(
-            || ra.bind(r_j, BindingOrder::LowToHigh),
-            || val.bind(r_j, BindingOrder::LowToHigh),
+            || ra.bind_parallel(r_j, BindingOrder::LowToHigh),
+            || val.bind_parallel(r_j, BindingOrder::LowToHigh),
         );
     }
 
@@ -389,7 +389,7 @@ pub fn prove_booleanity<F: JoltField, ProofTranscript: Transcript>(
 
         previous_claim = univariate_poly.evaluate(&r_j);
 
-        B.bind(r_j, BindingOrder::LowToHigh);
+        B.bind_parallel(r_j, BindingOrder::LowToHigh);
 
         let inner_span = tracing::span!(tracing::Level::INFO, "Update F");
         let _inner_guard = inner_span.enter();
@@ -415,7 +415,7 @@ pub fn prove_booleanity<F: JoltField, ProofTranscript: Transcript>(
     let _guard = span.enter();
 
     let eq_r_r = B.final_sumcheck_claim();
-    let H: Vec<F> = read_addresses.par_iter().map(|&k| F[k]).collect();
+    let H: Vec<F> = read_addresses.iter().map(|&k| F[k]).collect();
     let mut H = MultilinearPolynomial::from(H);
     let mut D = MultilinearPolynomial::from(D);
     let mut r_cycle_prime: Vec<F> = Vec::with_capacity(T.log_2());
@@ -475,8 +475,8 @@ pub fn prove_booleanity<F: JoltField, ProofTranscript: Transcript>(
 
         // Bind polynomials
         rayon::join(
-            || D.bind(r_j, BindingOrder::LowToHigh),
-            || H.bind(r_j, BindingOrder::LowToHigh),
+            || D.bind_parallel(r_j, BindingOrder::LowToHigh),
+            || H.bind_parallel(r_j, BindingOrder::LowToHigh),
         );
     }
 
@@ -538,7 +538,7 @@ pub fn prove_hamming_weight<F: JoltField, ProofTranscript: Transcript>(
 
         previous_claim = univariate_poly.evaluate(&r_j);
 
-        ra.bind(r_j, BindingOrder::LowToHigh);
+        ra.bind_parallel(r_j, BindingOrder::LowToHigh);
     }
 
     let ra_claim = ra.final_sumcheck_claim();
@@ -616,8 +616,8 @@ pub fn prove_raf_evaluation<F: JoltField, ProofTranscript: Transcript>(
 
         // Bind polynomials
         rayon::join(
-            || ra.bind(r_j, BindingOrder::LowToHigh),
-            || int.bind(r_j, BindingOrder::LowToHigh),
+            || ra.bind_parallel(r_j, BindingOrder::LowToHigh),
+            || int.bind_parallel(r_j, BindingOrder::LowToHigh),
         );
     }
 

--- a/jolt-core/src/subprotocols/shout.rs
+++ b/jolt-core/src/subprotocols/shout.rs
@@ -55,7 +55,7 @@ pub fn prove_shout<F: JoltField, ProofTranscript: Transcript>(
 
     const DEGREE: usize = 2;
     let mut compressed_polys: Vec<CompressedUniPoly<F>> = Vec::with_capacity(num_rounds);
-    for _round in 0..num_rounds {
+    for _ in 0..num_rounds {
         let univariate_poly_evals: [F; 2] = (0..ra.len() / 2)
             .into_par_iter()
             .map(|i| {
@@ -100,11 +100,72 @@ pub fn prove_shout<F: JoltField, ProofTranscript: Transcript>(
     )
 }
 
+/// Implements the sumcheck prover for the Hamming weight 1 check in step 5 of
+/// Figure 6 in the Twist+Shout paper.
+pub fn prove_hamming_weight<F: JoltField, ProofTranscript: Transcript>(
+    lookup_table: Vec<F>,
+    read_addresses: Vec<usize>,
+    r_cycle_prime: Vec<F>,
+    transcript: &mut ProofTranscript,
+) -> (SumcheckInstanceProof<F, ProofTranscript>, Vec<F>, F) {
+    let K = lookup_table.len();
+    let T = read_addresses.len();
+    debug_assert_eq!(T.log_2(), r_cycle_prime.len());
+
+    let num_rounds = K.log_2();
+    let mut r_address_double_prime: Vec<F> = Vec::with_capacity(num_rounds);
+
+    let E: Vec<F> = EqPolynomial::evals(&r_cycle_prime);
+    let F: Vec<_> = (0..K)
+        .into_par_iter()
+        .map(|k| {
+            read_addresses
+                .iter()
+                .enumerate()
+                .filter_map(|(cycle, address)| if *address == k { Some(E[cycle]) } else { None })
+                .sum::<F>()
+        })
+        .collect();
+
+    let mut ra = MultilinearPolynomial::from(F);
+    let mut previous_claim = F::one();
+
+    let mut compressed_polys: Vec<CompressedUniPoly<F>> = Vec::with_capacity(num_rounds);
+    for _ in 0..num_rounds {
+        let univariate_poly_eval: F = (0..ra.len() / 2)
+            .into_par_iter()
+            .map(|i| ra.get_bound_coeff(2 * i))
+            .sum();
+
+        let univariate_poly =
+            UniPoly::from_evals(&[univariate_poly_eval, previous_claim - univariate_poly_eval]);
+
+        let compressed_poly = univariate_poly.compress();
+        compressed_poly.append_to_transcript(transcript);
+        compressed_polys.push(compressed_poly);
+
+        let r_j = transcript.challenge_scalar::<F>();
+        r_address_double_prime.push(r_j);
+
+        previous_claim = univariate_poly.evaluate(&r_j);
+
+        ra.bind(r_j, BindingOrder::LowToHigh);
+    }
+
+    let ra_claim = ra.final_sumcheck_claim();
+    (
+        SumcheckInstanceProof::new(compressed_polys),
+        r_address_double_prime,
+        ra_claim,
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::utils::transcript::KeccakTranscript;
     use ark_bn254::Fr;
+    use ark_ff::One;
     use ark_std::test_rng;
     use rand_core::RngCore;
 
@@ -134,6 +195,40 @@ mod tests {
             2,
             &mut verifier_transcript,
         );
+        assert!(
+            verification_result.is_ok(),
+            "Verification failed with error: {:?}",
+            verification_result.err()
+        );
+    }
+
+    #[test]
+    fn hamming_weight_sumcheck() {
+        const TABLE_SIZE: usize = 64;
+        const NUM_LOOKUPS: usize = 1 << 10;
+
+        let mut rng = test_rng();
+
+        let lookup_table: Vec<Fr> = (0..TABLE_SIZE).map(|_| Fr::random(&mut rng)).collect();
+        let read_addresses: Vec<usize> = (0..NUM_LOOKUPS)
+            .map(|_| rng.next_u32() as usize % TABLE_SIZE)
+            .collect();
+
+        let mut prover_transcript = KeccakTranscript::new(b"test_transcript");
+        let r_cycle_prime: Vec<Fr> = prover_transcript.challenge_vector(NUM_LOOKUPS.log_2());
+        let (sumcheck_proof, _, _) = prove_hamming_weight(
+            lookup_table,
+            read_addresses,
+            r_cycle_prime,
+            &mut prover_transcript,
+        );
+
+        let mut verifier_transcript = KeccakTranscript::new(b"test_transcript");
+        verifier_transcript.compare_to(prover_transcript);
+        let _: Vec<Fr> = verifier_transcript.challenge_vector(NUM_LOOKUPS.log_2());
+
+        let verification_result =
+            sumcheck_proof.verify(Fr::one(), TABLE_SIZE.log_2(), 1, &mut verifier_transcript);
         assert!(
             verification_result.is_ok(),
             "Verification failed with error: {:?}",

--- a/jolt-core/src/subprotocols/shout.rs
+++ b/jolt-core/src/subprotocols/shout.rs
@@ -44,7 +44,7 @@ impl<F: JoltField, ProofTranscript: Transcript> ShoutProof<F, ProofTranscript> {
         let num_rounds = K.log_2();
         let mut r_address: Vec<F> = Vec::with_capacity(num_rounds);
 
-        let E: Vec<F> = EqPolynomial::evals(&r_cycle);
+        let E: Vec<F> = EqPolynomial::evals(r_cycle);
 
         let span = tracing::span!(tracing::Level::INFO, "compute F");
         let _guard = span.enter();
@@ -148,7 +148,7 @@ impl<F: JoltField, ProofTranscript: Transcript> ShoutProof<F, ProofTranscript> {
 
         let core_piop_sumcheck_proof = SumcheckInstanceProof::new(compressed_polys);
 
-        let (booleanity_sumcheck_proof, r_address_prime, r_cycle_prime, ra_claim_prime) =
+        let (booleanity_sumcheck_proof, _r_address_prime, _r_cycle_prime, ra_claim_prime) =
             prove_booleanity(read_addresses, &r_address, E, F, transcript);
 
         // TODO: Reduce 2 ra claims to 1 (Section 4.5.2 of Proofs, Arguments, and Zero-Knowledge)
@@ -190,7 +190,7 @@ impl<F: JoltField, ProofTranscript: Transcript> ShoutProof<F, ProofTranscript> {
                 .verify(F::zero(), K.log_2() + T.log_2(), 3, transcript)?;
         let (r_address_prime, r_cycle_prime) = r_booleanity.split_at(K.log_2());
         let eq_eval_address = EqPolynomial::new(r_address).evaluate(r_address_prime);
-        let r_cycle: Vec<_> = r_cycle.to_vec().into_iter().rev().collect();
+        let r_cycle: Vec<_> = r_cycle.iter().copied().rev().collect();
         let eq_eval_cycle = EqPolynomial::new(r_cycle).evaluate(r_cycle_prime);
 
         assert_eq!(

--- a/jolt-core/src/subprotocols/shout.rs
+++ b/jolt-core/src/subprotocols/shout.rs
@@ -1,0 +1,143 @@
+use crate::{
+    field::JoltField,
+    poly::{
+        eq_poly::EqPolynomial,
+        multilinear_polynomial::{
+            BindingOrder, MultilinearPolynomial, PolynomialBinding, PolynomialEvaluation,
+        },
+        unipoly::{CompressedUniPoly, UniPoly},
+    },
+    utils::{
+        math::Math,
+        transcript::{AppendToTranscript, Transcript},
+    },
+};
+use rayon::prelude::*;
+
+use super::sumcheck::SumcheckInstanceProof;
+
+/// Implements the sumcheck prover for the core Shout PIOP when d = 1. See
+/// Figure 5 from the Twist+Shout paper.
+pub fn prove_shout<F: JoltField, ProofTranscript: Transcript>(
+    lookup_table: Vec<F>,
+    read_addresses: Vec<usize>,
+    transcript: &mut ProofTranscript,
+) -> (SumcheckInstanceProof<F, ProofTranscript>, Vec<F>, F, F) {
+    let K = lookup_table.len();
+    let T = read_addresses.len();
+    let r_cycle: Vec<F> = transcript.challenge_vector(T.log_2());
+
+    // Sumcheck for the core Shout PIOP (Figure 5)
+    let num_rounds = K.log_2();
+    let mut r_address: Vec<F> = Vec::with_capacity(num_rounds);
+
+    let E: Vec<F> = EqPolynomial::evals(&r_cycle);
+    let F: Vec<_> = (0..K)
+        .into_par_iter()
+        .map(|k| {
+            read_addresses
+                .iter()
+                .enumerate()
+                .filter_map(|(cycle, address)| if *address == k { Some(E[cycle]) } else { None })
+                .sum::<F>()
+        })
+        .collect();
+
+    let sumcheck_claim: F = F
+        .par_iter()
+        .zip(lookup_table.par_iter())
+        .map(|(&ra, &val)| ra * val)
+        .sum();
+    let mut previous_claim = sumcheck_claim;
+
+    let mut ra = MultilinearPolynomial::from(F);
+    let mut val = MultilinearPolynomial::from(lookup_table);
+
+    const DEGREE: usize = 2;
+    let mut compressed_polys: Vec<CompressedUniPoly<F>> = Vec::with_capacity(num_rounds);
+    for _round in 0..num_rounds {
+        let univariate_poly_evals: [F; 2] = (0..ra.len() / 2)
+            .into_par_iter()
+            .map(|i| {
+                let ra_evals = ra.sumcheck_evals(i, DEGREE, BindingOrder::LowToHigh);
+                let val_evals = val.sumcheck_evals(i, DEGREE, BindingOrder::LowToHigh);
+
+                [ra_evals[0] * val_evals[0], ra_evals[1] * val_evals[1]]
+            })
+            .reduce(
+                || [F::zero(); 2],
+                |running, new| [running[0] + new[0], running[1] + new[1]],
+            );
+
+        let univariate_poly = UniPoly::from_evals(&[
+            univariate_poly_evals[0],
+            previous_claim - univariate_poly_evals[0],
+            univariate_poly_evals[1],
+        ]);
+
+        let compressed_poly = univariate_poly.compress();
+        compressed_poly.append_to_transcript(transcript);
+        compressed_polys.push(compressed_poly);
+
+        let r_j = transcript.challenge_scalar::<F>();
+        r_address.push(r_j);
+
+        previous_claim = univariate_poly.evaluate(&r_j);
+
+        // Bind polynomials
+        rayon::join(
+            || ra.bind(r_j, BindingOrder::LowToHigh),
+            || val.bind(r_j, BindingOrder::LowToHigh),
+        );
+    }
+
+    let ra_claim = ra.final_sumcheck_claim();
+    (
+        SumcheckInstanceProof::new(compressed_polys),
+        r_address,
+        sumcheck_claim,
+        ra_claim,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::utils::transcript::KeccakTranscript;
+    use ark_bn254::Fr;
+    use ark_std::test_rng;
+    use rand_core::RngCore;
+
+    #[test]
+    fn core_shout_sumcheck() {
+        const TABLE_SIZE: usize = 64;
+        const NUM_LOOKUPS: usize = 1 << 10;
+
+        let mut rng = test_rng();
+
+        let lookup_table: Vec<Fr> = (0..TABLE_SIZE).map(|_| Fr::random(&mut rng)).collect();
+        let read_addresses: Vec<usize> = (0..NUM_LOOKUPS)
+            .map(|_| rng.next_u32() as usize % TABLE_SIZE)
+            .collect();
+
+        let mut prover_transcript = KeccakTranscript::new(b"test_transcript");
+        let (sumcheck_proof, _, sumcheck_claim, _) =
+            prove_shout(lookup_table, read_addresses, &mut prover_transcript);
+
+        let mut verifier_transcript = KeccakTranscript::new(b"test_transcript");
+        verifier_transcript.compare_to(prover_transcript);
+
+        let _r_cycle: Vec<Fr> = verifier_transcript.challenge_vector(NUM_LOOKUPS.log_2());
+        let verification_result = sumcheck_proof.verify(
+            sumcheck_claim,
+            TABLE_SIZE.log_2(),
+            2,
+            &mut verifier_transcript,
+        );
+        assert!(
+            verification_result.is_ok(),
+            "Verification failed with error: {:?}",
+            verification_result.err()
+        );
+    }
+}


### PR DESCRIPTION
Implements the [Shout](https://eprint.iacr.org/2025/105.pdf) lookup argument, for the special case of $d = 1$. This case is described in Section 4.1 of the paper, while the fast prover implementation is detailed in Section 6.

Note that this implementation is currently standalone –– it is not hooked up to a polynomial commitment scheme or to the rest of Jolt. 