### PR TITLE
updated instructions with new fields for RvTraceRow struct

### DIFF
--- a/common/src/rv_trace.rs
+++ b/common/src/rv_trace.rs
@@ -12,6 +12,8 @@ pub struct RVTraceRow {
     pub register_state: RegisterState,
     pub memory_state: Option<MemoryState>,
     pub advice_value: Option<u64>,
+    pub precompile_input: Option<[u32; 16]>,
+    pub precompile_output_address: Option<u64>,
 }
 
 #[derive(Debug, PartialEq, Clone, Copy, Serialize, Deserialize)]

--- a/jolt-core/src/jolt/instruction/div.rs
+++ b/jolt-core/src/jolt/instruction/div.rs
@@ -77,6 +77,8 @@ impl<const WORD_SIZE: usize> VirtualInstructionSequence for DIVInstruction<WORD_
             },
             memory_state: None,
             advice_value: Some(quotient),
+            precompile_input: None,
+            precompile_output_address: None,
         });
 
         let r = ADVICEInstruction::<WORD_SIZE>(remainder).lookup_entry();
@@ -97,6 +99,8 @@ impl<const WORD_SIZE: usize> VirtualInstructionSequence for DIVInstruction<WORD_
             },
             memory_state: None,
             advice_value: Some(remainder),
+            precompile_input: None,
+            precompile_output_address: None,
         });
 
         let is_valid: u64 = AssertValidSignedRemainderInstruction::<WORD_SIZE>(r, y).lookup_entry();
@@ -118,6 +122,8 @@ impl<const WORD_SIZE: usize> VirtualInstructionSequence for DIVInstruction<WORD_
             },
             memory_state: None,
             advice_value: None,
+            precompile_input: None,
+            precompile_output_address: None,
         });
 
         let is_valid: u64 = AssertValidDiv0Instruction::<WORD_SIZE>(y, q).lookup_entry();
@@ -139,6 +145,8 @@ impl<const WORD_SIZE: usize> VirtualInstructionSequence for DIVInstruction<WORD_
             },
             memory_state: None,
             advice_value: None,
+            precompile_input: None,
+            precompile_output_address: None,
         });
 
         let q_y = MULInstruction::<WORD_SIZE>(q, y).lookup_entry();
@@ -159,6 +167,8 @@ impl<const WORD_SIZE: usize> VirtualInstructionSequence for DIVInstruction<WORD_
             },
             memory_state: None,
             advice_value: None,
+            precompile_input: None,
+            precompile_output_address: None,
         });
 
         let add_0 = ADDInstruction::<WORD_SIZE>(q_y, r).lookup_entry();
@@ -179,6 +189,8 @@ impl<const WORD_SIZE: usize> VirtualInstructionSequence for DIVInstruction<WORD_
             },
             memory_state: None,
             advice_value: None,
+            precompile_input: None,
+            precompile_output_address: None,
         });
 
         let _assert_eq = BEQInstruction::<WORD_SIZE>(add_0, x).lookup_entry();
@@ -199,6 +211,8 @@ impl<const WORD_SIZE: usize> VirtualInstructionSequence for DIVInstruction<WORD_
             },
             memory_state: None,
             advice_value: None,
+            precompile_input: None,
+            precompile_output_address: None,
         });
 
         virtual_trace.push(RVTraceRow {
@@ -218,6 +232,8 @@ impl<const WORD_SIZE: usize> VirtualInstructionSequence for DIVInstruction<WORD_
             },
             memory_state: None,
             advice_value: None,
+            precompile_input: None,
+            precompile_output_address: None,
         });
 
         virtual_trace

--- a/jolt-core/src/jolt/instruction/divu.rs
+++ b/jolt-core/src/jolt/instruction/divu.rs
@@ -60,6 +60,8 @@ impl<const WORD_SIZE: usize> VirtualInstructionSequence for DIVUInstruction<WORD
             },
             memory_state: None,
             advice_value: Some(quotient),
+            precompile_input: None,
+            precompile_output_address: None,
         });
 
         let r = ADVICEInstruction::<WORD_SIZE>(remainder).lookup_entry();
@@ -80,6 +82,8 @@ impl<const WORD_SIZE: usize> VirtualInstructionSequence for DIVUInstruction<WORD
             },
             memory_state: None,
             advice_value: Some(remainder),
+            precompile_input: None,
+            precompile_output_address: None,
         });
 
         let q_y = MULUInstruction::<WORD_SIZE>(q, y).lookup_entry();
@@ -100,6 +104,8 @@ impl<const WORD_SIZE: usize> VirtualInstructionSequence for DIVUInstruction<WORD
             },
             memory_state: None,
             advice_value: None,
+            precompile_input: None,
+            precompile_output_address: None,
         });
 
         let is_valid = AssertValidUnsignedRemainderInstruction::<WORD_SIZE>(r, y).lookup_entry();
@@ -121,6 +127,8 @@ impl<const WORD_SIZE: usize> VirtualInstructionSequence for DIVUInstruction<WORD
             },
             memory_state: None,
             advice_value: None,
+            precompile_input: None,
+            precompile_output_address: None,
         });
 
         let lte = ASSERTLTEInstruction::<WORD_SIZE>(q_y, x).lookup_entry();
