### PR TITLE
Feat/hyrax returns

### DIFF
--- a/jolt-core/benches/commit.rs
+++ b/jolt-core/benches/commit.rs
@@ -1,7 +1,7 @@
 use ark_bn254::{Bn254, Fr};
 use criterion::Criterion;
 use jolt_core::field::JoltField;
-use jolt_core::poly::commitment::commitment_scheme::{BatchType, CommitShape, CommitmentScheme};
+use jolt_core::poly::commitment::commitment_scheme::{CommitShape, CommitmentScheme};
 use jolt_core::poly::commitment::hyperkzg::HyperKZG;
 use jolt_core::poly::commitment::kzg::CommitMode;
 use jolt_core::poly::commitment::zeromorph::Zeromorph;
@@ -58,7 +58,7 @@ where
     // Compute known products (one per layer)
     let known_products: Vec<F> = leaves.iter().map(|layer| layer.iter().product()).collect();
 
-    let setup = PCS::setup(&[CommitShape::new(SRS_SIZE, BatchType::Big)]);
+    let setup = PCS::setup(&[CommitShape::new(SRS_SIZE)]);
 
     (leaves, setup, known_products)
 }
@@ -69,7 +69,6 @@ fn benchmark_commit<PCS, F, ProofTranscript>(
     num_layer: usize,
     layer_size: usize,
     threshold: u32,
-    batch_type: BatchType,
 ) where
     PCS: CommitmentScheme<ProofTranscript, Field = F>, // Generic over PCS implementing CommitmentScheme for field F
     F: JoltField,                                      // Generic over a field F
@@ -81,15 +80,11 @@ fn benchmark_commit<PCS, F, ProofTranscript>(
         .into_iter()
         .map(|layer| MultilinearPolynomial::from(layer))
         .collect::<Vec<_>>();
-    let mode = match batch_type {
-        BatchType::GrandProduct => CommitMode::GrandProduct,
-        _ => CommitMode::Default,
-    };
     c.bench_function(
         &format!("{} Commit(mode:{:?}): {}% Ones", name, mode, threshold),
         |b| {
             b.iter(|| {
-                PCS::batch_commit(&leaves, &setup, batch_type.clone());
+                PCS::batch_commit(&leaves, &setup);
             });
         },
     );
@@ -108,7 +103,6 @@ fn main() {
         num_layers,
         layer_size,
         90,
-        BatchType::Big,
     );
     benchmark_commit::<HyperKZG<Bn254, KeccakTranscript>, Fr, KeccakTranscript>(
         &mut criterion,
@@ -116,15 +110,6 @@ fn main() {
         num_layers,
         layer_size,
         90,
-        BatchType::GrandProduct,
-    );
-    benchmark_commit::<HyperKZG<Bn254, KeccakTranscript>, Fr, KeccakTranscript>(
-        &mut criterion,
-        "HyperKZG",
-        num_layers,
-        layer_size,
-        90,
-        BatchType::Big,
     );
 
     criterion.final_summary();

--- a/jolt-core/benches/commit.rs
+++ b/jolt-core/benches/commit.rs
@@ -1,9 +1,8 @@
 use ark_bn254::{Bn254, Fr};
 use criterion::Criterion;
 use jolt_core::field::JoltField;
-use jolt_core::poly::commitment::commitment_scheme::{CommitShape, CommitmentScheme};
+use jolt_core::poly::commitment::commitment_scheme::CommitmentScheme;
 use jolt_core::poly::commitment::hyperkzg::HyperKZG;
-use jolt_core::poly::commitment::kzg::CommitMode;
 use jolt_core::poly::commitment::zeromorph::Zeromorph;
 use jolt_core::poly::multilinear_polynomial::MultilinearPolynomial;
 use jolt_core::utils::transcript::{KeccakTranscript, Transcript};
@@ -58,7 +57,7 @@ where
     // Compute known products (one per layer)
     let known_products: Vec<F> = leaves.iter().map(|layer| layer.iter().product()).collect();
 
-    let setup = PCS::setup(&[CommitShape::new(SRS_SIZE)]);
+    let setup = PCS::setup(SRS_SIZE);
 
     (leaves, setup, known_products)
 }

--- a/jolt-core/benches/grand_product.rs
+++ b/jolt-core/benches/grand_product.rs
@@ -1,7 +1,7 @@
 use ark_bn254::{Bn254, Fr};
 use criterion::Criterion;
 use jolt_core::field::JoltField;
-use jolt_core::poly::commitment::commitment_scheme::{CommitShape, CommitmentScheme};
+use jolt_core::poly::commitment::commitment_scheme::CommitmentScheme;
 use jolt_core::poly::commitment::hyperkzg::HyperKZG;
 use jolt_core::poly::opening_proof::{ProverOpeningAccumulator, VerifierOpeningAccumulator};
 use jolt_core::subprotocols::grand_product::{
@@ -69,7 +69,7 @@ where
     // Compute known products (one per layer)
     let known_products: Vec<F> = leaves.iter().map(|layer| layer.iter().product()).collect();
 
-    let setup = PCS::setup(&[CommitShape::new(SRS_SIZE)]);
+    let setup = PCS::setup(SRS_SIZE);
 
     ((leaves.concat(), batch_size), setup, known_products)
 }

--- a/jolt-core/benches/grand_product.rs
+++ b/jolt-core/benches/grand_product.rs
@@ -1,7 +1,7 @@
 use ark_bn254::{Bn254, Fr};
 use criterion::Criterion;
 use jolt_core::field::JoltField;
-use jolt_core::poly::commitment::commitment_scheme::{BatchType, CommitShape, CommitmentScheme};
+use jolt_core::poly::commitment::commitment_scheme::{CommitShape, CommitmentScheme};
 use jolt_core::poly::commitment::hyperkzg::HyperKZG;
 use jolt_core::poly::opening_proof::{ProverOpeningAccumulator, VerifierOpeningAccumulator};
 use jolt_core::subprotocols::grand_product::{
@@ -69,7 +69,7 @@ where
     // Compute known products (one per layer)
     let known_products: Vec<F> = leaves.iter().map(|layer| layer.iter().product()).collect();
 
-    let setup = PCS::setup(&[CommitShape::new(SRS_SIZE, BatchType::Big)]);
+    let setup = PCS::setup(&[CommitShape::new(SRS_SIZE)]);
 
     ((leaves.concat(), batch_size), setup, known_products)
 }

--- a/jolt-core/src/jolt/vm/bytecode.rs
+++ b/jolt-core/src/jolt/vm/bytecode.rs
@@ -13,7 +13,7 @@ use crate::jolt::instruction::JoltInstructionSet;
 use crate::lasso::memory_checking::{
     Initializable, NoExogenousOpenings, StructuredPolynomialData, VerifierComputedOpening,
 };
-use crate::poly::commitment::commitment_scheme::{BatchType, CommitShape, CommitmentScheme};
+use crate::poly::commitment::commitment_scheme::{CommitShape, CommitmentScheme};
 use crate::poly::compact_polynomial::{CompactPolynomial, SmallScalar};
 use crate::poly::multilinear_polynomial::{MultilinearPolynomial, PolynomialEvaluation};
 use common::constants::{BYTES_PER_INSTRUCTION, RAM_START_ADDRESS};
@@ -477,8 +477,8 @@ where
         let max_bytecode_size = (max_bytecode_size + 1).next_power_of_two();
         let max_trace_length = max_trace_length.next_power_of_two();
 
-        let read_write_shape = CommitShape::new(max_trace_length, BatchType::Big);
-        let init_final_shape = CommitShape::new(max_bytecode_size, BatchType::Small);
+        let read_write_shape = CommitShape::new(max_trace_length);
+        let init_final_shape = CommitShape::new(max_bytecode_size);
 
         vec![read_write_shape, init_final_shape]
     }

