### PR TITLE
Feat/sparse dense shout 2

### DIFF
--- a/jolt-core/src/benches/bench.rs
+++ b/jolt-core/src/benches/bench.rs
@@ -8,7 +8,7 @@ use crate::poly::commitment::hyperkzg::HyperKZG;
 use crate::poly::commitment::zeromorph::Zeromorph;
 use crate::subprotocols::shout::ShoutProof;
 use crate::subprotocols::sparse_dense_shout::{
-    prove_multiple_instructions, verify_multiple_instructions,
+    prove_sparse_dense_shout, verify_sparse_dense_shout,
 };
 use crate::subprotocols::twist::{TwistAlgorithm, TwistProof};
 use crate::utils::math::Math;
@@ -141,16 +141,15 @@ where
     let r_cycle: Vec<F> = prover_transcript.challenge_vector(LOG_T);
 
     let task = move || {
-        let (proof, rv_claim, ra_claims, flag_claims) =
-            prove_multiple_instructions::<WORD_SIZE, _, _>(
-                &instructions,
-                r_cycle,
-                &mut prover_transcript,
-            );
+        let (proof, rv_claim, ra_claims, flag_claims) = prove_sparse_dense_shout::<WORD_SIZE, _, _>(
+            &instructions,
+            r_cycle,
+            &mut prover_transcript,
+        );
 
         let mut verifier_transcript = ProofTranscript::new(b"test_transcript");
         let r_cycle: Vec<F> = verifier_transcript.challenge_vector(LOG_T);
-        let verification_result = verify_multiple_instructions::<WORD_SIZE, _, _>(
+        let verification_result = verify_sparse_dense_shout::<WORD_SIZE, _, _>(
             proof,
             LOG_K,
             LOG_T,

--- a/jolt-core/src/benches/bench.rs
+++ b/jolt-core/src/benches/bench.rs
@@ -1,7 +1,6 @@
 use crate::field::JoltField;
 use crate::host;
-use crate::jolt::instruction::sltu::SLTUInstruction;
-use crate::jolt::instruction::JoltInstruction;
+use crate::jolt::instruction::LookupTables;
 use crate::jolt::vm::rv32i_vm::{RV32IJoltVM, C, M};
 use crate::jolt::vm::Jolt;
 use crate::poly::commitment::commitment_scheme::CommitmentScheme;
@@ -9,7 +8,7 @@ use crate::poly::commitment::hyperkzg::HyperKZG;
 use crate::poly::commitment::zeromorph::Zeromorph;
 use crate::subprotocols::shout::ShoutProof;
 use crate::subprotocols::sparse_dense_shout::{
-    prove_single_instruction, verify_single_instruction,
+    prove_multiple_instructions, verify_multiple_instructions,
 };
 use crate::subprotocols::twist::{TwistAlgorithm, TwistProof};
 use crate::utils::math::Math;
@@ -135,25 +134,30 @@ where
     let mut rng = StdRng::seed_from_u64(12345);
 
     let instructions: Vec<_> = (0..T)
-        .map(|_| SLTUInstruction::<32>::default().random(&mut rng))
+        .map(|_| LookupTables::random(&mut rng, None))
         .collect();
 
     let mut prover_transcript = ProofTranscript::new(b"test_transcript");
     let r_cycle: Vec<F> = prover_transcript.challenge_vector(LOG_T);
 
     let task = move || {
-        let (proof, rv_claim, ra_claims) =
-            prove_single_instruction::<32, _, _, _>(&instructions, r_cycle, &mut prover_transcript);
+        let (proof, rv_claim, ra_claims, flag_claims) =
+            prove_multiple_instructions::<WORD_SIZE, _, _>(
+                &instructions,
+                r_cycle,
+                &mut prover_transcript,
+            );
 
         let mut verifier_transcript = ProofTranscript::new(b"test_transcript");
         let r_cycle: Vec<F> = verifier_transcript.challenge_vector(LOG_T);
-        let verification_result = verify_single_instruction::<_, SLTUInstruction<32>, _>(
+        let verification_result = verify_multiple_instructions::<WORD_SIZE, _, _>(
             proof,
             LOG_K,
             LOG_T,
             r_cycle,
             rv_claim,
             ra_claims,
+            flag_claims,
             &mut verifier_transcript,
         );
         assert!(

--- a/jolt-core/src/jolt/instruction/add.rs
+++ b/jolt-core/src/jolt/instruction/add.rs
@@ -92,19 +92,15 @@ impl<const WORD_SIZE: usize> JoltInstruction for ADDInstruction<WORD_SIZE> {
     }
 }
 
-impl<const WORD_SIZE: usize, F: JoltField> PrefixSuffixDecomposition<WORD_SIZE, F>
-    for ADDInstruction<WORD_SIZE>
-{
-    fn prefixes() -> Vec<Prefixes> {
-        vec![Prefixes::LowerWord]
-    }
-
-    fn suffixes() -> Vec<Suffixes> {
+impl<const WORD_SIZE: usize> PrefixSuffixDecomposition<WORD_SIZE> for ADDInstruction<WORD_SIZE> {
+    fn suffixes(&self) -> Vec<Suffixes> {
         vec![Suffixes::One, Suffixes::LowerWord]
     }
 
-    fn combine(prefixes: &[PrefixEval<F>], suffixes: &[SuffixEval<F>]) -> F {
-        prefixes[Prefixes::LowerWord] * suffixes[Suffixes::One] + suffixes[Suffixes::LowerWord]
+    fn combine<F: JoltField>(&self, prefixes: &[PrefixEval<F>], suffixes: &[SuffixEval<F>]) -> F {
+        debug_assert_eq!(self.suffixes().len(), suffixes.len());
+        let [one, lower_word] = suffixes.try_into().unwrap();
+        prefixes[Prefixes::LowerWord] * one + lower_word
     }
 }
 

--- a/jolt-core/src/jolt/instruction/and.rs
+++ b/jolt-core/src/jolt/instruction/and.rs
@@ -73,19 +73,15 @@ impl<const WORD_SIZE: usize> JoltInstruction for ANDInstruction<WORD_SIZE> {
     }
 }
 
-impl<const WORD_SIZE: usize, F: JoltField> PrefixSuffixDecomposition<WORD_SIZE, F>
-    for ANDInstruction<WORD_SIZE>
-{
-    fn prefixes() -> Vec<Prefixes> {
-        vec![Prefixes::And]
-    }
-
-    fn suffixes() -> Vec<Suffixes> {
+impl<const WORD_SIZE: usize> PrefixSuffixDecomposition<WORD_SIZE> for ANDInstruction<WORD_SIZE> {
+    fn suffixes(&self) -> Vec<Suffixes> {
         vec![Suffixes::One, Suffixes::And]
     }
 
-    fn combine(prefixes: &[PrefixEval<F>], suffixes: &[SuffixEval<F>]) -> F {
-        prefixes[Prefixes::And] * suffixes[Suffixes::One] + suffixes[Suffixes::And]
+    fn combine<F: JoltField>(&self, prefixes: &[PrefixEval<F>], suffixes: &[SuffixEval<F>]) -> F {
+        debug_assert_eq!(self.suffixes().len(), suffixes.len());
+        let [one, and] = suffixes.try_into().unwrap();
+        prefixes[Prefixes::And] * one + and
     }
 }
 

--- a/jolt-core/src/jolt/instruction/beq.rs
+++ b/jolt-core/src/jolt/instruction/beq.rs
@@ -76,19 +76,15 @@ impl<const WORD_SIZE: usize> JoltInstruction for BEQInstruction<WORD_SIZE> {
     }
 }
 
-impl<const WORD_SIZE: usize, F: JoltField> PrefixSuffixDecomposition<WORD_SIZE, F>
-    for BEQInstruction<WORD_SIZE>
-{
-    fn prefixes() -> Vec<Prefixes> {
-        vec![Prefixes::Eq]
-    }
-
-    fn suffixes() -> Vec<Suffixes> {
+impl<const WORD_SIZE: usize> PrefixSuffixDecomposition<WORD_SIZE> for BEQInstruction<WORD_SIZE> {
+    fn suffixes(&self) -> Vec<Suffixes> {
         vec![Suffixes::Eq]
     }
 
-    fn combine(prefixes: &[PrefixEval<F>], suffixes: &[SuffixEval<F>]) -> F {
-        prefixes[Prefixes::Eq] * suffixes[Suffixes::Eq]
+    fn combine<F: JoltField>(&self, prefixes: &[PrefixEval<F>], suffixes: &[SuffixEval<F>]) -> F {
+        debug_assert_eq!(self.suffixes().len(), suffixes.len());
+        let [eq] = suffixes.try_into().unwrap();
+        prefixes[Prefixes::Eq] * eq
     }
 }
 

--- a/jolt-core/src/jolt/instruction/bge.rs
+++ b/jolt-core/src/jolt/instruction/bge.rs
@@ -90,27 +90,18 @@ impl<const WORD_SIZE: usize> JoltInstruction for BGEInstruction<WORD_SIZE> {
     }
 }
 
-impl<const WORD_SIZE: usize, F: JoltField> PrefixSuffixDecomposition<WORD_SIZE, F>
-    for BGEInstruction<WORD_SIZE>
-{
-    fn prefixes() -> Vec<Prefixes> {
-        vec![
-            Prefixes::LessThan,
-            Prefixes::Eq,
-            Prefixes::LeftOperandMsb,
-            Prefixes::RightOperandMsb,
-        ]
-    }
-
-    fn suffixes() -> Vec<Suffixes> {
+impl<const WORD_SIZE: usize> PrefixSuffixDecomposition<WORD_SIZE> for BGEInstruction<WORD_SIZE> {
+    fn suffixes(&self) -> Vec<Suffixes> {
         vec![Suffixes::One, Suffixes::LessThan]
     }
 
-    fn combine(prefixes: &[PrefixEval<F>], suffixes: &[SuffixEval<F>]) -> F {
-        suffixes[Suffixes::One] + prefixes[Prefixes::RightOperandMsb] * suffixes[Suffixes::One]
-            - prefixes[Prefixes::LeftOperandMsb] * suffixes[Suffixes::One]
-            - prefixes[Prefixes::LessThan] * suffixes[Suffixes::One]
-            - prefixes[Prefixes::Eq] * suffixes[Suffixes::LessThan]
+    fn combine<F: JoltField>(&self, prefixes: &[PrefixEval<F>], suffixes: &[SuffixEval<F>]) -> F {
+        debug_assert_eq!(self.suffixes().len(), suffixes.len());
+        let [one, less_than] = suffixes.try_into().unwrap();
+        one + prefixes[Prefixes::RightOperandMsb] * one
+            - prefixes[Prefixes::LeftOperandMsb] * one
+            - prefixes[Prefixes::LessThan] * one
+            - prefixes[Prefixes::Eq] * less_than
     }
 }
 

--- a/jolt-core/src/jolt/instruction/bge.rs
+++ b/jolt-core/src/jolt/instruction/bge.rs
@@ -98,6 +98,7 @@ impl<const WORD_SIZE: usize> PrefixSuffixDecomposition<WORD_SIZE> for BGEInstruc
     fn combine<F: JoltField>(&self, prefixes: &[PrefixEval<F>], suffixes: &[SuffixEval<F>]) -> F {
         debug_assert_eq!(self.suffixes().len(), suffixes.len());
         let [one, less_than] = suffixes.try_into().unwrap();
+        // 1 - LT(x, y) = 1 - (isNegative(x) && isPositive(y)) - LTU(x, y)
         one + prefixes[Prefixes::RightOperandMsb] * one
             - prefixes[Prefixes::LeftOperandMsb] * one
             - prefixes[Prefixes::LessThan] * one

--- a/jolt-core/src/jolt/instruction/bgeu.rs
+++ b/jolt-core/src/jolt/instruction/bgeu.rs
@@ -80,21 +80,15 @@ impl<const WORD_SIZE: usize> JoltInstruction for BGEUInstruction<WORD_SIZE> {
     }
 }
 
-impl<const WORD_SIZE: usize, F: JoltField> PrefixSuffixDecomposition<WORD_SIZE, F>
-    for BGEUInstruction<WORD_SIZE>
-{
-    fn prefixes() -> Vec<Prefixes> {
-        vec![Prefixes::LessThan, Prefixes::Eq]
-    }
-
-    fn suffixes() -> Vec<Suffixes> {
+impl<const WORD_SIZE: usize> PrefixSuffixDecomposition<WORD_SIZE> for BGEUInstruction<WORD_SIZE> {
+    fn suffixes(&self) -> Vec<Suffixes> {
         vec![Suffixes::One, Suffixes::LessThan]
     }
 
-    fn combine(prefixes: &[PrefixEval<F>], suffixes: &[SuffixEval<F>]) -> F {
-        suffixes[Suffixes::One]
-            - prefixes[Prefixes::LessThan] * suffixes[Suffixes::One]
-            - prefixes[Prefixes::Eq] * suffixes[Suffixes::LessThan]
+    fn combine<F: JoltField>(&self, prefixes: &[PrefixEval<F>], suffixes: &[SuffixEval<F>]) -> F {
+        debug_assert_eq!(self.suffixes().len(), suffixes.len());
+        let [one, less_than] = suffixes.try_into().unwrap();
+        one - prefixes[Prefixes::LessThan] * one - prefixes[Prefixes::Eq] * less_than
     }
 }
 

--- a/jolt-core/src/jolt/instruction/bgeu.rs
+++ b/jolt-core/src/jolt/instruction/bgeu.rs
@@ -88,6 +88,7 @@ impl<const WORD_SIZE: usize> PrefixSuffixDecomposition<WORD_SIZE> for BGEUInstru
     fn combine<F: JoltField>(&self, prefixes: &[PrefixEval<F>], suffixes: &[SuffixEval<F>]) -> F {
         debug_assert_eq!(self.suffixes().len(), suffixes.len());
         let [one, less_than] = suffixes.try_into().unwrap();
+        // 1 - LTU(x, y)
         one - prefixes[Prefixes::LessThan] * one - prefixes[Prefixes::Eq] * less_than
     }
 }

--- a/jolt-core/src/jolt/instruction/bne.rs
+++ b/jolt-core/src/jolt/instruction/bne.rs
@@ -73,19 +73,15 @@ impl<const WORD_SIZE: usize> JoltInstruction for BNEInstruction<WORD_SIZE> {
     }
 }
 
-impl<const WORD_SIZE: usize, F: JoltField> PrefixSuffixDecomposition<WORD_SIZE, F>
-    for BNEInstruction<WORD_SIZE>
-{
-    fn prefixes() -> Vec<Prefixes> {
-        vec![Prefixes::Eq]
-    }
-
-    fn suffixes() -> Vec<Suffixes> {
+impl<const WORD_SIZE: usize> PrefixSuffixDecomposition<WORD_SIZE> for BNEInstruction<WORD_SIZE> {
+    fn suffixes(&self) -> Vec<Suffixes> {
         vec![Suffixes::One, Suffixes::Eq]
     }
 
-    fn combine(prefixes: &[PrefixEval<F>], suffixes: &[SuffixEval<F>]) -> F {
-        suffixes[Suffixes::One] - prefixes[Prefixes::Eq] * suffixes[Suffixes::Eq]
+    fn combine<F: JoltField>(&self, prefixes: &[PrefixEval<F>], suffixes: &[SuffixEval<F>]) -> F {
+        debug_assert_eq!(self.suffixes().len(), suffixes.len());
+        let [one, eq] = suffixes.try_into().unwrap();
+        one - prefixes[Prefixes::Eq] * eq
     }
 }
 

--- a/jolt-core/src/jolt/instruction/mod.rs
+++ b/jolt-core/src/jolt/instruction/mod.rs
@@ -282,7 +282,7 @@ pub enum LookupTables<const WORD_SIZE: usize> {
     AssertValidDiv0(AssertValidDiv0Instruction<WORD_SIZE>),
     AssertHalfwordAlignment(AssertHalfwordAlignmentInstruction<WORD_SIZE>),
     Pow2(POW2Instruction<WORD_SIZE>),
-    // RightShiftPadding(RightShiftPaddingInstruction<WORD_SIZE>),
+    RightShiftPadding(RightShiftPaddingInstruction<WORD_SIZE>),
 }
 
 impl<const WORD_SIZE: usize> LookupTables<WORD_SIZE> {
@@ -317,7 +317,7 @@ impl<const WORD_SIZE: usize> LookupTables<WORD_SIZE> {
             LookupTables::AssertValidDiv0(instr) => instr.to_lookup_index(),
             LookupTables::AssertHalfwordAlignment(instr) => instr.to_lookup_index(),
             LookupTables::Pow2(instr) => instr.to_lookup_index(),
-            // LookupTables::RightShiftPadding(instr) => instr.to_lookup_index(),
+            LookupTables::RightShiftPadding(instr) => instr.to_lookup_index(),
         }
     }
 
@@ -347,7 +347,7 @@ impl<const WORD_SIZE: usize> LookupTables<WORD_SIZE> {
             LookupTables::AssertValidDiv0(instr) => instr.materialize(),
             LookupTables::AssertHalfwordAlignment(instr) => instr.materialize(),
             LookupTables::Pow2(instr) => instr.materialize(),
-            // LookupTables::RightShiftPadding(instr) => instr.materialize(),
+            LookupTables::RightShiftPadding(instr) => instr.materialize(),
         }
     }
 
@@ -376,7 +376,7 @@ impl<const WORD_SIZE: usize> LookupTables<WORD_SIZE> {
             LookupTables::AssertValidDiv0(instr) => instr.materialize_entry(index),
             LookupTables::AssertHalfwordAlignment(instr) => instr.materialize_entry(index),
             LookupTables::Pow2(instr) => instr.materialize_entry(index),
-            // LookupTables::RightShiftPadding(instr) => instr.materialize_entry(index),
+            LookupTables::RightShiftPadding(instr) => instr.materialize_entry(index),
         }
     }
 
@@ -405,7 +405,7 @@ impl<const WORD_SIZE: usize> LookupTables<WORD_SIZE> {
             LookupTables::AssertValidDiv0(instr) => instr.evaluate_mle(r),
             LookupTables::AssertHalfwordAlignment(instr) => instr.evaluate_mle(r),
             LookupTables::Pow2(instr) => instr.evaluate_mle(r),
-            // LookupTables::RightShiftPadding(instr) => instr.evaluate_mle(r),
+            LookupTables::RightShiftPadding(instr) => instr.evaluate_mle(r),
         }
     }
 
@@ -451,9 +451,9 @@ impl<const WORD_SIZE: usize> LookupTables<WORD_SIZE> {
                 LookupTables::AssertHalfwordAlignment(instr.random(rng))
             }
             LookupTables::Pow2(instr) => LookupTables::Pow2(instr.random(rng)),
-            // LookupTables::RightShiftPadding(instr) => {
-            //     LookupTables::RightShiftPadding(instr.random(rng))
-            // }
+            LookupTables::RightShiftPadding(instr) => {
+                LookupTables::RightShiftPadding(instr.random(rng))
+            }
         }
     }
 
@@ -482,7 +482,7 @@ impl<const WORD_SIZE: usize> LookupTables<WORD_SIZE> {
             LookupTables::AssertValidDiv0(instr) => instr.suffixes(),
             LookupTables::AssertHalfwordAlignment(instr) => instr.suffixes(),
             LookupTables::Pow2(instr) => instr.suffixes(),
-            // LookupTables::RightShiftPadding(instr) => instr.suffixes(),
+            LookupTables::RightShiftPadding(instr) => instr.suffixes(),
         }
     }
 
@@ -515,7 +515,7 @@ impl<const WORD_SIZE: usize> LookupTables<WORD_SIZE> {
             LookupTables::AssertValidDiv0(instr) => instr.combine(prefixes, suffixes),
             LookupTables::AssertHalfwordAlignment(instr) => instr.combine(prefixes, suffixes),
             LookupTables::Pow2(instr) => instr.combine(prefixes, suffixes),
-            // LookupTables::RightShiftPadding(instr) => instr.combine(prefixes, suffixes),
+            LookupTables::RightShiftPadding(instr) => instr.combine(prefixes, suffixes),
         }
     }
 }

--- a/jolt-core/src/jolt/instruction/mod.rs
+++ b/jolt-core/src/jolt/instruction/mod.rs
@@ -281,7 +281,7 @@ pub enum LookupTables<const WORD_SIZE: usize> {
     AssertValidUnsignedRemainder(AssertValidUnsignedRemainderInstruction<WORD_SIZE>),
     AssertValidDiv0(AssertValidDiv0Instruction<WORD_SIZE>),
     AssertHalfwordAlignment(AssertHalfwordAlignmentInstruction<WORD_SIZE>),
-    // Pow2(POW2Instruction<WORD_SIZE>),
+    Pow2(POW2Instruction<WORD_SIZE>),
     // RightShiftPadding(RightShiftPaddingInstruction<WORD_SIZE>),
 }
 
@@ -316,7 +316,7 @@ impl<const WORD_SIZE: usize> LookupTables<WORD_SIZE> {
             LookupTables::AssertValidUnsignedRemainder(instr) => instr.to_lookup_index(),
             LookupTables::AssertValidDiv0(instr) => instr.to_lookup_index(),
             LookupTables::AssertHalfwordAlignment(instr) => instr.to_lookup_index(),
-            // LookupTables::Pow2(instr) => instr.to_lookup_index(),
+            LookupTables::Pow2(instr) => instr.to_lookup_index(),
             // LookupTables::RightShiftPadding(instr) => instr.to_lookup_index(),
         }
     }
@@ -346,7 +346,7 @@ impl<const WORD_SIZE: usize> LookupTables<WORD_SIZE> {
             LookupTables::AssertValidUnsignedRemainder(instr) => instr.materialize(),
             LookupTables::AssertValidDiv0(instr) => instr.materialize(),
             LookupTables::AssertHalfwordAlignment(instr) => instr.materialize(),
-            // LookupTables::Pow2(instr) => instr.materialize(),
+            LookupTables::Pow2(instr) => instr.materialize(),
             // LookupTables::RightShiftPadding(instr) => instr.materialize(),
         }
     }
@@ -375,7 +375,7 @@ impl<const WORD_SIZE: usize> LookupTables<WORD_SIZE> {
             LookupTables::AssertValidUnsignedRemainder(instr) => instr.materialize_entry(index),
             LookupTables::AssertValidDiv0(instr) => instr.materialize_entry(index),
             LookupTables::AssertHalfwordAlignment(instr) => instr.materialize_entry(index),
-            // LookupTables::Pow2(instr) => instr.materialize_entry(index),
+            LookupTables::Pow2(instr) => instr.materialize_entry(index),
             // LookupTables::RightShiftPadding(instr) => instr.materialize_entry(index),
         }
     }
@@ -404,7 +404,7 @@ impl<const WORD_SIZE: usize> LookupTables<WORD_SIZE> {
             LookupTables::AssertValidUnsignedRemainder(instr) => instr.evaluate_mle(r),
             LookupTables::AssertValidDiv0(instr) => instr.evaluate_mle(r),
             LookupTables::AssertHalfwordAlignment(instr) => instr.evaluate_mle(r),
-            // LookupTables::Pow2(instr) => instr.evaluate_mle(r),
+            LookupTables::Pow2(instr) => instr.evaluate_mle(r),
             // LookupTables::RightShiftPadding(instr) => instr.evaluate_mle(r),
         }
     }
@@ -449,10 +449,11 @@ impl<const WORD_SIZE: usize> LookupTables<WORD_SIZE> {
             }
             LookupTables::AssertHalfwordAlignment(instr) => {
                 LookupTables::AssertHalfwordAlignment(instr.random(rng))
-            } // LookupTables::Pow2(instr) => LookupTables::Pow2(instr.random(rng)),
-              // LookupTables::RightShiftPadding(instr) => {
-              //     LookupTables::RightShiftPadding(instr.random(rng))
-              // }
+            }
+            LookupTables::Pow2(instr) => LookupTables::Pow2(instr.random(rng)),
+            // LookupTables::RightShiftPadding(instr) => {
+            //     LookupTables::RightShiftPadding(instr.random(rng))
+            // }
         }
     }
 
@@ -480,7 +481,7 @@ impl<const WORD_SIZE: usize> LookupTables<WORD_SIZE> {
             LookupTables::AssertValidUnsignedRemainder(instr) => instr.suffixes(),
             LookupTables::AssertValidDiv0(instr) => instr.suffixes(),
             LookupTables::AssertHalfwordAlignment(instr) => instr.suffixes(),
-            // LookupTables::Pow2(instr) => instr.suffixes(),
+            LookupTables::Pow2(instr) => instr.suffixes(),
             // LookupTables::RightShiftPadding(instr) => instr.suffixes(),
         }
     }
@@ -513,7 +514,7 @@ impl<const WORD_SIZE: usize> LookupTables<WORD_SIZE> {
             LookupTables::AssertValidUnsignedRemainder(instr) => instr.combine(prefixes, suffixes),
             LookupTables::AssertValidDiv0(instr) => instr.combine(prefixes, suffixes),
             LookupTables::AssertHalfwordAlignment(instr) => instr.combine(prefixes, suffixes),
-            // LookupTables::Pow2(instr) => instr.combine(prefixes, suffixes),
+            LookupTables::Pow2(instr) => instr.combine(prefixes, suffixes),
             // LookupTables::RightShiftPadding(instr) => instr.combine(prefixes, suffixes),
         }
     }

--- a/jolt-core/src/jolt/instruction/mod.rs
+++ b/jolt-core/src/jolt/instruction/mod.rs
@@ -1,9 +1,21 @@
 use add::ADDInstruction;
+use and::ANDInstruction;
+use beq::BEQInstruction;
+use bge::BGEInstruction;
+use bgeu::BGEUInstruction;
+use bne::BNEInstruction;
 use enum_dispatch::enum_dispatch;
 use fixedbitset::*;
+use mul::MULInstruction;
+use mulhu::MULHUInstruction;
+use mulu::MULUInstruction;
+use or::ORInstruction;
 use prefixes::PrefixEval;
 use rand::rngs::StdRng;
+use rand::RngCore;
 use serde::Serialize;
+use slt::SLTInstruction;
+use sltu::SLTUInstruction;
 use std::marker::Sync;
 use std::ops::Range;
 use strum::{EnumCount, IntoEnumIterator};
@@ -11,6 +23,17 @@ use strum_macros::{EnumCount as EnumCountMacro, EnumIter};
 use sub::SUBInstruction;
 use suffixes::{SuffixEval, Suffixes};
 use tracer::{RVTraceRow, RegisterState};
+use virtual_advice::ADVICEInstruction;
+use virtual_assert_halfword_alignment::AssertHalfwordAlignmentInstruction;
+use virtual_assert_lte::ASSERTLTEInstruction;
+use virtual_assert_valid_div0::AssertValidDiv0Instruction;
+use virtual_assert_valid_signed_remainder::AssertValidSignedRemainderInstruction;
+use virtual_assert_valid_unsigned_remainder::AssertValidUnsignedRemainderInstruction;
+use virtual_move::MOVEInstruction;
+use virtual_movsign::MOVSIGNInstruction;
+use virtual_pow2::POW2Instruction;
+use virtual_right_shift_padding::RightShiftPaddingInstruction;
+use xor::XORInstruction;
 
 use crate::field::JoltField;
 use crate::jolt::subtable::LassoSubtable;
@@ -233,11 +256,33 @@ pub mod xor;
 #[cfg(test)]
 pub mod test;
 
-#[derive(Clone, Debug, Serialize, EnumIter, EnumCountMacro)]
+#[derive(Copy, Clone, Debug, Serialize, EnumIter, EnumCountMacro)]
 #[repr(u8)]
 pub enum LookupTables<const WORD_SIZE: usize> {
-    ADD(ADDInstruction<WORD_SIZE>),
-    SUB(SUBInstruction<WORD_SIZE>),
+    Add(ADDInstruction<WORD_SIZE>),
+    Sub(SUBInstruction<WORD_SIZE>),
+    And(ANDInstruction<WORD_SIZE>),
+    Or(ORInstruction<WORD_SIZE>),
+    Xor(XORInstruction<WORD_SIZE>),
+    Beq(BEQInstruction<WORD_SIZE>),
+    Bge(BGEInstruction<WORD_SIZE>),
+    Bgeu(BGEUInstruction<WORD_SIZE>),
+    Bne(BNEInstruction<WORD_SIZE>),
+    Slt(SLTInstruction<WORD_SIZE>),
+    Sltu(SLTUInstruction<WORD_SIZE>),
+    Move(MOVEInstruction<WORD_SIZE>),
+    Movsign(MOVSIGNInstruction<WORD_SIZE>),
+    Mul(MULInstruction<WORD_SIZE>),
+    Mulu(MULUInstruction<WORD_SIZE>),
+    Mulhu(MULHUInstruction<WORD_SIZE>),
+    Advice(ADVICEInstruction<WORD_SIZE>),
+    AssertLte(ASSERTLTEInstruction<WORD_SIZE>),
+    AssertValidSignedRemainder(AssertValidSignedRemainderInstruction<WORD_SIZE>),
+    AssertValidUnsignedRemainder(AssertValidUnsignedRemainderInstruction<WORD_SIZE>),
+    AssertValidDiv0(AssertValidDiv0Instruction<WORD_SIZE>),
+    AssertHalfwordAlignment(AssertHalfwordAlignmentInstruction<WORD_SIZE>),
+    // Pow2(POW2Instruction<WORD_SIZE>),
+    // RightShiftPadding(RightShiftPaddingInstruction<WORD_SIZE>),
 }
 
 impl<const WORD_SIZE: usize> LookupTables<WORD_SIZE> {
@@ -249,51 +294,194 @@ impl<const WORD_SIZE: usize> LookupTables<WORD_SIZE> {
 
     pub fn to_lookup_index(&self) -> u64 {
         match self {
-            LookupTables::ADD(add) => add.to_lookup_index(),
-            LookupTables::SUB(sub) => sub.to_lookup_index(),
+            LookupTables::Add(instr) => instr.to_lookup_index(),
+            LookupTables::Sub(instr) => instr.to_lookup_index(),
+            LookupTables::And(instr) => instr.to_lookup_index(),
+            LookupTables::Or(instr) => instr.to_lookup_index(),
+            LookupTables::Xor(instr) => instr.to_lookup_index(),
+            LookupTables::Beq(instr) => instr.to_lookup_index(),
+            LookupTables::Bge(instr) => instr.to_lookup_index(),
+            LookupTables::Bgeu(instr) => instr.to_lookup_index(),
+            LookupTables::Bne(instr) => instr.to_lookup_index(),
+            LookupTables::Slt(instr) => instr.to_lookup_index(),
+            LookupTables::Sltu(instr) => instr.to_lookup_index(),
+            LookupTables::Move(instr) => instr.to_lookup_index(),
+            LookupTables::Movsign(instr) => instr.to_lookup_index(),
+            LookupTables::Mul(instr) => instr.to_lookup_index(),
+            LookupTables::Mulu(instr) => instr.to_lookup_index(),
+            LookupTables::Mulhu(instr) => instr.to_lookup_index(),
+            LookupTables::Advice(instr) => instr.to_lookup_index(),
+            LookupTables::AssertLte(instr) => instr.to_lookup_index(),
+            LookupTables::AssertValidSignedRemainder(instr) => instr.to_lookup_index(),
+            LookupTables::AssertValidUnsignedRemainder(instr) => instr.to_lookup_index(),
+            LookupTables::AssertValidDiv0(instr) => instr.to_lookup_index(),
+            LookupTables::AssertHalfwordAlignment(instr) => instr.to_lookup_index(),
+            // LookupTables::Pow2(instr) => instr.to_lookup_index(),
+            // LookupTables::RightShiftPadding(instr) => instr.to_lookup_index(),
         }
     }
 
     #[cfg(test)]
     pub fn materialize(&self) -> Vec<u64> {
         match self {
-            LookupTables::ADD(add) => add.materialize(),
-            LookupTables::SUB(sub) => sub.materialize(),
+            LookupTables::Add(instr) => instr.materialize(),
+            LookupTables::Sub(instr) => instr.materialize(),
+            LookupTables::And(instr) => instr.materialize(),
+            LookupTables::Or(instr) => instr.materialize(),
+            LookupTables::Xor(instr) => instr.materialize(),
+            LookupTables::Beq(instr) => instr.materialize(),
+            LookupTables::Bge(instr) => instr.materialize(),
+            LookupTables::Bgeu(instr) => instr.materialize(),
+            LookupTables::Bne(instr) => instr.materialize(),
+            LookupTables::Slt(instr) => instr.materialize(),
+            LookupTables::Sltu(instr) => instr.materialize(),
+            LookupTables::Move(instr) => instr.materialize(),
+            LookupTables::Movsign(instr) => instr.materialize(),
+            LookupTables::Mul(instr) => instr.materialize(),
+            LookupTables::Mulu(instr) => instr.materialize(),
+            LookupTables::Mulhu(instr) => instr.materialize(),
+            LookupTables::Advice(instr) => instr.materialize(),
+            LookupTables::AssertLte(instr) => instr.materialize(),
+            LookupTables::AssertValidSignedRemainder(instr) => instr.materialize(),
+            LookupTables::AssertValidUnsignedRemainder(instr) => instr.materialize(),
+            LookupTables::AssertValidDiv0(instr) => instr.materialize(),
+            LookupTables::AssertHalfwordAlignment(instr) => instr.materialize(),
+            // LookupTables::Pow2(instr) => instr.materialize(),
+            // LookupTables::RightShiftPadding(instr) => instr.materialize(),
         }
     }
 
     pub fn materialize_entry(&self, index: u64) -> u64 {
         match self {
-            LookupTables::ADD(add) => add.materialize_entry(index),
-            LookupTables::SUB(sub) => sub.materialize_entry(index),
+            LookupTables::Add(instr) => instr.materialize_entry(index),
+            LookupTables::Sub(instr) => instr.materialize_entry(index),
+            LookupTables::And(instr) => instr.materialize_entry(index),
+            LookupTables::Or(instr) => instr.materialize_entry(index),
+            LookupTables::Xor(instr) => instr.materialize_entry(index),
+            LookupTables::Beq(instr) => instr.materialize_entry(index),
+            LookupTables::Bge(instr) => instr.materialize_entry(index),
+            LookupTables::Bgeu(instr) => instr.materialize_entry(index),
+            LookupTables::Bne(instr) => instr.materialize_entry(index),
+            LookupTables::Slt(instr) => instr.materialize_entry(index),
+            LookupTables::Sltu(instr) => instr.materialize_entry(index),
+            LookupTables::Move(instr) => instr.materialize_entry(index),
+            LookupTables::Movsign(instr) => instr.materialize_entry(index),
+            LookupTables::Mul(instr) => instr.materialize_entry(index),
+            LookupTables::Mulu(instr) => instr.materialize_entry(index),
+            LookupTables::Mulhu(instr) => instr.materialize_entry(index),
+            LookupTables::Advice(instr) => instr.materialize_entry(index),
+            LookupTables::AssertLte(instr) => instr.materialize_entry(index),
+            LookupTables::AssertValidSignedRemainder(instr) => instr.materialize_entry(index),
+            LookupTables::AssertValidUnsignedRemainder(instr) => instr.materialize_entry(index),
+            LookupTables::AssertValidDiv0(instr) => instr.materialize_entry(index),
+            LookupTables::AssertHalfwordAlignment(instr) => instr.materialize_entry(index),
+            // LookupTables::Pow2(instr) => instr.materialize_entry(index),
+            // LookupTables::RightShiftPadding(instr) => instr.materialize_entry(index),
         }
     }
 
-    fn evaluate_mle<F: JoltField>(&self, r: &[F]) -> F {
+    pub fn evaluate_mle<F: JoltField>(&self, r: &[F]) -> F {
         match self {
-            LookupTables::ADD(add) => add.evaluate_mle(r),
-            LookupTables::SUB(sub) => sub.evaluate_mle(r),
+            LookupTables::Add(instr) => instr.evaluate_mle(r),
+            LookupTables::Sub(instr) => instr.evaluate_mle(r),
+            LookupTables::And(instr) => instr.evaluate_mle(r),
+            LookupTables::Or(instr) => instr.evaluate_mle(r),
+            LookupTables::Xor(instr) => instr.evaluate_mle(r),
+            LookupTables::Beq(instr) => instr.evaluate_mle(r),
+            LookupTables::Bge(instr) => instr.evaluate_mle(r),
+            LookupTables::Bgeu(instr) => instr.evaluate_mle(r),
+            LookupTables::Bne(instr) => instr.evaluate_mle(r),
+            LookupTables::Slt(instr) => instr.evaluate_mle(r),
+            LookupTables::Sltu(instr) => instr.evaluate_mle(r),
+            LookupTables::Move(instr) => instr.evaluate_mle(r),
+            LookupTables::Movsign(instr) => instr.evaluate_mle(r),
+            LookupTables::Mul(instr) => instr.evaluate_mle(r),
+            LookupTables::Mulu(instr) => instr.evaluate_mle(r),
+            LookupTables::Mulhu(instr) => instr.evaluate_mle(r),
+            LookupTables::Advice(instr) => instr.evaluate_mle(r),
+            LookupTables::AssertLte(instr) => instr.evaluate_mle(r),
+            LookupTables::AssertValidSignedRemainder(instr) => instr.evaluate_mle(r),
+            LookupTables::AssertValidUnsignedRemainder(instr) => instr.evaluate_mle(r),
+            LookupTables::AssertValidDiv0(instr) => instr.evaluate_mle(r),
+            LookupTables::AssertHalfwordAlignment(instr) => instr.evaluate_mle(r),
+            // LookupTables::Pow2(instr) => instr.evaluate_mle(r),
+            // LookupTables::RightShiftPadding(instr) => instr.evaluate_mle(r),
         }
     }
 
-    fn operands(&self) -> (u64, u64) {
-        match self {
-            LookupTables::ADD(add) => add.operands(),
-            LookupTables::SUB(sub) => sub.operands(),
-        }
-    }
-
-    fn random(&self, rng: &mut StdRng) -> Self {
-        match self {
-            LookupTables::ADD(add) => LookupTables::ADD(add.random(rng)),
-            LookupTables::SUB(sub) => LookupTables::SUB(sub.random(rng)),
+    pub fn random(rng: &mut StdRng, instruction: Option<Self>) -> Self {
+        let instruction = instruction.unwrap_or_else(|| {
+            let index = rng.next_u64() as usize % Self::COUNT;
+            Self::iter()
+                .enumerate()
+                .filter(|(i, _)| *i == index)
+                .map(|(_, x)| x)
+                .next()
+                .unwrap()
+        });
+        match instruction {
+            LookupTables::Add(instr) => LookupTables::Add(instr.random(rng)),
+            LookupTables::Sub(instr) => LookupTables::Sub(instr.random(rng)),
+            LookupTables::And(instr) => LookupTables::And(instr.random(rng)),
+            LookupTables::Or(instr) => LookupTables::Or(instr.random(rng)),
+            LookupTables::Xor(instr) => LookupTables::Xor(instr.random(rng)),
+            LookupTables::Beq(instr) => LookupTables::Beq(instr.random(rng)),
+            LookupTables::Bge(instr) => LookupTables::Bge(instr.random(rng)),
+            LookupTables::Bgeu(instr) => LookupTables::Bgeu(instr.random(rng)),
+            LookupTables::Bne(instr) => LookupTables::Bne(instr.random(rng)),
+            LookupTables::Slt(instr) => LookupTables::Slt(instr.random(rng)),
+            LookupTables::Sltu(instr) => LookupTables::Sltu(instr.random(rng)),
+            LookupTables::Move(instr) => LookupTables::Move(instr.random(rng)),
+            LookupTables::Movsign(instr) => LookupTables::Movsign(instr.random(rng)),
+            LookupTables::Mul(instr) => LookupTables::Mul(instr.random(rng)),
+            LookupTables::Mulu(instr) => LookupTables::Mulu(instr.random(rng)),
+            LookupTables::Mulhu(instr) => LookupTables::Mulhu(instr.random(rng)),
+            LookupTables::Advice(instr) => LookupTables::Advice(instr.random(rng)),
+            LookupTables::AssertLte(instr) => LookupTables::AssertLte(instr.random(rng)),
+            LookupTables::AssertValidSignedRemainder(instr) => {
+                LookupTables::AssertValidSignedRemainder(instr.random(rng))
+            }
+            LookupTables::AssertValidUnsignedRemainder(instr) => {
+                LookupTables::AssertValidUnsignedRemainder(instr.random(rng))
+            }
+            LookupTables::AssertValidDiv0(instr) => {
+                LookupTables::AssertValidDiv0(instr.random(rng))
+            }
+            LookupTables::AssertHalfwordAlignment(instr) => {
+                LookupTables::AssertHalfwordAlignment(instr.random(rng))
+            } // LookupTables::Pow2(instr) => LookupTables::Pow2(instr.random(rng)),
+              // LookupTables::RightShiftPadding(instr) => {
+              //     LookupTables::RightShiftPadding(instr.random(rng))
+              // }
         }
     }
 
     pub fn suffixes(&self) -> Vec<Suffixes> {
         match self {
-            LookupTables::ADD(add) => add.suffixes(),
-            LookupTables::SUB(sub) => sub.suffixes(),
+            LookupTables::Add(instr) => instr.suffixes(),
+            LookupTables::Sub(instr) => instr.suffixes(),
+            LookupTables::And(instr) => instr.suffixes(),
+            LookupTables::Or(instr) => instr.suffixes(),
+            LookupTables::Xor(instr) => instr.suffixes(),
+            LookupTables::Beq(instr) => instr.suffixes(),
+            LookupTables::Bge(instr) => instr.suffixes(),
+            LookupTables::Bgeu(instr) => instr.suffixes(),
+            LookupTables::Bne(instr) => instr.suffixes(),
+            LookupTables::Slt(instr) => instr.suffixes(),
+            LookupTables::Sltu(instr) => instr.suffixes(),
+            LookupTables::Move(instr) => instr.suffixes(),
+            LookupTables::Movsign(instr) => instr.suffixes(),
+            LookupTables::Mul(instr) => instr.suffixes(),
+            LookupTables::Mulu(instr) => instr.suffixes(),
+            LookupTables::Mulhu(instr) => instr.suffixes(),
+            LookupTables::Advice(instr) => instr.suffixes(),
+            LookupTables::AssertLte(instr) => instr.suffixes(),
+            LookupTables::AssertValidSignedRemainder(instr) => instr.suffixes(),
+            LookupTables::AssertValidUnsignedRemainder(instr) => instr.suffixes(),
+            LookupTables::AssertValidDiv0(instr) => instr.suffixes(),
+            LookupTables::AssertHalfwordAlignment(instr) => instr.suffixes(),
+            // LookupTables::Pow2(instr) => instr.suffixes(),
+            // LookupTables::RightShiftPadding(instr) => instr.suffixes(),
         }
     }
 
@@ -303,8 +491,30 @@ impl<const WORD_SIZE: usize> LookupTables<WORD_SIZE> {
         suffixes: &[SuffixEval<F>],
     ) -> F {
         match self {
-            LookupTables::ADD(add) => add.combine(prefixes, suffixes),
-            LookupTables::SUB(sub) => sub.combine(prefixes, suffixes),
+            LookupTables::Add(instr) => instr.combine(prefixes, suffixes),
+            LookupTables::Sub(instr) => instr.combine(prefixes, suffixes),
+            LookupTables::And(instr) => instr.combine(prefixes, suffixes),
+            LookupTables::Or(instr) => instr.combine(prefixes, suffixes),
+            LookupTables::Xor(instr) => instr.combine(prefixes, suffixes),
+            LookupTables::Beq(instr) => instr.combine(prefixes, suffixes),
+            LookupTables::Bge(instr) => instr.combine(prefixes, suffixes),
+            LookupTables::Bgeu(instr) => instr.combine(prefixes, suffixes),
+            LookupTables::Bne(instr) => instr.combine(prefixes, suffixes),
+            LookupTables::Slt(instr) => instr.combine(prefixes, suffixes),
+            LookupTables::Sltu(instr) => instr.combine(prefixes, suffixes),
+            LookupTables::Move(instr) => instr.combine(prefixes, suffixes),
+            LookupTables::Movsign(instr) => instr.combine(prefixes, suffixes),
+            LookupTables::Mul(instr) => instr.combine(prefixes, suffixes),
+            LookupTables::Mulu(instr) => instr.combine(prefixes, suffixes),
+            LookupTables::Mulhu(instr) => instr.combine(prefixes, suffixes),
+            LookupTables::Advice(instr) => instr.combine(prefixes, suffixes),
+            LookupTables::AssertLte(instr) => instr.combine(prefixes, suffixes),
+            LookupTables::AssertValidSignedRemainder(instr) => instr.combine(prefixes, suffixes),
+            LookupTables::AssertValidUnsignedRemainder(instr) => instr.combine(prefixes, suffixes),
+            LookupTables::AssertValidDiv0(instr) => instr.combine(prefixes, suffixes),
+            LookupTables::AssertHalfwordAlignment(instr) => instr.combine(prefixes, suffixes),
+            // LookupTables::Pow2(instr) => instr.combine(prefixes, suffixes),
+            // LookupTables::RightShiftPadding(instr) => instr.combine(prefixes, suffixes),
         }
     }
 }

--- a/jolt-core/src/jolt/instruction/mul.rs
+++ b/jolt-core/src/jolt/instruction/mul.rs
@@ -89,19 +89,15 @@ impl<const WORD_SIZE: usize> JoltInstruction for MULInstruction<WORD_SIZE> {
     }
 }
 
-impl<const WORD_SIZE: usize, F: JoltField> PrefixSuffixDecomposition<WORD_SIZE, F>
-    for MULInstruction<WORD_SIZE>
-{
-    fn prefixes() -> Vec<Prefixes> {
-        vec![Prefixes::LowerWord]
-    }
-
-    fn suffixes() -> Vec<Suffixes> {
+impl<const WORD_SIZE: usize> PrefixSuffixDecomposition<WORD_SIZE> for MULInstruction<WORD_SIZE> {
+    fn suffixes(&self) -> Vec<Suffixes> {
         vec![Suffixes::One, Suffixes::LowerWord]
     }
 
-    fn combine(prefixes: &[PrefixEval<F>], suffixes: &[SuffixEval<F>]) -> F {
-        prefixes[Prefixes::LowerWord] * suffixes[Suffixes::One] + suffixes[Suffixes::LowerWord]
+    fn combine<F: JoltField>(&self, prefixes: &[PrefixEval<F>], suffixes: &[SuffixEval<F>]) -> F {
+        debug_assert_eq!(self.suffixes().len(), suffixes.len());
+        let [one, lower_word] = suffixes.try_into().unwrap();
+        prefixes[Prefixes::LowerWord] * one + lower_word
     }
 }
 

--- a/jolt-core/src/jolt/instruction/mulhu.rs
+++ b/jolt-core/src/jolt/instruction/mulhu.rs
@@ -84,19 +84,15 @@ impl<const WORD_SIZE: usize> JoltInstruction for MULHUInstruction<WORD_SIZE> {
     }
 }
 
-impl<const WORD_SIZE: usize, F: JoltField> PrefixSuffixDecomposition<WORD_SIZE, F>
-    for MULHUInstruction<WORD_SIZE>
-{
-    fn prefixes() -> Vec<Prefixes> {
-        vec![Prefixes::UpperWord]
-    }
-
-    fn suffixes() -> Vec<Suffixes> {
+impl<const WORD_SIZE: usize> PrefixSuffixDecomposition<WORD_SIZE> for MULHUInstruction<WORD_SIZE> {
+    fn suffixes(&self) -> Vec<Suffixes> {
         vec![Suffixes::One, Suffixes::UpperWord]
     }
 
-    fn combine(prefixes: &[PrefixEval<F>], suffixes: &[SuffixEval<F>]) -> F {
-        prefixes[Prefixes::UpperWord] * suffixes[Suffixes::One] + suffixes[Suffixes::UpperWord]
+    fn combine<F: JoltField>(&self, prefixes: &[PrefixEval<F>], suffixes: &[SuffixEval<F>]) -> F {
+        debug_assert_eq!(self.suffixes().len(), suffixes.len());
+        let [one, upper_word] = suffixes.try_into().unwrap();
+        prefixes[Prefixes::UpperWord] * one + upper_word
     }
 }
 

--- a/jolt-core/src/jolt/instruction/mulu.rs
+++ b/jolt-core/src/jolt/instruction/mulu.rs
@@ -85,19 +85,15 @@ impl<const WORD_SIZE: usize> JoltInstruction for MULUInstruction<WORD_SIZE> {
     }
 }
 
-impl<const WORD_SIZE: usize, F: JoltField> PrefixSuffixDecomposition<WORD_SIZE, F>
-    for MULUInstruction<WORD_SIZE>
-{
-    fn prefixes() -> Vec<Prefixes> {
-        vec![Prefixes::LowerWord]
-    }
-
-    fn suffixes() -> Vec<Suffixes> {
+impl<const WORD_SIZE: usize> PrefixSuffixDecomposition<WORD_SIZE> for MULUInstruction<WORD_SIZE> {
+    fn suffixes(&self) -> Vec<Suffixes> {
         vec![Suffixes::One, Suffixes::LowerWord]
     }
 
-    fn combine(prefixes: &[PrefixEval<F>], suffixes: &[SuffixEval<F>]) -> F {
-        prefixes[Prefixes::LowerWord] * suffixes[Suffixes::One] + suffixes[Suffixes::LowerWord]
+    fn combine<F: JoltField>(&self, prefixes: &[PrefixEval<F>], suffixes: &[SuffixEval<F>]) -> F {
+        debug_assert_eq!(self.suffixes().len(), suffixes.len());
+        let [one, lower_word] = suffixes.try_into().unwrap();
+        prefixes[Prefixes::LowerWord] * one + lower_word
     }
 }
 

--- a/jolt-core/src/jolt/instruction/or.rs
+++ b/jolt-core/src/jolt/instruction/or.rs
@@ -73,19 +73,15 @@ impl<const WORD_SIZE: usize> JoltInstruction for ORInstruction<WORD_SIZE> {
     }
 }
 
-impl<const WORD_SIZE: usize, F: JoltField> PrefixSuffixDecomposition<WORD_SIZE, F>
-    for ORInstruction<WORD_SIZE>
-{
-    fn prefixes() -> Vec<Prefixes> {
-        vec![Prefixes::Or]
-    }
-
-    fn suffixes() -> Vec<Suffixes> {
+impl<const WORD_SIZE: usize> PrefixSuffixDecomposition<WORD_SIZE> for ORInstruction<WORD_SIZE> {
+    fn suffixes(&self) -> Vec<Suffixes> {
         vec![Suffixes::One, Suffixes::Or]
     }
 
-    fn combine(prefixes: &[PrefixEval<F>], suffixes: &[SuffixEval<F>]) -> F {
-        prefixes[Prefixes::Or] * suffixes[Suffixes::One] + suffixes[Suffixes::Or]
+    fn combine<F: JoltField>(&self, prefixes: &[PrefixEval<F>], suffixes: &[SuffixEval<F>]) -> F {
+        debug_assert_eq!(self.suffixes().len(), suffixes.len());
+        let [one, or] = suffixes.try_into().unwrap();
+        prefixes[Prefixes::Or] * one + or
     }
 }
 

--- a/jolt-core/src/jolt/instruction/prefixes/and.rs
+++ b/jolt-core/src/jolt/instruction/prefixes/and.rs
@@ -17,6 +17,7 @@ impl<const WORD_SIZE: usize, F: JoltField> SparseDensePrefix<F> for AndPrefix<WO
     ) -> F {
         let mut result = checkpoints[Prefixes::And].unwrap_or(F::zero());
 
+        // AND high-order variables of x and y
         if let Some(r_x) = r_x {
             let y = F::from_u8(c as u8);
             let shift = WORD_SIZE - 1 - j / 2;
@@ -26,6 +27,7 @@ impl<const WORD_SIZE: usize, F: JoltField> SparseDensePrefix<F> for AndPrefix<WO
             let shift = WORD_SIZE - 1 - j / 2;
             result += F::from_u32(c * y_msb) * F::from_u32(1 << shift);
         }
+        // AND remaining x and y bits
         let (x, y) = b.uninterleave();
         let suffix_len = current_suffix_len(2 * WORD_SIZE, j);
         result += F::from_u32((u32::from(x) & u32::from(y)) << (suffix_len / 2));

--- a/jolt-core/src/jolt/instruction/prefixes/div_by_zero.rs
+++ b/jolt-core/src/jolt/instruction/prefixes/div_by_zero.rs
@@ -13,6 +13,8 @@ impl<F: JoltField> SparseDensePrefix<F> for DivByZeroPrefix {
         _: usize,
     ) -> F {
         let (divisor, quotient) = b.uninterleave();
+        // If low-order bits of divisor are not 0s or low-order bits of quotient are not
+        // 1s, short-circuit and return 0.
         if u64::from(divisor) != 0 || u64::from(quotient) != (1 << quotient.len()) - 1 {
             return F::zero();
         }

--- a/jolt-core/src/jolt/instruction/prefixes/eq.rs
+++ b/jolt-core/src/jolt/instruction/prefixes/eq.rs
@@ -14,6 +14,7 @@ impl<F: JoltField> SparseDensePrefix<F> for EqPrefix {
     ) -> F {
         let mut result = checkpoints[Prefixes::Eq].unwrap_or(F::one());
 
+        // EQ high-order variables of x and y
         if let Some(r_x) = r_x {
             let y = F::from_u8(c as u8);
             result *= r_x * y + (F::one() - r_x) * (F::one() - y);
@@ -22,6 +23,7 @@ impl<F: JoltField> SparseDensePrefix<F> for EqPrefix {
             let y_msb = F::from_u8(b.pop_msb());
             result *= x * y_msb + (F::one() - x) * (F::one() - y_msb);
         }
+        // EQ remaining x and y bits
         let (x, y) = b.uninterleave();
         if x != y {
             return F::zero();

--- a/jolt-core/src/jolt/instruction/prefixes/left_is_zero.rs
+++ b/jolt-core/src/jolt/instruction/prefixes/left_is_zero.rs
@@ -13,6 +13,7 @@ impl<F: JoltField> SparseDensePrefix<F> for LeftOperandIsZeroPrefix {
         _: usize,
     ) -> F {
         let (x, _) = b.uninterleave();
+        // Short-circuit if low-order bits of `x` are not 0s
         if u64::from(x) != 0 {
             return F::zero();
         }

--- a/jolt-core/src/jolt/instruction/prefixes/lower_word.rs
+++ b/jolt-core/src/jolt/instruction/prefixes/lower_word.rs
@@ -15,6 +15,7 @@ impl<const WORD_SIZE: usize, F: JoltField> SparseDensePrefix<F> for LowerWordPre
         mut b: LookupBits,
         j: usize,
     ) -> F {
+        // Ignore high-order variables
         if j < WORD_SIZE {
             return F::zero();
         }
@@ -35,6 +36,7 @@ impl<const WORD_SIZE: usize, F: JoltField> SparseDensePrefix<F> for LowerWordPre
             result += F::from_u64(1 << y_shift) * F::from_u8(y_msb);
         }
 
+        // Add in low-order bits from `b`
         let suffix_len = current_suffix_len(2 * WORD_SIZE, j);
         result += F::from_u64(u64::from(b) << suffix_len);
 

--- a/jolt-core/src/jolt/instruction/prefixes/lsb.rs
+++ b/jolt-core/src/jolt/instruction/prefixes/lsb.rs
@@ -1,0 +1,34 @@
+use crate::{
+    field::JoltField,
+    subprotocols::sparse_dense_shout::{current_suffix_len, LookupBits},
+};
+
+use super::{PrefixCheckpoint, SparseDensePrefix};
+
+pub enum LsbPrefix<const WORD_SIZE: usize> {}
+
+impl<const WORD_SIZE: usize, F: JoltField> SparseDensePrefix<F> for LsbPrefix<WORD_SIZE> {
+    fn prefix_mle(_: &[PrefixCheckpoint<F>], _: Option<F>, c: u32, b: LookupBits, j: usize) -> F {
+        if j == 2 * WORD_SIZE - 1 {
+            debug_assert_eq!(b.len(), 0);
+            F::from_u32(c)
+        } else if current_suffix_len(2 * WORD_SIZE, j) == 0 {
+            F::from_u32(u32::from(b) & 1)
+        } else {
+            F::one()
+        }
+    }
+
+    fn update_prefix_checkpoint(
+        _: &[PrefixCheckpoint<F>],
+        _: F,
+        r_y: F,
+        j: usize,
+    ) -> PrefixCheckpoint<F> {
+        if j == 2 * WORD_SIZE - 1 {
+            Some(r_y).into()
+        } else {
+            Some(F::one().into()).into()
+        }
+    }
+}

--- a/jolt-core/src/jolt/instruction/prefixes/lsb.rs
+++ b/jolt-core/src/jolt/instruction/prefixes/lsb.rs
@@ -10,9 +10,11 @@ pub enum LsbPrefix<const WORD_SIZE: usize> {}
 impl<const WORD_SIZE: usize, F: JoltField> SparseDensePrefix<F> for LsbPrefix<WORD_SIZE> {
     fn prefix_mle(_: &[PrefixCheckpoint<F>], _: Option<F>, c: u32, b: LookupBits, j: usize) -> F {
         if j == 2 * WORD_SIZE - 1 {
+            // in the log(K)th round, `c` corresponds to the LSB
             debug_assert_eq!(b.len(), 0);
             F::from_u32(c)
         } else if current_suffix_len(2 * WORD_SIZE, j) == 0 {
+            // in the (log(K)-1)th round, the LSB of `b` is the LSB
             F::from_u32(u32::from(b) & 1)
         } else {
             F::one()

--- a/jolt-core/src/jolt/instruction/prefixes/lsb.rs
+++ b/jolt-core/src/jolt/instruction/prefixes/lsb.rs
@@ -28,7 +28,7 @@ impl<const WORD_SIZE: usize, F: JoltField> SparseDensePrefix<F> for LsbPrefix<WO
         if j == 2 * WORD_SIZE - 1 {
             Some(r_y).into()
         } else {
-            Some(F::one().into()).into()
+            Some(F::one()).into()
         }
     }
 }

--- a/jolt-core/src/jolt/instruction/prefixes/mod.rs
+++ b/jolt-core/src/jolt/instruction/prefixes/mod.rs
@@ -8,6 +8,7 @@ use positive_remainder_equals_divisor::PositiveRemainderEqualsDivisorPrefix;
 use positive_remainder_less_than_divisor::PositiveRemainderLessThanDivisorPrefix;
 use pow2::Pow2Prefix;
 use rayon::prelude::*;
+use right_shift_padding::RightShiftPaddingPrefix;
 use std::{fmt::Display, ops::Index};
 use strum::EnumCount;
 use strum_macros::{EnumCount as EnumCountMacro, EnumIter};
@@ -43,6 +44,7 @@ pub mod positive_remainder_less_than_divisor;
 pub mod pow2;
 pub mod right_is_zero;
 pub mod right_msb;
+pub mod right_shift_padding;
 pub mod upper_word;
 pub mod xor;
 
@@ -106,6 +108,7 @@ pub enum Prefixes {
     NegativeDivisorGreaterThanRemainder,
     Lsb,
     Pow2,
+    RightShiftPadding,
 }
 
 #[derive(Clone, Copy)]
@@ -200,6 +203,9 @@ impl Prefixes {
             }
             Prefixes::Lsb => LsbPrefix::<WORD_SIZE>::prefix_mle(checkpoints, r_x, c, b, j),
             Prefixes::Pow2 => Pow2Prefix::<WORD_SIZE>::prefix_mle(checkpoints, r_x, c, b, j),
+            Prefixes::RightShiftPadding => {
+                RightShiftPaddingPrefix::<WORD_SIZE>::prefix_mle(checkpoints, r_x, c, b, j)
+            }
         };
         PrefixEval(eval)
     }
@@ -323,6 +329,14 @@ impl Prefixes {
             }
             Prefixes::Pow2 => {
                 Pow2Prefix::<WORD_SIZE>::update_prefix_checkpoint(checkpoints, r_x, r_y, j)
+            }
+            Prefixes::RightShiftPadding => {
+                RightShiftPaddingPrefix::<WORD_SIZE>::update_prefix_checkpoint(
+                    checkpoints,
+                    r_x,
+                    r_y,
+                    j,
+                )
             }
         }
     }

--- a/jolt-core/src/jolt/instruction/prefixes/mod.rs
+++ b/jolt-core/src/jolt/instruction/prefixes/mod.rs
@@ -1,10 +1,12 @@
 use crate::{field::JoltField, subprotocols::sparse_dense_shout::LookupBits};
+use lsb::LsbPrefix;
 use negative_divisor_equals_remainder::NegativeDivisorEqualsRemainderPrefix;
 use negative_divisor_greater_than_remainder::NegativeDivisorGreaterThanRemainderPrefix;
 use negative_divisor_zero_remainder::NegativeDivisorZeroRemainderPrefix;
 use num_derive::FromPrimitive;
 use positive_remainder_equals_divisor::PositiveRemainderEqualsDivisorPrefix;
 use positive_remainder_less_than_divisor::PositiveRemainderLessThanDivisorPrefix;
+use pow2::Pow2Prefix;
 use rayon::prelude::*;
 use std::{fmt::Display, ops::Index};
 use strum::EnumCount;
@@ -30,6 +32,7 @@ pub mod eq;
 pub mod left_is_zero;
 pub mod left_msb;
 pub mod lower_word;
+pub mod lsb;
 pub mod lt;
 pub mod negative_divisor_equals_remainder;
 pub mod negative_divisor_greater_than_remainder;
@@ -37,6 +40,7 @@ pub mod negative_divisor_zero_remainder;
 pub mod or;
 pub mod positive_remainder_equals_divisor;
 pub mod positive_remainder_less_than_divisor;
+pub mod pow2;
 pub mod right_is_zero;
 pub mod right_msb;
 pub mod upper_word;
@@ -100,6 +104,8 @@ pub enum Prefixes {
     NegativeDivisorZeroRemainder,
     NegativeDivisorEqualsRemainder,
     NegativeDivisorGreaterThanRemainder,
+    Lsb,
+    Pow2,
 }
 
 #[derive(Clone, Copy)]
@@ -192,6 +198,8 @@ impl Prefixes {
             Prefixes::NegativeDivisorGreaterThanRemainder => {
                 NegativeDivisorGreaterThanRemainderPrefix::prefix_mle(checkpoints, r_x, c, b, j)
             }
+            Prefixes::Lsb => LsbPrefix::<WORD_SIZE>::prefix_mle(checkpoints, r_x, c, b, j),
+            Prefixes::Pow2 => Pow2Prefix::<WORD_SIZE>::prefix_mle(checkpoints, r_x, c, b, j),
         };
         PrefixEval(eval)
     }
@@ -309,6 +317,12 @@ impl Prefixes {
                     r_y,
                     j,
                 )
+            }
+            Prefixes::Lsb => {
+                LsbPrefix::<WORD_SIZE>::update_prefix_checkpoint(checkpoints, r_x, r_y, j)
+            }
+            Prefixes::Pow2 => {
+                Pow2Prefix::<WORD_SIZE>::update_prefix_checkpoint(checkpoints, r_x, r_y, j)
             }
         }
     }

--- a/jolt-core/src/jolt/instruction/prefixes/mod.rs
+++ b/jolt-core/src/jolt/instruction/prefixes/mod.rs
@@ -214,6 +214,7 @@ impl Prefixes {
     /// prefix, incorporating the two random challenges `r_x` and `r_y` received
     /// since the last update.
     /// This function updates all the prefix checkpoints.
+    #[tracing::instrument(skip_all)]
     pub fn update_checkpoints<const WORD_SIZE: usize, F: JoltField>(
         checkpoints: &mut [PrefixCheckpoint<F>],
         r_x: F,

--- a/jolt-core/src/jolt/instruction/prefixes/negative_divisor_equals_remainder.rs
+++ b/jolt-core/src/jolt/instruction/prefixes/negative_divisor_equals_remainder.rs
@@ -42,6 +42,7 @@ impl<F: JoltField> SparseDensePrefix<F> for NegativeDivisorEqualsRemainderPrefix
 
         if let Some(r_x) = r_x {
             let (remainder, divisor) = b.uninterleave();
+            // Short-circuit if low-order bits of remainder and divisor are not equal
             if remainder != divisor {
                 return F::zero();
             }
@@ -50,6 +51,7 @@ impl<F: JoltField> SparseDensePrefix<F> for NegativeDivisorEqualsRemainderPrefix
         } else {
             let y_msb = F::from_u8(b.pop_msb());
             let (remainder, divisor) = b.uninterleave();
+            // Short-circuit if low-order bits of remainder and divisor are not equal
             if remainder != divisor {
                 return F::zero();
             }

--- a/jolt-core/src/jolt/instruction/prefixes/negative_divisor_greater_than_remainder.rs
+++ b/jolt-core/src/jolt/instruction/prefixes/negative_divisor_greater_than_remainder.rs
@@ -44,11 +44,10 @@ impl<F: JoltField> SparseDensePrefix<F> for NegativeDivisorGreaterThanRemainderP
             let c = F::from_u32(c);
             let y_msb = F::from_u8(b.pop_msb());
             let (x, y) = b.uninterleave();
+            gt *= c * (F::one() - y_msb);
             if u64::from(x) > u64::from(y) {
                 eq *= c * y_msb + (F::one() - c) * (F::one() - y_msb);
-                gt *= eq + c * (F::one() - y_msb);
-            } else {
-                gt *= c * (F::one() - y_msb);
+                gt += eq;
             }
             return gt;
         }
@@ -56,11 +55,10 @@ impl<F: JoltField> SparseDensePrefix<F> for NegativeDivisorGreaterThanRemainderP
             let r_x = r_x.unwrap();
             let c = F::from_u32(c);
             let (x, y) = b.uninterleave();
+            gt *= r_x * (F::one() - c);
             if u64::from(x) > u64::from(y) {
                 eq *= r_x * c + (F::one() - r_x) * (F::one() - c);
-                gt *= eq + r_x * (F::one() - c);
-            } else {
-                gt *= r_x * (F::one() - c);
+                gt += eq;
             }
             return gt;
         }

--- a/jolt-core/src/jolt/instruction/prefixes/negative_divisor_greater_than_remainder.rs
+++ b/jolt-core/src/jolt/instruction/prefixes/negative_divisor_greater_than_remainder.rs
@@ -40,6 +40,9 @@ impl<F: JoltField> SparseDensePrefix<F> for NegativeDivisorGreaterThanRemainderP
         let mut gt = checkpoints[Prefixes::NegativeDivisorGreaterThanRemainder].unwrap();
         let mut eq = checkpoints[Prefixes::NegativeDivisorEqualsRemainder].unwrap();
 
+        // For j=2 and j=3, the two checkpoints are the same (they both store isNegative(divisor))
+        // so to avoid double-counting we multiply `gt` by x * (1 - y) instead of adding
+        // eq * x * (1 - y) as we do in subsequent rounds.
         if j == 2 {
             let c = F::from_u32(c);
             let y_msb = F::from_u8(b.pop_msb());

--- a/jolt-core/src/jolt/instruction/prefixes/negative_divisor_zero_remainder.rs
+++ b/jolt-core/src/jolt/instruction/prefixes/negative_divisor_zero_remainder.rs
@@ -42,6 +42,7 @@ impl<F: JoltField> SparseDensePrefix<F> for NegativeDivisorZeroRemainderPrefix {
 
         if let Some(r_x) = r_x {
             let (remainder, _) = b.uninterleave();
+            // Short-circuit if low-order bits of remainder are not 0s
             if u64::from(remainder) != 0 {
                 return F::zero();
             }
@@ -50,7 +51,7 @@ impl<F: JoltField> SparseDensePrefix<F> for NegativeDivisorZeroRemainderPrefix {
         } else {
             let _ = b.pop_msb();
             let (remainder, _) = b.uninterleave();
-
+            // Short-circuit if low-order bits of remainder are not 0s
             if u64::from(remainder) != 0 {
                 return F::zero();
             }

--- a/jolt-core/src/jolt/instruction/prefixes/or.rs
+++ b/jolt-core/src/jolt/instruction/prefixes/or.rs
@@ -17,6 +17,7 @@ impl<const WORD_SIZE: usize, F: JoltField> SparseDensePrefix<F> for OrPrefix<WOR
     ) -> F {
         let mut result = checkpoints[Prefixes::Or].unwrap_or(F::zero());
 
+        // OR high-order variables of x and y
         if let Some(r_x) = r_x {
             let y = F::from_u8(c as u8);
             let shift = WORD_SIZE - 1 - j / 2;
@@ -26,6 +27,7 @@ impl<const WORD_SIZE: usize, F: JoltField> SparseDensePrefix<F> for OrPrefix<WOR
             let shift = WORD_SIZE - 1 - j / 2;
             result += F::from_u32(c + y_msb - c * y_msb) * F::from_u32(1 << shift);
         }
+        // OR remaining x and y bits
         let (x, y) = b.uninterleave();
         let suffix_len = current_suffix_len(2 * WORD_SIZE, j);
         result += F::from_u32((u32::from(x) | u32::from(y)) << (suffix_len / 2));

--- a/jolt-core/src/jolt/instruction/prefixes/positive_remainder_equals_divisor.rs
+++ b/jolt-core/src/jolt/instruction/prefixes/positive_remainder_equals_divisor.rs
@@ -42,6 +42,7 @@ impl<F: JoltField> SparseDensePrefix<F> for PositiveRemainderEqualsDivisorPrefix
 
         if let Some(r_x) = r_x {
             let (remainder, divisor) = b.uninterleave();
+            // Short-circuit if low-order bits of remainder and divisor are not equal
             if u64::from(remainder) != u64::from(divisor) {
                 return F::zero();
             }
@@ -50,6 +51,7 @@ impl<F: JoltField> SparseDensePrefix<F> for PositiveRemainderEqualsDivisorPrefix
         } else {
             let y = F::from_u8(b.pop_msb());
             let (remainder, divisor) = b.uninterleave();
+            // Short-circuit if low-order bits of remainder and divisor are not equal
             if u64::from(remainder) != u64::from(divisor) {
                 return F::zero();
             }

--- a/jolt-core/src/jolt/instruction/prefixes/positive_remainder_less_than_divisor.rs
+++ b/jolt-core/src/jolt/instruction/prefixes/positive_remainder_less_than_divisor.rs
@@ -44,11 +44,10 @@ impl<F: JoltField> SparseDensePrefix<F> for PositiveRemainderLessThanDivisorPref
             let c = F::from_u32(c);
             let y_msb = F::from_u8(b.pop_msb());
             let (x, y) = b.uninterleave();
+            lt *= (F::one() - c) * y_msb;
             if u64::from(x) < u64::from(y) {
                 eq *= c * y_msb + (F::one() - c) * (F::one() - y_msb);
-                lt *= eq + (F::one() - c) * y_msb;
-            } else {
-                lt *= (F::one() - c) * y_msb;
+                lt += eq;
             }
             return lt;
         }
@@ -56,11 +55,10 @@ impl<F: JoltField> SparseDensePrefix<F> for PositiveRemainderLessThanDivisorPref
             let r_x = r_x.unwrap();
             let c = F::from_u32(c);
             let (x, y) = b.uninterleave();
+            lt *= (F::one() - r_x) * c;
             if u64::from(x) < u64::from(y) {
                 eq *= r_x * c + (F::one() - r_x) * (F::one() - c);
-                lt *= eq + (F::one() - r_x) * c;
-            } else {
-                lt *= (F::one() - r_x) * c;
+                lt += eq;
             }
             return lt;
         }

--- a/jolt-core/src/jolt/instruction/prefixes/positive_remainder_less_than_divisor.rs
+++ b/jolt-core/src/jolt/instruction/prefixes/positive_remainder_less_than_divisor.rs
@@ -40,6 +40,9 @@ impl<F: JoltField> SparseDensePrefix<F> for PositiveRemainderLessThanDivisorPref
         let mut lt = checkpoints[Prefixes::PositiveRemainderLessThanDivisor].unwrap();
         let mut eq = checkpoints[Prefixes::PositiveRemainderEqualsDivisor].unwrap();
 
+        // For j=2 and j=3, the two checkpoints are the same (they both store isNegative(divisor))
+        // so to avoid double-counting we multiply `lt` by (1 - x) * y instead of adding
+        // eq * (1 - x) * y as we do in subsequent rounds.
         if j == 2 {
             let c = F::from_u32(c);
             let y_msb = F::from_u8(b.pop_msb());

--- a/jolt-core/src/jolt/instruction/prefixes/pow2.rs
+++ b/jolt-core/src/jolt/instruction/prefixes/pow2.rs
@@ -17,7 +17,7 @@ impl<const WORD_SIZE: usize, F: JoltField> SparseDensePrefix<F> for Pow2Prefix<W
         j: usize,
     ) -> F {
         if current_suffix_len(2 * WORD_SIZE, j) != 0 {
-            // Pow2 is handled by suffix
+            // Handled by suffix
             return F::one();
         }
 
@@ -54,7 +54,7 @@ impl<const WORD_SIZE: usize, F: JoltField> SparseDensePrefix<F> for Pow2Prefix<W
         j: usize,
     ) -> PrefixCheckpoint<F> {
         if current_suffix_len(2 * WORD_SIZE, j) != 0 {
-            return Some(F::one().into()).into();
+            return Some(F::one()).into();
         }
 
         // r_y is the highest bit of the shift amount
@@ -73,6 +73,6 @@ impl<const WORD_SIZE: usize, F: JoltField> SparseDensePrefix<F> for Pow2Prefix<W
             return Some(checkpoint).into();
         }
 
-        Some(F::one().into()).into()
+        Some(F::one()).into()
     }
 }

--- a/jolt-core/src/jolt/instruction/prefixes/pow2.rs
+++ b/jolt-core/src/jolt/instruction/prefixes/pow2.rs
@@ -1,0 +1,78 @@
+use crate::{
+    field::JoltField,
+    subprotocols::sparse_dense_shout::{current_suffix_len, LookupBits},
+    utils::math::Math,
+};
+
+use super::{PrefixCheckpoint, Prefixes, SparseDensePrefix};
+
+pub enum Pow2Prefix<const WORD_SIZE: usize> {}
+
+impl<const WORD_SIZE: usize, F: JoltField> SparseDensePrefix<F> for Pow2Prefix<WORD_SIZE> {
+    fn prefix_mle(
+        checkpoints: &[PrefixCheckpoint<F>],
+        r_x: Option<F>,
+        c: u32,
+        b: LookupBits,
+        j: usize,
+    ) -> F {
+        if current_suffix_len(2 * WORD_SIZE, j) != 0 {
+            // Pow2 is handled by suffix
+            return F::one();
+        }
+
+        // Shift amount is the last WORD_SIZE bits of b
+        if b.len() >= WORD_SIZE.log_2() {
+            return F::from_u64(1 << (b % WORD_SIZE));
+        }
+
+        let mut result = F::from_u64(1 << (b % WORD_SIZE));
+        let mut num_bits = b.len();
+        let mut shift = 1 << (1 << num_bits);
+        result *= F::from_u32(1 + (shift - 1) * c);
+
+        // Shift amount is [c, b]
+        if b.len() == WORD_SIZE.log_2() - 1 {
+            return result;
+        }
+
+        // Shift amount is [(r, r_x), c, b]
+        num_bits += 1;
+        shift = 1 << (1 << num_bits);
+        if let Some(r_x) = r_x {
+            result *= F::one() + F::from_u32(shift - 1) * r_x;
+        }
+
+        result *= checkpoints[Prefixes::Pow2].unwrap_or(F::one());
+        result
+    }
+
+    fn update_prefix_checkpoint(
+        checkpoints: &[PrefixCheckpoint<F>],
+        r_x: F,
+        r_y: F,
+        j: usize,
+    ) -> PrefixCheckpoint<F> {
+        if current_suffix_len(2 * WORD_SIZE, j) != 0 {
+            return Some(F::one().into()).into();
+        }
+
+        // r_y is the highest bit of the shift amount
+        if j == 2 * WORD_SIZE - WORD_SIZE.log_2() {
+            let shift = 1 << (WORD_SIZE / 2);
+            return Some(F::one() + F::from_u64(shift - 1) * r_y).into();
+        }
+
+        // r_x and r_y are bits in the shift amount
+        if 2 * WORD_SIZE - j < WORD_SIZE.log_2() {
+            let mut checkpoint = checkpoints[Prefixes::Pow2].unwrap();
+            let shift = 1 << (1 << (2 * WORD_SIZE - j));
+            checkpoint *= F::one() + F::from_u64(shift - 1) * r_x;
+            let shift = 1 << (1 << (2 * WORD_SIZE - j - 1));
+            checkpoint *= F::one() + F::from_u64(shift - 1) * r_y;
+            return Some(checkpoint).into();
+        }
+
+        Some(F::one().into()).into()
+    }
+}

--- a/jolt-core/src/jolt/instruction/prefixes/right_is_zero.rs
+++ b/jolt-core/src/jolt/instruction/prefixes/right_is_zero.rs
@@ -13,6 +13,7 @@ impl<F: JoltField> SparseDensePrefix<F> for RightOperandIsZeroPrefix {
         _: usize,
     ) -> F {
         let (_, y) = b.uninterleave();
+        // Short-circuit if low-order bits of `y` are not 0s
         if u64::from(y) != 0 {
             return F::zero();
         }

--- a/jolt-core/src/jolt/instruction/prefixes/right_shift_padding.rs
+++ b/jolt-core/src/jolt/instruction/prefixes/right_shift_padding.rs
@@ -6,6 +6,16 @@ use crate::{
 
 use super::{PrefixCheckpoint, Prefixes, SparseDensePrefix};
 
+/// RightShiftPaddingPrefix and RightShiftPaddingSuffix are used to compute
+///  a bitmask for the padding bits obtained from an arithmetic right shift.
+/// `shift` := the lower log_2(WORD_SIZE) bits of the second operand.
+/// The bitmask has 1s in the upper `shift` bits and 0s in the lower bits.
+///
+/// Together, `RightShiftPaddingPrefix and RightShiftPaddingSuffix` compute:
+/// - 2^WORD_SIZE if shift == 0
+/// - 2^shift otherwise
+///
+/// This gets subtracted from 2^WORD_SIZE to obtain the desired bitmask.
 pub enum RightShiftPaddingPrefix<const WORD_SIZE: usize> {}
 
 impl<const WORD_SIZE: usize, F: JoltField> SparseDensePrefix<F>
@@ -19,7 +29,7 @@ impl<const WORD_SIZE: usize, F: JoltField> SparseDensePrefix<F>
         j: usize,
     ) -> F {
         if current_suffix_len(2 * WORD_SIZE, j) != 0 {
-            // Handled by suffix
+            // Suffix is off by a factor of 2 to avoid shift overflow
             return F::from_u8(2);
         }
 

--- a/jolt-core/src/jolt/instruction/prefixes/right_shift_padding.rs
+++ b/jolt-core/src/jolt/instruction/prefixes/right_shift_padding.rs
@@ -26,7 +26,7 @@ impl<const WORD_SIZE: usize, F: JoltField> SparseDensePrefix<F>
         // Shift amount is the last WORD_SIZE bits of b
         if b.len() >= WORD_SIZE.log_2() {
             let shift = b % WORD_SIZE;
-            return F::from_u64(1 << (WORD_SIZE - shift as usize));
+            return F::from_u64(1 << (WORD_SIZE - shift));
         }
 
         let mut result = F::from_u64(1 << (WORD_SIZE - usize::from(b)));

--- a/jolt-core/src/jolt/instruction/prefixes/right_shift_padding.rs
+++ b/jolt-core/src/jolt/instruction/prefixes/right_shift_padding.rs
@@ -1,0 +1,87 @@
+use crate::{
+    field::JoltField,
+    subprotocols::sparse_dense_shout::{current_suffix_len, LookupBits},
+    utils::math::Math,
+};
+
+use super::{PrefixCheckpoint, Prefixes, SparseDensePrefix};
+
+pub enum RightShiftPaddingPrefix<const WORD_SIZE: usize> {}
+
+impl<const WORD_SIZE: usize, F: JoltField> SparseDensePrefix<F>
+    for RightShiftPaddingPrefix<WORD_SIZE>
+{
+    fn prefix_mle(
+        checkpoints: &[PrefixCheckpoint<F>],
+        r_x: Option<F>,
+        c: u32,
+        b: LookupBits,
+        j: usize,
+    ) -> F {
+        if current_suffix_len(2 * WORD_SIZE, j) != 0 {
+            // Handled by suffix
+            return F::from_u8(2);
+        }
+
+        // Shift amount is the last WORD_SIZE bits of b
+        if b.len() >= WORD_SIZE.log_2() {
+            let shift = b % WORD_SIZE;
+            return F::from_u64(1 << (WORD_SIZE - shift as usize));
+        }
+
+        let mut result = F::from_u64(1 << (WORD_SIZE - usize::from(b)));
+        let mut num_bits = b.len();
+        let pow2 = 1 << (1 << num_bits);
+        result *= F::one() - (F::one() - F::from_u64(pow2).inverse().unwrap()) * F::from_u32(c);
+
+        // Shift amount is [c, b]
+        if b.len() == WORD_SIZE.log_2() - 1 {
+            return result;
+        }
+
+        // Shift amount is [(r, r_x), c, b]
+        num_bits += 1;
+        let pow2 = 1 << (1 << num_bits);
+        if let Some(r_x) = r_x {
+            result *= F::one() - (F::one() - F::from_u64(pow2).inverse().unwrap()) * r_x;
+        }
+
+        result *= checkpoints[Prefixes::RightShiftPadding].unwrap();
+        result
+    }
+
+    fn update_prefix_checkpoint(
+        checkpoints: &[PrefixCheckpoint<F>],
+        r_x: F,
+        r_y: F,
+        j: usize,
+    ) -> PrefixCheckpoint<F> {
+        if current_suffix_len(2 * WORD_SIZE, j) != 0 {
+            // Handled by suffix
+            return Some(F::from_u8(2)).into();
+        }
+
+        // r_y is the highest bit of the shift amount
+        if j == 2 * WORD_SIZE - WORD_SIZE.log_2() {
+            let pow2 = 1 << (WORD_SIZE / 2);
+            return Some(F::one() - (F::one() - F::from_u64(pow2).inverse().unwrap()) * r_y).into();
+        }
+
+        // r_x and r_y are bits in the shift amount
+        if 2 * WORD_SIZE - j < WORD_SIZE.log_2() {
+            let mut checkpoint = checkpoints[Prefixes::RightShiftPadding].unwrap_or(F::one());
+            let mut bit_index = 2 * WORD_SIZE - j;
+            let pow2 = 1 << (1 << bit_index);
+            checkpoint *= F::one() - (F::one() - F::from_u64(pow2).inverse().unwrap()) * r_x;
+            bit_index -= 1;
+            let pow2 = 1 << (1 << bit_index);
+            checkpoint *= F::one() - (F::one() - F::from_u64(pow2).inverse().unwrap()) * r_y;
+            if j == 2 * WORD_SIZE - 1 {
+                checkpoint *= F::from_u64(1 << WORD_SIZE);
+            }
+            return Some(checkpoint).into();
+        }
+
+        None.into()
+    }
+}

--- a/jolt-core/src/jolt/instruction/prefixes/upper_word.rs
+++ b/jolt-core/src/jolt/instruction/prefixes/upper_word.rs
@@ -17,6 +17,7 @@ impl<const WORD_SIZE: usize, F: JoltField> SparseDensePrefix<F> for UpperWordPre
         j: usize,
     ) -> F {
         let mut result = checkpoints[Prefixes::UpperWord].unwrap_or(F::zero());
+        // Ignore low-order variables
         if j >= WORD_SIZE {
             return result;
         }
@@ -36,6 +37,7 @@ impl<const WORD_SIZE: usize, F: JoltField> SparseDensePrefix<F> for UpperWordPre
             result += F::from_u64(1 << y_shift) * F::from_u8(y_msb);
         }
 
+        // Add in bits of `b` that fall in upper word
         let suffix_len = current_suffix_len(2 * WORD_SIZE, j);
         if suffix_len > WORD_SIZE {
             result += F::from_u64(u64::from(b) << (suffix_len - WORD_SIZE));

--- a/jolt-core/src/jolt/instruction/prefixes/xor.rs
+++ b/jolt-core/src/jolt/instruction/prefixes/xor.rs
@@ -17,6 +17,7 @@ impl<const WORD_SIZE: usize, F: JoltField> SparseDensePrefix<F> for XorPrefix<WO
     ) -> F {
         let mut result = checkpoints[Prefixes::Xor].unwrap_or(F::zero());
 
+        // XOR high-order variables of x and y
         if let Some(r_x) = r_x {
             let y = F::from_u8(c as u8);
             let shift = WORD_SIZE - 1 - j / 2;
@@ -27,6 +28,7 @@ impl<const WORD_SIZE: usize, F: JoltField> SparseDensePrefix<F> for XorPrefix<WO
             let shift = WORD_SIZE - 1 - j / 2;
             result += F::from_u32(1 << shift) * ((F::one() - x) * y_msb + x * (F::one() - y_msb));
         }
+        // XOR remaining x and y bits
         let (x, y) = b.uninterleave();
         let suffix_len = current_suffix_len(2 * WORD_SIZE, j);
         result += F::from_u32((u32::from(x) ^ u32::from(y)) << (suffix_len / 2));

--- a/jolt-core/src/jolt/instruction/slt.rs
+++ b/jolt-core/src/jolt/instruction/slt.rs
@@ -125,27 +125,17 @@ impl<const WORD_SIZE: usize> JoltInstruction for SLTInstruction<WORD_SIZE> {
     }
 }
 
-impl<const WORD_SIZE: usize, F: JoltField> PrefixSuffixDecomposition<WORD_SIZE, F>
-    for SLTInstruction<WORD_SIZE>
-{
-    fn prefixes() -> Vec<Prefixes> {
-        vec![
-            Prefixes::LessThan,
-            Prefixes::Eq,
-            Prefixes::LeftOperandMsb,
-            Prefixes::RightOperandMsb,
-        ]
-    }
-
-    fn suffixes() -> Vec<Suffixes> {
+impl<const WORD_SIZE: usize> PrefixSuffixDecomposition<WORD_SIZE> for SLTInstruction<WORD_SIZE> {
+    fn suffixes(&self) -> Vec<Suffixes> {
         vec![Suffixes::One, Suffixes::LessThan]
     }
 
-    fn combine(prefixes: &[PrefixEval<F>], suffixes: &[SuffixEval<F>]) -> F {
-        prefixes[Prefixes::LeftOperandMsb] * suffixes[Suffixes::One]
-            - prefixes[Prefixes::RightOperandMsb] * suffixes[Suffixes::One]
-            + prefixes[Prefixes::LessThan] * suffixes[Suffixes::One]
-            + prefixes[Prefixes::Eq] * suffixes[Suffixes::LessThan]
+    fn combine<F: JoltField>(&self, prefixes: &[PrefixEval<F>], suffixes: &[SuffixEval<F>]) -> F {
+        debug_assert_eq!(self.suffixes().len(), suffixes.len());
+        let [one, less_than] = suffixes.try_into().unwrap();
+        prefixes[Prefixes::LeftOperandMsb] * one - prefixes[Prefixes::RightOperandMsb] * one
+            + prefixes[Prefixes::LessThan] * one
+            + prefixes[Prefixes::Eq] * less_than
     }
 }
 

--- a/jolt-core/src/jolt/instruction/sltu.rs
+++ b/jolt-core/src/jolt/instruction/sltu.rs
@@ -98,20 +98,15 @@ impl<const WORD_SIZE: usize> JoltInstruction for SLTUInstruction<WORD_SIZE> {
     }
 }
 
-impl<const WORD_SIZE: usize, F: JoltField> PrefixSuffixDecomposition<WORD_SIZE, F>
-    for SLTUInstruction<WORD_SIZE>
-{
-    fn prefixes() -> Vec<Prefixes> {
-        vec![Prefixes::LessThan, Prefixes::Eq]
-    }
-
-    fn suffixes() -> Vec<Suffixes> {
+impl<const WORD_SIZE: usize> PrefixSuffixDecomposition<WORD_SIZE> for SLTUInstruction<WORD_SIZE> {
+    fn suffixes(&self) -> Vec<Suffixes> {
         vec![Suffixes::One, Suffixes::LessThan]
     }
 
-    fn combine(prefixes: &[PrefixEval<F>], suffixes: &[SuffixEval<F>]) -> F {
-        prefixes[Prefixes::LessThan] * suffixes[Suffixes::One]
-            + prefixes[Prefixes::Eq] * suffixes[Suffixes::LessThan]
+    fn combine<F: JoltField>(&self, prefixes: &[PrefixEval<F>], suffixes: &[SuffixEval<F>]) -> F {
+        debug_assert_eq!(self.suffixes().len(), suffixes.len());
+        let [one, less_than] = suffixes.try_into().unwrap();
+        prefixes[Prefixes::LessThan] * one + prefixes[Prefixes::Eq] * less_than
     }
 }
 

--- a/jolt-core/src/jolt/instruction/sub.rs
+++ b/jolt-core/src/jolt/instruction/sub.rs
@@ -93,19 +93,15 @@ impl<const WORD_SIZE: usize> JoltInstruction for SUBInstruction<WORD_SIZE> {
     }
 }
 
-impl<const WORD_SIZE: usize, F: JoltField> PrefixSuffixDecomposition<WORD_SIZE, F>
-    for SUBInstruction<WORD_SIZE>
-{
-    fn prefixes() -> Vec<Prefixes> {
-        vec![Prefixes::LowerWord]
-    }
-
-    fn suffixes() -> Vec<Suffixes> {
+impl<const WORD_SIZE: usize> PrefixSuffixDecomposition<WORD_SIZE> for SUBInstruction<WORD_SIZE> {
+    fn suffixes(&self) -> Vec<Suffixes> {
         vec![Suffixes::One, Suffixes::LowerWord]
     }
 
-    fn combine(prefixes: &[PrefixEval<F>], suffixes: &[SuffixEval<F>]) -> F {
-        prefixes[Prefixes::LowerWord] * suffixes[Suffixes::One] + suffixes[Suffixes::LowerWord]
+    fn combine<F: JoltField>(&self, prefixes: &[PrefixEval<F>], suffixes: &[SuffixEval<F>]) -> F {
+        debug_assert_eq!(self.suffixes().len(), suffixes.len());
+        let [one, lower_word] = suffixes.try_into().unwrap();
+        prefixes[Prefixes::LowerWord] * one + lower_word
     }
 }
 

--- a/jolt-core/src/jolt/instruction/suffixes/lsb.rs
+++ b/jolt-core/src/jolt/instruction/suffixes/lsb.rs
@@ -7,6 +7,10 @@ pub enum LsbSuffix {}
 
 impl SparseDenseSuffix for LsbSuffix {
     fn suffix_mle(b: LookupBits) -> u32 {
-        (u64::from(b) & 1) as u32
+        if b.len() == 0 {
+            1
+        } else {
+            (u64::from(b) & 1) as u32
+        }
     }
 }

--- a/jolt-core/src/jolt/instruction/suffixes/mod.rs
+++ b/jolt-core/src/jolt/instruction/suffixes/mod.rs
@@ -1,5 +1,3 @@
-use std::{fmt::Display, ops::Index};
-
 use crate::{field::JoltField, subprotocols::sparse_dense_shout::LookupBits};
 use div_by_zero::DivByZeroSuffix;
 use eq::EqSuffix;
@@ -63,41 +61,15 @@ pub enum Suffixes {
     RightShiftPadding,
 }
 
-#[derive(Clone, Copy)]
-pub struct SuffixEval<F>(F);
-pub type SuffixCheckpoint<F: JoltField> = SuffixEval<Option<F>>;
-
-impl<F: Display> Display for SuffixEval<F> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.0)
-    }
-}
-
-impl<F> From<F> for SuffixEval<F> {
-    fn from(value: F) -> Self {
-        Self(value)
-    }
-}
-
-impl<F> SuffixCheckpoint<F> {
-    pub fn unwrap(self) -> SuffixEval<F> {
-        self.0.unwrap().into()
-    }
-}
-
-impl<F> Index<Suffixes> for &[SuffixEval<F>] {
-    type Output = F;
-
-    fn index(&self, prefix: Suffixes) -> &Self::Output {
-        let index = prefix as usize;
-        &self.get(index).unwrap().0
-    }
-}
+pub type SuffixEval<F: JoltField> = F;
 
 impl Suffixes {
     /// Evaluates the MLE for this suffix on the bitvector `b`, where
     /// `b` represents `b.len()` variables, each assuming a Boolean value.
     pub fn suffix_mle<const WORD_SIZE: usize>(&self, b: LookupBits) -> u32 {
+        if b.len() == 0 {
+            return 1;
+        }
         match self {
             Suffixes::One => OneSuffix::suffix_mle(b),
             Suffixes::And => AndSuffix::suffix_mle(b),

--- a/jolt-core/src/jolt/instruction/suffixes/mod.rs
+++ b/jolt-core/src/jolt/instruction/suffixes/mod.rs
@@ -67,9 +67,6 @@ impl Suffixes {
     /// Evaluates the MLE for this suffix on the bitvector `b`, where
     /// `b` represents `b.len()` variables, each assuming a Boolean value.
     pub fn suffix_mle<const WORD_SIZE: usize>(&self, b: LookupBits) -> u32 {
-        if b.len() == 0 {
-            return 1;
-        }
         match self {
             Suffixes::One => OneSuffix::suffix_mle(b),
             Suffixes::And => AndSuffix::suffix_mle(b),

--- a/jolt-core/src/jolt/instruction/suffixes/pow2.rs
+++ b/jolt-core/src/jolt/instruction/suffixes/pow2.rs
@@ -8,7 +8,11 @@ pub enum Pow2Suffix<const WORD_SIZE: usize> {}
 
 impl<const WORD_SIZE: usize> SparseDenseSuffix for Pow2Suffix<WORD_SIZE> {
     fn suffix_mle(b: LookupBits) -> u32 {
-        let (_, shift) = b.split(WORD_SIZE.log_2());
-        1 << u32::from(shift)
+        if b.len() == 0 {
+            1
+        } else {
+            let (_, shift) = b.split(WORD_SIZE.log_2());
+            1 << u32::from(shift)
+        }
     }
 }

--- a/jolt-core/src/jolt/instruction/suffixes/right_shift_padding.rs
+++ b/jolt-core/src/jolt/instruction/suffixes/right_shift_padding.rs
@@ -9,6 +9,9 @@ pub enum RightShiftPaddingSuffix<const WORD_SIZE: usize> {}
 
 impl<const WORD_SIZE: usize> SparseDenseSuffix for RightShiftPaddingSuffix<WORD_SIZE> {
     fn suffix_mle(b: LookupBits) -> u32 {
+        if b.len() == 0 {
+            return 1;
+        }
         let (_, shift) = b.split(WORD_SIZE.log_2());
         let shift = u32::from(shift);
         if shift == 0 {

--- a/jolt-core/src/jolt/instruction/suffixes/right_shift_padding.rs
+++ b/jolt-core/src/jolt/instruction/suffixes/right_shift_padding.rs
@@ -2,9 +2,16 @@ use crate::{subprotocols::sparse_dense_shout::LookupBits, utils::math::Math};
 
 use super::SparseDenseSuffix;
 
-/// Computes a bitmask for the padding bits obtained from an arithmetic right shift.
+/// RightShiftPaddingPrefix and RightShiftPaddingSuffix are used to compute
+///  a bitmask for the padding bits obtained from an arithmetic right shift.
 /// `shift` := the lower log_2(WORD_SIZE) bits of the second operand.
 /// The bitmask has 1s in the upper `shift` bits and 0s in the lower bits.
+///
+/// Together, `RightShiftPaddingPrefix and RightShiftPaddingSuffix` compute:
+/// - 2^WORD_SIZE if shift == 0
+/// - 2^shift otherwise
+///
+/// This gets subtracted from 2^WORD_SIZE to obtain the desired bitmask.
 pub enum RightShiftPaddingSuffix<const WORD_SIZE: usize> {}
 
 impl<const WORD_SIZE: usize> SparseDenseSuffix for RightShiftPaddingSuffix<WORD_SIZE> {

--- a/jolt-core/src/jolt/instruction/suffixes/right_shift_padding.rs
+++ b/jolt-core/src/jolt/instruction/suffixes/right_shift_padding.rs
@@ -10,14 +10,13 @@ pub enum RightShiftPaddingSuffix<const WORD_SIZE: usize> {}
 impl<const WORD_SIZE: usize> SparseDenseSuffix for RightShiftPaddingSuffix<WORD_SIZE> {
     fn suffix_mle(b: LookupBits) -> u32 {
         if b.len() == 0 {
+            // Handled by prefix
             return 1;
         }
         let (_, shift) = b.split(WORD_SIZE.log_2());
         let shift = u32::from(shift);
-        if shift == 0 {
-            return 0;
-        }
-        let ones = (1 << shift) - 1;
-        ones << (WORD_SIZE as u32 - shift)
+        // Subtract 1 to avoid shift overflow; `RightShiftPaddingPrefix::prefix_mle`
+        // will return 2 to compensate
+        1 << (WORD_SIZE - 1 - shift as usize)
     }
 }

--- a/jolt-core/src/jolt/instruction/test.rs
+++ b/jolt-core/src/jolt/instruction/test.rs
@@ -3,7 +3,7 @@ use crate::{
     jolt::{
         instruction::{
             prefixes::{PrefixCheckpoint, Prefixes},
-            suffixes::{SuffixEval, Suffixes},
+            suffixes::SuffixEval,
         },
         vm::rv32i_vm::RV32I,
     },
@@ -192,7 +192,7 @@ pub fn materialize_entry_test<F: JoltField, I: JoltInstruction + Default>() {
     }
 }
 
-pub fn prefix_suffix_test<F: JoltField, I: PrefixSuffixDecomposition<32, F>>() {
+pub fn prefix_suffix_test<F: JoltField, I: PrefixSuffixDecomposition<32>>() {
     let mut rng = StdRng::seed_from_u64(12345);
 
     for _ in 0..1000 {
@@ -209,7 +209,9 @@ pub fn prefix_suffix_test<F: JoltField, I: PrefixSuffixDecomposition<32, F>>() {
             let (mut prefix_bits, suffix_bits) =
                 LookupBits::new(lookup_index, 64 - phase * 16).split(suffix_len);
 
-            let suffix_evals: Vec<_> = Suffixes::iter()
+            let suffix_evals: Vec<_> = instr
+                .suffixes()
+                .iter()
                 .map(|suffix| SuffixEval::from(F::from_u32(suffix.suffix_mle::<32>(suffix_bits))))
                 .collect();
 
@@ -234,7 +236,7 @@ pub fn prefix_suffix_test<F: JoltField, I: PrefixSuffixDecomposition<32, F>>() {
                     })
                     .collect();
 
-                let combined = I::combine(&prefix_evals, &suffix_evals);
+                let combined = instr.combine(&prefix_evals, &suffix_evals);
                 if combined != result {
                     println!("{instr:?} -> {lookup_index}");
                     println!("{j} {prefix_bits} {suffix_bits}");

--- a/jolt-core/src/jolt/instruction/test.rs
+++ b/jolt-core/src/jolt/instruction/test.rs
@@ -204,7 +204,7 @@ pub fn prefix_suffix_test<F: JoltField, I: PrefixSuffixDecomposition<32>>() {
 
         let mut j = 0;
         let mut r: Vec<u8> = vec![];
-        for phase in 0..3 {
+        for phase in 0..4 {
             let suffix_len = (3 - phase) * 16;
             let (mut prefix_bits, suffix_bits) =
                 LookupBits::new(lookup_index, 64 - phase * 16).split(suffix_len);

--- a/jolt-core/src/jolt/instruction/virtual_advice.rs
+++ b/jolt-core/src/jolt/instruction/virtual_advice.rs
@@ -76,19 +76,15 @@ impl<const WORD_SIZE: usize> JoltInstruction for ADVICEInstruction<WORD_SIZE> {
     }
 }
 
-impl<const WORD_SIZE: usize, F: JoltField> PrefixSuffixDecomposition<WORD_SIZE, F>
-    for ADVICEInstruction<WORD_SIZE>
-{
-    fn prefixes() -> Vec<Prefixes> {
-        vec![Prefixes::LowerWord]
-    }
-
-    fn suffixes() -> Vec<Suffixes> {
+impl<const WORD_SIZE: usize> PrefixSuffixDecomposition<WORD_SIZE> for ADVICEInstruction<WORD_SIZE> {
+    fn suffixes(&self) -> Vec<Suffixes> {
         vec![Suffixes::One, Suffixes::LowerWord]
     }
 
-    fn combine(prefixes: &[PrefixEval<F>], suffixes: &[SuffixEval<F>]) -> F {
-        prefixes[Prefixes::LowerWord] * suffixes[Suffixes::One] + suffixes[Suffixes::LowerWord]
+    fn combine<F: JoltField>(&self, prefixes: &[PrefixEval<F>], suffixes: &[SuffixEval<F>]) -> F {
+        debug_assert_eq!(self.suffixes().len(), suffixes.len());
+        let [one, lower_word] = suffixes.try_into().unwrap();
+        prefixes[Prefixes::LowerWord] * one + lower_word
     }
 }
 

--- a/jolt-core/src/jolt/instruction/virtual_assert_halfword_alignment.rs
+++ b/jolt-core/src/jolt/instruction/virtual_assert_halfword_alignment.rs
@@ -2,7 +2,7 @@ use rand::prelude::StdRng;
 use rand::RngCore;
 use serde::{Deserialize, Serialize};
 
-use super::prefixes::{PrefixEval, Prefixes};
+use super::prefixes::PrefixEval;
 use super::suffixes::{SuffixEval, Suffixes};
 use super::{JoltInstruction, SubtableIndices};
 use crate::subprotocols::sparse_dense_shout::PrefixSuffixDecomposition;
@@ -87,19 +87,17 @@ impl<const WORD_SIZE: usize> JoltInstruction for AssertHalfwordAlignmentInstruct
     }
 }
 
-impl<const WORD_SIZE: usize, F: JoltField> PrefixSuffixDecomposition<WORD_SIZE, F>
+impl<const WORD_SIZE: usize> PrefixSuffixDecomposition<WORD_SIZE>
     for AssertHalfwordAlignmentInstruction<WORD_SIZE>
 {
-    fn prefixes() -> Vec<Prefixes> {
-        vec![]
-    }
-
-    fn suffixes() -> Vec<Suffixes> {
+    fn suffixes(&self) -> Vec<Suffixes> {
         vec![Suffixes::One, Suffixes::Lsb]
     }
 
-    fn combine(_prefixes: &[PrefixEval<F>], suffixes: &[SuffixEval<F>]) -> F {
-        suffixes[Suffixes::One] - suffixes[Suffixes::Lsb]
+    fn combine<F: JoltField>(&self, _prefixes: &[PrefixEval<F>], suffixes: &[SuffixEval<F>]) -> F {
+        debug_assert_eq!(self.suffixes().len(), suffixes.len());
+        let [one, lsb] = suffixes.try_into().unwrap();
+        one - lsb
     }
 }
 

--- a/jolt-core/src/jolt/instruction/virtual_assert_halfword_alignment.rs
+++ b/jolt-core/src/jolt/instruction/virtual_assert_halfword_alignment.rs
@@ -5,6 +5,7 @@ use serde::{Deserialize, Serialize};
 use super::prefixes::PrefixEval;
 use super::suffixes::{SuffixEval, Suffixes};
 use super::{JoltInstruction, SubtableIndices};
+use crate::jolt::instruction::prefixes::Prefixes;
 use crate::subprotocols::sparse_dense_shout::PrefixSuffixDecomposition;
 use crate::{
     field::JoltField,
@@ -94,10 +95,10 @@ impl<const WORD_SIZE: usize> PrefixSuffixDecomposition<WORD_SIZE>
         vec![Suffixes::One, Suffixes::Lsb]
     }
 
-    fn combine<F: JoltField>(&self, _prefixes: &[PrefixEval<F>], suffixes: &[SuffixEval<F>]) -> F {
+    fn combine<F: JoltField>(&self, prefixes: &[PrefixEval<F>], suffixes: &[SuffixEval<F>]) -> F {
         debug_assert_eq!(self.suffixes().len(), suffixes.len());
         let [one, lsb] = suffixes.try_into().unwrap();
-        one - lsb
+        one - prefixes[Prefixes::Lsb] * lsb
     }
 }
 

--- a/jolt-core/src/jolt/instruction/virtual_assert_lte.rs
+++ b/jolt-core/src/jolt/instruction/virtual_assert_lte.rs
@@ -104,6 +104,7 @@ impl<const WORD_SIZE: usize> PrefixSuffixDecomposition<WORD_SIZE>
     fn combine<F: JoltField>(&self, prefixes: &[PrefixEval<F>], suffixes: &[SuffixEval<F>]) -> F {
         debug_assert_eq!(self.suffixes().len(), suffixes.len());
         let [one, less_than, eq] = suffixes.try_into().unwrap();
+        // LT(x, y) + EQ(x, y)
         prefixes[Prefixes::LessThan] * one
             + prefixes[Prefixes::Eq] * less_than
             + prefixes[Prefixes::Eq] * eq

--- a/jolt-core/src/jolt/instruction/virtual_assert_lte.rs
+++ b/jolt-core/src/jolt/instruction/virtual_assert_lte.rs
@@ -94,21 +94,19 @@ impl<const WORD_SIZE: usize> JoltInstruction for ASSERTLTEInstruction<WORD_SIZE>
     }
 }
 
-impl<const WORD_SIZE: usize, F: JoltField> PrefixSuffixDecomposition<WORD_SIZE, F>
+impl<const WORD_SIZE: usize> PrefixSuffixDecomposition<WORD_SIZE>
     for ASSERTLTEInstruction<WORD_SIZE>
 {
-    fn prefixes() -> Vec<Prefixes> {
-        vec![Prefixes::LessThan, Prefixes::Eq]
-    }
-
-    fn suffixes() -> Vec<Suffixes> {
+    fn suffixes(&self) -> Vec<Suffixes> {
         vec![Suffixes::One, Suffixes::LessThan, Suffixes::Eq]
     }
 
-    fn combine(prefixes: &[PrefixEval<F>], suffixes: &[SuffixEval<F>]) -> F {
-        prefixes[Prefixes::LessThan] * suffixes[Suffixes::One]
-            + prefixes[Prefixes::Eq] * suffixes[Suffixes::LessThan]
-            + prefixes[Prefixes::Eq] * suffixes[Suffixes::Eq]
+    fn combine<F: JoltField>(&self, prefixes: &[PrefixEval<F>], suffixes: &[SuffixEval<F>]) -> F {
+        debug_assert_eq!(self.suffixes().len(), suffixes.len());
+        let [one, less_than, eq] = suffixes.try_into().unwrap();
+        prefixes[Prefixes::LessThan] * one
+            + prefixes[Prefixes::Eq] * less_than
+            + prefixes[Prefixes::Eq] * eq
     }
 }
 

--- a/jolt-core/src/jolt/instruction/virtual_assert_valid_div0.rs
+++ b/jolt-core/src/jolt/instruction/virtual_assert_valid_div0.rs
@@ -124,6 +124,13 @@ impl<const WORD_SIZE: usize> PrefixSuffixDecomposition<WORD_SIZE>
     fn combine<F: JoltField>(&self, prefixes: &[PrefixEval<F>], suffixes: &[SuffixEval<F>]) -> F {
         debug_assert_eq!(self.suffixes().len(), suffixes.len());
         let [one, left_operand_is_zero, div_by_zero] = suffixes.try_into().unwrap();
+        // If the divisor is *not* zero, both:
+        // `prefixes[Prefixes::LeftOperandIsZero] * left_operand_is_zero` and
+        // `prefixes[Prefixes::DivByZero] * div_by_zero`
+        // will be zero.
+        //
+        // If the divisor *is* zero, returns 1 (on the Boolean hypercube)
+        // iff the quotient is valid (i.e. 2^WORD_SIZE - 1).
         one - prefixes[Prefixes::LeftOperandIsZero] * left_operand_is_zero
             + prefixes[Prefixes::DivByZero] * div_by_zero
     }

--- a/jolt-core/src/jolt/instruction/virtual_assert_valid_div0.rs
+++ b/jolt-core/src/jolt/instruction/virtual_assert_valid_div0.rs
@@ -110,14 +110,10 @@ impl<const WORD_SIZE: usize> JoltInstruction for AssertValidDiv0Instruction<WORD
     }
 }
 
-impl<const WORD_SIZE: usize, F: JoltField> PrefixSuffixDecomposition<WORD_SIZE, F>
+impl<const WORD_SIZE: usize> PrefixSuffixDecomposition<WORD_SIZE>
     for AssertValidDiv0Instruction<WORD_SIZE>
 {
-    fn prefixes() -> Vec<Prefixes> {
-        vec![Prefixes::LeftOperandIsZero, Prefixes::DivByZero]
-    }
-
-    fn suffixes() -> Vec<Suffixes> {
+    fn suffixes(&self) -> Vec<Suffixes> {
         vec![
             Suffixes::One,
             Suffixes::LeftOperandIsZero,
@@ -125,10 +121,11 @@ impl<const WORD_SIZE: usize, F: JoltField> PrefixSuffixDecomposition<WORD_SIZE, 
         ]
     }
 
-    fn combine(prefixes: &[PrefixEval<F>], suffixes: &[SuffixEval<F>]) -> F {
-        suffixes[Suffixes::One]
-            - prefixes[Prefixes::LeftOperandIsZero] * suffixes[Suffixes::LeftOperandIsZero]
-            + prefixes[Prefixes::DivByZero] * suffixes[Suffixes::DivByZero]
+    fn combine<F: JoltField>(&self, prefixes: &[PrefixEval<F>], suffixes: &[SuffixEval<F>]) -> F {
+        debug_assert_eq!(self.suffixes().len(), suffixes.len());
+        let [one, left_operand_is_zero, div_by_zero] = suffixes.try_into().unwrap();
+        one - prefixes[Prefixes::LeftOperandIsZero] * left_operand_is_zero
+            + prefixes[Prefixes::DivByZero] * div_by_zero
     }
 }
 

--- a/jolt-core/src/jolt/instruction/virtual_assert_valid_signed_remainder.rs
+++ b/jolt-core/src/jolt/instruction/virtual_assert_valid_signed_remainder.rs
@@ -225,6 +225,7 @@ impl<const WORD_SIZE: usize> PrefixSuffixDecomposition<WORD_SIZE>
         debug_assert_eq!(self.suffixes().len(), suffixes.len());
         let [one, less_than, greater_than, left_operand_is_zero, right_operand_is_zero] =
             suffixes.try_into().unwrap();
+        // divisor == 0 || (isPositive(remainder) && remainder <= diviisor) || (isNegative(divisor) && divisor >= remainder)
         prefixes[Prefixes::RightOperandIsZero] * right_operand_is_zero
             + prefixes[Prefixes::PositiveRemainderEqualsDivisor] * less_than
             + prefixes[Prefixes::PositiveRemainderLessThanDivisor] * one

--- a/jolt-core/src/jolt/instruction/virtual_assert_valid_signed_remainder.rs
+++ b/jolt-core/src/jolt/instruction/virtual_assert_valid_signed_remainder.rs
@@ -208,21 +208,10 @@ impl<const WORD_SIZE: usize> JoltInstruction for AssertValidSignedRemainderInstr
     }
 }
 
-impl<const WORD_SIZE: usize, F: JoltField> PrefixSuffixDecomposition<WORD_SIZE, F>
+impl<const WORD_SIZE: usize> PrefixSuffixDecomposition<WORD_SIZE>
     for AssertValidSignedRemainderInstruction<WORD_SIZE>
 {
-    fn prefixes() -> Vec<Prefixes> {
-        vec![
-            Prefixes::RightOperandIsZero,
-            Prefixes::PositiveRemainderEqualsDivisor,
-            Prefixes::PositiveRemainderLessThanDivisor,
-            Prefixes::NegativeDivisorZeroRemainder,
-            Prefixes::NegativeDivisorEqualsRemainder,
-            Prefixes::NegativeDivisorGreaterThanRemainder,
-        ]
-    }
-
-    fn suffixes() -> Vec<Suffixes> {
+    fn suffixes(&self) -> Vec<Suffixes> {
         vec![
             Suffixes::One,
             Suffixes::LessThan,
@@ -232,14 +221,16 @@ impl<const WORD_SIZE: usize, F: JoltField> PrefixSuffixDecomposition<WORD_SIZE, 
         ]
     }
 
-    fn combine(prefixes: &[PrefixEval<F>], suffixes: &[SuffixEval<F>]) -> F {
-        prefixes[Prefixes::RightOperandIsZero] * suffixes[Suffixes::RightOperandIsZero]
-            + prefixes[Prefixes::PositiveRemainderEqualsDivisor] * suffixes[Suffixes::LessThan]
-            + prefixes[Prefixes::PositiveRemainderLessThanDivisor] * suffixes[Suffixes::One]
-            + prefixes[Prefixes::NegativeDivisorZeroRemainder]
-                * suffixes[Suffixes::LeftOperandIsZero]
-            + prefixes[Prefixes::NegativeDivisorEqualsRemainder] * suffixes[Suffixes::GreaterThan]
-            + prefixes[Prefixes::NegativeDivisorGreaterThanRemainder] * suffixes[Suffixes::One]
+    fn combine<F: JoltField>(&self, prefixes: &[PrefixEval<F>], suffixes: &[SuffixEval<F>]) -> F {
+        debug_assert_eq!(self.suffixes().len(), suffixes.len());
+        let [one, less_than, greater_than, left_operand_is_zero, right_operand_is_zero] =
+            suffixes.try_into().unwrap();
+        prefixes[Prefixes::RightOperandIsZero] * right_operand_is_zero
+            + prefixes[Prefixes::PositiveRemainderEqualsDivisor] * less_than
+            + prefixes[Prefixes::PositiveRemainderLessThanDivisor] * one
+            + prefixes[Prefixes::NegativeDivisorZeroRemainder] * left_operand_is_zero
+            + prefixes[Prefixes::NegativeDivisorEqualsRemainder] * greater_than
+            + prefixes[Prefixes::NegativeDivisorGreaterThanRemainder] * one
     }
 }
 

--- a/jolt-core/src/jolt/instruction/virtual_assert_valid_unsigned_remainder.rs
+++ b/jolt-core/src/jolt/instruction/virtual_assert_valid_unsigned_remainder.rs
@@ -103,18 +103,10 @@ impl<const WORD_SIZE: usize> JoltInstruction
     }
 }
 
-impl<const WORD_SIZE: usize, F: JoltField> PrefixSuffixDecomposition<WORD_SIZE, F>
+impl<const WORD_SIZE: usize> PrefixSuffixDecomposition<WORD_SIZE>
     for AssertValidUnsignedRemainderInstruction<WORD_SIZE>
 {
-    fn prefixes() -> Vec<Prefixes> {
-        vec![
-            Prefixes::LessThan,
-            Prefixes::Eq,
-            Prefixes::RightOperandIsZero,
-        ]
-    }
-
-    fn suffixes() -> Vec<Suffixes> {
+    fn suffixes(&self) -> Vec<Suffixes> {
         vec![
             Suffixes::One,
             Suffixes::LessThan,
@@ -122,11 +114,13 @@ impl<const WORD_SIZE: usize, F: JoltField> PrefixSuffixDecomposition<WORD_SIZE, 
         ]
     }
 
-    fn combine(prefixes: &[PrefixEval<F>], suffixes: &[SuffixEval<F>]) -> F {
+    fn combine<F: JoltField>(&self, prefixes: &[PrefixEval<F>], suffixes: &[SuffixEval<F>]) -> F {
+        debug_assert_eq!(self.suffixes().len(), suffixes.len());
+        let [one, less_than, right_operand_is_zero] = suffixes.try_into().unwrap();
         // divisor == 0 || remainder < divisor
-        prefixes[Prefixes::RightOperandIsZero] * suffixes[Suffixes::RightOperandIsZero]
-            + prefixes[Prefixes::LessThan] * suffixes[Suffixes::One]
-            + prefixes[Prefixes::Eq] * suffixes[Suffixes::LessThan]
+        prefixes[Prefixes::RightOperandIsZero] * right_operand_is_zero
+            + prefixes[Prefixes::LessThan] * one
+            + prefixes[Prefixes::Eq] * less_than
     }
 }
 

--- a/jolt-core/src/jolt/instruction/virtual_move.rs
+++ b/jolt-core/src/jolt/instruction/virtual_move.rs
@@ -84,19 +84,15 @@ impl<const WORD_SIZE: usize> JoltInstruction for MOVEInstruction<WORD_SIZE> {
     }
 }
 
-impl<const WORD_SIZE: usize, F: JoltField> PrefixSuffixDecomposition<WORD_SIZE, F>
-    for MOVEInstruction<WORD_SIZE>
-{
-    fn prefixes() -> Vec<Prefixes> {
-        vec![Prefixes::LowerWord]
-    }
-
-    fn suffixes() -> Vec<Suffixes> {
+impl<const WORD_SIZE: usize> PrefixSuffixDecomposition<WORD_SIZE> for MOVEInstruction<WORD_SIZE> {
+    fn suffixes(&self) -> Vec<Suffixes> {
         vec![Suffixes::One, Suffixes::LowerWord]
     }
 
-    fn combine(prefixes: &[PrefixEval<F>], suffixes: &[SuffixEval<F>]) -> F {
-        prefixes[Prefixes::LowerWord] * suffixes[Suffixes::One] + suffixes[Suffixes::LowerWord]
+    fn combine<F: JoltField>(&self, prefixes: &[PrefixEval<F>], suffixes: &[SuffixEval<F>]) -> F {
+        debug_assert_eq!(self.suffixes().len(), suffixes.len());
+        let [one, lower_word] = suffixes.try_into().unwrap();
+        prefixes[Prefixes::LowerWord] * one + lower_word
     }
 }
 

--- a/jolt-core/src/jolt/instruction/virtual_movsign.rs
+++ b/jolt-core/src/jolt/instruction/virtual_movsign.rs
@@ -123,20 +123,18 @@ impl<const WORD_SIZE: usize> JoltInstruction for MOVSIGNInstruction<WORD_SIZE> {
     }
 }
 
-impl<const WORD_SIZE: usize, F: JoltField> PrefixSuffixDecomposition<WORD_SIZE, F>
+impl<const WORD_SIZE: usize> PrefixSuffixDecomposition<WORD_SIZE>
     for MOVSIGNInstruction<WORD_SIZE>
 {
-    fn prefixes() -> Vec<Prefixes> {
-        vec![Prefixes::LeftOperandMsb]
-    }
-
-    fn suffixes() -> Vec<Suffixes> {
+    fn suffixes(&self) -> Vec<Suffixes> {
         vec![Suffixes::One]
     }
 
-    fn combine(prefixes: &[PrefixEval<F>], suffixes: &[SuffixEval<F>]) -> F {
+    fn combine<F: JoltField>(&self, prefixes: &[PrefixEval<F>], suffixes: &[SuffixEval<F>]) -> F {
+        debug_assert_eq!(self.suffixes().len(), suffixes.len());
+        let [one] = suffixes.try_into().unwrap();
         let ones: u64 = (1 << WORD_SIZE) - 1;
-        F::from_u64(ones) * prefixes[Prefixes::LeftOperandMsb] * suffixes[Suffixes::One]
+        F::from_u64(ones) * prefixes[Prefixes::LeftOperandMsb] * one
     }
 }
 

--- a/jolt-core/src/jolt/instruction/virtual_pow2.rs
+++ b/jolt-core/src/jolt/instruction/virtual_pow2.rs
@@ -2,7 +2,7 @@ use rand::prelude::StdRng;
 use rand::RngCore;
 use serde::{Deserialize, Serialize};
 
-use super::prefixes::{PrefixEval, Prefixes};
+use super::prefixes::PrefixEval;
 use super::suffixes::{SuffixEval, Suffixes};
 use super::{JoltInstruction, SubtableIndices};
 use crate::field::JoltField;
@@ -70,19 +70,15 @@ impl<const WORD_SIZE: usize> JoltInstruction for POW2Instruction<WORD_SIZE> {
     }
 }
 
-impl<const WORD_SIZE: usize, F: JoltField> PrefixSuffixDecomposition<WORD_SIZE, F>
-    for POW2Instruction<WORD_SIZE>
-{
-    fn prefixes() -> Vec<Prefixes> {
-        vec![]
-    }
-
-    fn suffixes() -> Vec<Suffixes> {
+impl<const WORD_SIZE: usize> PrefixSuffixDecomposition<WORD_SIZE> for POW2Instruction<WORD_SIZE> {
+    fn suffixes(&self) -> Vec<Suffixes> {
         vec![Suffixes::Pow2]
     }
 
-    fn combine(_: &[PrefixEval<F>], suffixes: &[SuffixEval<F>]) -> F {
-        suffixes[Suffixes::Pow2]
+    fn combine<F: JoltField>(&self, _: &[PrefixEval<F>], suffixes: &[SuffixEval<F>]) -> F {
+        debug_assert_eq!(self.suffixes().len(), suffixes.len());
+        let [pow2] = suffixes.try_into().unwrap();
+        pow2
     }
 }
 

--- a/jolt-core/src/jolt/instruction/virtual_pow2.rs
+++ b/jolt-core/src/jolt/instruction/virtual_pow2.rs
@@ -6,6 +6,7 @@ use super::prefixes::PrefixEval;
 use super::suffixes::{SuffixEval, Suffixes};
 use super::{JoltInstruction, SubtableIndices};
 use crate::field::JoltField;
+use crate::jolt::instruction::prefixes::Prefixes;
 use crate::jolt::subtable::LassoSubtable;
 use crate::subprotocols::sparse_dense_shout::PrefixSuffixDecomposition;
 use crate::utils::math::Math;
@@ -75,10 +76,10 @@ impl<const WORD_SIZE: usize> PrefixSuffixDecomposition<WORD_SIZE> for POW2Instru
         vec![Suffixes::Pow2]
     }
 
-    fn combine<F: JoltField>(&self, _: &[PrefixEval<F>], suffixes: &[SuffixEval<F>]) -> F {
+    fn combine<F: JoltField>(&self, prefixes: &[PrefixEval<F>], suffixes: &[SuffixEval<F>]) -> F {
         debug_assert_eq!(self.suffixes().len(), suffixes.len());
         let [pow2] = suffixes.try_into().unwrap();
-        pow2
+        prefixes[Prefixes::Pow2] * pow2
     }
 }
 

--- a/jolt-core/src/jolt/instruction/virtual_right_shift_padding.rs
+++ b/jolt-core/src/jolt/instruction/virtual_right_shift_padding.rs
@@ -2,7 +2,7 @@ use rand::prelude::StdRng;
 use rand::RngCore;
 use serde::{Deserialize, Serialize};
 
-use super::prefixes::{PrefixEval, Prefixes};
+use super::prefixes::PrefixEval;
 use super::suffixes::{SuffixEval, Suffixes};
 use super::{JoltInstruction, SubtableIndices};
 use crate::field::JoltField;
@@ -79,19 +79,17 @@ impl<const WORD_SIZE: usize> JoltInstruction for RightShiftPaddingInstruction<WO
     }
 }
 
-impl<const WORD_SIZE: usize, F: JoltField> PrefixSuffixDecomposition<WORD_SIZE, F>
+impl<const WORD_SIZE: usize> PrefixSuffixDecomposition<WORD_SIZE>
     for RightShiftPaddingInstruction<WORD_SIZE>
 {
-    fn prefixes() -> Vec<Prefixes> {
-        vec![]
-    }
-
-    fn suffixes() -> Vec<Suffixes> {
+    fn suffixes(&self) -> Vec<Suffixes> {
         vec![Suffixes::RightShiftPadding]
     }
 
-    fn combine(_: &[PrefixEval<F>], suffixes: &[SuffixEval<F>]) -> F {
-        suffixes[Suffixes::RightShiftPadding]
+    fn combine<F: JoltField>(&self, _: &[PrefixEval<F>], suffixes: &[SuffixEval<F>]) -> F {
+        debug_assert_eq!(self.suffixes().len(), suffixes.len());
+        let [right_shift_padding] = suffixes.try_into().unwrap();
+        right_shift_padding
     }
 }
 

--- a/jolt-core/src/jolt/instruction/virtual_right_shift_padding.rs
+++ b/jolt-core/src/jolt/instruction/virtual_right_shift_padding.rs
@@ -90,6 +90,7 @@ impl<const WORD_SIZE: usize> PrefixSuffixDecomposition<WORD_SIZE>
     fn combine<F: JoltField>(&self, prefixes: &[PrefixEval<F>], suffixes: &[SuffixEval<F>]) -> F {
         debug_assert_eq!(self.suffixes().len(), suffixes.len());
         let [one, right_shift_padding] = suffixes.try_into().unwrap();
+        // 2^WORD_SIZE - 2^shift = 0b11...100..0
         F::from_u64(1 << WORD_SIZE) * one
             - prefixes[Prefixes::RightShiftPadding] * right_shift_padding
     }

--- a/jolt-core/src/jolt/instruction/virtual_right_shift_padding.rs
+++ b/jolt-core/src/jolt/instruction/virtual_right_shift_padding.rs
@@ -6,6 +6,7 @@ use super::prefixes::PrefixEval;
 use super::suffixes::{SuffixEval, Suffixes};
 use super::{JoltInstruction, SubtableIndices};
 use crate::field::JoltField;
+use crate::jolt::instruction::prefixes::Prefixes;
 use crate::jolt::subtable::LassoSubtable;
 use crate::poly::eq_poly::EqPolynomial;
 use crate::subprotocols::sparse_dense_shout::PrefixSuffixDecomposition;
@@ -83,13 +84,14 @@ impl<const WORD_SIZE: usize> PrefixSuffixDecomposition<WORD_SIZE>
     for RightShiftPaddingInstruction<WORD_SIZE>
 {
     fn suffixes(&self) -> Vec<Suffixes> {
-        vec![Suffixes::RightShiftPadding]
+        vec![Suffixes::One, Suffixes::RightShiftPadding]
     }
 
-    fn combine<F: JoltField>(&self, _: &[PrefixEval<F>], suffixes: &[SuffixEval<F>]) -> F {
+    fn combine<F: JoltField>(&self, prefixes: &[PrefixEval<F>], suffixes: &[SuffixEval<F>]) -> F {
         debug_assert_eq!(self.suffixes().len(), suffixes.len());
-        let [right_shift_padding] = suffixes.try_into().unwrap();
-        right_shift_padding
+        let [one, right_shift_padding] = suffixes.try_into().unwrap();
+        F::from_u64(1 << WORD_SIZE) * one
+            - prefixes[Prefixes::RightShiftPadding] * right_shift_padding
     }
 }
 

--- a/jolt-core/src/jolt/instruction/xor.rs
+++ b/jolt-core/src/jolt/instruction/xor.rs
@@ -75,19 +75,15 @@ impl<const WORD_SIZE: usize> JoltInstruction for XORInstruction<WORD_SIZE> {
     }
 }
 
-impl<const WORD_SIZE: usize, F: JoltField> PrefixSuffixDecomposition<WORD_SIZE, F>
-    for XORInstruction<WORD_SIZE>
-{
-    fn prefixes() -> Vec<Prefixes> {
-        vec![Prefixes::Xor]
-    }
-
-    fn suffixes() -> Vec<Suffixes> {
+impl<const WORD_SIZE: usize> PrefixSuffixDecomposition<WORD_SIZE> for XORInstruction<WORD_SIZE> {
+    fn suffixes(&self) -> Vec<Suffixes> {
         vec![Suffixes::One, Suffixes::Xor]
     }
 
-    fn combine(prefixes: &[PrefixEval<F>], suffixes: &[SuffixEval<F>]) -> F {
-        prefixes[Prefixes::Xor] * suffixes[Suffixes::One] + suffixes[Suffixes::Xor]
+    fn combine<F: JoltField>(&self, prefixes: &[PrefixEval<F>], suffixes: &[SuffixEval<F>]) -> F {
+        debug_assert_eq!(self.suffixes().len(), suffixes.len());
+        let [one, xor] = suffixes.try_into().unwrap();
+        prefixes[Prefixes::Xor] * one + xor
     }
 }
 

--- a/jolt-core/src/lasso/memory_checking.rs
+++ b/jolt-core/src/lasso/memory_checking.rs
@@ -180,7 +180,7 @@ pub trait Initializable<T, Preprocessing>: StructuredPolynomialData<T> + Default
             .collect();
         for (i, (ptr, ptr_mut)) in zip_eq(read_write_pointers, read_write_pointers_mut).enumerate()
         {
-            assert!(ptr == ptr_mut, "Read-write pointer mismatch at index {}", i);
+            assert!(std::ptr::eq(ptr, ptr_mut), "Read-write pointer mismatch at index {}", i);
         }
 
         let init_final_pointers: Vec<_> = data
@@ -195,7 +195,7 @@ pub trait Initializable<T, Preprocessing>: StructuredPolynomialData<T> + Default
             .collect();
         for (i, (ptr, ptr_mut)) in zip_eq(init_final_pointers, init_final_pointers_mut).enumerate()
         {
-            assert!(ptr == ptr_mut, "Init-final pointer mismatch at index {}", i);
+            assert!(std::ptr::eq(ptr, ptr_mut), "Init-final pointer mismatch at index {}", i);
         }
     }
 }

--- a/jolt-core/src/lasso/memory_checking.rs
+++ b/jolt-core/src/lasso/memory_checking.rs
@@ -180,7 +180,11 @@ pub trait Initializable<T, Preprocessing>: StructuredPolynomialData<T> + Default
             .collect();
         for (i, (ptr, ptr_mut)) in zip_eq(read_write_pointers, read_write_pointers_mut).enumerate()
         {
-            assert!(std::ptr::eq(ptr, ptr_mut), "Read-write pointer mismatch at index {}", i);
+            assert!(
+                std::ptr::eq(ptr, ptr_mut),
+                "Read-write pointer mismatch at index {}",
+                i
+            );
         }
 
         let init_final_pointers: Vec<_> = data
@@ -195,7 +199,11 @@ pub trait Initializable<T, Preprocessing>: StructuredPolynomialData<T> + Default
             .collect();
         for (i, (ptr, ptr_mut)) in zip_eq(init_final_pointers, init_final_pointers_mut).enumerate()
         {
-            assert!(std::ptr::eq(ptr, ptr_mut), "Init-final pointer mismatch at index {}", i);
+            assert!(
+                std::ptr::eq(ptr, ptr_mut),
+                "Init-final pointer mismatch at index {}",
+                i
+            );
         }
     }
 }

--- a/jolt-core/src/subprotocols/sparse_dense_shout.rs
+++ b/jolt-core/src/subprotocols/sparse_dense_shout.rs
@@ -258,10 +258,8 @@ fn compute_sumcheck_prover_message<const WORD_SIZE: usize, F: JoltField>(
                 .iter()
                 .zip(suffix_polys.iter())
                 .map(move |(table, suffixes)| {
-                    let suffixes_left: Vec<_> = suffixes
-                        .iter()
-                        .map(|suffix| suffix[b.into()])
-                        .collect();
+                    let suffixes_left: Vec<_> =
+                        suffixes.iter().map(|suffix| suffix[b.into()]).collect();
                     let suffixes_right: Vec<_> = suffixes
                         .iter()
                         .map(|suffix| suffix[usize::from(b) + len / 2])

--- a/jolt-core/src/subprotocols/sparse_dense_shout.rs
+++ b/jolt-core/src/subprotocols/sparse_dense_shout.rs
@@ -260,11 +260,11 @@ fn compute_sumcheck_prover_message<const WORD_SIZE: usize, F: JoltField>(
                 .map(move |(table, suffixes)| {
                     let suffixes_left: Vec<_> = suffixes
                         .iter()
-                        .map(|suffix| suffix[b.into()].into())
+                        .map(|suffix| suffix[b.into()])
                         .collect();
                     let suffixes_right: Vec<_> = suffixes
                         .iter()
-                        .map(|suffix| suffix[usize::from(b) + len / 2].into())
+                        .map(|suffix| suffix[usize::from(b) + len / 2])
                         .collect();
                     (
                         table.combine(&prefixes_c0, &suffixes_left),

--- a/jolt-core/src/subprotocols/sparse_dense_shout.rs
+++ b/jolt-core/src/subprotocols/sparse_dense_shout.rs
@@ -435,6 +435,8 @@ pub fn prove_single_instruction<
             let univariate_poly_evals =
                 I::compute_sumcheck_prover_message(&prefix_checkpoints, &suffix_polys, &r, j);
 
+            println!("round {_round}: {univariate_poly_evals:?}");
+
             #[cfg(test)]
             {
                 let expected: [F; 2] = (0..val_test.len() / 2)
@@ -610,6 +612,8 @@ pub fn prove_single_instruction<
                 || [F::zero(); 2],
                 |running, new| [running[0] + new[0], running[1] + new[1]],
             );
+
+        println!("round {_round}: {univariate_poly_evals:?}");
 
         let univariate_poly = UniPoly::from_evals(&[
             univariate_poly_evals[0],
@@ -1003,6 +1007,8 @@ pub fn prove_multiple_instructions<
                 &r,
                 j,
             );
+
+            println!("round {_round}: {univariate_poly_evals:?}");
 
             // #[cfg(test)]
             // {
@@ -1606,10 +1612,10 @@ mod tests {
         ));
     }
 
-    // #[test]
-    // fn test_multiple_pow2() {
-    //     test_multiple_instructions(LookupTables::Pow2(POW2Instruction::default()));
-    // }
+    #[test]
+    fn test_multiple_pow2() {
+        test_multiple_instructions(LookupTables::Pow2(POW2Instruction::default()));
+    }
 
     // #[test]
     // fn test_multiple_right_shift_padding() {

--- a/jolt-core/src/subprotocols/sparse_dense_shout.rs
+++ b/jolt-core/src/subprotocols/sparse_dense_shout.rs
@@ -4,7 +4,7 @@ use crate::{
     jolt::instruction::{
         prefixes::{PrefixCheckpoint, PrefixEval, Prefixes},
         suffixes::{SuffixEval, Suffixes},
-        JoltInstruction,
+        JoltInstruction, LookupTables,
     },
     poly::{
         dense_mlpoly::DensePolynomial,
@@ -22,7 +22,6 @@ use crate::{
         uninterleave_bits,
     },
 };
-use num::FromPrimitive;
 use rayon::{prelude::*, slice::Iter};
 use std::{fmt::Display, ops::Index};
 use strum::{EnumCount, IntoEnumIterator};
@@ -211,12 +210,9 @@ pub fn current_suffix_len(log_K: usize, j: usize) -> usize {
     log_K - (j / phase_length + 1) * phase_length
 }
 
-pub trait PrefixSuffixDecomposition<const WORD_SIZE: usize, F: JoltField>:
-    JoltInstruction + Default
-{
-    fn prefixes() -> Vec<Prefixes>;
-    fn suffixes() -> Vec<Suffixes>;
-    fn combine(prefixes: &[PrefixEval<F>], suffixes: &[SuffixEval<F>]) -> F;
+pub trait PrefixSuffixDecomposition<const WORD_SIZE: usize>: JoltInstruction + Default {
+    fn suffixes(&self) -> Vec<Suffixes>;
+    fn combine<F: JoltField>(&self, prefixes: &[PrefixEval<F>], suffixes: &[SuffixEval<F>]) -> F;
 
     /// Compute the sumcheck prover message in round `j` using the prefix-suffix
     /// decomposition. In the first 3/4 * log(K) rounds of sumcheck, while we're
@@ -229,8 +225,8 @@ pub trait PrefixSuffixDecomposition<const WORD_SIZE: usize, F: JoltField>:
     /// non-overlapping variables of k (and the eq term doesn't involve k at all).
     /// Val(k) is clearly multilinear in k, so the whole summand
     ///   eq(r', j) (\prod_i ra_i(k_i, j)) * Val(k)
-    /// is degree 2 in the "address" variables k.
-    fn compute_sumcheck_prover_message(
+    /// is degree 2 in each "address" variable k.
+    fn compute_sumcheck_prover_message<F: JoltField>(
         prefix_checkpoints: &[PrefixCheckpoint<F>],
         suffix_polys: &[DensePolynomial<F>],
         r: &[F],
@@ -266,9 +262,9 @@ pub trait PrefixSuffixDecomposition<const WORD_SIZE: usize, F: JoltField>:
                     .map(|suffix_poly| suffix_poly[usize::from(b) + len / 2].into())
                     .collect();
                 (
-                    Self::combine(&prefixes_c0, &suffixes_left),
-                    Self::combine(&prefixes_c2, &suffixes_left),
-                    Self::combine(&prefixes_c2, &suffixes_right),
+                    Self::default().combine(&prefixes_c0, &suffixes_left),
+                    Self::default().combine(&prefixes_c2, &suffixes_left),
+                    Self::default().combine(&prefixes_c2, &suffixes_right),
                 )
             })
             .reduce(
@@ -283,7 +279,7 @@ pub trait PrefixSuffixDecomposition<const WORD_SIZE: usize, F: JoltField>:
 pub fn prove_single_instruction<
     const WORD_SIZE: usize,
     F: JoltField,
-    I: PrefixSuffixDecomposition<WORD_SIZE, F>,
+    I: PrefixSuffixDecomposition<WORD_SIZE>,
     ProofTranscript: Transcript,
 >(
     instructions: &[I],
@@ -349,7 +345,8 @@ pub fn prove_single_instruction<
     let mut j: usize = 0;
     let mut ra: Vec<MultilinearPolynomial<F>> = Vec::with_capacity(4);
 
-    let mut suffix_polys: Vec<DensePolynomial<F>> = (0..Suffixes::COUNT)
+    let mut suffix_polys: Vec<DensePolynomial<F>> = I::default()
+        .suffixes()
         .into_par_iter()
         .map(|_| DensePolynomial::new(unsafe_allocate_zero_vec(m)))
         .collect();
@@ -405,9 +402,8 @@ pub fn prove_single_instruction<
         let _guard = span.enter();
         suffix_polys
             .par_iter_mut()
-            .enumerate()
-            .for_each(|(suffix_index, poly)| {
-                let suffix: Suffixes = FromPrimitive::from_u8(suffix_index as u8).unwrap();
+            .zip(I::default().suffixes().par_iter())
+            .for_each(|(poly, suffix)| {
                 if phase != 0 {
                     // Reset polynomial
                     poly.len = m;
@@ -571,13 +567,15 @@ pub fn prove_single_instruction<
     let val: Vec<F> = (0..m)
         .into_par_iter()
         .map(|k| {
-            let suffixes: Vec<_> = Suffixes::iter()
+            let suffixes: Vec<_> = I::default()
+                .suffixes()
+                .iter()
                 .map(|suffix| {
                     F::from_u32(suffix.suffix_mle::<WORD_SIZE>(LookupBits::new(k as u64, log_m)))
                         .into()
                 })
                 .collect();
-            I::combine(&prefixes, &suffixes)
+            I::default().combine(&prefixes, &suffixes)
         })
         .collect();
     let mut val = MultilinearPolynomial::from(val);
@@ -779,6 +777,411 @@ pub fn verify_single_instruction<
     Ok(())
 }
 
+fn compute_sumcheck_prover_message<const WORD_SIZE: usize, F: JoltField>(
+    prefix_checkpoints: &[PrefixCheckpoint<F>],
+    suffix_polys: &[Vec<DensePolynomial<F>>],
+    r: &[F],
+    j: usize,
+) -> [F; 2] {
+    let lookup_tables: Vec<_> = LookupTables::<WORD_SIZE>::iter().collect();
+
+    let len = suffix_polys[0][0].len();
+    let log_len = len.log_2();
+
+    let r_x = if j % 2 == 1 { r.last().copied() } else { None };
+
+    let (eval_0, eval_2_left, eval_2_right): (F, F, F) = (0..len / 2)
+        .into_par_iter()
+        .flat_map_iter(|b| {
+            let b = LookupBits::new(b as u64, log_len - 1);
+            // Evaluate all prefix MLEs with the current variable fixed to c=0
+            let prefixes_c0: Vec<_> = Prefixes::iter()
+                .map(|prefix| prefix.prefix_mle::<WORD_SIZE, F>(prefix_checkpoints, r_x, 0, b, j))
+                .collect();
+            // Evaluate all prefix MLEs with the current variable fixed to c=2
+            let prefixes_c2: Vec<_> = Prefixes::iter()
+                .map(|prefix| prefix.prefix_mle::<WORD_SIZE, F>(prefix_checkpoints, r_x, 2, b, j))
+                .collect();
+
+            lookup_tables
+                .iter()
+                .zip(suffix_polys.iter())
+                .map(move |(table, suffixes)| {
+                    let suffixes_left: Vec<_> = suffixes
+                        .iter()
+                        .map(|suffix| suffix[b.into()].into())
+                        .collect();
+                    let suffixes_right: Vec<_> = suffixes
+                        .iter()
+                        .map(|suffix| suffix[usize::from(b) + len / 2].into())
+                        .collect();
+                    (
+                        table.combine(&prefixes_c0, &suffixes_left),
+                        table.combine(&prefixes_c2, &suffixes_left),
+                        table.combine(&prefixes_c2, &suffixes_right),
+                    )
+                })
+        })
+        .reduce(
+            || (F::zero(), F::zero(), F::zero()),
+            |running, new| (running.0 + new.0, running.1 + new.1, running.2 + new.2),
+        );
+
+    [eval_0, eval_2_right + eval_2_right - eval_2_left]
+}
+
+pub fn prove_multiple_instructions<
+    const WORD_SIZE: usize,
+    F: JoltField,
+    ProofTranscript: Transcript,
+>(
+    lookups: &[LookupTables<WORD_SIZE>],
+    r_cycle: Vec<F>,
+    transcript: &mut ProofTranscript,
+) -> (SumcheckInstanceProof<F, ProofTranscript>, F, [F; 4]) {
+    let log_K: usize = 2 * WORD_SIZE;
+    let log_m = log_K / 4;
+    let m = log_m.pow2();
+
+    let T = lookups.len();
+    let log_T = T.log_2();
+    debug_assert_eq!(r_cycle.len(), log_T);
+
+    let num_rounds = log_K + log_T;
+    let mut r: Vec<F> = Vec::with_capacity(num_rounds);
+    let mut compressed_polys: Vec<CompressedUniPoly<F>> = Vec::with_capacity(num_rounds);
+
+    let span = tracing::span!(tracing::Level::INFO, "compute lookup indices");
+    let _guard = span.enter();
+    let lookup_indices: Vec<_> = lookups
+        .par_iter()
+        .map(|instruction| LookupBits::new(instruction.to_lookup_index(), log_K))
+        .collect();
+    drop(_guard);
+    drop(span);
+
+    let (eq_r_prime, mut u_evals) = rayon::join(
+        || EqPolynomial::evals(&r_cycle),
+        || EqPolynomial::evals_with_r2(&r_cycle),
+    );
+
+    let mut prefix_checkpoints: Vec<PrefixCheckpoint<F>> = vec![None.into(); Prefixes::COUNT];
+    let mut v = ExpandingTable::new(m);
+
+    let span = tracing::span!(tracing::Level::INFO, "compute rv_claim");
+    let _guard = span.enter();
+    let rv_claim = lookups
+        .par_iter()
+        .zip(lookup_indices.par_iter())
+        .zip(u_evals.par_iter())
+        .map(|((instruction, k), u)| u.mul_u64_unchecked(instruction.materialize_entry(k.into())))
+        .sum();
+    drop(_guard);
+    drop(span);
+
+    let mut previous_claim = rv_claim;
+
+    #[cfg(test)]
+    let mut val_test: Vec<MultilinearPolynomial<F>> = LookupTables::<WORD_SIZE>::iter()
+        .map(|instruction| MultilinearPolynomial::from(instruction.materialize()))
+        .collect();
+    #[cfg(test)]
+    let mut eq_ra_test: MultilinearPolynomial<F> = {
+        let mut eq_ra: Vec<F> = unsafe_allocate_zero_vec(val_test.len());
+        for (j, k) in lookup_indices.iter().enumerate() {
+            eq_ra[usize::from(k)] += eq_r_prime[j];
+        }
+        MultilinearPolynomial::from(eq_ra)
+    };
+
+    let mut j: usize = 0;
+    let mut ra: Vec<MultilinearPolynomial<F>> = Vec::with_capacity(4);
+
+    let lookup_tables: Vec<_> = LookupTables::<WORD_SIZE>::iter().collect();
+    let mut suffix_polys: Vec<Vec<DensePolynomial<F>>> = lookup_tables
+        .par_iter()
+        .map(|table| {
+            table
+                .suffixes()
+                .par_iter()
+                .map(|_| DensePolynomial::new(unsafe_allocate_zero_vec(m)))
+                .collect()
+        })
+        .collect();
+
+    for phase in 0..4 {
+        let span = tracing::span!(tracing::Level::INFO, "sparse-dense phase");
+        let _guard = span.enter();
+
+        // Condensation
+        if phase != 0 {
+            let span = tracing::span!(tracing::Level::INFO, "Update u_evals");
+            let _guard = span.enter();
+            lookup_indices
+                .par_iter()
+                .zip(u_evals.par_iter_mut())
+                .for_each(|(k, u)| {
+                    let (prefix, _) = k.split((4 - phase) * log_m);
+                    let k_bound: usize = prefix % m;
+                    *u *= v[k_bound];
+                });
+            drop(_guard);
+            drop(span);
+        }
+
+        let suffix_len = (3 - phase) * log_m;
+
+        // Initialize suffix poly for each suffix
+        let span = tracing::span!(tracing::Level::INFO, "Compute suffix polys");
+        let _guard = span.enter();
+        lookup_tables
+            .par_iter()
+            .zip(suffix_polys.par_iter_mut())
+            .for_each(|(table, polys)| {
+                table
+                    .suffixes()
+                    .par_iter()
+                    .zip(polys.par_iter_mut())
+                    .for_each(|(suffix, poly)| {
+                        if phase != 0 {
+                            // Reset polynomial
+                            poly.len = m;
+                            poly.num_vars = poly.len.log_2();
+                            poly.Z.par_iter_mut().for_each(|eval| *eval = F::zero());
+                        }
+
+                        for ((instruction, k), u) in lookups
+                            .iter()
+                            .zip(lookup_indices.iter())
+                            .zip(u_evals.iter())
+                        {
+                            if LookupTables::enum_index(instruction)
+                                != LookupTables::enum_index(table)
+                            {
+                                continue;
+                            }
+                            let (prefix_bits, suffix_bits) = k.split(suffix_len);
+                            let t = suffix.suffix_mle::<WORD_SIZE>(suffix_bits);
+                            if t != 0 {
+                                poly.Z[prefix_bits % m] += u.mul_u64_unchecked(t as u64);
+                            }
+                        }
+                    });
+            });
+
+        v.reset(F::one());
+
+        for _round in 0..log_m {
+            let span = tracing::span!(tracing::Level::INFO, "sparse-dense sumcheck round");
+            let _guard = span.enter();
+
+            let univariate_poly_evals = compute_sumcheck_prover_message::<WORD_SIZE, F>(
+                &prefix_checkpoints,
+                &suffix_polys,
+                &r,
+                j,
+            );
+
+            // #[cfg(test)]
+            // {
+            //     let expected: [F; 2] = (0..val_test.len() / 2)
+            //         .into_par_iter()
+            //         .map(|i| {
+            //             let eq_ra_evals = eq_ra_test.sumcheck_evals(i, 2, BindingOrder::HighToLow);
+            //             let val_evals: Vec<_> = val_test
+            //                 .iter()
+            //                 .map(|val_i| val_i.sumcheck_evals(i, 2, BindingOrder::HighToLow))
+            //                 .collect();
+
+            //             [eq_ra_evals[0] * val_evals[0], eq_ra_evals[1] * val_evals[1]]
+            //         })
+            //         .reduce(
+            //             || [F::zero(); 2],
+            //             |running, new| [running[0] + new[0], running[1] + new[1]],
+            //         );
+            //     assert_eq!(
+            //         expected, univariate_poly_evals,
+            //         "Sumcheck sanity check failed in phase {phase} round {_round}"
+            //     );
+            // }
+
+            let univariate_poly = UniPoly::from_evals(&[
+                univariate_poly_evals[0],
+                previous_claim - univariate_poly_evals[0],
+                univariate_poly_evals[1],
+            ]);
+
+            let compressed_poly = univariate_poly.compress();
+            compressed_poly.append_to_transcript(transcript);
+            compressed_polys.push(compressed_poly);
+
+            let r_j = transcript.challenge_scalar::<F>();
+            r.push(r_j);
+
+            previous_claim = univariate_poly.evaluate(&r_j);
+
+            suffix_polys.par_iter_mut().for_each(|polys| {
+                polys
+                    .par_iter_mut()
+                    .for_each(|poly| poly.bind_parallel(r_j, BindingOrder::HighToLow))
+            });
+            v.update(r_j);
+
+            {
+                if r.len() % 2 == 0 {
+                    let span = tracing::span!(tracing::Level::INFO, "Update prefix checkpoints");
+                    let _guard = span.enter();
+
+                    Prefixes::update_checkpoints::<WORD_SIZE, F>(
+                        &mut prefix_checkpoints,
+                        r[r.len() - 2],
+                        r[r.len() - 1],
+                        j,
+                    );
+                }
+            }
+
+            #[cfg(test)]
+            {
+                eq_ra_test.bind_parallel(r_j, BindingOrder::HighToLow);
+                val_test
+                    .par_iter_mut()
+                    .for_each(|val_i| val_i.bind_parallel(r_j, BindingOrder::HighToLow));
+            }
+
+            j += 1;
+        }
+
+        let span = tracing::span!(tracing::Level::INFO, "cache ra_i");
+        let _guard = span.enter();
+
+        let ra_i: Vec<F> = lookup_indices
+            .par_iter()
+            .map(|k| {
+                let (prefix, _) = k.split(suffix_len);
+                let k_bound: usize = prefix % m;
+                v[k_bound]
+            })
+            .collect();
+        ra.push(MultilinearPolynomial::from(ra_i));
+    }
+
+    let mut eq_r_prime = MultilinearPolynomial::from(eq_r_prime);
+
+    let span = tracing::span!(tracing::Level::INFO, "compute instruction val");
+    let _guard = span.enter();
+    let prefixes: Vec<_> = prefix_checkpoints
+        .into_iter()
+        .map(|checkpoint| checkpoint.unwrap())
+        .collect();
+
+    let mut instruction_val: Vec<Vec<F>> =
+        vec![unsafe_allocate_zero_vec(m); LookupTables::<WORD_SIZE>::COUNT];
+    for (j, table) in lookups.iter().enumerate() {
+        let instruction_index = LookupTables::enum_index(table);
+        instruction_val[instruction_index][j] =
+            table.combine(&prefixes, &vec![F::one(); table.suffixes().len()]);
+    }
+
+    let mut instruction_val_polys: Vec<MultilinearPolynomial<F>> = instruction_val
+        .into_par_iter()
+        .map(MultilinearPolynomial::from)
+        .collect();
+    drop(_guard);
+    drop(span);
+
+    let span = tracing::span!(tracing::Level::INFO, "last log(T) sumcheck rounds");
+    let _guard = span.enter();
+
+    for _round in 0..log_T {
+        let span = tracing::span!(tracing::Level::INFO, "Compute univariate poly");
+        let _guard = span.enter();
+
+        let univariate_poly_evals: [F; 5] = (0..eq_r_prime.len() / 2)
+            .into_par_iter()
+            .map(|i| {
+                let eq_evals = eq_r_prime.sumcheck_evals(i, 5, BindingOrder::HighToLow);
+                let ra_0_evals = ra[0].sumcheck_evals(i, 5, BindingOrder::HighToLow);
+                let ra_1_evals = ra[1].sumcheck_evals(i, 5, BindingOrder::HighToLow);
+                let ra_2_evals = ra[2].sumcheck_evals(i, 5, BindingOrder::HighToLow);
+                let ra_3_evals = ra[3].sumcheck_evals(i, 5, BindingOrder::HighToLow);
+                let val_evals = instruction_val_polys
+                    .iter()
+                    .map(|poly| poly.sumcheck_evals(i, 5, BindingOrder::HighToLow))
+                    .fold([F::zero(); 5], |running, new| {
+                        [
+                            running[0] + new[0],
+                            running[1] + new[1],
+                            running[2] + new[2],
+                            running[3] + new[3],
+                            running[4] + new[4],
+                        ]
+                    });
+
+                std::array::from_fn(|i| {
+                    eq_evals[i]
+                        * ra_0_evals[i]
+                        * ra_1_evals[i]
+                        * ra_2_evals[i]
+                        * ra_3_evals[i]
+                        * val_evals[i]
+                })
+            })
+            .reduce(
+                || [F::zero(); 5],
+                |running, new| {
+                    [
+                        running[0] + new[0],
+                        running[1] + new[1],
+                        running[2] + new[2],
+                        running[3] + new[3],
+                        running[4] + new[4],
+                    ]
+                },
+            );
+
+        let univariate_poly = UniPoly::from_evals(&[
+            univariate_poly_evals[0],
+            previous_claim - univariate_poly_evals[0],
+            univariate_poly_evals[1],
+            univariate_poly_evals[2],
+            univariate_poly_evals[3],
+            univariate_poly_evals[4],
+        ]);
+
+        drop(_guard);
+        drop(span);
+
+        let compressed_poly = univariate_poly.compress();
+        compressed_poly.append_to_transcript(transcript);
+        compressed_polys.push(compressed_poly);
+
+        let r_j = transcript.challenge_scalar::<F>();
+        r.push(r_j);
+
+        previous_claim = univariate_poly.evaluate(&r_j);
+
+        let span = tracing::span!(tracing::Level::INFO, "Binding");
+        let _guard = span.enter();
+
+        ra.par_iter_mut()
+            .chain(instruction_val_polys.par_iter_mut())
+            .chain([&mut eq_r_prime].into_par_iter())
+            .for_each(|poly| poly.bind_parallel(r_j, BindingOrder::HighToLow));
+    }
+
+    (
+        SumcheckInstanceProof::new(compressed_polys),
+        rv_claim,
+        [
+            ra[0].final_sumcheck_claim(),
+            ra[1].final_sumcheck_claim(),
+            ra[2].final_sumcheck_claim(),
+            ra[3].final_sumcheck_claim(),
+        ],
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -807,7 +1210,7 @@ mod tests {
     const LOG_T: usize = 8;
     const T: usize = 1 << LOG_T;
 
-    fn test_single_instruction<I: PrefixSuffixDecomposition<WORD_SIZE, Fr>>() {
+    fn test_single_instruction<I: PrefixSuffixDecomposition<WORD_SIZE>>() {
         let mut rng = StdRng::seed_from_u64(12345);
 
         let instructions: Vec<_> = (0..T).map(|_| I::default().random(&mut rng)).collect();

--- a/jolt-core/src/subprotocols/sparse_dense_shout.rs
+++ b/jolt-core/src/subprotocols/sparse_dense_shout.rs
@@ -213,570 +213,20 @@ pub fn current_suffix_len(log_K: usize, j: usize) -> usize {
 pub trait PrefixSuffixDecomposition<const WORD_SIZE: usize>: JoltInstruction + Default {
     fn suffixes(&self) -> Vec<Suffixes>;
     fn combine<F: JoltField>(&self, prefixes: &[PrefixEval<F>], suffixes: &[SuffixEval<F>]) -> F;
-
-    /// Compute the sumcheck prover message in round `j` using the prefix-suffix
-    /// decomposition. In the first 3/4 * log(K) rounds of sumcheck, while we're
-    /// binding the "address" variables (and the "cycle" variables remain unbound),
-    /// the univariate polynomial computed each round is degree 2.
-    ///
-    /// To see this, observe that:
-    ///   eq(r', j) * ra_1(k_1, j) * ra_2(k_2, j) * ra_3(k_3, j) * ra_4(k_4, j)
-    /// is multilinear in k, since ra_1, ra_2, ra_3, and ra_4 are polynomials in
-    /// non-overlapping variables of k (and the eq term doesn't involve k at all).
-    /// Val(k) is clearly multilinear in k, so the whole summand
-    ///   eq(r', j) (\prod_i ra_i(k_i, j)) * Val(k)
-    /// is degree 2 in each "address" variable k.
-    fn compute_sumcheck_prover_message<F: JoltField>(
-        prefix_checkpoints: &[PrefixCheckpoint<F>],
-        suffix_polys: &[DensePolynomial<F>],
-        r: &[F],
-        j: usize,
-    ) -> [F; 2] {
-        let len = suffix_polys[0].len();
-        let log_len = len.log_2();
-
-        let r_x = if j % 2 == 1 { r.last().copied() } else { None };
-
-        let (eval_0, eval_2_left, eval_2_right): (F, F, F) = (0..len / 2)
-            .into_par_iter()
-            .map(|b| {
-                let b = LookupBits::new(b as u64, log_len - 1);
-                // Evaluate all prefix MLEs with the current variable fixed to c=0
-                let prefixes_c0: Vec<_> = Prefixes::iter()
-                    .map(|prefix| {
-                        prefix.prefix_mle::<WORD_SIZE, F>(prefix_checkpoints, r_x, 0, b, j)
-                    })
-                    .collect();
-                // Evaluate all prefix MLEs with the current variable fixed to c=2
-                let prefixes_c2: Vec<_> = Prefixes::iter()
-                    .map(|prefix| {
-                        prefix.prefix_mle::<WORD_SIZE, F>(prefix_checkpoints, r_x, 2, b, j)
-                    })
-                    .collect();
-                let suffixes_left: Vec<_> = suffix_polys
-                    .iter()
-                    .map(|suffix_poly| suffix_poly[b.into()].into())
-                    .collect();
-                let suffixes_right: Vec<_> = suffix_polys
-                    .iter()
-                    .map(|suffix_poly| suffix_poly[usize::from(b) + len / 2].into())
-                    .collect();
-                (
-                    Self::default().combine(&prefixes_c0, &suffixes_left),
-                    Self::default().combine(&prefixes_c2, &suffixes_left),
-                    Self::default().combine(&prefixes_c2, &suffixes_right),
-                )
-            })
-            .reduce(
-                || (F::zero(), F::zero(), F::zero()),
-                |running, new| (running.0 + new.0, running.1 + new.1, running.2 + new.2),
-            );
-
-        [eval_0, eval_2_right + eval_2_right - eval_2_left]
-    }
 }
 
-pub fn prove_single_instruction<
-    const WORD_SIZE: usize,
-    F: JoltField,
-    I: PrefixSuffixDecomposition<WORD_SIZE>,
-    ProofTranscript: Transcript,
->(
-    instructions: &[I],
-    r_cycle: Vec<F>,
-    transcript: &mut ProofTranscript,
-) -> (SumcheckInstanceProof<F, ProofTranscript>, F, [F; 4]) {
-    let log_K: usize = 2 * WORD_SIZE;
-    let log_m = log_K / 4;
-    let m = log_m.pow2();
-
-    let T = instructions.len();
-    let log_T = T.log_2();
-    debug_assert_eq!(r_cycle.len(), log_T);
-
-    let num_chunks = rayon::current_num_threads().next_power_of_two().min(T);
-    let chunk_size = (m / num_chunks).max(1);
-
-    let num_rounds = log_K + log_T;
-    let mut r: Vec<F> = Vec::with_capacity(num_rounds);
-    let mut compressed_polys: Vec<CompressedUniPoly<F>> = Vec::with_capacity(num_rounds);
-
-    let span = tracing::span!(tracing::Level::INFO, "compute lookup indices");
-    let _guard = span.enter();
-    let lookup_indices: Vec<_> = instructions
-        .par_iter()
-        .map(|instruction| LookupBits::new(instruction.to_lookup_index(), log_K))
-        .collect();
-    drop(_guard);
-    drop(span);
-
-    let (eq_r_prime, mut u_evals) = rayon::join(
-        || EqPolynomial::evals(&r_cycle),
-        || EqPolynomial::evals_with_r2(&r_cycle),
-    );
-
-    let mut prefix_checkpoints: Vec<PrefixCheckpoint<F>> = vec![None.into(); Prefixes::COUNT];
-    let mut v = ExpandingTable::new(m);
-
-    let span = tracing::span!(tracing::Level::INFO, "compute rv_claim");
-    let _guard = span.enter();
-    let rv_claim = lookup_indices
-        .par_iter()
-        .zip(u_evals.par_iter())
-        .map(|(k, u)| u.mul_u64_unchecked(I::default().materialize_entry(k.into())))
-        .sum();
-    drop(_guard);
-    drop(span);
-
-    let mut previous_claim = rv_claim;
-
-    #[cfg(test)]
-    let mut val_test: MultilinearPolynomial<F> =
-        MultilinearPolynomial::from(I::default().materialize());
-    #[cfg(test)]
-    let mut eq_ra_test: MultilinearPolynomial<F> = {
-        let mut eq_ra: Vec<F> = unsafe_allocate_zero_vec(val_test.len());
-        for (j, k) in lookup_indices.iter().enumerate() {
-            eq_ra[usize::from(k)] += eq_r_prime[j];
-        }
-        MultilinearPolynomial::from(eq_ra)
-    };
-
-    let mut j: usize = 0;
-    let mut ra: Vec<MultilinearPolynomial<F>> = Vec::with_capacity(4);
-
-    let mut suffix_polys: Vec<DensePolynomial<F>> = I::default()
-        .suffixes()
-        .into_par_iter()
-        .map(|_| DensePolynomial::new(unsafe_allocate_zero_vec(m)))
-        .collect();
-
-    for phase in 0..3 {
-        let span = tracing::span!(tracing::Level::INFO, "sparse-dense phase");
-        let _guard = span.enter();
-
-        // Condensation
-        if phase != 0 {
-            let span = tracing::span!(tracing::Level::INFO, "Update u_evals");
-            let _guard = span.enter();
-            lookup_indices
-                .par_iter()
-                .zip(u_evals.par_iter_mut())
-                .for_each(|(k, u)| {
-                    let (prefix, _) = k.split((4 - phase) * log_m);
-                    let k_bound: usize = prefix % m;
-                    *u *= v[k_bound];
-                });
-            drop(_guard);
-            drop(span);
-        }
-
-        let suffix_len = (3 - phase) * log_m;
-
-        // Split lookups into parallelizable groups
-        let span = tracing::span!(tracing::Level::INFO, "compute parallelizable_groups");
-        let _guard = span.enter();
-        let parallelizable_groups: Vec<Vec<_>> = (0..num_chunks)
-            .into_par_iter()
-            .map(|i| {
-                lookup_indices
-                    .iter()
-                    .zip(u_evals.iter())
-                    .filter_map(move |(k, u)| {
-                        let (prefix_bits, suffix_bits) = k.split(suffix_len);
-                        let group = (prefix_bits % m) / chunk_size;
-                        if group == i {
-                            Some((prefix_bits, suffix_bits, u))
-                        } else {
-                            None
-                        }
-                    })
-                    .collect()
-            })
-            .collect();
-        drop(_guard);
-        drop(span);
-
-        // Initialize suffix poly for each suffix
-        let span = tracing::span!(tracing::Level::INFO, "Compute suffix polys");
-        let _guard = span.enter();
-        suffix_polys
-            .par_iter_mut()
-            .zip(I::default().suffixes().par_iter())
-            .for_each(|(poly, suffix)| {
-                if phase != 0 {
-                    // Reset polynomial
-                    poly.len = m;
-                    poly.num_vars = poly.len.log_2();
-                    poly.Z.par_iter_mut().for_each(|eval| *eval = F::zero());
-                }
-                parallelizable_groups
-                    .par_iter()
-                    .zip(poly.Z.par_chunks_mut(chunk_size))
-                    .for_each(|(group, evals)| {
-                        group.iter().for_each(|(prefix_bits, suffix_bits, u)| {
-                            let t = suffix.suffix_mle::<WORD_SIZE>(*suffix_bits);
-                            if t != 0 {
-                                evals[prefix_bits % chunk_size] += u.mul_u64_unchecked(t as u64);
-                            }
-                        });
-                    });
-            });
-
-        drop(_guard);
-        drop(span);
-
-        v.reset(F::one());
-
-        for _round in 0..log_m {
-            let span = tracing::span!(tracing::Level::INFO, "sparse-dense sumcheck round");
-            let _guard = span.enter();
-
-            let univariate_poly_evals =
-                I::compute_sumcheck_prover_message(&prefix_checkpoints, &suffix_polys, &r, j);
-
-            #[cfg(test)]
-            {
-                let expected: [F; 2] = (0..val_test.len() / 2)
-                    .into_par_iter()
-                    .map(|i| {
-                        let eq_ra_evals = eq_ra_test.sumcheck_evals(i, 2, BindingOrder::HighToLow);
-                        let val_evals = val_test.sumcheck_evals(i, 2, BindingOrder::HighToLow);
-
-                        [eq_ra_evals[0] * val_evals[0], eq_ra_evals[1] * val_evals[1]]
-                    })
-                    .reduce(
-                        || [F::zero(); 2],
-                        |running, new| [running[0] + new[0], running[1] + new[1]],
-                    );
-                assert_eq!(
-                    expected, univariate_poly_evals,
-                    "Sumcheck sanity check failed in phase {phase} round {_round}"
-                );
-            }
-
-            let univariate_poly = UniPoly::from_evals(&[
-                univariate_poly_evals[0],
-                previous_claim - univariate_poly_evals[0],
-                univariate_poly_evals[1],
-            ]);
-
-            let compressed_poly = univariate_poly.compress();
-            compressed_poly.append_to_transcript(transcript);
-            compressed_polys.push(compressed_poly);
-
-            let r_j = transcript.challenge_scalar::<F>();
-            r.push(r_j);
-
-            previous_claim = univariate_poly.evaluate(&r_j);
-
-            suffix_polys
-                .par_iter_mut()
-                .for_each(|poly| poly.bind_parallel(r_j, BindingOrder::HighToLow));
-            v.update(r_j);
-
-            {
-                if r.len() % 2 == 0 {
-                    let span = tracing::span!(tracing::Level::INFO, "Update prefix checkpoints");
-                    let _guard = span.enter();
-
-                    Prefixes::update_checkpoints::<WORD_SIZE, F>(
-                        &mut prefix_checkpoints,
-                        r[r.len() - 2],
-                        r[r.len() - 1],
-                        j,
-                    );
-                }
-            }
-
-            #[cfg(test)]
-            {
-                eq_ra_test.bind_parallel(r_j, BindingOrder::HighToLow);
-                val_test.bind_parallel(r_j, BindingOrder::HighToLow);
-            }
-
-            j += 1;
-        }
-
-        let span = tracing::span!(tracing::Level::INFO, "cache ra_i");
-        let _guard = span.enter();
-
-        let ra_i: Vec<F> = lookup_indices
-            .par_iter()
-            .map(|k| {
-                let (prefix, _) = k.split(suffix_len);
-                let k_bound: usize = prefix % m;
-                v[k_bound]
-            })
-            .collect();
-        ra.push(MultilinearPolynomial::from(ra_i));
-    }
-
-    // At this point we switch from sparse-dense sumcheck (see Section 7.1 of the Twist+Shout
-    // paper) to "vanilla" Shout, i.e. Section 6.2 where d=4.
-    // Note that we've already bound 3/4 of the address variables, so ra_1, ra_2, and ra_3
-    // are fully bound when we start "vanilla" Shout.
-
-    // Modified version of the C array described in Equation (47) of the Twist+Shout paper
-    let span = tracing::span!(tracing::Level::INFO, "Materialize eq_ra");
-    let _guard = span.enter();
-    let instruction_index_iters: Vec<_> = (0..num_chunks)
-        .into_par_iter()
-        .map(|i| {
-            lookup_indices.iter().enumerate().filter_map(move |(j, k)| {
-                let group = (k % m) / chunk_size;
-                if group == i {
-                    Some(j)
-                } else {
-                    None
-                }
-            })
-        })
-        .collect();
-
-    let mut eq_ra: Vec<F> = unsafe_allocate_zero_vec(m);
-    instruction_index_iters
-        .into_par_iter()
-        .zip(eq_ra.par_chunks_mut(chunk_size))
-        .for_each(|(j_iter, chunk)| {
-            j_iter.for_each(|j| {
-                let k = lookup_indices[j];
-                chunk[k % chunk_size] +=
-                    eq_r_prime[j] * ra[0].get_coeff(j) * ra[1].get_coeff(j) * ra[2].get_coeff(j);
-            });
-        });
-    let mut eq_ra = MultilinearPolynomial::from(eq_ra);
-    drop(_guard);
-    drop(span);
-
-    #[cfg(test)]
-    {
-        for i in 0..m {
-            assert_eq!(eq_ra.get_bound_coeff(i), eq_ra_test.get_bound_coeff(i));
-        }
-    }
-
-    let span = tracing::span!(tracing::Level::INFO, "Materialize val");
-    let _guard = span.enter();
-    let prefixes: Vec<_> = prefix_checkpoints
-        .into_iter()
-        .map(|checkpoint| checkpoint.unwrap())
-        .collect();
-    // At this point, Val(r, k') is the combination of the prefix checkpoints (which are
-    // equal to prefix(r)) and suffixes evaluated at k' \in {0, 1}^log(m)
-    let val: Vec<F> = (0..m)
-        .into_par_iter()
-        .map(|k| {
-            let suffixes: Vec<_> = I::default()
-                .suffixes()
-                .iter()
-                .map(|suffix| {
-                    F::from_u32(suffix.suffix_mle::<WORD_SIZE>(LookupBits::new(k as u64, log_m)))
-                        .into()
-                })
-                .collect();
-            I::default().combine(&prefixes, &suffixes)
-        })
-        .collect();
-    let mut val = MultilinearPolynomial::from(val);
-    drop(_guard);
-    drop(span);
-
-    #[cfg(test)]
-    {
-        for i in 0..m {
-            assert_eq!(val.get_bound_coeff(i), val_test.get_bound_coeff(i));
-        }
-    }
-
-    v.reset(F::one());
-
-    let span = tracing::span!(tracing::Level::INFO, "Next log(m) sumcheck rounds");
-    let _guard = span.enter();
-
-    for _round in 0..log_m {
-        let span = tracing::span!(tracing::Level::INFO, "Compute univariate poly");
-        let _guard = span.enter();
-
-        let univariate_poly_evals: [F; 2] = (0..eq_ra.len() / 2)
-            .into_par_iter()
-            .map(|i| {
-                let eq_ra_evals = eq_ra.sumcheck_evals(i, 2, BindingOrder::HighToLow);
-                let val_evals = val.sumcheck_evals(i, 2, BindingOrder::HighToLow);
-
-                [eq_ra_evals[0] * val_evals[0], eq_ra_evals[1] * val_evals[1]]
-            })
-            .reduce(
-                || [F::zero(); 2],
-                |running, new| [running[0] + new[0], running[1] + new[1]],
-            );
-
-        let univariate_poly = UniPoly::from_evals(&[
-            univariate_poly_evals[0],
-            previous_claim - univariate_poly_evals[0],
-            univariate_poly_evals[1],
-        ]);
-
-        drop(_guard);
-        drop(span);
-
-        let compressed_poly = univariate_poly.compress();
-        compressed_poly.append_to_transcript(transcript);
-        compressed_polys.push(compressed_poly);
-
-        let r_j = transcript.challenge_scalar::<F>();
-        r.push(r_j);
-
-        previous_claim = univariate_poly.evaluate(&r_j);
-
-        let span = tracing::span!(tracing::Level::INFO, "Binding");
-        let _guard = span.enter();
-
-        // Bind polynomials
-        rayon::join(
-            || eq_ra.bind_parallel(r_j, BindingOrder::HighToLow),
-            || val.bind_parallel(r_j, BindingOrder::HighToLow),
-        );
-
-        v.update(r_j);
-        j += 1;
-    }
-
-    drop(_guard);
-    drop(span);
-
-    let span = tracing::span!(tracing::Level::INFO, "cache ra_i");
-    let _guard = span.enter();
-
-    let ra_i: Vec<F> = lookup_indices
-        .par_iter()
-        .map(|k| {
-            let k_bound = k % m;
-            v[k_bound]
-        })
-        .collect();
-    ra.push(MultilinearPolynomial::from(ra_i));
-    drop(_guard);
-    drop(span);
-
-    let mut eq_r_prime = MultilinearPolynomial::from(eq_r_prime);
-    // Val(k) is fully bound at this point
-    let val_eval = val.final_sumcheck_claim();
-
-    let span = tracing::span!(tracing::Level::INFO, "last log(T) sumcheck rounds");
-    let _guard = span.enter();
-
-    for _round in 0..log_T {
-        let span = tracing::span!(tracing::Level::INFO, "Compute univariate poly");
-        let _guard = span.enter();
-
-        let mut univariate_poly_evals: [F; 5] = (0..eq_r_prime.len() / 2)
-            .into_par_iter()
-            .map(|i| {
-                let eq_evals = eq_r_prime.sumcheck_evals(i, 5, BindingOrder::HighToLow);
-                let ra_0_evals = ra[0].sumcheck_evals(i, 5, BindingOrder::HighToLow);
-                let ra_1_evals = ra[1].sumcheck_evals(i, 5, BindingOrder::HighToLow);
-                let ra_2_evals = ra[2].sumcheck_evals(i, 5, BindingOrder::HighToLow);
-                let ra_3_evals = ra[3].sumcheck_evals(i, 5, BindingOrder::HighToLow);
-
-                [
-                    eq_evals[0] * ra_0_evals[0] * ra_1_evals[0] * ra_2_evals[0] * ra_3_evals[0],
-                    eq_evals[1] * ra_0_evals[1] * ra_1_evals[1] * ra_2_evals[1] * ra_3_evals[1],
-                    eq_evals[2] * ra_0_evals[2] * ra_1_evals[2] * ra_2_evals[2] * ra_3_evals[2],
-                    eq_evals[3] * ra_0_evals[3] * ra_1_evals[3] * ra_2_evals[3] * ra_3_evals[3],
-                    eq_evals[4] * ra_0_evals[4] * ra_1_evals[4] * ra_2_evals[4] * ra_3_evals[4],
-                ]
-            })
-            .reduce(
-                || [F::zero(); 5],
-                |running, new| {
-                    [
-                        running[0] + new[0],
-                        running[1] + new[1],
-                        running[2] + new[2],
-                        running[3] + new[3],
-                        running[4] + new[4],
-                    ]
-                },
-            );
-        univariate_poly_evals
-            .iter_mut()
-            .for_each(|eval| *eval *= val_eval);
-
-        let univariate_poly = UniPoly::from_evals(&[
-            univariate_poly_evals[0],
-            previous_claim - univariate_poly_evals[0],
-            univariate_poly_evals[1],
-            univariate_poly_evals[2],
-            univariate_poly_evals[3],
-            univariate_poly_evals[4],
-        ]);
-
-        drop(_guard);
-        drop(span);
-
-        let compressed_poly = univariate_poly.compress();
-        compressed_poly.append_to_transcript(transcript);
-        compressed_polys.push(compressed_poly);
-
-        let r_j = transcript.challenge_scalar::<F>();
-        r.push(r_j);
-
-        previous_claim = univariate_poly.evaluate(&r_j);
-
-        let span = tracing::span!(tracing::Level::INFO, "Binding");
-        let _guard = span.enter();
-
-        ra.par_iter_mut()
-            .chain([&mut eq_r_prime].into_par_iter())
-            .for_each(|poly| poly.bind_parallel(r_j, BindingOrder::HighToLow));
-    }
-
-    (
-        SumcheckInstanceProof::new(compressed_polys),
-        rv_claim,
-        [
-            ra[0].final_sumcheck_claim(),
-            ra[1].final_sumcheck_claim(),
-            ra[2].final_sumcheck_claim(),
-            ra[3].final_sumcheck_claim(),
-        ],
-    )
-}
-
-pub fn verify_single_instruction<
-    F: JoltField,
-    I: JoltInstruction + Default,
-    ProofTranscript: Transcript,
->(
-    proof: SumcheckInstanceProof<F, ProofTranscript>,
-    log_K: usize,
-    log_T: usize,
-    r_cycle: Vec<F>,
-    rv_claim: F,
-    ra_claims: [F; 4],
-    transcript: &mut ProofTranscript,
-) -> Result<(), ProofVerifyError> {
-    let first_log_K_rounds = SumcheckInstanceProof::new(proof.compressed_polys[..log_K].to_vec());
-    let last_log_T_rounds = SumcheckInstanceProof::new(proof.compressed_polys[log_K..].to_vec());
-    // The first log(K) rounds' univariate polynomials are degree 2
-    let (sumcheck_claim, r_address) = first_log_K_rounds.verify(rv_claim, log_K, 2, transcript)?;
-    // The last log(T) rounds' univariate polynomials are degree 5
-    let (sumcheck_claim, r_cycle_prime) =
-        last_log_T_rounds.verify(sumcheck_claim, log_T, 5, transcript)?;
-
-    let val_eval = I::default().evaluate_mle(&r_address);
-    let eq_eval_cycle = EqPolynomial::new(r_cycle).evaluate(&r_cycle_prime);
-
-    assert_eq!(
-        eq_eval_cycle * ra_claims.iter().product::<F>() * val_eval,
-        sumcheck_claim,
-        "Read-checking sumcheck failed"
-    );
-
-    Ok(())
-}
-
+/// Compute the sumcheck prover message in round `j` using the prefix-suffix
+/// decomposition. In the first log(K) rounds of sumcheck, while we're
+/// binding the "address" variables (and the "cycle" variables remain unbound),
+/// the univariate polynomial computed each round is degree 2.
+///
+/// To see this, observe that:
+///   eq(r', j) * ra_1(k_1, j) * ra_2(k_2, j) * ra_3(k_3, j) * ra_4(k_4, j)
+/// is multilinear in k, since ra_1, ra_2, ra_3, and ra_4 are polynomials in
+/// non-overlapping variables of k (and the eq term doesn't involve k at all).
+/// Val(k) is clearly multilinear in k, so the whole summand
+///   eq(r', j) (\prod_i ra_i(k_i, j)) * \sum_l flag_l * Val_l(k)
+/// is degree 2 in each "address" variable k.
 #[tracing::instrument(skip_all)]
 fn compute_sumcheck_prover_message<const WORD_SIZE: usize, F: JoltField>(
     prefix_checkpoints: &[PrefixCheckpoint<F>],
@@ -831,7 +281,7 @@ fn compute_sumcheck_prover_message<const WORD_SIZE: usize, F: JoltField>(
     [eval_0, eval_2_right + eval_2_right - eval_2_left]
 }
 
-pub fn prove_multiple_instructions<
+pub fn prove_sparse_dense_shout<
     const WORD_SIZE: usize,
     F: JoltField,
     ProofTranscript: Transcript,
@@ -1030,28 +480,6 @@ pub fn prove_multiple_instructions<
 
     let mut eq_r_prime = MultilinearPolynomial::from(eq_r_prime);
 
-    let span = tracing::span!(tracing::Level::INFO, "compute instruction flags");
-    let _guard = span.enter();
-
-    let mut instruction_flags: Vec<Vec<u8>> = vec![vec![0; T]; LookupTables::<WORD_SIZE>::COUNT];
-    instruction_flags
-        .par_iter_mut()
-        .enumerate()
-        .for_each(|(instruction_index, poly)| {
-            for (j, table) in lookups.iter().enumerate() {
-                if instruction_index == LookupTables::enum_index(table) {
-                    poly[j] = 1;
-                }
-            }
-        });
-    let mut instruction_flags_polys: Vec<MultilinearPolynomial<F>> = instruction_flags
-        .into_iter()
-        .map(MultilinearPolynomial::from)
-        .collect();
-
-    drop(_guard);
-    drop(span);
-
     let span = tracing::span!(
         tracing::Level::INFO,
         "compute combined_instruction_val_poly"
@@ -1148,16 +576,33 @@ pub fn prove_multiple_instructions<
         let _guard = span.enter();
 
         ra.par_iter_mut()
-            .chain(instruction_flags_polys.par_iter_mut())
             .chain([&mut combined_instruction_val_poly].into_par_iter())
             .chain([&mut eq_r_prime].into_par_iter())
             .for_each(|poly| poly.bind_parallel(r_j, BindingOrder::HighToLow));
     }
 
-    let flag_claims = instruction_flags_polys
-        .iter()
-        .map(|poly| poly.final_sumcheck_claim())
+    let span = tracing::span!(tracing::Level::INFO, "compute flag claims");
+    let _guard = span.enter();
+
+    let r_cycle_prime = &r[r.len() - log_T..];
+    let eq_r_cycle_prime = EqPolynomial::evals(r_cycle_prime);
+
+    // Evaluate each flag polynomial on `r_cycle_prime` by computing its
+    // dot product with EQ(r_cycle_prime, j)
+    let flag_claims: Vec<_> = (0..LookupTables::<WORD_SIZE>::COUNT)
+        .into_par_iter()
+        .map(|table_index| {
+            lookups
+                .iter()
+                .enumerate()
+                .filter(|(_, lookup)| LookupTables::enum_index(lookup) == table_index)
+                .map(|(j, _)| eq_r_cycle_prime[j])
+                .sum::<F>()
+        })
         .collect();
+    drop(_guard);
+    drop(span);
+
     let ra_claims = [
         ra[0].final_sumcheck_claim(),
         ra[1].final_sumcheck_claim(),
@@ -1165,12 +610,7 @@ pub fn prove_multiple_instructions<
         ra[3].final_sumcheck_claim(),
     ];
 
-    drop_in_background_thread((
-        instruction_flags_polys,
-        combined_instruction_val_poly,
-        eq_r_prime,
-        ra,
-    ));
+    drop_in_background_thread((combined_instruction_val_poly, eq_r_prime, ra));
 
     (
         SumcheckInstanceProof::new(compressed_polys),
@@ -1180,7 +620,7 @@ pub fn prove_multiple_instructions<
     )
 }
 
-pub fn verify_multiple_instructions<
+pub fn verify_sparse_dense_shout<
     const WORD_SIZE: usize,
     F: JoltField,
     ProofTranscript: Transcript,
@@ -1250,15 +690,17 @@ mod tests {
     const LOG_T: usize = 8;
     const T: usize = 1 << LOG_T;
 
-    fn test_single_instruction<I: PrefixSuffixDecomposition<WORD_SIZE>>() {
+    fn test_sparse_dense_shout(instruction: Option<LookupTables<WORD_SIZE>>) {
         let mut rng = StdRng::seed_from_u64(12345);
 
-        let instructions: Vec<_> = (0..T).map(|_| I::default().random(&mut rng)).collect();
+        let instructions: Vec<_> = (0..T)
+            .map(|_| LookupTables::random(&mut rng, instruction))
+            .collect();
 
         let mut prover_transcript = KeccakTranscript::new(b"test_transcript");
         let r_cycle: Vec<Fr> = prover_transcript.challenge_vector(LOG_T);
 
-        let (proof, rv_claim, ra_claims) = prove_single_instruction::<WORD_SIZE, _, _, _>(
+        let (proof, rv_claim, ra_claims, flag_claims) = prove_sparse_dense_shout::<WORD_SIZE, _, _>(
             &instructions,
             r_cycle,
             &mut prover_transcript,
@@ -1267,43 +709,7 @@ mod tests {
         let mut verifier_transcript = KeccakTranscript::new(b"test_transcript");
         verifier_transcript.compare_to(prover_transcript);
         let r_cycle: Vec<Fr> = verifier_transcript.challenge_vector(LOG_T);
-        let verification_result = verify_single_instruction::<_, I, _>(
-            proof,
-            LOG_K,
-            LOG_T,
-            r_cycle,
-            rv_claim,
-            ra_claims,
-            &mut verifier_transcript,
-        );
-        assert!(
-            verification_result.is_ok(),
-            "Verification failed with error: {:?}",
-            verification_result.err()
-        );
-    }
-
-    fn test_multiple_instructions(instruction: LookupTables<WORD_SIZE>) {
-        let mut rng = StdRng::seed_from_u64(12345);
-
-        let instructions: Vec<_> = (0..T)
-            .map(|_| LookupTables::random(&mut rng, Some(instruction)))
-            .collect();
-
-        let mut prover_transcript = KeccakTranscript::new(b"test_transcript");
-        let r_cycle: Vec<Fr> = prover_transcript.challenge_vector(LOG_T);
-
-        let (proof, rv_claim, ra_claims, flag_claims) =
-            prove_multiple_instructions::<WORD_SIZE, _, _>(
-                &instructions,
-                r_cycle,
-                &mut prover_transcript,
-            );
-
-        let mut verifier_transcript = KeccakTranscript::new(b"test_transcript");
-        verifier_transcript.compare_to(prover_transcript);
-        let r_cycle: Vec<Fr> = verifier_transcript.challenge_vector(LOG_T);
-        let verification_result = verify_multiple_instructions::<WORD_SIZE, _, _>(
+        let verification_result = verify_sparse_dense_shout::<WORD_SIZE, _, _>(
             proof,
             LOG_K,
             LOG_T,
@@ -1321,252 +727,139 @@ mod tests {
     }
 
     #[test]
+    fn test_random_instructions() {
+        test_sparse_dense_shout(None);
+    }
+
+    #[test]
     fn test_add() {
-        test_single_instruction::<ADDInstruction<WORD_SIZE>>();
+        test_sparse_dense_shout(Some(LookupTables::Add(ADDInstruction::default())));
     }
 
     #[test]
     fn test_sub() {
-        test_single_instruction::<SUBInstruction<WORD_SIZE>>();
+        test_sparse_dense_shout(Some(LookupTables::Sub(SUBInstruction::default())));
     }
 
     #[test]
     fn test_and() {
-        test_single_instruction::<ANDInstruction<WORD_SIZE>>();
+        test_sparse_dense_shout(Some(LookupTables::And(ANDInstruction::default())));
     }
 
     #[test]
     fn test_or() {
-        test_single_instruction::<ORInstruction<WORD_SIZE>>();
+        test_sparse_dense_shout(Some(LookupTables::Or(ORInstruction::default())));
     }
 
     #[test]
     fn test_xor() {
-        test_single_instruction::<XORInstruction<WORD_SIZE>>();
+        test_sparse_dense_shout(Some(LookupTables::Xor(XORInstruction::default())));
     }
 
     #[test]
     fn test_beq() {
-        test_single_instruction::<BEQInstruction<WORD_SIZE>>();
+        test_sparse_dense_shout(Some(LookupTables::Beq(BEQInstruction::default())));
     }
 
     #[test]
     fn test_bge() {
-        test_single_instruction::<BGEInstruction<WORD_SIZE>>();
+        test_sparse_dense_shout(Some(LookupTables::Bge(BGEInstruction::default())));
     }
 
     #[test]
     fn test_bgeu() {
-        test_single_instruction::<BGEUInstruction<WORD_SIZE>>();
+        test_sparse_dense_shout(Some(LookupTables::Bgeu(BGEUInstruction::default())));
     }
 
     #[test]
     fn test_bne() {
-        test_single_instruction::<BNEInstruction<WORD_SIZE>>();
+        test_sparse_dense_shout(Some(LookupTables::Bne(BNEInstruction::default())));
     }
 
     #[test]
     fn test_slt() {
-        test_single_instruction::<SLTInstruction<WORD_SIZE>>();
+        test_sparse_dense_shout(Some(LookupTables::Slt(SLTInstruction::default())));
     }
 
     #[test]
     fn test_sltu() {
-        test_single_instruction::<SLTUInstruction<WORD_SIZE>>();
+        test_sparse_dense_shout(Some(LookupTables::Sltu(SLTUInstruction::default())));
     }
 
     #[test]
     fn test_move() {
-        test_single_instruction::<MOVEInstruction<WORD_SIZE>>();
+        test_sparse_dense_shout(Some(LookupTables::Move(MOVEInstruction::default())));
     }
 
     #[test]
     fn test_movsign() {
-        test_single_instruction::<MOVSIGNInstruction<WORD_SIZE>>();
+        test_sparse_dense_shout(Some(LookupTables::Movsign(MOVSIGNInstruction::default())));
     }
 
     #[test]
     fn test_mul() {
-        test_single_instruction::<MULInstruction<WORD_SIZE>>();
+        test_sparse_dense_shout(Some(LookupTables::Mul(MULInstruction::default())));
     }
 
     #[test]
     fn test_mulu() {
-        test_single_instruction::<MULUInstruction<WORD_SIZE>>();
+        test_sparse_dense_shout(Some(LookupTables::Mulu(MULUInstruction::default())));
     }
 
     #[test]
     fn test_mulhu() {
-        test_single_instruction::<MULHUInstruction<WORD_SIZE>>();
+        test_sparse_dense_shout(Some(LookupTables::Mulhu(MULHUInstruction::default())));
     }
 
     #[test]
     fn test_advice() {
-        test_single_instruction::<ADVICEInstruction<WORD_SIZE>>();
+        test_sparse_dense_shout(Some(LookupTables::Advice(ADVICEInstruction::default())));
     }
 
     #[test]
     fn test_assert_lte() {
-        test_single_instruction::<ASSERTLTEInstruction<WORD_SIZE>>();
+        test_sparse_dense_shout(Some(LookupTables::AssertLte(
+            ASSERTLTEInstruction::default(),
+        )));
     }
 
     #[test]
     fn test_assert_valid_signed_remainder() {
-        test_single_instruction::<AssertValidSignedRemainderInstruction<WORD_SIZE>>();
+        test_sparse_dense_shout(Some(LookupTables::AssertValidSignedRemainder(
+            AssertValidSignedRemainderInstruction::default(),
+        )));
     }
 
     #[test]
     fn test_assert_valid_unsigned_remainder() {
-        test_single_instruction::<AssertValidUnsignedRemainderInstruction<WORD_SIZE>>();
+        test_sparse_dense_shout(Some(LookupTables::AssertValidUnsignedRemainder(
+            AssertValidUnsignedRemainderInstruction::default(),
+        )));
     }
 
     #[test]
     fn test_assert_valid_div0() {
-        test_single_instruction::<AssertValidDiv0Instruction<WORD_SIZE>>();
+        test_sparse_dense_shout(Some(LookupTables::AssertValidDiv0(
+            AssertValidDiv0Instruction::default(),
+        )));
     }
 
     #[test]
     fn test_assert_halfword_alignment() {
-        test_single_instruction::<AssertHalfwordAlignmentInstruction<WORD_SIZE>>();
+        test_sparse_dense_shout(Some(LookupTables::AssertHalfwordAlignment(
+            AssertHalfwordAlignmentInstruction::default(),
+        )));
     }
 
     #[test]
     fn test_pow2() {
-        test_single_instruction::<POW2Instruction<WORD_SIZE>>();
+        test_sparse_dense_shout(Some(LookupTables::Pow2(POW2Instruction::default())));
     }
 
     #[test]
     fn test_right_shift_padding() {
-        test_single_instruction::<RightShiftPaddingInstruction<WORD_SIZE>>();
-    }
-
-    #[test]
-    fn test_multiple_add() {
-        test_multiple_instructions(LookupTables::Add(ADDInstruction::default()));
-    }
-
-    #[test]
-    fn test_multiple_sub() {
-        test_multiple_instructions(LookupTables::Sub(SUBInstruction::default()));
-    }
-
-    #[test]
-    fn test_multiple_and() {
-        test_multiple_instructions(LookupTables::And(ANDInstruction::default()));
-    }
-
-    #[test]
-    fn test_multiple_or() {
-        test_multiple_instructions(LookupTables::Or(ORInstruction::default()));
-    }
-
-    #[test]
-    fn test_multiple_xor() {
-        test_multiple_instructions(LookupTables::Xor(XORInstruction::default()));
-    }
-
-    #[test]
-    fn test_multiple_beq() {
-        test_multiple_instructions(LookupTables::Beq(BEQInstruction::default()));
-    }
-
-    #[test]
-    fn test_multiple_bge() {
-        test_multiple_instructions(LookupTables::Bge(BGEInstruction::default()));
-    }
-
-    #[test]
-    fn test_multiple_bgeu() {
-        test_multiple_instructions(LookupTables::Bgeu(BGEUInstruction::default()));
-    }
-
-    #[test]
-    fn test_multiple_bne() {
-        test_multiple_instructions(LookupTables::Bne(BNEInstruction::default()));
-    }
-
-    #[test]
-    fn test_multiple_slt() {
-        test_multiple_instructions(LookupTables::Slt(SLTInstruction::default()));
-    }
-
-    #[test]
-    fn test_multiple_sltu() {
-        test_multiple_instructions(LookupTables::Sltu(SLTUInstruction::default()));
-    }
-
-    #[test]
-    fn test_multiple_move() {
-        test_multiple_instructions(LookupTables::Move(MOVEInstruction::default()));
-    }
-
-    #[test]
-    fn test_multiple_movsign() {
-        test_multiple_instructions(LookupTables::Movsign(MOVSIGNInstruction::default()));
-    }
-
-    #[test]
-    fn test_multiple_mul() {
-        test_multiple_instructions(LookupTables::Mul(MULInstruction::default()));
-    }
-
-    #[test]
-    fn test_multiple_mulu() {
-        test_multiple_instructions(LookupTables::Mulu(MULUInstruction::default()));
-    }
-
-    #[test]
-    fn test_multiple_mulhu() {
-        test_multiple_instructions(LookupTables::Mulhu(MULHUInstruction::default()));
-    }
-
-    #[test]
-    fn test_multiple_advice() {
-        test_multiple_instructions(LookupTables::Advice(ADVICEInstruction::default()));
-    }
-
-    #[test]
-    fn test_multiple_assert_lte() {
-        test_multiple_instructions(LookupTables::AssertLte(ASSERTLTEInstruction::default()));
-    }
-
-    #[test]
-    fn test_multiple_assert_valid_signed_remainder() {
-        test_multiple_instructions(LookupTables::AssertValidSignedRemainder(
-            AssertValidSignedRemainderInstruction::default(),
-        ));
-    }
-
-    #[test]
-    fn test_multiple_assert_valid_unsigned_remainder() {
-        test_multiple_instructions(LookupTables::AssertValidUnsignedRemainder(
-            AssertValidUnsignedRemainderInstruction::default(),
-        ));
-    }
-
-    #[test]
-    fn test_multiple_assert_valid_div0() {
-        test_multiple_instructions(LookupTables::AssertValidDiv0(
-            AssertValidDiv0Instruction::default(),
-        ));
-    }
-
-    #[test]
-    fn test_multiple_assert_halfword_alignment() {
-        test_multiple_instructions(LookupTables::AssertHalfwordAlignment(
-            AssertHalfwordAlignmentInstruction::default(),
-        ));
-    }
-
-    #[test]
-    fn test_multiple_pow2() {
-        test_multiple_instructions(LookupTables::Pow2(POW2Instruction::default()));
-    }
-
-    #[test]
-    fn test_multiple_right_shift_padding() {
-        test_multiple_instructions(LookupTables::RightShiftPadding(
+        test_sparse_dense_shout(Some(LookupTables::RightShiftPadding(
             RightShiftPaddingInstruction::default(),
-        ));
+        )));
     }
 }


### PR DESCRIPTION
Follow-up to https://github.com/a16z/jolt/pull/625
Enables "multiplexing" between lookup tables in sparse-dense shout, i.e. the vector of lookups can access different tables, instead of all accessing the same lookup table as in #625 

Also fixes a bug in the prefix-suffix decomposition for AssertValidSIgnedRemainder