@@ -142,6 +150,8 @@ impl<const WORD_SIZE: usize> VirtualInstructionSequence for DIVUInstruction<WORD
             },
             memory_state: None,
             advice_value: None,
+            precompile_input: None,
+            precompile_output_address: None,
         });
 
         let is_valid = AssertValidDiv0Instruction::<WORD_SIZE>(y, q).lookup_entry();
@@ -163,6 +173,8 @@ impl<const WORD_SIZE: usize> VirtualInstructionSequence for DIVUInstruction<WORD
             },
             memory_state: None,
             advice_value: None,
+            precompile_input: None,
+            precompile_output_address: None,
         });
 
         let add_0 = ADDInstruction::<WORD_SIZE>(q_y, r).lookup_entry();
@@ -183,6 +195,8 @@ impl<const WORD_SIZE: usize> VirtualInstructionSequence for DIVUInstruction<WORD
             },
             memory_state: None,
             advice_value: None,
+            precompile_input: None,
+            precompile_output_address: None,
         });
 
         let _assert_eq = BEQInstruction::<WORD_SIZE>(add_0, x).lookup_entry();
@@ -203,6 +217,8 @@ impl<const WORD_SIZE: usize> VirtualInstructionSequence for DIVUInstruction<WORD
             },
             memory_state: None,
             advice_value: None,
+            precompile_input: None,
+            precompile_output_address: None,
         });
 
         virtual_trace.push(RVTraceRow {
@@ -222,6 +238,8 @@ impl<const WORD_SIZE: usize> VirtualInstructionSequence for DIVUInstruction<WORD
             },
             memory_state: None,
             advice_value: None,
+            precompile_input: None,
+            precompile_output_address: None,
         });
 
         virtual_trace

--- a/jolt-core/src/jolt/instruction/lb.rs
+++ b/jolt-core/src/jolt/instruction/lb.rs
@@ -117,6 +117,8 @@ impl<const WORD_SIZE: usize> VirtualInstructionSequence for LBInstruction<WORD_S
                 value: word,
             }),
             advice_value: None,
+            precompile_input: None,
+            precompile_output_address: None,
         });
 
         let byte_shift = XORInstruction::<WORD_SIZE>(ram_address, 0b11).lookup_entry();
@@ -228,6 +230,8 @@ impl<const WORD_SIZE: usize> VirtualInstructionSequence for LBInstruction<WORD_S
                 value: 0,
             }),
             advice_value: None,
+            precompile_input: None,
+            precompile_output_address: None,
         };
         Self::virtual_trace(dummy_trace_row)
             .into_iter()

--- a/jolt-core/src/jolt/instruction/lb.rs
+++ b/jolt-core/src/jolt/instruction/lb.rs
@@ -53,6 +53,8 @@ impl<const WORD_SIZE: usize> VirtualInstructionSequence for LBInstruction<WORD_S
             },
             memory_state: None,
             advice_value: None,
+            precompile_input: None,
+            precompile_output_address: None,
         });
 
         let word_address_bitmask = ((1u128 << WORD_SIZE) - 4) as u64;
@@ -75,6 +77,8 @@ impl<const WORD_SIZE: usize> VirtualInstructionSequence for LBInstruction<WORD_S
             },
             memory_state: None,
             advice_value: None,
+            precompile_input: None,
+            precompile_output_address: None,
         });
 
         let word = match trace_row.memory_state.unwrap() {
@@ -133,6 +137,8 @@ impl<const WORD_SIZE: usize> VirtualInstructionSequence for LBInstruction<WORD_S
             },
             memory_state: None,
             advice_value: None,
+            precompile_input: None,
+            precompile_output_address: None,
         });
 
         let bit_shift = SLLInstruction::<WORD_SIZE>(byte_shift, 3).lookup_entry();
@@ -153,6 +159,8 @@ impl<const WORD_SIZE: usize> VirtualInstructionSequence for LBInstruction<WORD_S
             },
             memory_state: None,
             advice_value: None,
+            precompile_input: None,
+            precompile_output_address: None,
         });
 
         let left_aligned_byte = SLLInstruction::<WORD_SIZE>(word, bit_shift).lookup_entry();
@@ -173,6 +181,8 @@ impl<const WORD_SIZE: usize> VirtualInstructionSequence for LBInstruction<WORD_S
             },
             memory_state: None,
             advice_value: None,
+            precompile_input: None,
+            precompile_output_address: None,
         });
 
         let sign_extended_byte = SRAInstruction::<WORD_SIZE>(left_aligned_byte, 24).lookup_entry();
@@ -194,6 +204,8 @@ impl<const WORD_SIZE: usize> VirtualInstructionSequence for LBInstruction<WORD_S
             },
             memory_state: None,
             advice_value: None,
+            precompile_input: None,
+            precompile_output_address: None,
         });
 
         virtual_trace
@@ -279,6 +291,8 @@ mod test {
                     value: word,
                 }),
                 advice_value: None,
+                precompile_input: None,
+                precompile_output_address: None,
             };
 
             let trace = LBInstruction::<32>::virtual_trace(lb_trace_row);

