### PR TITLE
fix prover input in fibonacci

### DIFF
--- a/examples/fibonacci/src/main.rs
+++ b/examples/fibonacci/src/main.rs
@@ -18,7 +18,7 @@ pub fn main() {
     let now = Instant::now();
     let (output, proof) = prove_fib(50);
     println!("Prover runtime: {} s", now.elapsed().as_secs_f64());
-    let is_valid = verify_fib(10, output, proof);
+    let is_valid = verify_fib(50, output, proof);
 
     println!("output: {}", output);
     println!("valid: {}", is_valid);


### PR DESCRIPTION
I copied the input from the `analyze_fib` function instead of from `prove_fib`, so [the action that runs the examples failed](https://github.com/a16z/jolt/actions/runs/14324219897/job/40146699700). This should fix it!