### PR TITLE
chore: fix typos in code & docs, add CI job

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -109,6 +109,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: crate-ci/typos@v1
+      - uses: crate-ci/typos@v1.30.0
         with:
           files: .

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -104,3 +104,11 @@ jobs:
       - name: Check Format
         working-directory: ./jolt-evm-verifier
         run: forge fmt --check
+
+  typos:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: crate-ci/typos@v1
+        with:
+          files: .

--- a/book/src/future/groth-16.md
+++ b/book/src/future/groth-16.md
@@ -8,7 +8,7 @@ We call directly representing the Jolt verifier (with HyperKZG polynomial commit
 as constraints to then feeding those constraints into Groth16 "naive composition". Unfortunately, this naive procedure
 will result 
 in over a hundred millions of constraints. Applying Groth16 
-to such a large constraint system will result in far more latency than we'd lik, (and may even be impossible over the BN254 scalar field
+to such a large constraint system will result in far more latency than we'd like, (and may even be impossible over the BN254 scalar field
 because that field only supports FFTs of length $2^{27}$. 
 Below, we describe alternate ways forward. 
 

--- a/book/src/future/proof-size-breakdown.md
+++ b/book/src/future/proof-size-breakdown.md
@@ -47,7 +47,7 @@ and one attests to the validity of initialization of memory plus a final pass ov
 The reason we do not run these grand products "together as one big grand product" is they are 
 each potentially of different sizes,
 and it is annoying (though possible) to "batch prove" differently-sized grand products together.
-However, a relatively easy way to get down to 3 grand prodcuts is to set the memory size
+However, a relatively easy way to get down to 3 grand products is to set the memory size
 in each of the three categories above to equal the number of reads/writes. This simply involves 
 padding the memory with zeros to make it equal in size to 
 the number of reads/writes into the memory (i.e., NUM_CYCLES). Doing this will not substantially increase

--- a/book/src/how/m-extension.md
+++ b/book/src/how/m-extension.md
@@ -113,5 +113,5 @@ If the current instruction is virtual, we can constrain the next instruction in 
 next instruction in the bytecode.
 We observe that the virtual sequences used in the M extension don't involve jumps or branches,
 so this should always hold, *except* if we encounter a virtual instruction followed by a padding instruction.
-But that should never happend because an execution trace should always end with some return handling,
+But that should never happen because an execution trace should always end with some return handling,
 which shouldn't involve a virtual sequence.

--- a/book/src/how/r1cs_constraints.md
+++ b/book/src/how/r1cs_constraints.md
@@ -44,7 +44,7 @@ the preprocessed bytecode in Jolt.
     1. `ConcatLookupQueryChunks`: Indicates whether the instruction performs a concat-type lookup.
     1. `Virtual`: 1 if the instruction is "virtual", as defined in Section 6.1 of the Jolt paper.
     1. `Assert`: 1 if the instruction is an assert, as defined in Section 6.1.1 of the Jolt paper.
-    1. `DoNotUpdatePC`: Used in virtual sequences; the program counter should be the same for the full seqeuence.
+    1. `DoNotUpdatePC`: Used in virtual sequences; the program counter should be the same for the full sequence.
 * Instruction flags: these are the unary bits used to indicate instruction is executed at a given step.
 There are as many per step as the number of unique instruction lookup tables in Jolt.
 

--- a/book/src/how/read_write_memory.md
+++ b/book/src/how/read_write_memory.md
@@ -24,7 +24,7 @@ Program inputs populate the designated input space upon initialization:
 
 The verifier can efficiently compute the MLE of this initial memory state on its own (i.e. in time proportional to the IO size, not the total memory size).
 
-### Ouputs and panic
+### Outputs and panic
 
 On the other hand, the verifier cannot compute the MLE of the final memory state on its own –– though the program I/O is known to the verifier, the final memory state contains values written to registers/RAM over the course of program execution, which are *not* known to the verifier.
 

--- a/book/src/how/sparse-constraint-systems.md
+++ b/book/src/how/sparse-constraint-systems.md
@@ -50,7 +50,7 @@ we can "switch over" to the standard "dense" linear-time sum-check proving algor
 so that $n/2^i \approx m$. In Jolt, we expect this "switchover" to happen by round $4$ or $5$. 
 In the end, the amount of extra field work done by the prover owing to the sparsity will only be a factor of $2$ or so.
 
-Jolt uses this approach within Lasso as well. Across all of the primtive RISC-V instructions,
+Jolt uses this approach within Lasso as well. Across all of the primitive RISC-V instructions,
 there are about 80 "subtables" that get used. Any particular primitive instruction only needs
 to access between 4 and 10 of these subtables. We "pretend" that every primitive instruction
 actually accesses all 80 of the subtables, but use binary flags to "turn off" any subtable
@@ -63,7 +63,7 @@ commitment time, and that our grand product prover does not pay any field work f
 There are alternative approaches we could take to achieve "a la carte" prover costs, e.g., [vRAM](https://web.eecs.umich.edu/~genkin/papers/vram.pdf)'s approach
 of having the prover sort all cycles by which primitive operation or pre-compile was executed at that cycle
 (see also the much more recent work [Ceno](https://eprint.iacr.org/2024/387)).
-But the above approach is compatable with a streaming prover, avoids committing to the same data multiple times,
+But the above approach is compatible with a streaming prover, avoids committing to the same data multiple times,
 and has other benefits.
 
 We call this technique (fast proving for) "sparse constraint systems". Note that the term sparse here

--- a/examples/overflow/src/main.rs
+++ b/examples/overflow/src/main.rs
@@ -22,13 +22,13 @@ pub fn main() {
 
     // valid case for stack allocation, calls overflow_stack() under the hood
     // but with stack_size=8192
-    let (prove_allocate_stack_with_increased_size, verfiy_allocate_stack_with_increased_size) =
+    let (prove_allocate_stack_with_increased_size, verify_allocate_stack_with_increased_size) =
         guest::build_allocate_stack_with_increased_size();
 
     let now = Instant::now();
     let (output, proof) = prove_allocate_stack_with_increased_size();
     println!("Prover runtime: {} s", now.elapsed().as_secs_f64());
-    let is_valid = verfiy_allocate_stack_with_increased_size(proof);
+    let is_valid = verify_allocate_stack_with_increased_size(proof);
 
     println!("output: {}", output);
     println!("valid: {}", is_valid);

--- a/jolt-core/src/lasso/memory_checking.rs
+++ b/jolt-core/src/lasso/memory_checking.rs
@@ -69,7 +69,7 @@ where
 }
 
 /// This type, used within a `StructuredPolynomialData` struct, indicates that the
-/// field has a corresponding opening but no corrresponding polynomial or commitment ––
+/// field has a corresponding opening but no corresponding polynomial or commitment ––
 /// the prover doesn't need to compute a witness polynomial or commitment because
 /// the verifier can compute the opening on its own.
 pub type VerifierComputedOpening<T> = Option<T>;

--- a/jolt-core/src/poly/commitment/hyrax.rs
+++ b/jolt-core/src/poly/commitment/hyrax.rs
@@ -79,7 +79,7 @@ impl<const RATIO: usize, F: JoltField, G: CurveGroup<ScalarField = F> + Icicle>
         Self { row_commitments }
     }
 
-    /// Same result as commiting to each polynomial in the batch individually,
+    /// Same result as committing to each polynomial in the batch individually,
     /// but tends to have better parallelism.
     #[tracing::instrument(skip_all, name = "HyraxCommitment::batch_commit")]
     pub fn batch_commit(

--- a/jolt-core/src/poly/commitment/zeromorph.rs
+++ b/jolt-core/src/poly/commitment/zeromorph.rs
@@ -198,7 +198,7 @@ where
     };
 
     let vs = {
-        let v_number = squares_of_x[num_vars] - P::ScalarField::one();
+        let v_numer = squares_of_x[num_vars] - P::ScalarField::one();
         let mut v_denoms = squares_of_x
             .iter()
             .map(|squares_of_x| *squares_of_x - P::ScalarField::one())
@@ -206,7 +206,7 @@ where
         batch_inversion(&mut v_denoms);
         v_denoms
             .iter()
-            .map(|v_denom| v_number * *v_denom)
+            .map(|v_denom| v_numer * *v_denom)
             .collect::<Vec<_>>()
     };
 

--- a/jolt-core/src/poly/commitment/zeromorph.rs
+++ b/jolt-core/src/poly/commitment/zeromorph.rs
@@ -198,7 +198,7 @@ where
     };
 
     let vs = {
-        let v_numer = squares_of_x[num_vars] - P::ScalarField::one();
+        let v_number = squares_of_x[num_vars] - P::ScalarField::one();
         let mut v_denoms = squares_of_x
             .iter()
             .map(|squares_of_x| *squares_of_x - P::ScalarField::one())
@@ -206,7 +206,7 @@ where
         batch_inversion(&mut v_denoms);
         v_denoms
             .iter()
-            .map(|v_denom| v_numer * *v_denom)
+            .map(|v_denom| v_number * *v_denom)
             .collect::<Vec<_>>()
     };
 
@@ -517,7 +517,7 @@ mod test {
     use ark_std::{test_rng, UniformRand};
     use rand_core::SeedableRng;
 
-    // Evaluate Phi_k(x) = \sum_{i=0}^k x^i using the direct inefficent formula
+    // Evaluate Phi_k(x) = \sum_{i=0}^k x^i using the direct inefficient formula
     fn phi<P: Pairing>(challenge: &P::ScalarField, subscript: usize) -> P::ScalarField {
         let len = (1 << subscript) as u64;
         (0..len).fold(P::ScalarField::zero(), |mut acc, i| {

--- a/jolt-core/src/poly/sparse_interleaved_poly.rs
+++ b/jolt-core/src/poly/sparse_interleaved_poly.rs
@@ -227,7 +227,7 @@ impl<F: JoltField> SparseInterleavedPolynomial<F> {
                             continue;
                         }
                         if coeff.index % 2 == 0 {
-                            // Left node; try to find correspoding right node
+                            // Left node; try to find corresponding right node
                             let right = segment
                                 .get(j + 1)
                                 .cloned()

--- a/jolt-core/src/poly/spartan_interleaved_poly.rs
+++ b/jolt-core/src/poly/spartan_interleaved_poly.rs
@@ -449,7 +449,7 @@ impl<F: JoltField> SpartanInterleavedPolynomial<F> {
     }
 
     /// All subsequent rounds of the first Spartan sumcheck.
-    pub fn subseqeunt_sumcheck_round<ProofTranscript: Transcript>(
+    pub fn subsequent_sumcheck_round<ProofTranscript: Transcript>(
         &mut self,
         eq_poly: &mut SplitEqPolynomial<F>,
         transcript: &mut ProofTranscript,

--- a/jolt-core/src/r1cs/inputs.rs
+++ b/jolt-core/src/r1cs/inputs.rs
@@ -237,7 +237,7 @@ impl<const C: usize, I: ConstraintInput, F: JoltField, ProofTranscript: Transcri
     }
 }
 
-/// Jolt's R1CS constraint inputs are typically represneted as an enum.
+/// Jolt's R1CS constraint inputs are typically represented as an enum.
 /// This trait serves two main purposes:
 /// - Defines a canonical ordering over inputs (and thus indices for each input).
 ///   This is needed for sumcheck.

--- a/jolt-core/src/r1cs/spartan.rs
+++ b/jolt-core/src/r1cs/spartan.rs
@@ -39,7 +39,7 @@ pub enum SpartanError {
     #[error("InvalidSumcheckProof")]
     InvalidSumcheckProof,
 
-    /// returned when the recusive sumcheck proof fails
+    /// returned when the recursive sumcheck proof fails
     #[error("InvalidOuterSumcheckProof")]
     InvalidOuterSumcheckProof,
 
@@ -47,7 +47,7 @@ pub enum SpartanError {
     #[error("InvalidOuterSumcheckClaim")]
     InvalidOuterSumcheckClaim,
 
-    /// returned when the recusive sumcheck proof fails
+    /// returned when the recursive sumcheck proof fails
     #[error("InvalidInnerSumcheckProof")]
     InvalidInnerSumcheckProof,
 

--- a/jolt-core/src/subprotocols/sparse_grand_product.rs
+++ b/jolt-core/src/subprotocols/sparse_grand_product.rs
@@ -38,11 +38,11 @@ struct BatchedGrandProductToggleLayer<F: JoltField> {
     flag_values: Vec<Vec<F>>,
     /// The Reed-Solomon fingerprints for each circuit in the batch.
     fingerprints: Vec<Vec<F>>,
-    /// Once the sparse flag/fingerprint vectors cannnot be bound further
+    /// Once the sparse flag/fingerprint vectors cannot be bound further
     /// (i.e. binding would require processing values in different vectors),
     /// we switch to using `coalesced_flags` to represent the flag values.
     coalesced_flags: Option<Vec<F>>,
-    /// Once the sparse flag/fingerprint vectors cannnot be bound further
+    /// Once the sparse flag/fingerprint vectors cannot be bound further
     /// (i.e. binding would require processing values in different vectors),
     /// we switch to using `coalesced_fingerprints` to represent the fingerprint values.
     coalesced_fingerprints: Option<Vec<F>>,
@@ -127,7 +127,7 @@ impl<F: JoltField> BatchedGrandProductToggleLayer<F> {
 
     /// Computes the grand product layer output by this one.
     /// Since this is a toggle layer, most of the output values are 1s, so
-    /// the return type is a SparseInterleavedPolyomial
+    /// the return type is a SparseInterleavedPolynomial
     ///   o      o     o      o    <-  output layer
     ///  / \    / \   / \    / \
     /// 🏴  o  🏳️ o  🏳️ o  🏴  o  <- toggle layer

--- a/jolt-core/src/subprotocols/sparse_grand_product.rs
+++ b/jolt-core/src/subprotocols/sparse_grand_product.rs
@@ -210,11 +210,11 @@ impl<F: JoltField> Bindable<F> for BatchedGrandProductToggleLayer<F> {
             }
             self.coalesced_flags = Some(bound_flags);
 
-            let coalesced_fingerpints = self.coalesced_fingerprints.as_mut().unwrap();
-            let mut bound_fingerprints = vec![F::zero(); coalesced_fingerpints.len() / 2];
+            let coalesced_fingerprints = self.coalesced_fingerprints.as_mut().unwrap();
+            let mut bound_fingerprints = vec![F::zero(); coalesced_fingerprints.len() / 2];
             for i in 0..bound_fingerprints.len() {
-                bound_fingerprints[i] = coalesced_fingerpints[2 * i]
-                    + r * (coalesced_fingerpints[2 * i + 1] - coalesced_fingerpints[2 * i]);
+                bound_fingerprints[i] = coalesced_fingerprints[2 * i]
+                    + r * (coalesced_fingerprints[2 * i + 1] - coalesced_fingerprints[2 * i]);
             }
             self.coalesced_fingerprints = Some(bound_fingerprints);
             self.batched_layer_len /= 2;
@@ -399,14 +399,14 @@ impl<F: JoltField, ProofTranscript: Transcript> BatchedCubicSumcheck<F, ProofTra
     #[tracing::instrument(skip_all, name = "BatchedGrandProductToggleLayer::compute_cubic")]
     fn compute_cubic(&self, eq_poly: &SplitEqPolynomial<F>, previous_round_claim: F) -> UniPoly<F> {
         if let Some(coalesced_flags) = &self.coalesced_flags {
-            let coalesced_fingerpints = self.coalesced_fingerprints.as_ref().unwrap();
+            let coalesced_fingerprints = self.coalesced_fingerprints.as_ref().unwrap();
 
             let cubic_evals = if eq_poly.E1_len == 1 {
                 // 1. Flags/fingerprints are coalesced, and E1 is fully bound
                 // This is similar to the if case of `DenseInterleavedPolynomial::compute_cubic`
                 coalesced_flags
                     .par_chunks(2)
-                    .zip(coalesced_fingerpints.par_chunks(2))
+                    .zip(coalesced_fingerprints.par_chunks(2))
                     .zip(eq_poly.E2.par_chunks(2))
                     .map(|((flags, fingerprints), eq_chunk)| {
                         let eq_evals = {
@@ -453,12 +453,12 @@ impl<F: JoltField, ProofTranscript: Transcript> BatchedCubicSumcheck<F, ProofTra
 
                 let flag_chunk_size = coalesced_flags.len().next_power_of_two() / eq_poly.E2_len;
                 let fingerprint_chunk_size =
-                    coalesced_fingerpints.len().next_power_of_two() / eq_poly.E2_len;
+                    coalesced_fingerprints.len().next_power_of_two() / eq_poly.E2_len;
 
                 eq_poly.E2[..eq_poly.E2_len]
                     .par_iter()
                     .zip(coalesced_flags.par_chunks(flag_chunk_size))
-                    .zip(coalesced_fingerpints.par_chunks(fingerprint_chunk_size))
+                    .zip(coalesced_fingerprints.par_chunks(fingerprint_chunk_size))
                     .map(|((E2_eval, flag_x2), fingerprint_x2)| {
                         let mut inner_sum = (F::zero(), F::zero(), F::zero());
                         for ((E1_evals, flag_chunk), fingerprint_chunk) in E1_evals

--- a/jolt-core/src/subprotocols/sumcheck.rs
+++ b/jolt-core/src/subprotocols/sumcheck.rs
@@ -159,7 +159,7 @@ impl<F: JoltField, ProofTranscript: Transcript> SumcheckInstanceProof<F, ProofTr
             let r_j = transcript.challenge_scalar();
             r.push(r_j);
 
-            // bound all tables to the verifier's challenege
+            // bound all tables to the verifier's challenge
             polys
                 .par_iter_mut()
                 .for_each(|poly| poly.bind(r_j, BindingOrder::HighToLow));
@@ -192,7 +192,7 @@ impl<F: JoltField, ProofTranscript: Transcript> SumcheckInstanceProof<F, ProofTr
                     .first_sumcheck_round(eq_poly, transcript, &mut r, &mut polys, &mut claim);
             } else {
                 az_bz_cz_poly
-                    .subseqeunt_sumcheck_round(eq_poly, transcript, &mut r, &mut polys, &mut claim);
+                    .subsequent_sumcheck_round(eq_poly, transcript, &mut r, &mut polys, &mut claim);
             }
         }
 
@@ -207,7 +207,7 @@ impl<F: JoltField, ProofTranscript: Transcript> SumcheckInstanceProof<F, ProofTr
     // A specialized sumcheck implementation with the 0th round unrolled from the rest of the
     // `for` loop. This allows us to pass in `witness_polynomials` by reference instead of
     // passing them in as a single `DensePolynomial`, which would require an expensive
-    // concatenation. We defer the actual instantation of a `DensePolynomial` to the end of the
+    // concatenation. We defer the actual instantiation of a `DensePolynomial` to the end of the
     // 0th round.
     pub fn prove_spartan_quadratic(
         claim: &F,

--- a/jolt-core/src/subprotocols/twist.rs
+++ b/jolt-core/src/subprotocols/twist.rs
@@ -19,7 +19,7 @@ use rayon::prelude::*;
 
 /// The Twist+Shout paper gives two different prover algorithms for the read-checking
 /// and write-checking algorithms in Twist, called the "local algorithm" and
-/// "alternative algorithm". The local algorithm has worse dependence on the pararmeter
+/// "alternative algorithm". The local algorithm has worse dependence on the parameter
 /// d, but benefits from locality of memory accesses.
 pub enum TwistAlgorithm {
     /// The "local algorithm" for Twist's read-checking and write-checking sumchecks,

--- a/jolt-core/src/utils/thread.rs
+++ b/jolt-core/src/utils/thread.rs
@@ -37,7 +37,7 @@ pub fn unsafe_allocate_zero_vec<F: JoltField + Sized>(size: usize) -> Vec<F> {
         let ptr = std::alloc::alloc_zeroed(layout) as *mut F;
 
         if ptr.is_null() {
-            panic!("Zero vec allocaiton failed");
+            panic!("Zero vec allocation failed");
         }
 
         result = Vec::from_raw_parts(ptr, size, size);

--- a/tracer/src/emulator/cpu.rs
+++ b/tracer/src/emulator/cpu.rs
@@ -2696,7 +2696,7 @@ pub const INSTRUCTIONS: [Instruction; INSTRUCTION_NUM] = [
     Instruction {
         mask: 0xfe00707f,
         data: 0xa2000053,
-        name: "FILE.D",
+        name: "FLE.D",
         operation: |cpu, word, _address| {
             let f = parse_format_r(word);
             cpu.x[f.rd] = match cpu.f[f.rs1] <= cpu.f[f.rs2] {

--- a/tracer/src/emulator/cpu.rs
+++ b/tracer/src/emulator/cpu.rs
@@ -158,7 +158,7 @@ pub fn get_privilege_mode(encoding: u64) -> PrivilegeMode {
         0 => PrivilegeMode::User,
         1 => PrivilegeMode::Supervisor,
         3 => PrivilegeMode::Machine,
-        _ => panic!("Unknown privilege uncoding"),
+        _ => panic!("Unknown privilege encoding"),
     }
 }
 
@@ -770,7 +770,7 @@ impl Cpu {
     // SSTATUS, SIE, and SIP are subsets of MSTATUS, MIE, and MIP
     fn read_csr_raw(&self, address: u16) -> u64 {
         match address {
-            // @TODO: Mask shuld consider of 32-bit mode
+            // @TODO: Mask should consider of 32-bit mode
             CSR_FFLAGS_ADDRESS => self.csr[CSR_FCSR_ADDRESS as usize] & 0x1f,
             CSR_FRM_ADDRESS => (self.csr[CSR_FCSR_ADDRESS as usize] >> 5) & 0x7,
             CSR_SSTATUS_ADDRESS => self.csr[CSR_MSTATUS_ADDRESS as usize] & 0x80000003000de162,
@@ -1286,7 +1286,7 @@ impl Cpu {
                         if rd != 0 {
                             return (offset << 20) | (2 << 15) | (3 << 12) | (rd << 7) | 0x7;
                         }
-                        // rd == 0 is reseved instruction
+                        // rd == 0 is reserved instruction
                     }
                     2 => {
                         // C.LWSP
@@ -1298,7 +1298,7 @@ impl Cpu {
                         if r != 0 {
                             return (offset << 20) | (2 << 15) | (2 << 12) | (r << 7) | 0x3;
                         }
-                        // r == 0 is reseved instruction
+                        // r == 0 is reserved instruction
                     }
                     3 => {
                         // @TODO: Support C.FLWSP in 32-bit mode
@@ -1311,7 +1311,7 @@ impl Cpu {
                         if rd != 0 {
                             return (offset << 20) | (2 << 15) | (3 << 12) | (rd << 7) | 0x3;
                         }
-                        // rd == 0 is reseved instruction
+                        // rd == 0 is reserved instruction
                     }
                     4 => {
                         let funct1 = (halfword >> 12) & 1; // [12]
@@ -2696,7 +2696,7 @@ pub const INSTRUCTIONS: [Instruction; INSTRUCTION_NUM] = [
     Instruction {
         mask: 0xfe00707f,
         data: 0xa2000053,
-        name: "FLE.D",
+        name: "FILE.D",
         operation: |cpu, word, _address| {
             let f = parse_format_r(word);
             cpu.x[f.rd] = match cpu.f[f.rs1] <= cpu.f[f.rs2] {

--- a/tracer/src/emulator/cpu.rs
+++ b/tracer/src/emulator/cpu.rs
@@ -1406,7 +1406,7 @@ impl Cpu {
                     _ => {} // Not happens
                 };
             }
-            _ => {} // No happnes
+            _ => {} // Not happens
         };
         0xffffffff // Return invalid value
     }

--- a/tracer/src/emulator/device/virtio_block_disk.rs
+++ b/tracer/src/emulator/device/virtio_block_disk.rs
@@ -453,7 +453,7 @@ impl VirtioBlockDisk {
         (self.get_base_avail_address() + 4 + queue_size * 2).div_ceil(align) * align
     }
 
-    // @TODO: Follow the virtio block specification more propertly.
+    // @TODO: Follow the virtio block specification more properly.
     fn handle_disk_access(&mut self, memory: &mut MemoryWrapper) {
         let base_desc_address = self.get_base_desc_address();
         let base_avail_address = self.get_base_avail_address();

--- a/tracer/src/emulator/mmu.rs
+++ b/tracer/src/emulator/mmu.rs
@@ -532,7 +532,7 @@ impl Mmu {
             false => match effective_address {
                 // I don't know why but dtb data seems to be stored from 0x1020 on Linux.
                 // It might be from self.x[0xb] initialization?
-                // And DTB size is arbitray.
+                // And DTB size is arbitrary.
                 0x00001020..=0x00001fff => self.dtb[effective_address as usize - 0x1020],
                 0x02000000..=0x0200ffff => self.clint.load(effective_address),
                 0x0C000000..=0x0fffffff => self.plic.load(effective_address),

--- a/tracer/src/emulator/mod.rs
+++ b/tracer/src/emulator/mod.rs
@@ -99,7 +99,7 @@ impl Emulator {
 
             // It seems in riscv-tests ends with end code
             // written to a certain physical memory address
-            // (0x80001000 in mose test cases) so checking
+            // (0x80001000 in more test cases) so checking
             // the data in the address and terminating the test
             // if non-zero data is written.
             // End code 1 seems to mean pass.

--- a/typos.toml
+++ b/typos.toml
@@ -1,0 +1,6 @@
+[default.extend-words]
+"groth" = "groth"
+"sie" = "sie"
+"stip" = "stip"
+"thr" = "thr"
+"thre" = "thre"

--- a/typos.toml
+++ b/typos.toml
@@ -1,5 +1,6 @@
 [default.extend-words]
 "groth" = "groth"
+"fle" = "fle"
 "sie" = "sie"
 "stip" = "stip"
 "thr" = "thr"

--- a/typos.toml
+++ b/typos.toml
@@ -4,3 +4,4 @@
 "stip" = "stip"
 "thr" = "thr"
 "thre" = "thre"
+"numer" = "numer"


### PR DESCRIPTION
I noticed a typo in the book ('lik' instead of 'like') and decided to fix it, and also check for other typos along the way with [typos](https://crates.io/crates/typos).

This PR:
- fixes all detected typos in code and docs
- adds a CI job for typos detection