--- a/jolt-core/src/jolt/instruction/lbu.rs
+++ b/jolt-core/src/jolt/instruction/lbu.rs
@@ -53,6 +53,8 @@ impl<const WORD_SIZE: usize> VirtualInstructionSequence for LBUInstruction<WORD_
             },
             memory_state: None,
             advice_value: None,
+            precompile_input: None,
+            precompile_output_address: None,
         });
 
         let word_address_bitmask = ((1u128 << WORD_SIZE) - 4) as u64;
@@ -75,6 +77,8 @@ impl<const WORD_SIZE: usize> VirtualInstructionSequence for LBUInstruction<WORD_
             },
             memory_state: None,
             advice_value: None,
+            precompile_input: None,
+            precompile_output_address: None,
         });
 
         let word = match trace_row.memory_state.unwrap() {
@@ -113,6 +117,8 @@ impl<const WORD_SIZE: usize> VirtualInstructionSequence for LBUInstruction<WORD_
                 value: word,
             }),
             advice_value: None,
+            precompile_input: None,
+            precompile_output_address: None,
         });
 
         let byte_shift = XORInstruction::<WORD_SIZE>(ram_address, 0b11).lookup_entry();
@@ -133,6 +139,8 @@ impl<const WORD_SIZE: usize> VirtualInstructionSequence for LBUInstruction<WORD_
             },
             memory_state: None,
             advice_value: None,
+            precompile_input: None,
+            precompile_output_address: None,
         });
 
         let bit_shift = SLLInstruction::<WORD_SIZE>(byte_shift, 3).lookup_entry();
@@ -153,6 +161,8 @@ impl<const WORD_SIZE: usize> VirtualInstructionSequence for LBUInstruction<WORD_
             },
             memory_state: None,
             advice_value: None,
+            precompile_input: None,
+            precompile_output_address: None,
         });
 
         let left_aligned_byte = SLLInstruction::<WORD_SIZE>(word, bit_shift).lookup_entry();
@@ -173,6 +183,8 @@ impl<const WORD_SIZE: usize> VirtualInstructionSequence for LBUInstruction<WORD_
             },
             memory_state: None,
             advice_value: None,
+            precompile_input: None,
+            precompile_output_address: None,
         });
 
         let zero_extended_byte = SRLInstruction::<WORD_SIZE>(left_aligned_byte, 24).lookup_entry();
@@ -194,6 +206,8 @@ impl<const WORD_SIZE: usize> VirtualInstructionSequence for LBUInstruction<WORD_
             },
             memory_state: None,
             advice_value: None,
+            precompile_input: None,
+            precompile_output_address: None,
         });
 
         virtual_trace
@@ -279,6 +293,8 @@ mod test {
                     value: word,
                 }),
                 advice_value: None,
+                precompile_input: None,
+                precompile_output_address: None,
             };
 
             let trace = LBUInstruction::<32>::virtual_trace(lbu_trace_row);

--- a/jolt-core/src/jolt/instruction/lbu.rs
+++ b/jolt-core/src/jolt/instruction/lbu.rs
@@ -230,6 +230,8 @@ impl<const WORD_SIZE: usize> VirtualInstructionSequence for LBUInstruction<WORD_
                 value: 0,
             }),
             advice_value: None,
+            precompile_input: None,
+            precompile_output_address: None,
         };
         Self::virtual_trace(dummy_trace_row)
             .into_iter()

--- a/jolt-core/src/jolt/instruction/lh.rs
+++ b/jolt-core/src/jolt/instruction/lh.rs
@@ -57,6 +57,8 @@ impl<const WORD_SIZE: usize> VirtualInstructionSequence for LHInstruction<WORD_S
             },
             memory_state: None,
             advice_value: None,
+            precompile_input: None,
+            precompile_output_address: None,
         });
 
         let ram_address = ADDInstruction::<WORD_SIZE>(rs1_val, offset_unsigned).lookup_entry();
@@ -77,6 +79,8 @@ impl<const WORD_SIZE: usize> VirtualInstructionSequence for LHInstruction<WORD_S
             },
             memory_state: None,
             advice_value: None,
+            precompile_input: None,
+            precompile_output_address: None,
         });
 
         let word_address_bitmask = ((1u128 << WORD_SIZE) - 4) as u64;
@@ -99,6 +103,8 @@ impl<const WORD_SIZE: usize> VirtualInstructionSequence for LHInstruction<WORD_S
             },
             memory_state: None,
             advice_value: None,
+            precompile_input: None,
+            precompile_output_address: None,
         });
 
         let word = match trace_row.memory_state.unwrap() {
@@ -137,6 +143,8 @@ impl<const WORD_SIZE: usize> VirtualInstructionSequence for LHInstruction<WORD_S
                 value: word,
             }),
             advice_value: None,
+            precompile_input: None,
+            precompile_output_address: None,
         });
 
         let byte_shift = XORInstruction::<WORD_SIZE>(ram_address, 0b10).lookup_entry();
@@ -157,6 +165,8 @@ impl<const WORD_SIZE: usize> VirtualInstructionSequence for LHInstruction<WORD_S
             },
             memory_state: None,
             advice_value: None,