--- a/jolt-core/src/jolt/vm/bytecode.rs
+++ b/jolt-core/src/jolt/vm/bytecode.rs
@@ -13,7 +13,7 @@ use crate::jolt::instruction::JoltInstructionSet;
 use crate::lasso::memory_checking::{
     Initializable, NoExogenousOpenings, StructuredPolynomialData, VerifierComputedOpening,
 };
-use crate::poly::commitment::commitment_scheme::{CommitShape, CommitmentScheme};
+use crate::poly::commitment::commitment_scheme::CommitmentScheme;
 use crate::poly::compact_polynomial::{CompactPolynomial, SmallScalar};
 use crate::poly::multilinear_polynomial::{MultilinearPolynomial, PolynomialEvaluation};
 use common::constants::{BYTES_PER_INSTRUCTION, RAM_START_ADDRESS};
@@ -469,18 +469,6 @@ where
                 *trace_row
             );
         }
-    }
-
-    /// Computes the shape of all commitment for use in PCS::setup().
-    pub fn commit_shapes(max_bytecode_size: usize, max_trace_length: usize) -> Vec<CommitShape> {
-        // Account for no-op prepended to bytecode
-        let max_bytecode_size = (max_bytecode_size + 1).next_power_of_two();
-        let max_trace_length = max_trace_length.next_power_of_two();
-
-        let read_write_shape = CommitShape::new(max_trace_length);
-        let init_final_shape = CommitShape::new(max_bytecode_size);
-
-        vec![read_write_shape, init_final_shape]
     }
 }
 

--- a/jolt-core/src/jolt/vm/instruction_lookups.rs
+++ b/jolt-core/src/jolt/vm/instruction_lookups.rs
@@ -20,7 +20,7 @@ use crate::lasso::memory_checking::{
     Initializable, MultisetHashes, NoExogenousOpenings, StructuredPolynomialData,
     VerifierComputedOpening,
 };
-use crate::poly::commitment::commitment_scheme::{BatchType, CommitShape, CommitmentScheme};
+use crate::poly::commitment::commitment_scheme::{CommitShape, CommitmentScheme};
 use crate::utils::transcript::Transcript;
 use crate::{
     lasso::memory_checking::{MemoryCheckingProof, MemoryCheckingProver, MemoryCheckingVerifier},
@@ -1256,8 +1256,8 @@ where
     pub fn commitment_shapes(max_trace_length: usize) -> Vec<CommitShape> {
         let max_trace_length = max_trace_length.next_power_of_two();
 
-        let read_write_shape = CommitShape::new(max_trace_length, BatchType::Big);
-        let init_final_shape = CommitShape::new(M, BatchType::Small);
+        let read_write_shape = CommitShape::new(max_trace_length);
+        let init_final_shape = CommitShape::new(M);
 
         vec![read_write_shape, init_final_shape]
     }

--- a/jolt-core/src/jolt/vm/instruction_lookups.rs
+++ b/jolt-core/src/jolt/vm/instruction_lookups.rs
@@ -20,7 +20,7 @@ use crate::lasso::memory_checking::{
     Initializable, MultisetHashes, NoExogenousOpenings, StructuredPolynomialData,
     VerifierComputedOpening,
 };
-use crate::poly::commitment::commitment_scheme::{CommitShape, CommitmentScheme};
+use crate::poly::commitment::commitment_scheme::CommitmentScheme;
 use crate::utils::transcript::Transcript;
 use crate::{
     lasso::memory_checking::{MemoryCheckingProof, MemoryCheckingProver, MemoryCheckingVerifier},
@@ -1250,16 +1250,6 @@ where
             subtable_lookup_indices.push(access_sequence);
         }
         subtable_lookup_indices
-    }
-
-    /// Computes the shape of all commitments.
-    pub fn commitment_shapes(max_trace_length: usize) -> Vec<CommitShape> {
-        let max_trace_length = max_trace_length.next_power_of_two();
-
-        let read_write_shape = CommitShape::new(max_trace_length);
-        let init_final_shape = CommitShape::new(M);
-
-        vec![read_write_shape, init_final_shape]
     }
 
     #[tracing::instrument(skip_all, name = "InstructionLookupsProof::compute_lookup_outputs")]

--- a/jolt-core/src/jolt/vm/mod.rs
+++ b/jolt-core/src/jolt/vm/mod.rs
@@ -29,7 +29,7 @@ use crate::lasso::memory_checking::{
     Initializable, MemoryCheckingProver, MemoryCheckingVerifier, StructuredPolynomialData,
 };
 use crate::msm::icicle;
-use crate::poly::commitment::commitment_scheme::{BatchType, CommitmentScheme};
+use crate::poly::commitment::commitment_scheme::CommitmentScheme;
 use crate::r1cs::inputs::{ConstraintInput, R1CSPolynomials, R1CSProof, R1CSStuff};
 use crate::utils::errors::ProofVerifyError;
 use crate::utils::thread::drop_in_background_thread;
