### PR TITLE
Fixed Typo and Corrected String Comparison

### DIFF
--- a/examples/overflow/src/main.rs
+++ b/examples/overflow/src/main.rs
@@ -22,7 +22,7 @@ pub fn main() {
 
     // valid case for stack allocation, calls overflow_stack() under the hood
     // but with stack_size=8192
-    let (prove_allocate_stack_with_increased_size, verfiy_allocate_stack_with_increased_size) =
+    let (prove_allocate_stack_with_increased_size, verify_allocate_stack_with_increased_size) =
         guest::build_allocate_stack_with_increased_size();
 
     let now = Instant::now();

--- a/examples/run_benchmarks.sh
+++ b/examples/run_benchmarks.sh
@@ -32,7 +32,7 @@ function write_to_json() {
   printf "        \"unit\": \"%s\",\n" "$3" >>"$output_file"
   printf "        \"value\": %.4f,\n" "$2" >>"$output_file"
   printf "        \"extra\": \"\"\n" >>"$output_file"
-  if [ "$4" = false ]; then
+  if [ "$4" = "false" ]; then
     printf "    },\n" >>"$output_file"
   else
     printf "    }\n" >>"$output_file"


### PR DESCRIPTION
File: examples/overflow/src/main.rs

Change: The variable name verfiy_allocate_stack_with_increased_size was corrected to verify_allocate_stack_with_increased_size.
Reason: This was a typo in the variable name that needed fixing to maintain consistency and prevent compilation errors.
File: examples/run_benchmarks.sh

Change: The conditional check if [ "$4" = false ]; then was modified to if [ "$4" = "false" ]; then.
Reason: The original check was comparing the boolean value false instead of the string "false", which is the correct format when using string comparison in Bash.