+            precompile_input: None,
+            precompile_output_address: None,
         });
 
         let bit_shift = SLLInstruction::<WORD_SIZE>(byte_shift, 3).lookup_entry();
@@ -177,6 +187,8 @@ impl<const WORD_SIZE: usize> VirtualInstructionSequence for LHInstruction<WORD_S
             },
             memory_state: None,
             advice_value: None,
+            precompile_input: None,
+            precompile_output_address: None,
         });
 
         let left_aligned_halfword = SLLInstruction::<WORD_SIZE>(word, bit_shift).lookup_entry();
@@ -197,6 +209,8 @@ impl<const WORD_SIZE: usize> VirtualInstructionSequence for LHInstruction<WORD_S
             },
             memory_state: None,
             advice_value: None,
+            precompile_input: None,
+            precompile_output_address: None,
         });
 
         let sign_extended_halfword =
@@ -219,6 +233,8 @@ impl<const WORD_SIZE: usize> VirtualInstructionSequence for LHInstruction<WORD_S
             },
             memory_state: None,
             advice_value: None,
+            precompile_input: None,
+            precompile_output_address: None,
         });
 
         virtual_trace
@@ -241,6 +257,8 @@ impl<const WORD_SIZE: usize> VirtualInstructionSequence for LHInstruction<WORD_S
                 value: 0,
             }),
             advice_value: None,
+            precompile_input: None,
+            precompile_output_address: None,
         };
         Self::virtual_trace(dummy_trace_row)
             .into_iter()
@@ -302,6 +320,8 @@ mod test {
                     value: word,
                 }),
                 advice_value: None,
+                precompile_input: None,
+                precompile_output_address: None,
             };
 
             let trace = LHInstruction::<32>::virtual_trace(lh_trace_row);

--- a/jolt-core/src/jolt/instruction/lhu.rs
+++ b/jolt-core/src/jolt/instruction/lhu.rs
@@ -57,6 +57,8 @@ impl<const WORD_SIZE: usize> VirtualInstructionSequence for LHUInstruction<WORD_
             },
             memory_state: None,
             advice_value: None,
+            precompile_input: None,
+            precompile_output_address: None,
         });
 
         let ram_address = ADDInstruction::<WORD_SIZE>(rs1_val, offset_unsigned).lookup_entry();
@@ -77,6 +79,8 @@ impl<const WORD_SIZE: usize> VirtualInstructionSequence for LHUInstruction<WORD_
             },
             memory_state: None,
             advice_value: None,
+            precompile_input: None,
+            precompile_output_address: None,
         });
 
         let word_address_bitmask = ((1u128 << WORD_SIZE) - 4) as u64;
@@ -99,6 +103,8 @@ impl<const WORD_SIZE: usize> VirtualInstructionSequence for LHUInstruction<WORD_
             },
             memory_state: None,
             advice_value: None,
+            precompile_input: None,
+            precompile_output_address: None,
         });
 
         let word = match trace_row.memory_state.unwrap() {
@@ -137,6 +143,8 @@ impl<const WORD_SIZE: usize> VirtualInstructionSequence for LHUInstruction<WORD_
                 value: word,
             }),
             advice_value: None,
+            precompile_input: None,
+            precompile_output_address: None,
         });
 
         let byte_shift = XORInstruction::<WORD_SIZE>(ram_address, 0b10).lookup_entry();
@@ -157,6 +165,8 @@ impl<const WORD_SIZE: usize> VirtualInstructionSequence for LHUInstruction<WORD_
             },
             memory_state: None,
             advice_value: None,
+            precompile_input: None,
+            precompile_output_address: None,
         });
 
         let bit_shift = SLLInstruction::<WORD_SIZE>(byte_shift, 3).lookup_entry();
@@ -177,6 +187,8 @@ impl<const WORD_SIZE: usize> VirtualInstructionSequence for LHUInstruction<WORD_
             },
             memory_state: None,
             advice_value: None,
+            precompile_input: None,
+            precompile_output_address: None,
         });
 
         let left_aligned_byte = SLLInstruction::<WORD_SIZE>(word, bit_shift).lookup_entry();
@@ -197,6 +209,8 @@ impl<const WORD_SIZE: usize> VirtualInstructionSequence for LHUInstruction<WORD_
             },
             memory_state: None,
             advice_value: None,
+            precompile_input: None,
+            precompile_output_address: None,
         });
 
         let zero_extended_halfword =
@@ -219,6 +233,8 @@ impl<const WORD_SIZE: usize> VirtualInstructionSequence for LHUInstruction<WORD_
             },
             memory_state: None,
             advice_value: None,
+            precompile_input: None,
+            precompile_output_address: None,
         });
 
         virtual_trace
@@ -241,6 +257,8 @@ impl<const WORD_SIZE: usize> VirtualInstructionSequence for LHUInstruction<WORD_
                 value: 0,
             }),
             advice_value: None,
+            precompile_input: None,
+            precompile_output_address: None,
         };
         Self::virtual_trace(dummy_trace_row)
             .into_iter()

