### PR TITLE
fix: Fix incorrect bit shift in read_doubleword function

### DIFF
--- a/tracer/src/emulator/memory.rs
+++ b/tracer/src/emulator/memory.rs
@@ -69,7 +69,7 @@ impl Memory {
             self.data[index]
         } else if (address % 4) == 0 {
             (self.read_word(address) as u64)
-                | ((self.read_word(address.wrapping_add(4)) as u64) << 4)
+                | ((self.read_word(address.wrapping_add(4)) as u64) << 32)
         } else {
             self.read_bytes(address, 8)
         }


### PR DESCRIPTION
I've corrected the bit shift error in the `read_doubleword` function. The shift in the original implementation was incorrectly set to 4 bits:

```rust
(self.read_word(address.wrapping_add(4)) as u64) << 4
```

It has now been updated to 32 bits to ensure the correct behavior:

```rust
(self.read_word(address.wrapping_add(4)) as u64) << 32
```

This should resolve the issue and properly align the data.