### PR TITLE
Remove unnecessary truncateOverflow subtable

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,10 @@ Where `--name` can be `sha2`, `sha3`, `sha2-chain`, or `fibonacci`. The correspo
 
 The above command will output a JSON file, e.g. `trace-1712455107389520.json`, which can be viewed in [Perfetto](https://ui.perfetto.dev/).
 
+## CI Benchmarking
+
+We have enabled [benchmarking during CI](https://a16z.github.io/jolt/dev/bench/) to track performance changes over time in terms of prover runtime and peak memory usage.
+
 ## Acknowledgements
 
 *This repository started as a fork of https://github.com/arkworks-rs/spartan. Original Spartan [code](https://github.com/microsoft/Spartan) by Srinath Setty.*

--- a/jolt-core/src/jolt/instruction/mulu.rs
+++ b/jolt-core/src/jolt/instruction/mulu.rs
@@ -5,9 +5,7 @@ use serde::{Deserialize, Serialize};
 
 use super::{JoltInstruction, SubtableIndices};
 use crate::field::JoltField;
-use crate::jolt::subtable::{
-    identity::IdentitySubtable, truncate_overflow::TruncateOverflowSubtable, LassoSubtable,
-};
+use crate::jolt::subtable::{identity::IdentitySubtable, LassoSubtable};
 use crate::utils::instruction_utils::{
     assert_valid_parameters, concatenate_lookups, multiply_and_chunk_operands,
 };
@@ -21,8 +19,8 @@ impl<const WORD_SIZE: usize> JoltInstruction for MULUInstruction<WORD_SIZE> {
     }
 
     fn combine_lookups<F: JoltField>(&self, vals: &[F], C: usize, M: usize) -> F {
-        assert!(vals.len() == C);
-        concatenate_lookups(vals, C, log2(M) as usize)
+        assert!(vals.len() == C / 2);
+        concatenate_lookups(vals, C / 2, log2(M) as usize)
     }
 
     fn g_poly_degree(&self, _: usize) -> usize {
@@ -35,16 +33,10 @@ impl<const WORD_SIZE: usize> JoltInstruction for MULUInstruction<WORD_SIZE> {
         M: usize,
     ) -> Vec<(Box<dyn LassoSubtable<F>>, SubtableIndices)> {
         let msb_chunk_index = C - (WORD_SIZE / log2(M) as usize) - 1;
-        vec![
-            (
-                Box::new(TruncateOverflowSubtable::<F, WORD_SIZE>::new()),
-                SubtableIndices::from(0..msb_chunk_index + 1),
-            ),
-            (
-                Box::new(IdentitySubtable::new()),
-                SubtableIndices::from(msb_chunk_index + 1..C),
-            ),
-        ]
+        vec![(
+            Box::new(IdentitySubtable::new()),
+            SubtableIndices::from(msb_chunk_index + 1..C),
+        )]
     }
 
     fn to_indices(&self, C: usize, log_M: usize) -> Vec<usize> {

--- a/jolt-core/src/jolt/instruction/sub.rs
+++ b/jolt-core/src/jolt/instruction/sub.rs
@@ -5,9 +5,7 @@ use rand::RngCore;
 use serde::{Deserialize, Serialize};
 
 use super::{JoltInstruction, SubtableIndices};
-use crate::jolt::subtable::{
-    identity::IdentitySubtable, truncate_overflow::TruncateOverflowSubtable, LassoSubtable,
-};
+use crate::jolt::subtable::{identity::IdentitySubtable, LassoSubtable};
 use crate::utils::instruction_utils::{
     add_and_chunk_operands, assert_valid_parameters, concatenate_lookups,
 };
@@ -21,9 +19,9 @@ impl<const WORD_SIZE: usize> JoltInstruction for SUBInstruction<WORD_SIZE> {
     }
 
     fn combine_lookups<F: JoltField>(&self, vals: &[F], C: usize, M: usize) -> F {
-        assert!(vals.len() == C);
-        // The output is the TruncateOverflow(most significant chunk) || Identity of other chunks
-        concatenate_lookups(vals, C, log2(M) as usize)
+        assert!(vals.len() == C / 2);
+        // The output is Identity of lower chunks
+        concatenate_lookups(vals, C / 2, log2(M) as usize)
     }
 
     fn g_poly_degree(&self, _: usize) -> usize {
@@ -36,16 +34,10 @@ impl<const WORD_SIZE: usize> JoltInstruction for SUBInstruction<WORD_SIZE> {
         M: usize,
     ) -> Vec<(Box<dyn LassoSubtable<F>>, SubtableIndices)> {
         let msb_chunk_index = C - (WORD_SIZE / log2(M) as usize) - 1;
-        vec![
-            (
-                Box::new(TruncateOverflowSubtable::<F, WORD_SIZE>::new()),
-                SubtableIndices::from(0..msb_chunk_index + 1),
-            ),
-            (
-                Box::new(IdentitySubtable::new()),
-                SubtableIndices::from(msb_chunk_index + 1..C),
-            ),
-        ]
+        vec![(
+            Box::new(IdentitySubtable::new()),
+            SubtableIndices::from(msb_chunk_index + 1..C),
+        )]
     }
 
     fn to_indices(&self, C: usize, log_M: usize) -> Vec<usize> {

--- a/jolt-core/src/jolt/subtable/mod.rs
+++ b/jolt-core/src/jolt/subtable/mod.rs
@@ -46,7 +46,7 @@ pub mod sign_extend;
 pub mod sll;
 pub mod sra_sign;
 pub mod srl;
-pub mod truncate_overflow;
+// pub mod truncate_overflow;
 pub mod xor;
 
 #[cfg(test)]

--- a/jolt-core/src/jolt/vm/rv32i_vm.rs
+++ b/jolt-core/src/jolt/vm/rv32i_vm.rs
@@ -33,9 +33,8 @@ use crate::jolt::subtable::{
     and::AndSubtable, eq::EqSubtable, eq_abs::EqAbsSubtable, identity::IdentitySubtable,
     left_is_zero::LeftIsZeroSubtable, left_msb::LeftMSBSubtable, lt_abs::LtAbsSubtable,
     ltu::LtuSubtable, or::OrSubtable, right_msb::RightMSBSubtable, sign_extend::SignExtendSubtable,
-    sll::SllSubtable, sra_sign::SraSignSubtable, srl::SrlSubtable,
-    truncate_overflow::TruncateOverflowSubtable, xor::XorSubtable, JoltSubtableSet, LassoSubtable,
-    SubtableId,
+    sll::SllSubtable, sra_sign::SraSignSubtable, srl::SrlSubtable, xor::XorSubtable,
+    JoltSubtableSet, LassoSubtable, SubtableId,
 };
 use crate::poly::commitment::commitment_scheme::CommitmentScheme;
 
@@ -155,7 +154,6 @@ subtable_enum!(
   SRL1: SrlSubtable<F, 1, WORD_SIZE>,
   SRL2: SrlSubtable<F, 2, WORD_SIZE>,
   SRL3: SrlSubtable<F, 3, WORD_SIZE>,
-  TRUNCATE: TruncateOverflowSubtable<F, WORD_SIZE>,
   XOR: XorSubtable<F>,
   LEFT_IS_ZERO: LeftIsZeroSubtable<F>,
   RIGHT_IS_ZERO: RightIsZeroSubtable<F>,


### PR DESCRIPTION
The truncateOverflow subtable always returns 0 with WORD_SIZE = 32 or 64 bits. All the calls to this subtable are eliminated.