--- a/jolt-core/src/jolt/instruction/mod.rs
+++ b/jolt-core/src/jolt/instruction/mod.rs
@@ -137,6 +137,8 @@ pub trait VirtualInstructionSequence {
             },
             memory_state: None,
             advice_value: None,
+            precompile_input: None,
+            precompile_output_address: None,
         };
         Self::virtual_trace(dummy_trace_row)
             .into_iter()

--- a/jolt-core/src/jolt/instruction/mulh.rs
+++ b/jolt-core/src/jolt/instruction/mulh.rs
@@ -48,6 +48,8 @@ impl<const WORD_SIZE: usize> VirtualInstructionSequence for MULHInstruction<WORD
             },
             memory_state: None,
             advice_value: None,
+            precompile_input: None,
+            precompile_output_address: None,
         });
 
         let s_y = MOVSIGNInstruction::<WORD_SIZE>(y).lookup_entry();
@@ -68,6 +70,8 @@ impl<const WORD_SIZE: usize> VirtualInstructionSequence for MULHInstruction<WORD
             },
             memory_state: None,
             advice_value: None,
+            precompile_input: None,
+            precompile_output_address: None,
         });
 
         let xy_high_bits = MULHUInstruction::<WORD_SIZE>(x, y).lookup_entry();
@@ -88,6 +92,8 @@ impl<const WORD_SIZE: usize> VirtualInstructionSequence for MULHInstruction<WORD
             },
             memory_state: None,
             advice_value: None,
+            precompile_input: None,
+            precompile_output_address: None,
         });
 
         let sx_y_low_bits = MULUInstruction::<WORD_SIZE>(s_x, y).lookup_entry();
@@ -108,6 +114,8 @@ impl<const WORD_SIZE: usize> VirtualInstructionSequence for MULHInstruction<WORD
             },
             memory_state: None,
             advice_value: None,
+            precompile_input: None,
+            precompile_output_address: None,
         });
 
         let sy_x_low_bits = MULUInstruction::<WORD_SIZE>(s_y, x).lookup_entry();
@@ -128,6 +136,8 @@ impl<const WORD_SIZE: usize> VirtualInstructionSequence for MULHInstruction<WORD
             },
             memory_state: None,
             advice_value: None,
+            precompile_input: None,
+            precompile_output_address: None,
         });
 
         let partial_sum = ADDInstruction::<WORD_SIZE>(xy_high_bits, sx_y_low_bits).lookup_entry();
@@ -148,6 +158,8 @@ impl<const WORD_SIZE: usize> VirtualInstructionSequence for MULHInstruction<WORD
             },
             memory_state: None,
             advice_value: None,
+            precompile_input: None,
+            precompile_output_address: None,
         });
 
         let result = ADDInstruction::<WORD_SIZE>(partial_sum, sy_x_low_bits).lookup_entry();
@@ -168,6 +180,8 @@ impl<const WORD_SIZE: usize> VirtualInstructionSequence for MULHInstruction<WORD
             },
             memory_state: None,
             advice_value: None,
+            precompile_input: None,
+            precompile_output_address: None,
         });
         virtual_trace
     }

--- a/jolt-core/src/jolt/instruction/mulhsu.rs
+++ b/jolt-core/src/jolt/instruction/mulhsu.rs
@@ -46,6 +46,8 @@ impl<const WORD_SIZE: usize> VirtualInstructionSequence for MULHSUInstruction<WO
             },
             memory_state: None,
             advice_value: None,
+            precompile_input: None,
+            precompile_output_address: None,
         });
 
         let xy_high_bits = MULHUInstruction::<WORD_SIZE>(x, y).lookup_entry();
@@ -66,6 +68,8 @@ impl<const WORD_SIZE: usize> VirtualInstructionSequence for MULHSUInstruction<WO
             },
             memory_state: None,
             advice_value: None,
+            precompile_input: None,
+            precompile_output_address: None,
         });
 
         let sx_y_low_bits = MULUInstruction::<WORD_SIZE>(s_x, y).lookup_entry();
@@ -86,6 +90,8 @@ impl<const WORD_SIZE: usize> VirtualInstructionSequence for MULHSUInstruction<WO
             },
             memory_state: None,
             advice_value: None,
+            precompile_input: None,
+            precompile_output_address: None,
         });
 
         let result = ADDInstruction::<WORD_SIZE>(xy_high_bits, sx_y_low_bits).lookup_entry();
@@ -106,6 +112,8 @@ impl<const WORD_SIZE: usize> VirtualInstructionSequence for MULHSUInstruction<WO
             },
             memory_state: None,
             advice_value: None,
+            precompile_input: None,
+            precompile_output_address: None,
         });
         virtual_trace
     }

--- a/jolt-core/src/jolt/instruction/rem.rs
+++ b/jolt-core/src/jolt/instruction/rem.rs
@@ -78,6 +78,8 @@ impl<const WORD_SIZE: usize> VirtualInstructionSequence for REMInstruction<WORD_
             },
             memory_state: None,
             advice_value: Some(quotient),
+            precompile_input: None,
+            precompile_output_address: None,
         });
 
         let r = ADVICEInstruction::<WORD_SIZE>(remainder).lookup_entry();
