### PR TITLE
Fix potential bit mask overflow in SllSubtable's materialize function

### DIFF
--- a/jolt-core/src/jolt/subtable/sll.rs
+++ b/jolt-core/src/jolt/subtable/sll.rs
@@ -39,8 +39,10 @@ impl<F: JoltField, const CHUNK_INDEX: usize, const WORD_SIZE: usize> LassoSubtab
             // Need to handle u64::MAX in a special case because of overflow
             let truncate_mask = if WORD_SIZE - suffix_length >= 64 {
                 u64::MAX
+            } else if WORD_SIZE <= suffix_length {
+                0 // If WORD_SIZE is less than or equal to suffix_length, the mask should be 0
             } else {
-                (1 << (WORD_SIZE - suffix_length)) - 1
+                (1u64 << (WORD_SIZE - suffix_length)) - 1
             };
 
             let row = (x as u64).checked_shl((y % WORD_SIZE) as u32).unwrap_or(0) & truncate_mask;


### PR DESCRIPTION
This pull request fixes a potential issue in the SllSubtable's materialize function where a bit mask 
calculation could lead to incorrect results when WORD_SIZE is less than or equal to the suffix_length.

The fix adds an explicit check for this edge case and returns a mask of 0 when 
WORD_SIZE <= suffix_length, preventing potential undefined behavior. Also modified the bit shift
operation to use u64 explicitly to avoid potential integer overflow issues.

This change ensures the bitwise operations work correctly across all possible input parameters
and prevents potential bugs with bit masks in extreme cases.