@@ -248,8 +248,7 @@ impl<F: JoltField> JoltPolynomials<F> {
         drop(span);
 
         let trace_polys = self.read_write_values();
-        let trace_commitments =
-            PCS::batch_commit(&trace_polys, &preprocessing.generators, BatchType::Big);
+        let trace_commitments = PCS::batch_commit(&trace_polys, &preprocessing.generators);
 
         commitments
             .read_write_values_mut()
@@ -276,7 +275,6 @@ impl<F: JoltField> JoltPolynomials<F> {
         commitments.instruction_lookups.final_cts = PCS::batch_commit(
             &self.instruction_lookups.final_cts,
             &preprocessing.generators,
-            BatchType::Big,
         );
         drop(_guard);
         drop(span);

--- a/jolt-core/src/jolt/vm/read_write_memory.rs
+++ b/jolt-core/src/jolt/vm/read_write_memory.rs
@@ -12,7 +12,7 @@ use rayon::prelude::*;
 use std::collections::HashSet;
 use std::marker::PhantomData;
 
-use crate::poly::commitment::commitment_scheme::{BatchType, CommitShape, CommitmentScheme};
+use crate::poly::commitment::commitment_scheme::{CommitShape, CommitmentScheme};
 use crate::utils::transcript::Transcript;
 use crate::{
     lasso::memory_checking::{
@@ -501,8 +501,8 @@ impl<F: JoltField> ReadWriteMemoryPolynomials<F> {
         let max_memory_address = max_memory_address.next_power_of_two();
         let max_trace_length = max_trace_length.next_power_of_two();
 
-        let read_write_shape = CommitShape::new(max_trace_length, BatchType::Big);
-        let init_final_shape = CommitShape::new(max_memory_address, BatchType::Small);
+        let read_write_shape = CommitShape::new(max_trace_length);
+        let init_final_shape = CommitShape::new(max_memory_address);
 
         vec![read_write_shape, init_final_shape]
     }

--- a/jolt-core/src/jolt/vm/read_write_memory.rs
+++ b/jolt-core/src/jolt/vm/read_write_memory.rs
@@ -12,7 +12,7 @@ use rayon::prelude::*;
 use std::collections::HashSet;
 use std::marker::PhantomData;
 
-use crate::poly::commitment::commitment_scheme::{CommitShape, CommitmentScheme};
+use crate::poly::commitment::commitment_scheme::CommitmentScheme;
 use crate::utils::transcript::Transcript;
 use crate::{
     lasso::memory_checking::{
@@ -491,20 +491,6 @@ impl<F: JoltField> ReadWriteMemoryPolynomials<F> {
             a_init_final: None,
             identity: None,
         }
-    }
-
-    /// Computes the shape of all commitments.
-    pub fn commitment_shapes(
-        max_memory_address: usize,
-        max_trace_length: usize,
-    ) -> Vec<CommitShape> {
-        let max_memory_address = max_memory_address.next_power_of_two();
-        let max_trace_length = max_trace_length.next_power_of_two();
-
-        let read_write_shape = CommitShape::new(max_trace_length);
-        let init_final_shape = CommitShape::new(max_memory_address);
-
-        vec![read_write_shape, init_final_shape]
     }
 }
 

--- a/jolt-core/src/jolt/vm/timestamp_range_check.rs
+++ b/jolt-core/src/jolt/vm/timestamp_range_check.rs
@@ -3,7 +3,7 @@ use crate::field::JoltField;
 use crate::lasso::memory_checking::{
     ExogenousOpenings, Initializable, StructuredPolynomialData, VerifierComputedOpening,
 };
-use crate::poly::commitment::commitment_scheme::{CommitShape, CommitmentScheme};
+use crate::poly::commitment::commitment_scheme::CommitmentScheme;
 use crate::poly::compact_polynomial::{CompactPolynomial, SmallScalar};
 use crate::poly::multilinear_polynomial::{MultilinearPolynomial, PolynomialEvaluation};
 use crate::poly::opening_proof::{ProverOpeningAccumulator, VerifierOpeningAccumulator};
@@ -912,13 +912,6 @@ where
         assert_eq!(combined_hash, grand_product_claim);
 
         Ok(())
-    }
-
-    /// Computes the shape of all commitments.
-    pub fn commitment_shapes(max_trace_length: usize) -> Vec<CommitShape> {
-        let max_trace_length = max_trace_length.next_power_of_two();
-
-        vec![CommitShape::new(max_trace_length)]
     }
 
     fn protocol_name() -> &'static [u8] {

--- a/jolt-core/src/jolt/vm/timestamp_range_check.rs
+++ b/jolt-core/src/jolt/vm/timestamp_range_check.rs
@@ -3,7 +3,7 @@ use crate::field::JoltField;
 use crate::lasso::memory_checking::{
     ExogenousOpenings, Initializable, StructuredPolynomialData, VerifierComputedOpening,
 };
-use crate::poly::commitment::commitment_scheme::{BatchType, CommitShape, CommitmentScheme};
+use crate::poly::commitment::commitment_scheme::{CommitShape, CommitmentScheme};
 use crate::poly::compact_polynomial::{CompactPolynomial, SmallScalar};
 use crate::poly::multilinear_polynomial::{MultilinearPolynomial, PolynomialEvaluation};
 use crate::poly::opening_proof::{ProverOpeningAccumulator, VerifierOpeningAccumulator};
@@ -918,7 +918,7 @@ where
     pub fn commitment_shapes(max_trace_length: usize) -> Vec<CommitShape> {
         let max_trace_length = max_trace_length.next_power_of_two();
 
-        vec![CommitShape::new(max_trace_length, BatchType::Big)]
+        vec![CommitShape::new(max_trace_length)]
     }
 
     fn protocol_name() -> &'static [u8] {

--- a/jolt-core/src/lasso/surge.rs
+++ b/jolt-core/src/lasso/surge.rs
@@ -673,10 +673,7 @@ mod tests {
     use crate::{
         jolt::instruction::xor::XORInstruction,
         lasso::surge::SurgeProof,
-        poly::commitment::{
-            commitment_scheme::{CommitShape, CommitmentScheme},
-            hyperkzg::HyperKZG,
-        },
+        poly::commitment::{commitment_scheme::CommitmentScheme, hyperkzg::HyperKZG},
     };
     use ark_bn254::{Bn254, Fr};
     use ark_std::test_rng;
@@ -697,7 +694,7 @@ mod tests {
         .collect();
 
         let preprocessing = SurgePreprocessing::preprocess();
-        let generators = HyperKZG::<_, KeccakTranscript>::setup(&[CommitShape::new(M)]);
+        let generators = HyperKZG::<_, KeccakTranscript>::setup(M);
         let (proof, debug_info) = SurgeProof::<
             Fr,
             HyperKZG<Bn254, KeccakTranscript>,
@@ -726,7 +723,7 @@ mod tests {
         .collect();
 
         let preprocessing = SurgePreprocessing::preprocess();
-        let generators = HyperKZG::<_, KeccakTranscript>::setup(&[CommitShape::new(M)]);
+        let generators = HyperKZG::<_, KeccakTranscript>::setup(M);
         let (proof, debug_info) = SurgeProof::<
             Fr,
             HyperKZG<Bn254, KeccakTranscript>,

--- a/jolt-core/src/lasso/surge.rs
+++ b/jolt-core/src/lasso/surge.rs
@@ -2,7 +2,6 @@ use crate::{
     field::JoltField,
     jolt::vm::{JoltCommitments, JoltPolynomials, ProverDebugInfo},
     poly::{
-        commitment::commitment_scheme::BatchType,
         compact_polynomial::{CompactPolynomial, SmallScalar},
         multilinear_polynomial::{MultilinearPolynomial, PolynomialEvaluation},
         opening_proof::{ProverOpeningAccumulator, VerifierOpeningAccumulator},
@@ -416,18 +415,13 @@ where
 
         let mut commitments = SurgeCommitments::<PCS, ProofTranscript>::initialize(preprocessing);
         let trace_polys = polynomials.read_write_values();
-        let trace_comitments =
-            PCS::batch_commit(&trace_polys, generators, BatchType::SurgeReadWrite);
+        let trace_comitments = PCS::batch_commit(&trace_polys, generators);
         commitments
             .read_write_values_mut()
             .into_iter()
             .zip(trace_comitments.into_iter())
             .for_each(|(dest, src)| *dest = src);
-        commitments.final_cts = PCS::batch_commit(
-            &polynomials.final_cts,
-            generators,
-            BatchType::SurgeInitFinal,
-        );
+        commitments.final_cts = PCS::batch_commit(&polynomials.final_cts, generators);
 
         let num_rounds = num_lookups.log_2();
         let instruction = Instruction::default();
@@ -680,7 +674,7 @@ mod tests {
         jolt::instruction::xor::XORInstruction,
         lasso::surge::SurgeProof,
         poly::commitment::{
-            commitment_scheme::{BatchType, CommitShape, CommitmentScheme},
+            commitment_scheme::{CommitShape, CommitmentScheme},
             hyperkzg::HyperKZG,
         },
     };
@@ -703,10 +697,7 @@ mod tests {
         .collect();
 
         let preprocessing = SurgePreprocessing::preprocess();
-        let generators = HyperKZG::<_, KeccakTranscript>::setup(&[CommitShape::new(
-            M,
-            BatchType::SurgeReadWrite,
-        )]);
+        let generators = HyperKZG::<_, KeccakTranscript>::setup(&[CommitShape::new(M)]);
         let (proof, debug_info) = SurgeProof::<
             Fr,
             HyperKZG<Bn254, KeccakTranscript>,
@@ -735,10 +726,7 @@ mod tests {
         .collect();
 
         let preprocessing = SurgePreprocessing::preprocess();
-        let generators = HyperKZG::<_, KeccakTranscript>::setup(&[CommitShape::new(
-            M,
-            BatchType::SurgeReadWrite,
-        )]);
+        let generators = HyperKZG::<_, KeccakTranscript>::setup(&[CommitShape::new(M)]);
         let (proof, debug_info) = SurgeProof::<
             Fr,
             HyperKZG<Bn254, KeccakTranscript>,

--- a/jolt-core/src/poly/commitment/binius.rs
+++ b/jolt-core/src/poly/commitment/binius.rs
@@ -1,6 +1,5 @@
 #![allow(dead_code)]
 
-use crate::poly::commitment::commitment_scheme::CommitShape;
 use crate::poly::commitment::commitment_scheme::CommitmentScheme;
 use crate::poly::multilinear_polynomial::MultilinearPolynomial;
 use crate::utils::errors::ProofVerifyError;
@@ -41,7 +40,7 @@ impl<ProofTranscript: Transcript> CommitmentScheme<ProofTranscript>
     type Proof = BiniusProof;
     type BatchedProof = BiniusBatchedProof;
 
-    fn setup(_shapes: &[CommitShape]) -> Self::Setup {
+    fn setup(_max_poly_len: usize) -> Self::Setup {
         None {}
     }
     fn commit(

--- a/jolt-core/src/poly/commitment/binius.rs
+++ b/jolt-core/src/poly/commitment/binius.rs
@@ -1,6 +1,5 @@
 #![allow(dead_code)]
 
-use crate::poly::commitment::commitment_scheme::BatchType;
 use crate::poly::commitment::commitment_scheme::CommitShape;
 use crate::poly::commitment::commitment_scheme::CommitmentScheme;
 use crate::poly::multilinear_polynomial::MultilinearPolynomial;
@@ -51,11 +50,7 @@ impl<ProofTranscript: Transcript> CommitmentScheme<ProofTranscript>
     ) -> Self::Commitment {
         todo!()
     }
-    fn batch_commit<P>(
-        _polys: &[P],
-        _gens: &Self::Setup,
-        _batch_type: BatchType,
-    ) -> Vec<Self::Commitment>
+    fn batch_commit<P>(_polys: &[P], _gens: &Self::Setup) -> Vec<Self::Commitment>
     where
         P: Borrow<MultilinearPolynomial<Self::Field>>,
     {

--- a/jolt-core/src/poly/commitment/commitment_scheme.rs
+++ b/jolt-core/src/poly/commitment/commitment_scheme.rs
@@ -9,17 +9,6 @@ use crate::{
     utils::{errors::ProofVerifyError, transcript::AppendToTranscript},
 };
 
-#[derive(Clone, Debug)]
-pub struct CommitShape {
-    pub input_length: usize,
-}
-
-impl CommitShape {
-    pub fn new(input_length: usize) -> Self {
-        Self { input_length }
-    }
-}
-
 pub trait CommitmentScheme<ProofTranscript: Transcript>: Clone + Sync + Send + 'static {
     type Field: JoltField + Sized;
     type Setup: Clone + Sync + Send;
@@ -34,7 +23,7 @@ pub trait CommitmentScheme<ProofTranscript: Transcript>: Clone + Sync + Send + '
     type Proof: Sync + Send + CanonicalSerialize + CanonicalDeserialize;
     type BatchedProof: Sync + Send + CanonicalSerialize + CanonicalDeserialize;
 
-    fn setup(shapes: &[CommitShape]) -> Self::Setup;
+    fn setup(max_len: usize) -> Self::Setup;
     fn commit(poly: &MultilinearPolynomial<Self::Field>, setup: &Self::Setup) -> Self::Commitment;
     fn batch_commit<U>(polys: &[U], gens: &Self::Setup) -> Vec<Self::Commitment>
     where

--- a/jolt-core/src/poly/commitment/commitment_scheme.rs
+++ b/jolt-core/src/poly/commitment/commitment_scheme.rs
@@ -12,25 +12,12 @@ use crate::{
 #[derive(Clone, Debug)]
 pub struct CommitShape {
     pub input_length: usize,
-    pub batch_type: BatchType,
 }
 
 impl CommitShape {
-    pub fn new(input_length: usize, batch_type: BatchType) -> Self {
-        Self {
-            input_length,
-            batch_type,
-        }
+    pub fn new(input_length: usize) -> Self {
+        Self { input_length }
     }
-}
-
-#[derive(Clone, Debug)]
-pub enum BatchType {
-    Big,
-    Small,
-    SurgeInitFinal,
-    SurgeReadWrite,
-    GrandProduct,
 }
 
 pub trait CommitmentScheme<ProofTranscript: Transcript>: Clone + Sync + Send + 'static {
@@ -49,11 +36,7 @@ pub trait CommitmentScheme<ProofTranscript: Transcript>: Clone + Sync + Send + '
 
     fn setup(shapes: &[CommitShape]) -> Self::Setup;
     fn commit(poly: &MultilinearPolynomial<Self::Field>, setup: &Self::Setup) -> Self::Commitment;
-    fn batch_commit<U>(
-        polys: &[U],
-        gens: &Self::Setup,
-        batch_type: BatchType,
-    ) -> Vec<Self::Commitment>
+    fn batch_commit<U>(polys: &[U], gens: &Self::Setup) -> Vec<Self::Commitment>
     where
         U: Borrow<MultilinearPolynomial<Self::Field>> + Sync;
 

--- a/jolt-core/src/poly/commitment/hyperkzg.rs
+++ b/jolt-core/src/poly/commitment/hyperkzg.rs
@@ -8,7 +8,7 @@
 //! (2) HyperKZG is specialized to use KZG as the univariate commitment scheme, so it includes several optimizations (both during the transformation of multilinear-to-univariate claims
 //! and within the KZG commitment scheme implementation itself).
 use super::{
-    commitment_scheme::{BatchType, CommitmentScheme},
+    commitment_scheme::CommitmentScheme,
     kzg::{KZGProverKey, KZGVerifierKey, UnivariateKZG},
 };
 use crate::field::JoltField;
@@ -442,11 +442,7 @@ where
     }
 
     #[tracing::instrument(skip_all, name = "HyperKZG::batch_commit")]
-    fn batch_commit<U>(
-        polys: &[U],
-        gens: &Self::Setup,
-        _batch_type: BatchType,
-    ) -> Vec<Self::Commitment>
+    fn batch_commit<U>(polys: &[U], gens: &Self::Setup) -> Vec<Self::Commitment>
     where
         U: Borrow<MultilinearPolynomial<Self::Field>> + Sync,
     {

--- a/jolt-core/src/poly/commitment/hyperkzg.rs
+++ b/jolt-core/src/poly/commitment/hyperkzg.rs
@@ -12,7 +12,6 @@ use super::{
     kzg::{KZGProverKey, KZGVerifierKey, UnivariateKZG},
 };
 use crate::field::JoltField;
-use crate::poly::commitment::commitment_scheme::CommitShape;
 use crate::poly::multilinear_polynomial::{MultilinearPolynomial, PolynomialEvaluation};
 use crate::utils::transcript::Transcript;
 use crate::{
@@ -419,15 +418,13 @@ where
     type Proof = HyperKZGProof<P>;
     type BatchedProof = HyperKZGProof<P>;
 
-    fn setup(shapes: &[CommitShape]) -> Self::Setup {
-        let max_len = shapes.iter().map(|shape| shape.input_length).max().unwrap();
-
+    fn setup(max_poly_len: usize) -> Self::Setup {
         HyperKZGSRS(Arc::new(SRS::setup(
             &mut ChaCha20Rng::from_seed(*b"HyperKZG_POLY_COMMITMENT_SCHEMEE"),
-            max_len,
+            max_poly_len,
             2,
         )))
-        .trim(max_len)
+        .trim(max_poly_len)
     }
 
     #[tracing::instrument(skip_all, name = "HyperKZG::commit")]

--- a/jolt-core/src/poly/commitment/hyrax.rs
+++ b/jolt-core/src/poly/commitment/hyrax.rs
@@ -1,3 +1,11 @@
+//! This file implements the Hyrax polynomial commitment scheme.
+//! Note that we choose not to implement the `CommitmentScheme` trait, as
+//! Hyrax is not intended to be used as the core PCS for Jolt itself (in fact,
+//! there are some incompatibilities with the batched opening proof protocol
+//! used in Jolt).
+//!
+//! Instead, Hyrax will be used as the PCS in Spartan to prove the verification
+//! of a Jolt proof (i.e. SNARK composition).
 use super::pedersen::{PedersenCommitment, PedersenGenerators};
 use crate::field::JoltField;
 use crate::poly::dense_mlpoly::DensePolynomial;

--- a/jolt-core/src/poly/commitment/hyrax.rs
+++ b/jolt-core/src/poly/commitment/hyrax.rs
@@ -1,0 +1,333 @@
+use super::pedersen::{PedersenCommitment, PedersenGenerators};
+use crate::field::JoltField;
+use crate::poly::dense_mlpoly::DensePolynomial;
+use crate::poly::eq_poly::EqPolynomial;
+use crate::poly::multilinear_polynomial::MultilinearPolynomial;
+use crate::utils::errors::ProofVerifyError;
+use crate::utils::math::Math;
+use crate::utils::transcript::{AppendToTranscript, Transcript};
+use crate::utils::{compute_dotproduct, mul_0_1_optimized};
+use ark_ec::CurveGroup;
+use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
+use num_integer::Roots;
+use rayon::prelude::*;
+use tracing::trace_span;
+
+use crate::msm::{Icicle, VariableBaseMSM};
+
+pub fn matrix_dimensions(num_vars: usize, matrix_aspect_ratio: usize) -> (usize, usize) {
+    let mut row_size = (num_vars / 2).pow2();
+    row_size = (row_size * matrix_aspect_ratio.sqrt()).next_power_of_two();
+
+    let right_num_vars = std::cmp::min(row_size.log_2(), num_vars - 1);
+    row_size = right_num_vars.pow2();
+    let left_num_vars = num_vars - right_num_vars;
+    let col_size = left_num_vars.pow2();
+
+    (col_size, row_size)
+}
+
+#[derive(Clone, CanonicalSerialize, CanonicalDeserialize)]
+pub struct HyraxGenerators<const RATIO: usize, G: CurveGroup> {
+    pub gens: PedersenGenerators<G>,
+}
+
+impl<const RATIO: usize, G: CurveGroup> HyraxGenerators<RATIO, G> {
+    pub fn new(num_vars: usize) -> Self {
+        let (_left, right) = matrix_dimensions(num_vars, RATIO);
+        let gens = PedersenGenerators::new(right, b"Jolt v1 Hyrax generators");
+        HyraxGenerators { gens }
+    }
+}
+
+#[derive(Default, Clone, Debug, PartialEq, CanonicalSerialize, CanonicalDeserialize)]
+pub struct HyraxCommitment<const RATIO: usize, G: CurveGroup> {
+    pub row_commitments: Vec<G>,
+}
+
+impl<const RATIO: usize, F: JoltField, G: CurveGroup<ScalarField = F> + Icicle>
+    HyraxCommitment<RATIO, G>
+{
+    #[tracing::instrument(skip_all, name = "HyraxCommitment::commit")]
+    pub fn commit(
+        poly: &DensePolynomial<G::ScalarField>,
+        generators: &PedersenGenerators<G>,
+    ) -> Self {
+        let n = poly.len();
+        let ell = n.log_2();
+
+        let (L_size, R_size) = matrix_dimensions(ell, 1);
+        assert_eq!(L_size * R_size, n);
+
+        let gens = CurveGroup::normalize_batch(&generators.generators[..R_size]);
+        let row_commitments = poly
+            .Z
+            .par_chunks(R_size)
+            .map(|row| PedersenCommitment::commit_vector(row, &gens))
+            .collect();
+        Self { row_commitments }
+    }
+
+    #[tracing::instrument(skip_all, name = "HyraxCommitment::batch_commit")]
+    pub fn batch_commit(
+        batch: &[&[G::ScalarField]],
+        generators: &PedersenGenerators<G>,
+    ) -> Vec<Self> {
+        let n = batch[0].len();
+        batch.iter().for_each(|poly| assert_eq!(poly.len(), n));
+        let ell = n.log_2();
+
+        let (L_size, R_size) = matrix_dimensions(ell, RATIO);
+        assert_eq!(L_size * R_size, n);
+
+        let gens = CurveGroup::normalize_batch(&generators.generators[..R_size]);
+
+        let rows = batch.par_iter().flat_map(|poly| poly.par_chunks(R_size));
+        let row_commitments: Vec<G> = rows
+            .map(|row| PedersenCommitment::commit_vector(row, &gens))
+            .collect();
+
+        row_commitments
+            .par_chunks(L_size)
+            .map(|chunk| Self {
+                row_commitments: chunk.to_vec(),
+            })
+            .collect()
+    }
+}
+
+impl<const RATIO: usize, G: CurveGroup> AppendToTranscript for HyraxCommitment<RATIO, G> {
+    fn append_to_transcript<ProofTranscript: Transcript>(&self, transcript: &mut ProofTranscript) {
+        for i in 0..self.row_commitments.len() {
+            transcript.append_point(&self.row_commitments[i]);
+        }
+    }
+}
+
+#[derive(Debug, CanonicalSerialize, CanonicalDeserialize)]
+pub struct HyraxOpeningProof<const RATIO: usize, G: CurveGroup> {
+    pub vector_matrix_product: Vec<G::ScalarField>,
+}
+
+/// See Section 14.3 of Thaler's Proofs, Arguments, and Zero-Knowledge
+impl<const RATIO: usize, F: JoltField, G: CurveGroup<ScalarField = F> + Icicle>
+    HyraxOpeningProof<RATIO, G>
+{
+    #[tracing::instrument(skip_all, name = "HyraxOpeningProof::prove")]
+    pub fn prove(
+        poly: &DensePolynomial<G::ScalarField>,
+        opening_point: &[G::ScalarField], // point at which the polynomial is evaluated
+        ratio: usize,
+    ) -> HyraxOpeningProof<RATIO, G> {
+        // assert vectors are of the right size
+        assert_eq!(poly.get_num_vars(), opening_point.len());
+
+        // compute the L and R vectors
+        let (L_size, _R_size) = matrix_dimensions(poly.get_num_vars(), ratio);
+        let L = EqPolynomial::evals(&opening_point[..L_size.log_2()]);
+
+        // compute vector-matrix product between L and Z viewed as a matrix
+        let vector_matrix_product = Self::vector_matrix_product(poly, &L, ratio);
+
+        HyraxOpeningProof {
+            vector_matrix_product,
+        }
+    }
+
+    pub fn verify(
+        &self,
+        pedersen_generators: &PedersenGenerators<G>,
+        opening_point: &[G::ScalarField], // point at which the polynomial is evaluated
+        opening: &G::ScalarField,         // evaluation \widetilde{Z}(r)
+        commitment: &HyraxCommitment<RATIO, G>,
+    ) -> Result<(), ProofVerifyError> {
+        // compute L and R
+        let (L_size, R_size) = matrix_dimensions(opening_point.len(), RATIO);
+        let L = EqPolynomial::evals(&opening_point[..L_size.log_2()]);
+        let R = EqPolynomial::evals(&opening_point[L_size.log_2()..]);
+
+        // Verifier-derived commitment to u * a = \prod Com(u_j)^{a_j}
+        let homomorphically_derived_commitment: G = VariableBaseMSM::msm(
+            &G::normalize_batch(&commitment.row_commitments),
+            None,
+            &MultilinearPolynomial::from(L),
+            None,
+        )
+        .unwrap();
+
+        let product_commitment = VariableBaseMSM::msm_field_elements(
+            &G::normalize_batch(&pedersen_generators.generators[..R_size]),
+            None,
+            &self.vector_matrix_product,
+            None,
+            false,
+        )
+        .unwrap();
+
+        let dot_product = compute_dotproduct(&self.vector_matrix_product, &R);
+
+        if (homomorphically_derived_commitment == product_commitment) && (dot_product == *opening) {
+            Ok(())
+        } else {
+            Err(ProofVerifyError::InternalError)
+        }
+    }
+
+    #[tracing::instrument(skip_all, name = "HyraxOpeningProof::vector_matrix_product")]
+    fn vector_matrix_product(
+        poly: &DensePolynomial<G::ScalarField>,
+        L: &[G::ScalarField],
+        ratio: usize,
+    ) -> Vec<G::ScalarField> {
+        let (_, R_size) = matrix_dimensions(poly.get_num_vars(), ratio);
+
+        poly.evals_ref()
+            .par_chunks(R_size)
+            .enumerate()
+            .map(|(i, row)| {
+                row.iter()
+                    .map(|x| mul_0_1_optimized(&L[i], x))
+                    .collect::<Vec<G::ScalarField>>()
+            })
+            .reduce(
+                || vec![G::ScalarField::zero(); R_size],
+                |mut acc: Vec<_>, row| {
+                    acc.iter_mut().zip(row).for_each(|(x, y)| *x += y);
+                    acc
+                },
+            )
+    }
+}
+
+#[derive(Debug, CanonicalSerialize, CanonicalDeserialize)]
+pub struct BatchedHyraxOpeningProof<const RATIO: usize, G: CurveGroup> {
+    pub joint_proof: HyraxOpeningProof<RATIO, G>,
+}
+
+/// See Section 16.1 of Thaler's Proofs, Arguments, and Zero-Knowledge
+impl<const RATIO: usize, F: JoltField, G: CurveGroup<ScalarField = F> + Icicle>
+    BatchedHyraxOpeningProof<RATIO, G>
+{
+    #[tracing::instrument(skip_all, name = "BatchedHyraxOpeningProof::prove")]
+    pub fn prove<ProofTranscript: Transcript>(
+        polynomials: &[&DensePolynomial<G::ScalarField>],
+        opening_point: &[G::ScalarField],
+        openings: &[G::ScalarField],
+        transcript: &mut ProofTranscript,
+    ) -> Self {
+        // append the claimed evaluations to transcript
+        transcript.append_scalars(openings);
+
+        let rlc_coefficients: Vec<_> = transcript.challenge_vector(polynomials.len());
+
+        let _span = trace_span!("Compute RLC of polynomials");
+        let _enter = _span.enter();
+
+        let poly_len = polynomials[0].len();
+
+        let num_chunks = rayon::current_num_threads().next_power_of_two();
+        let chunk_size = poly_len / num_chunks;
+
+        let rlc_poly = if chunk_size > 0 {
+            (0..num_chunks)
+                .into_par_iter()
+                .flat_map_iter(|chunk_index| {
+                    let mut chunk = vec![G::ScalarField::zero(); chunk_size];
+                    for (coeff, poly) in rlc_coefficients.iter().zip(polynomials.iter()) {
+                        for (rlc, poly_eval) in chunk
+                            .iter_mut()
+                            .zip(poly.evals_ref()[chunk_index * chunk_size..].iter())
+                        {
+                            *rlc += mul_0_1_optimized(poly_eval, coeff);
+                        }
+                    }
+                    chunk
+                })
+                .collect::<Vec<_>>()
+        } else {
+            rlc_coefficients
+                .par_iter()
+                .zip(polynomials.par_iter())
+                .map(|(coeff, poly)| poly.evals_ref().iter().map(|eval| *coeff * *eval).collect())
+                .reduce(
+                    || vec![G::ScalarField::zero(); poly_len],
+                    |running, new| {
+                        debug_assert_eq!(running.len(), new.len());
+                        running
+                            .iter()
+                            .zip(new.iter())
+                            .map(|(r, n)| *r + *n)
+                            .collect()
+                    },
+                )
+        };
+
+        drop(_enter);
+        drop(_span);
+
+        let joint_proof =
+            HyraxOpeningProof::prove(&DensePolynomial::new(rlc_poly), opening_point, RATIO);
+
+        Self { joint_proof }
+    }
+
+    #[tracing::instrument(skip_all, name = "BatchedHyraxOpeningProof::verify")]
+    pub fn verify<ProofTranscript: Transcript>(
+        &self,
+        pedersen_generators: &PedersenGenerators<G>,
+        opening_point: &[G::ScalarField],
+        openings: &[G::ScalarField],
+        commitments: &[&HyraxCommitment<RATIO, G>],
+        transcript: &mut ProofTranscript,
+    ) -> Result<(), ProofVerifyError> {
+        assert_eq!(openings.len(), commitments.len());
+        let (L_size, _R_size) = matrix_dimensions(opening_point.len(), RATIO);
+        commitments.iter().enumerate().for_each(|(i, commitment)| {
+            assert_eq!(
+                L_size,
+                commitment.row_commitments.len(),
+                "Row commitment {}/{} wrong length.",
+                i,
+                commitments.len()
+            )
+        });
+
+        // append the claimed evaluations to transcript
+        transcript.append_scalars(openings);
+
+        let rlc_coefficients: Vec<_> = transcript.challenge_vector(openings.len());
+
+        let rlc_eval = compute_dotproduct(&rlc_coefficients, openings);
+
+        let rlc_commitment = rlc_coefficients
+            .par_iter()
+            .zip(commitments.par_iter())
+            .map(|(coeff, commitment)| {
+                commitment
+                    .row_commitments
+                    .iter()
+                    .map(|row_commitment| *row_commitment * coeff)
+                    .collect()
+            })
+            .reduce(
+                || vec![G::zero(); L_size],
+                |running, new| {
+                    debug_assert_eq!(running.len(), new.len());
+                    running
+                        .iter()
+                        .zip(new.iter())
+                        .map(|(r, n)| *r + n)
+                        .collect()
+                },
+            );
+
+        self.joint_proof.verify(
+            pedersen_generators,
+            opening_point,
+            &rlc_eval,
+            &HyraxCommitment {
+                row_commitments: rlc_commitment,
+            },
+        )
+    }
+}

--- a/jolt-core/src/poly/commitment/kzg.rs
+++ b/jolt-core/src/poly/commitment/kzg.rs
@@ -175,15 +175,6 @@ pub struct KZGVerifierKey<P: Pairing> {
     pub beta_g2: P::G2Affine,
 }
 
-#[derive(Clone, Copy, Debug)]
-pub enum CommitMode {
-    Default,
-    // We noticed that most (93%) of the coefficients arising from lasso grand products are 1.
-    // This mode uses a precomputed commitment, G, to save some compute.
-    // Where G is the commitment to the all-ones vector of length 2^k```
-    GrandProduct,
-}
-
 #[derive(Debug, Clone, Eq, PartialEq, Default)]
 pub struct UnivariateKZG<P: Pairing> {
     _phantom: PhantomData<P>,

--- a/jolt-core/src/poly/commitment/mock.rs
+++ b/jolt-core/src/poly/commitment/mock.rs
@@ -12,7 +12,7 @@ use crate::{
     },
 };
 
-use super::commitment_scheme::{CommitShape, CommitmentScheme};
+use super::commitment_scheme::CommitmentScheme;
 
 #[derive(Clone)]
 pub struct MockCommitScheme<F: JoltField, ProofTranscript: Transcript> {
@@ -46,7 +46,7 @@ where
     type Proof = MockProof<F>;
     type BatchedProof = MockProof<F>;
 
-    fn setup(_shapes: &[CommitShape]) -> Self::Setup {}
+    fn setup(_max_poly_len: usize) -> Self::Setup {}
     fn commit(poly: &MultilinearPolynomial<Self::Field>, _setup: &Self::Setup) -> Self::Commitment {
         MockCommitment { poly: poly.clone() }
     }

--- a/jolt-core/src/poly/commitment/mock.rs
+++ b/jolt-core/src/poly/commitment/mock.rs
@@ -12,7 +12,7 @@ use crate::{
     },
 };
 
-use super::commitment_scheme::{BatchType, CommitShape, CommitmentScheme};
+use super::commitment_scheme::{CommitShape, CommitmentScheme};
 
 #[derive(Clone)]
 pub struct MockCommitScheme<F: JoltField, ProofTranscript: Transcript> {
@@ -50,11 +50,7 @@ where
     fn commit(poly: &MultilinearPolynomial<Self::Field>, _setup: &Self::Setup) -> Self::Commitment {
         MockCommitment { poly: poly.clone() }
     }
-    fn batch_commit<P>(
-        polys: &[P],
-        setup: &Self::Setup,
-        _batch_type: BatchType,
-    ) -> Vec<Self::Commitment>
+    fn batch_commit<P>(polys: &[P], setup: &Self::Setup) -> Vec<Self::Commitment>
     where
         P: Borrow<MultilinearPolynomial<Self::Field>>,
     {

--- a/jolt-core/src/poly/commitment/mod.rs
+++ b/jolt-core/src/poly/commitment/mod.rs
@@ -1,7 +1,9 @@
 pub mod binius;
 pub mod commitment_scheme;
 pub mod hyperkzg;
+pub mod hyrax;
 pub mod kzg;
+pub mod pedersen;
 pub mod zeromorph;
 
 #[cfg(test)]

--- a/jolt-core/src/poly/commitment/pedersen.rs
+++ b/jolt-core/src/poly/commitment/pedersen.rs
@@ -1,0 +1,72 @@
+use ark_ec::CurveGroup;
+use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
+use ark_std::rand::SeedableRng;
+use rand_chacha::ChaCha20Rng;
+use sha3::digest::{ExtendableOutput, Update};
+use sha3::Shake256;
+use std::io::Read;
+
+use crate::field::JoltField;
+use crate::msm::{Icicle, VariableBaseMSM};
+
+#[derive(Clone, CanonicalSerialize, CanonicalDeserialize)]
+pub struct PedersenGenerators<G: CurveGroup> {
+    pub generators: Vec<G>,
+}
+
+impl<G: CurveGroup> PedersenGenerators<G> {
+    #[tracing::instrument(skip_all, name = "PedersenGenerators::new")]
+    pub fn new(len: usize, label: &[u8]) -> Self {
+        let mut shake = Shake256::default();
+        shake.update(label);
+        let mut buf = vec![];
+        G::generator().serialize_compressed(&mut buf).unwrap();
+        shake.update(&buf);
+
+        let mut reader = shake.finalize_xof();
+        let mut seed = [0u8; 32];
+        reader.read_exact(&mut seed).unwrap();
+        let mut rng = ChaCha20Rng::from_seed(seed);
+
+        let mut generators: Vec<G> = Vec::new();
+        for _ in 0..len {
+            generators.push(G::rand(&mut rng));
+        }
+
+        Self { generators }
+    }
+
+    pub fn clone_n(&self, n: usize) -> PedersenGenerators<G> {
+        assert!(
+            self.generators.len() >= n,
+            "Insufficient number of generators for clone_n: required {}, available {}",
+            n,
+            self.generators.len()
+        );
+        let slice = &self.generators[..n];
+        PedersenGenerators {
+            generators: slice.into(),
+        }
+    }
+}
+
+pub trait PedersenCommitment<G: CurveGroup>: Sized {
+    fn commit(&self, gens: &PedersenGenerators<G>) -> G;
+    fn commit_vector(inputs: &[Self], bases: &[G::Affine]) -> G;
+}
+
+impl<G: CurveGroup + Icicle> PedersenCommitment<G> for G::ScalarField
+where
+    G::ScalarField: JoltField,
+{
+    #[tracing::instrument(skip_all, name = "PedersenCommitment::commit")]
+    fn commit(&self, gens: &PedersenGenerators<G>) -> G {
+        assert_eq!(gens.generators.len(), 1);
+        gens.generators[0] * self
+    }
+
+    fn commit_vector(inputs: &[Self], bases: &[G::Affine]) -> G {
+        assert_eq!(bases.len(), inputs.len());
+        VariableBaseMSM::msm_field_elements(bases, None, inputs, None, false).unwrap()
+    }
+}

--- a/jolt-core/src/poly/commitment/zeromorph.rs
+++ b/jolt-core/src/poly/commitment/zeromorph.rs
@@ -20,7 +20,7 @@ use std::sync::Arc;
 use std::{iter, marker::PhantomData};
 
 use super::{
-    commitment_scheme::{BatchType, CommitShape, CommitmentScheme},
+    commitment_scheme::{CommitShape, CommitmentScheme},
     kzg::{KZGProverKey, KZGVerifierKey, UnivariateKZG, SRS},
 };
 use crate::field::JoltField;
@@ -452,11 +452,7 @@ where
         ZeromorphCommitment(UnivariateKZG::commit_as_univariate(&setup.0.commit_pp, poly).unwrap())
     }
 
-    fn batch_commit<U>(
-        polys: &[U],
-        gens: &Self::Setup,
-        _batch_type: BatchType,
-    ) -> Vec<Self::Commitment>
+    fn batch_commit<U>(polys: &[U], gens: &Self::Setup) -> Vec<Self::Commitment>
     where
         U: Borrow<MultilinearPolynomial<Self::Field>> + Sync,
     {

--- a/jolt-core/src/poly/commitment/zeromorph.rs
+++ b/jolt-core/src/poly/commitment/zeromorph.rs
@@ -20,7 +20,7 @@ use std::sync::Arc;
 use std::{iter, marker::PhantomData};
 
 use super::{
-    commitment_scheme::{CommitShape, CommitmentScheme},
+    commitment_scheme::CommitmentScheme,
     kzg::{KZGProverKey, KZGVerifierKey, UnivariateKZG, SRS},
 };
 use crate::field::JoltField;
@@ -427,19 +427,17 @@ where
     type Proof = ZeromorphProof<P>;
     type BatchedProof = ZeromorphProof<P>;
 
-    fn setup(shapes: &[CommitShape]) -> Self::Setup
+    fn setup(max_poly_len: usize) -> Self::Setup
     where
         P::ScalarField: JoltField,
         P::G1: Icicle,
     {
-        let max_len = shapes.iter().map(|shape| shape.input_length).max().unwrap();
-
         ZeromorphSRS(Arc::new(SRS::setup(
             &mut ChaCha20Rng::from_seed(*b"ZEROMORPH_POLY_COMMITMENT_SCHEME"),
-            max_len,
-            max_len,
+            max_poly_len,
+            max_poly_len,
         )))
-        .trim(max_len)
+        .trim(max_poly_len)
     }
 
     fn commit(poly: &MultilinearPolynomial<Self::Field>, setup: &Self::Setup) -> Self::Commitment {


### PR DESCRIPTION
Brings back Hyrax for use as a commitment scheme in Spartan in the context of two-stage SNARK composition for Jolt i.e. Groth16(Spartan(Jolt))