@@ -98,6 +100,8 @@ impl<const WORD_SIZE: usize> VirtualInstructionSequence for REMInstruction<WORD_
             },
             memory_state: None,
             advice_value: Some(remainder),
+            precompile_input: None,
+            precompile_output_address: None,
         });
 
         let is_valid: u64 = AssertValidSignedRemainderInstruction::<WORD_SIZE>(r, y).lookup_entry();
@@ -119,6 +123,8 @@ impl<const WORD_SIZE: usize> VirtualInstructionSequence for REMInstruction<WORD_
             },
             memory_state: None,
             advice_value: None,
+            precompile_input: None,
+            precompile_output_address: None,
         });
 
         let q_y = MULInstruction::<WORD_SIZE>(q, y).lookup_entry();
@@ -139,6 +145,8 @@ impl<const WORD_SIZE: usize> VirtualInstructionSequence for REMInstruction<WORD_
             },
             memory_state: None,
             advice_value: None,
+            precompile_input: None,
+            precompile_output_address: None,
         });
 
         let add_0: u64 = ADDInstruction::<WORD_SIZE>(q_y, r).lookup_entry();
@@ -159,6 +167,8 @@ impl<const WORD_SIZE: usize> VirtualInstructionSequence for REMInstruction<WORD_
             },
             memory_state: None,
             advice_value: None,
+            precompile_input: None,
+            precompile_output_address: None,
         });
 
         let _assert_eq = BEQInstruction::<WORD_SIZE>(add_0, x).lookup_entry();
@@ -179,6 +189,8 @@ impl<const WORD_SIZE: usize> VirtualInstructionSequence for REMInstruction<WORD_
             },
             memory_state: None,
             advice_value: None,
+            precompile_input: None,
+            precompile_output_address: None,
         });
 
         virtual_trace.push(RVTraceRow {
@@ -198,6 +210,8 @@ impl<const WORD_SIZE: usize> VirtualInstructionSequence for REMInstruction<WORD_
             },
             memory_state: None,
             advice_value: None,
+            precompile_input: None,
+            precompile_output_address: None,
         });
 
         virtual_trace

--- a/jolt-core/src/jolt/instruction/remu.rs
+++ b/jolt-core/src/jolt/instruction/remu.rs
@@ -60,6 +60,8 @@ impl<const WORD_SIZE: usize> VirtualInstructionSequence for REMUInstruction<WORD
             },
             memory_state: None,
             advice_value: Some(quotient),
+            precompile_input: None,
+            precompile_output_address: None,
         });
 
         let r = ADVICEInstruction::<WORD_SIZE>(remainder).lookup_entry();
@@ -80,6 +82,8 @@ impl<const WORD_SIZE: usize> VirtualInstructionSequence for REMUInstruction<WORD
             },
             memory_state: None,
             advice_value: Some(remainder),
+            precompile_input: None,
+            precompile_output_address: None,
         });
 
         let q_y = MULUInstruction::<WORD_SIZE>(q, y).lookup_entry();
@@ -100,6 +104,8 @@ impl<const WORD_SIZE: usize> VirtualInstructionSequence for REMUInstruction<WORD
             },
             memory_state: None,
             advice_value: None,
+            precompile_input: None,
+            precompile_output_address: None,
         });
 
         let is_valid = AssertValidUnsignedRemainderInstruction::<WORD_SIZE>(r, y).lookup_entry();
@@ -121,6 +127,8 @@ impl<const WORD_SIZE: usize> VirtualInstructionSequence for REMUInstruction<WORD
             },
             memory_state: None,
             advice_value: None,
+            precompile_input: None,
+            precompile_output_address: None,
         });
 
         let _lte = ASSERTLTEInstruction::<WORD_SIZE>(q_y, x).lookup_entry();
@@ -141,6 +149,8 @@ impl<const WORD_SIZE: usize> VirtualInstructionSequence for REMUInstruction<WORD
             },
             memory_state: None,
             advice_value: None,
+            precompile_input: None,
+            precompile_output_address: None,
         });
 
         let add_0: u64 = ADDInstruction::<WORD_SIZE>(q_y, r).lookup_entry();
@@ -161,6 +171,8 @@ impl<const WORD_SIZE: usize> VirtualInstructionSequence for REMUInstruction<WORD
             },
             memory_state: None,
             advice_value: None,
+            precompile_input: None,
+            precompile_output_address: None,
         });
 
         let _assert_eq = BEQInstruction::<WORD_SIZE>(add_0, x).lookup_entry();
@@ -181,6 +193,8 @@ impl<const WORD_SIZE: usize> VirtualInstructionSequence for REMUInstruction<WORD
             },
             memory_state: None,
             advice_value: None,
+            precompile_input: None,
+            precompile_output_address: None,
         });
 
         virtual_trace.push(RVTraceRow {
@@ -200,6 +214,8 @@ impl<const WORD_SIZE: usize> VirtualInstructionSequence for REMUInstruction<WORD
             },
             memory_state: None,
             advice_value: None,
+            precompile_input: None,
+            precompile_output_address: None,
         });
 
         virtual_trace

