### PR TITLE
fix: Fix incorrect use of unsigned_abs() for i32 type in rv_trace.rs

### DIFF
--- a/common/src/rv_trace.rs
+++ b/common/src/rv_trace.rs
@@ -32,7 +32,7 @@ impl MemoryOp {
 
 fn sum_u64_i32(a: u64, b: i32) -> u64 {
     if b.is_negative() {
-        let abs_b = b.unsigned_abs() as u64;
+        let abs_b = b.abs() as u64;
         if a < abs_b {
             panic!("overflow")
         }


### PR DESCRIPTION
`unsigned_abs()` was being used on an `i32` type, which doesn't exist.
I replaced it with `abs()` to correctly get the absolute value as `i32`, and then cast it to `u64` as needed. 