### PR TITLE
fix: grammar an typos in comments across codebase

### DIFF
--- a/jolt-core/src/r1cs/spartan.rs
+++ b/jolt-core/src/r1cs/spartan.rs
@@ -39,7 +39,7 @@ pub enum SpartanError {
     #[error("InvalidSumcheckProof")]
     InvalidSumcheckProof,
 
-    /// returned when the recusive sumcheck proof fails
+    /// returned when the recursive sumcheck proof fails
     #[error("InvalidOuterSumcheckProof")]
     InvalidOuterSumcheckProof,
 

--- a/jolt-evm-verifier/src/subprotocols/HyperKZG.sol
+++ b/jolt-evm-verifier/src/subprotocols/HyperKZG.sol
@@ -20,7 +20,7 @@ contract HyperKZG {
     using FrLib for Fr;
 
     // These are initialized using the trusted setup values. NOTE - You must negate the point
-    // VK_g2 in order to have the checks pass, unlike the the rust which checks e(L, VK_G2) =
+    // VK_g2 in order to have the checks pass, unlike the rust which checks e(L, VK_G2) =
     // e(R, VK_Beta_G2) we use a precompile which checks e(L,-VK_G2)e(R, VK_Beta_G2) = 1
     uint256 immutable VK_g1_x;
     uint256 immutable VK_g1_y;

--- a/jolt-evm-verifier/src/subprotocols/SpartanVerifier.sol
+++ b/jolt-evm-verifier/src/subprotocols/SpartanVerifier.sol
@@ -115,7 +115,7 @@ contract SpartanVerifier is HyperKZG {
             mstore(new_ptr, sub(len, n_prefix))
             r_y := new_ptr
         }
-        // Assembly conversion because we know this will is sampled within the modulus
+        // Assembly conversion because we know this is sampled within the modulus
         assembly ("memory-safe") {
             opening_r := r_y
         }


### PR DESCRIPTION
Fixed several typos and grammatical errors in comments:

1. Removed duplicate "the" in HyperKZG.sol
2. Fixed "recusive" to "recursive" in spartan.rs error message
3. Fixed "will is" to "is" in SpartanVerifier.sol assembly comment