--- a/jolt-core/src/jolt/instruction/sb.rs
+++ b/jolt-core/src/jolt/instruction/sb.rs
@@ -55,6 +55,8 @@ impl<const WORD_SIZE: usize> VirtualInstructionSequence for SBInstruction<WORD_S
             },
             memory_state: None,
             advice_value: None,
+            precompile_input: None,
+            precompile_output_address: None,
         });
 
         let word_address_bitmask = ((1u128 << WORD_SIZE) - 4) as u64;
@@ -77,6 +79,8 @@ impl<const WORD_SIZE: usize> VirtualInstructionSequence for SBInstruction<WORD_S
             },
             memory_state: None,
             advice_value: None,
+            precompile_input: None,
+            precompile_output_address: None,
         });
 
         let (word_loaded, word_stored) = match trace_row.memory_state.unwrap() {
@@ -118,6 +122,8 @@ impl<const WORD_SIZE: usize> VirtualInstructionSequence for SBInstruction<WORD_S
                 value: word_loaded,
             }),
             advice_value: None,
+            precompile_input: None,
+            precompile_output_address: None,
         });
 
         let bit_shift = SLLInstruction::<WORD_SIZE>(ram_address, 3).lookup_entry();
@@ -138,6 +144,8 @@ impl<const WORD_SIZE: usize> VirtualInstructionSequence for SBInstruction<WORD_S
             },
             memory_state: None,
             advice_value: None,
+            precompile_input: None,
+            precompile_output_address: None,
         });
 
         // Technically such a LUI instruction isn't valid RISC-V, since the lower
@@ -160,6 +168,8 @@ impl<const WORD_SIZE: usize> VirtualInstructionSequence for SBInstruction<WORD_S
             },
             memory_state: None,
             advice_value: None,
+            precompile_input: None,
+            precompile_output_address: None,
         });
 
         let shifted_mask = SLLInstruction::<WORD_SIZE>(byte_mask as u64, bit_shift).lookup_entry();
@@ -186,6 +196,8 @@ impl<const WORD_SIZE: usize> VirtualInstructionSequence for SBInstruction<WORD_S
             },
             memory_state: None,
             advice_value: None,
+            precompile_input: None,
+            precompile_output_address: None,
         });
 
         let shifted_value = SLLInstruction::<WORD_SIZE>(value, bit_shift).lookup_entry();
@@ -206,6 +218,8 @@ impl<const WORD_SIZE: usize> VirtualInstructionSequence for SBInstruction<WORD_S
             },
             memory_state: None,
             advice_value: None,
+            precompile_input: None,
+            precompile_output_address: None,
         });
 
         // The next three instructions (XOR, AND, XOR) splices the byte into
@@ -230,6 +244,8 @@ impl<const WORD_SIZE: usize> VirtualInstructionSequence for SBInstruction<WORD_S
             },
             memory_state: None,
             advice_value: None,
+            precompile_input: None,
+            precompile_output_address: None,
         });
 
         let masked = ANDInstruction::<WORD_SIZE>(word_xor_halfword, shifted_mask).lookup_entry();
@@ -250,6 +266,8 @@ impl<const WORD_SIZE: usize> VirtualInstructionSequence for SBInstruction<WORD_S
             },
             memory_state: None,
             advice_value: None,
+            precompile_input: None,
+            precompile_output_address: None,
         });
 
         let result = XORInstruction::<WORD_SIZE>(word_loaded, masked).lookup_entry();
@@ -271,6 +289,8 @@ impl<const WORD_SIZE: usize> VirtualInstructionSequence for SBInstruction<WORD_S
             },
             memory_state: None,
             advice_value: None,
+            precompile_input: None,
+            precompile_output_address: None,
         });
 
         virtual_trace.push(RVTraceRow {
@@ -294,6 +314,8 @@ impl<const WORD_SIZE: usize> VirtualInstructionSequence for SBInstruction<WORD_S
                 post_value: result,
             }),
             advice_value: None,
+            precompile_input: None,
+            precompile_output_address: None,
         });
 
         virtual_trace
@@ -317,6 +339,8 @@ impl<const WORD_SIZE: usize> VirtualInstructionSequence for SBInstruction<WORD_S
                 post_value: 0,
             }),
             advice_value: None,
+            precompile_input: None,
+            precompile_output_address: None,
         };
         Self::virtual_trace(dummy_trace_row)
             .into_iter()
@@ -384,6 +408,8 @@ mod test {
                     post_value: word_after,
                 }),
                 advice_value: None,
+                precompile_input: None,
+                precompile_output_address: None,
             };
 
             let trace = SBInstruction::<32>::virtual_trace(sb_trace_row);

--- a/jolt-core/src/jolt/instruction/sh.rs
+++ b/jolt-core/src/jolt/instruction/sh.rs
@@ -59,6 +59,8 @@ impl<const WORD_SIZE: usize> VirtualInstructionSequence for SHInstruction<WORD_S
             },
             memory_state: None,
             advice_value: None,
+            precompile_input: None,
+            precompile_output_address: None,
         });
 
         let ram_address = ADDInstruction::<WORD_SIZE>(dest, offset_unsigned).lookup_entry();
@@ -80,6 +82,8 @@ impl<const WORD_SIZE: usize> VirtualInstructionSequence for SHInstruction<WORD_S
             },
             memory_state: None,
             advice_value: None,
