### PR TITLE
chore: fixed function calls and improved comment readability

### DIFF
--- a/examples/overflow/src/main.rs
+++ b/examples/overflow/src/main.rs
@@ -6,22 +6,22 @@ pub fn main() {
     let (prove_overflow_stack, _) = guest::build_overflow_stack();
 
     let res = panic::catch_unwind(|| {
-        // trying to allocate 1024 elems array and sum it up
-        // with stack_size=1024, should panic
-        let (_, _) = prove_overflow_stack();
+        // Trying to allocate a 1024-element array and sum it up.
+        // With stack_size=1024, this should panic.
+        prove_overflow_stack(); 
     });
     handle_result(res);
 
-    // now lets try to overflow the heap, should also panic
+    // Now let's try to overflow the heap, this should also panic.
     let (prove_overflow_heap, _) = guest::build_overflow_heap();
 
     let res = panic::catch_unwind(|| {
-        let (_, _) = prove_overflow_heap();
+        prove_overflow_heap();
     });
     handle_result(res);
 
-    // valid case for stack allocation, calls overflow_stack() under the hood
-    // but with stack_size=8192
+    // Valid case for stack allocation. Calls overflow_stack() under the hood
+    // but with stack_size=8192.
     let (prove_allocate_stack_with_increased_size, verify_allocate_stack_with_increased_size) =
         guest::build_allocate_stack_with_increased_size();
 


### PR DESCRIPTION
Noticed a small issue with function calls where unnecessary tuple unpacking was used.
Cleaned it up for clarity. Also fixed a minor typo in a comment to improve readability.  
