### PR TITLE
fix: undefined symbols when compiling guest in host environemnt

### DIFF
--- a/jolt-sdk/src/lib.rs
+++ b/jolt-sdk/src/lib.rs
@@ -12,3 +12,10 @@ pub use host_utils::*;
 
 pub mod alloc;
 pub use alloc::*;
+
+// This is a dummy _HEAP_PTR to keep the compiler happy.
+// It should never be used when compiled as a guest or with
+// our custom allocator
+#[no_mangle]
+#[cfg(feature = "host")]
+pub static mut _HEAP_PTR: u8 = 0;


### PR DESCRIPTION
closes #623

It turns out the rust compiler (or LLVM) has updated to error if there is an undefined symbol, even if that piece of the code is never compiled. When compiling the guest in host mode (to generate the helpers from the macro), rust now gets mad that the `_HEAP_PTR` symbol in the unused allocator is undefined. We can easily fix this by adding a dummy `_HEAP_PTR` value in the sdk that only is enabled when compiling in host mode (technically since the sdk isn't imported in guest mode we don't need this, but extra safety doesn't hurt). One thing to note is that we need to ensure the custom allocator is never used in host mode (which we do not at the moment), otherwise it will use the dummy pointer and do all sorts of horrible things with our memory and likely crash the host.