### PR TITLE
chore: fix typo in command option

### DIFF
--- a/book/src/dev/tools.md
+++ b/book/src/dev/tools.md
@@ -1,7 +1,7 @@
 # Development Tools
 ## Tracing
 Jolt is instrumented using [tokio-rs/tracing](https://github.com/tokio-rs/tracing). These traces can be displayed using the `--format chrome` flag, for example:
-`cargo run -p jolt-core --release -- trace --name sha2-chain --format chrome`
+`cargo run -p jolt-core --release --trace --name sha2-chain --format chrome`
 
 After tracing, files can be found in the workspace root with a name `trace-<timestamp>.json`. Load these traces into [perfetto](https://ui.perfetto.dev/).
 


### PR DESCRIPTION
A typo in the command option: `"-- trace"` → `"--trace"`. Fixed it so the command runs correctly.