### PR TITLE
Fix Typographical Errors and Standardize Terminology in Documentation

### DIFF
--- a/book/src/background/gkr.md
+++ b/book/src/background/gkr.md
@@ -7,7 +7,7 @@ $\widetilde{\text{add}}_i(j, a, b)$ evaluates to 1 if the $j$-th gate of the $i$
 
 $\widetilde{\text{mult}}_i(j, a, b)$ evaluates to 1 if the $j$-th gate of the $i$-th layer is a multiplication gate whose inputs are the $a$'th and $b$'th gates at the preceding layer. 
 
-The sumcheck protocol is applied to the following:
+The sum-check protocol is applied to the following:
 $$
 \widetilde{V}_i(z) = \sum_{(p,\omega_1,\omega_2) \in \{0,1\}^{s_i+2s_{i+1}}} f_{i,z}(p,\omega_1,\omega_2),
 $$
@@ -23,7 +23,7 @@ $$
 
 (See [the eq-polynomial page](https://jolt.a16zcrypto.com/background/eq-polynomial.html) for details.)
 
-Lasso and Jolt currently use the variant of GKR described in [Thaler13](https://eprint.iacr.org/2013/351.pdf), which is optimized for the far simpler case of a binary tree of multiplication gates. This simplifies each sumcheck to:
+Lasso and Jolt currently use the variant of GKR described in [Thaler13](https://eprint.iacr.org/2013/351.pdf), which is optimized for the far simpler case of a binary tree of multiplication gates. This simplifies each sum-check to:
 $$
 \widetilde{V}_i(z) = \sum_{p \in \{0,1\}^{s_i}} g^{(i)}_z(p),
 $$

--- a/book/src/background/risc-v.md
+++ b/book/src/background/risc-v.md
@@ -9,7 +9,7 @@ Jolt implements the base RISC-V instruction set, making it a RISC-V-compliant vi
 
 ### Base Sets
 #### __RV32I__
-The RV32I is the base 32-bit integer instruction set. It's designed to be sufficient for a complete software toolchain while being simple and minimal. Everything else in RISC-V (multiplication, floating point, atomic operations)q is built as extensions on top of this base ISA.
+The RV32I is the base 32-bit integer instruction set. It's designed to be sufficient for a complete software toolchain while being simple and minimal. Everything else in RISC-V (multiplication, floating point, atomic operations) is built as extensions on top of this base ISA.
 ##### Key properties:
 - 32-bit fixed-width instructions
 

--- a/book/src/background/sumcheck.md
+++ b/book/src/background/sumcheck.md
@@ -13,7 +13,7 @@ The protocol proceeds in $v$ rounds as follows. In the first round, the prover s
 
 $$ g_1(X_1) = \sum_{x_2, \ldots, x_v \in \{0,1\}^{v-1}} g(X_1, x_2, \ldots, x_v). $$
 
-Observe that if $g_1$ is as claimed, then $H = g_1(0) + g_1(1)$. Also observe that the polynomial $g_1(X_1)$ has degree $\text{deg}_1(g)$, the degree of variable $x_1$ in $g$. Hence $g_1$ can be specified with $\text{deg}_1(g) + 1$ field elements. In our implementation, $P$ will specify $g$ by sending the evaluation of $g_1$ at each point in the set $\{0,1, \ldots, \text{deg}_1(g)\}$. (Actually, the prover does _not_ need to send $g_1(1)$, since since the verifier can _infer_ that $g_1(1) = H-g_1(0)$, as if this were not the case, the verifier would reject). 
+Observe that if $g_1$ is as claimed, then $H = g_1(0) + g_1(1)$. Also observe that the polynomial $g_1(X_1)$ has degree $\text{deg}_1(g)$, the degree of variable $x_1$ in $g$. Hence $g_1$ can be specified with $\text{deg}_1(g) + 1$ field elements. In our implementation, $P$ will specify $g$ by sending the evaluation of $g_1$ at each point in the set $\{0,1, \ldots, \text{deg}_1(g)\}$. (Actually, the prover does _not_ need to send $g_1(1)$, since the verifier can _infer_ that $g_1(1) = H-g_1(0)$, as if this were not the case, the verifier would reject). 
 
 Then, in round $j > 1$, $V$ chooses a value $r_{j-1}$ uniformly at random from $\mathbb{F}$ and sends $r_{j-1}$ to $P$. We will often refer to this step by saying that variable $j - 1$ gets bound to value $r_{j-1}$. In return, the prover sends a polynomial $g_j(X_j)$, and claims that
 


### PR DESCRIPTION
Standardizing "sumcheck" vs. "sum-check"
Old: "The sumcheck protocol is applied to the following:"
New: "The sum-check protocol is applied to the following:"
Old: "This simplifies each sumcheck to:"
New: "This simplifies each sum-check to:"
Reason: Maintains consistency in terminology. "Sum-check" is the more commonly accepted academic form when referring to the protocol.

Fixing a Typographical Error in RISC-V Documentation
Old: "Everything else in RISC-V (multiplication, floating point, atomic operations)q is built as extensions on top of this base ISA."
New: "Everything else in RISC-V (multiplication, floating point, atomic operations) is built as extensions on top of this base ISA."
Reason: The letter "q" was likely a typographical mistake. Removing it ensures proper readability.

Removing Duplicate Words
Old: "(Actually, the prover does not need to send $g_1(1)$, since since the verifier can infer that $g_1(1) = H - g_1(0)$, as if this were not the case, the verifier would reject)."
New: "(Actually, the prover does not need to send $g_1(1)$, since the verifier can infer that $g_1(1) = H - g_1(0)$, as if this were not the case, the verifier would reject)."
Reason: The phrase contained an unnecessary repetition of "since," which was a grammatical error.