+            precompile_input: None,
+            precompile_output_address: None,
         });
 
         let word_address_bitmask = ((1u128 << WORD_SIZE) - 4) as u64;
@@ -102,6 +106,8 @@ impl<const WORD_SIZE: usize> VirtualInstructionSequence for SHInstruction<WORD_S
             },
             memory_state: None,
             advice_value: None,
+            precompile_input: None,
+            precompile_output_address: None,
         });
 
         let (word_loaded, word_stored) = match trace_row.memory_state.unwrap() {
@@ -143,6 +149,8 @@ impl<const WORD_SIZE: usize> VirtualInstructionSequence for SHInstruction<WORD_S
                 value: word_loaded,
             }),
             advice_value: None,
+            precompile_input: None,
+            precompile_output_address: None,
         });
 
         let bit_shift = SLLInstruction::<WORD_SIZE>(ram_address, 3).lookup_entry();
@@ -163,6 +171,8 @@ impl<const WORD_SIZE: usize> VirtualInstructionSequence for SHInstruction<WORD_S
             },
             memory_state: None,
             advice_value: None,
+            precompile_input: None,
+            precompile_output_address: None,
         });
 
         // Technically such a LUI instruction isn't valid RISC-V, since the lower
@@ -185,6 +195,8 @@ impl<const WORD_SIZE: usize> VirtualInstructionSequence for SHInstruction<WORD_S
             },
             memory_state: None,
             advice_value: None,
+            precompile_input: None,
+            precompile_output_address: None,
         });
 
         let shifted_mask =
@@ -207,6 +219,8 @@ impl<const WORD_SIZE: usize> VirtualInstructionSequence for SHInstruction<WORD_S
             },
             memory_state: None,
             advice_value: None,
+            precompile_input: None,
+            precompile_output_address: None,
         });
 
         let shifted_value = SLLInstruction::<WORD_SIZE>(value, bit_shift).lookup_entry();
@@ -227,6 +241,8 @@ impl<const WORD_SIZE: usize> VirtualInstructionSequence for SHInstruction<WORD_S
             },
             memory_state: None,
             advice_value: None,
+            precompile_input: None,
+            precompile_output_address: None,
         });
 
         // The next three instructions (XOR, AND, XOR) splices the halfword into
@@ -251,6 +267,8 @@ impl<const WORD_SIZE: usize> VirtualInstructionSequence for SHInstruction<WORD_S
             },
             memory_state: None,
             advice_value: None,
+            precompile_input: None,
+            precompile_output_address: None,
         });
 
         let masked = ANDInstruction::<WORD_SIZE>(word_xor_halfword, shifted_mask).lookup_entry();
@@ -271,6 +289,8 @@ impl<const WORD_SIZE: usize> VirtualInstructionSequence for SHInstruction<WORD_S
             },
             memory_state: None,
             advice_value: None,
+            precompile_input: None,
+            precompile_output_address: None,
         });
 
         let result = XORInstruction::<WORD_SIZE>(word_loaded, masked).lookup_entry();
@@ -292,6 +312,8 @@ impl<const WORD_SIZE: usize> VirtualInstructionSequence for SHInstruction<WORD_S
             },
             memory_state: None,
             advice_value: None,
+            precompile_input: None,
+            precompile_output_address: None,
         });
 
         virtual_trace.push(RVTraceRow {
@@ -315,6 +337,8 @@ impl<const WORD_SIZE: usize> VirtualInstructionSequence for SHInstruction<WORD_S
                 post_value: result,
             }),
             advice_value: None,
+            precompile_input: None,
+            precompile_output_address: None,
         });
 
         virtual_trace
@@ -338,6 +362,8 @@ impl<const WORD_SIZE: usize> VirtualInstructionSequence for SHInstruction<WORD_S
                 post_value: 0,
             }),
             advice_value: None,
+            precompile_input: None,
+            precompile_output_address: None,
         };
         Self::virtual_trace(dummy_trace_row)
             .into_iter()
@@ -403,6 +429,8 @@ mod test {
                     post_value: word_after,
                 }),
                 advice_value: None,
+                precompile_input: None,
+                precompile_output_address: None,
             };
 
             let trace = SHInstruction::<32>::virtual_trace(sh_trace_row);

--- a/jolt-core/src/jolt/instruction/test.rs
+++ b/jolt-core/src/jolt/instruction/test.rs
@@ -73,6 +73,8 @@ macro_rules! jolt_virtual_sequence_test {
             },
             memory_state: None,
             advice_value: None,
+            precompile_input: None,
+            precompile_output_address: None,
         };
 
         let virtual_sequence = <$instr_type>::virtual_trace(trace_row);

--- a/tracer/src/trace.rs
+++ b/tracer/src/trace.rs
@@ -26,6 +26,8 @@ impl Tracer {
             register_state: RegisterState::default(),
             memory_state: None,
             advice_value: None,
+            precompile_input: None,
+            precompile_output_address: None,
         });
     }
 


### PR DESCRIPTION
This PR updated the `RvTraceRow` struct to include two new optional fields: `precompile_input` and `precompile_output_address`.