### PR TITLE
Fix clippy errors

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -23,10 +23,7 @@ jobs:
         with:
           components: rustfmt
       - name: cargo fmt
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all --check
+        run: cargo fmt --all --check
 
   clippy:
     runs-on: ubuntu-latest
@@ -36,10 +33,7 @@ jobs:
         with:
           components: clippy
       - name: cargo clippy
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --all
+        run: cargo clippy --all
 
   machete:
     runs-on: ubuntu-latest
@@ -90,7 +84,7 @@ jobs:
           version: nightly
 
       - name: Build the rust integration testing scripts
-        working-directory: ./jolt-evm-verifier          
+        working-directory: ./jolt-evm-verifier
         run: cargo build --manifest-path script/Cargo.toml --release
 
       - name: Check build and denny warnings

--- a/book/src/usage/hosts.md
+++ b/book/src/usage/hosts.md
@@ -14,13 +14,13 @@ pub fn main() {
     let (output, proof) = prove_sha2(input);
     let is_valid = verify_sha2(proof);
 
-    println!("sha2 output: {}", output);
-    println!("sha2 valid: {}", is_valid);
+    println!("sha2 output: {output}");
+    println!("sha2 valid: {is_valid}");
 
     let (output, proof) = prove_sha3(input);
     let is_valid = verify_sha3(proof);
 
-    println!("sha3 output: {}", output);
-    println!("sha3 valid: {}", is_valid);
+    println!("sha3 output: {output}");
+    println!("sha3 valid: {is_valid}");
 }
 ```

--- a/book/src/usage/quickstart.md
+++ b/book/src/usage/quickstart.md
@@ -50,8 +50,8 @@ pub fn main() {
     let (output, proof) = prove_fib(50);
     let is_valid = verify_fib(proof);
 
-    println!("output: {}", output);
-    println!("valid: {}", is_valid);
+    println!("output: {output}");
+    println!("valid: {is_valid}");
 }
 ```
 

--- a/examples/alloc/src/main.rs
+++ b/examples/alloc/src/main.rs
@@ -16,6 +16,6 @@ pub fn main() {
     println!("Prover runtime: {} s", now.elapsed().as_secs_f64());
     let is_valid = verify_alloc(input, output, proof);
 
-    println!("output: {:?}", output);
-    println!("valid: {}", is_valid);
+    println!("output: {output:?}");
+    println!("valid: {is_valid}");
 }

--- a/examples/collatz/src/main.rs
+++ b/examples/collatz/src/main.rs
@@ -18,8 +18,8 @@ pub fn main() {
     println!("Prover runtime: {} s", now.elapsed().as_secs_f64());
     let is_valid = verify_collatz_single(input, output, proof);
 
-    println!("output: {}", output);
-    println!("valid: {}", is_valid);
+    println!("output: {output}");
+    println!("valid: {is_valid}");
 
     // Prove/verify convergence for a range of numbers:
     let program = guest::compile_collatz_convergence_range(target_dir);
@@ -39,6 +39,6 @@ pub fn main() {
     println!("Prover runtime: {} s", now.elapsed().as_secs_f64());
     let is_valid = verify_collatz_convergence(start, start + 100, output, proof);
 
-    println!("output: {}", output);
-    println!("valid: {}", is_valid);
+    println!("output: {output}");
+    println!("valid: {is_valid}");
 }

--- a/examples/fibonacci/src/main.rs
+++ b/examples/fibonacci/src/main.rs
@@ -20,6 +20,6 @@ pub fn main() {
     println!("Prover runtime: {} s", now.elapsed().as_secs_f64());
     let is_valid = verify_fib(50, output, proof);
 
-    println!("output: {}", output);
-    println!("valid: {}", is_valid);
+    println!("output: {output}");
+    println!("valid: {is_valid}");
 }

--- a/examples/memory-ops/src/main.rs
+++ b/examples/memory-ops/src/main.rs
@@ -19,5 +19,5 @@ pub fn main() {
         "outputs: {} {} {} {}",
         output.0, output.1, output.2, output.3
     );
-    println!("valid: {}", is_valid);
+    println!("valid: {is_valid}");
 }

--- a/examples/muldiv/src/main.rs
+++ b/examples/muldiv/src/main.rs
@@ -15,6 +15,6 @@ pub fn main() {
     println!("Prover runtime: {} s", now.elapsed().as_secs_f64());
     let is_valid = verify(12031293, 17, 92, output, proof);
 
-    println!("output: {}", output);
-    println!("valid: {}", is_valid);
+    println!("output: {output}");
+    println!("valid: {is_valid}");
 }

--- a/examples/multi-function/src/main.rs
+++ b/examples/multi-function/src/main.rs
@@ -26,12 +26,12 @@ pub fn main() {
     println!("Prover runtime: {} s", now.elapsed().as_secs_f64());
     let is_valid = verify_add(5, 10, output, proof);
 
-    println!("add output: {}", output);
-    println!("add valid: {}", is_valid);
+    println!("add output: {output}");
+    println!("add valid: {is_valid}");
 
     let (output, proof) = prove_mul(5, 10);
     let is_valid = verify_mul(5, 10, output, proof);
 
-    println!("mul output: {}", output);
-    println!("mul valid: {}", is_valid);
+    println!("mul output: {output}");
+    println!("mul valid: {is_valid}");
 }

--- a/examples/overflow/src/main.rs
+++ b/examples/overflow/src/main.rs
@@ -45,14 +45,14 @@ pub fn main() {
     println!("Prover runtime: {} s", now.elapsed().as_secs_f64());
     let is_valid = verify_allocate_stack_with_increased_size(output, proof);
 
-    println!("output: {}", output);
-    println!("valid: {}", is_valid);
+    println!("output: {output}");
+    println!("valid: {is_valid}");
 }
 
 fn handle_result(res: Result<(), Box<dyn Any + Send>>) {
     if let Err(e) = &res {
         if let Some(msg) = e.downcast_ref::<String>() {
-            println!("--> Panic occurred with message: {}\n", msg);
+            println!("--> Panic occurred with message: {msg}\n");
         }
     }
 }

--- a/examples/sha2-chain/src/main.rs
+++ b/examples/sha2-chain/src/main.rs
@@ -21,5 +21,5 @@ pub fn main() {
     assert_eq!(output, native_output, "output mismatch");
     println!("output: {}", hex::encode(output));
     println!("native_output: {}", hex::encode(native_output));
-    println!("valid: {}", is_valid);
+    println!("valid: {is_valid}");
 }

--- a/examples/sha2-ex/src/main.rs
+++ b/examples/sha2-ex/src/main.rs
@@ -17,5 +17,5 @@ pub fn main() {
     let is_valid = verify_sha2(input, output, proof);
 
     println!("output: {}", hex::encode(output));
-    println!("valid: {}", is_valid);
+    println!("valid: {is_valid}");
 }

--- a/examples/sha3-chain/src/main.rs
+++ b/examples/sha3-chain/src/main.rs
@@ -18,5 +18,5 @@ pub fn main() {
     let is_valid = verify_sha3_chain(input, iters, output, proof);
 
     println!("output: {}", hex::encode(output));
-    println!("valid: {}", is_valid);
+    println!("valid: {is_valid}");
 }

--- a/examples/sha3-ex/src/main.rs
+++ b/examples/sha3-ex/src/main.rs
@@ -17,5 +17,5 @@ pub fn main() {
     let is_valid = verify_sha3(input, output, proof);
 
     println!("output: {}", hex::encode(output));
-    println!("valid: {}", is_valid);
+    println!("valid: {is_valid}");
 }

--- a/examples/stdlib/src/main.rs
+++ b/examples/stdlib/src/main.rs
@@ -11,10 +11,10 @@ pub fn main() {
     let verify = guest::build_verifier_int_to_string(verifier_preprocessing);
 
     let (output, proof) = prove(81);
-    println!("int to string output: {:?}", output);
+    println!("int to string output: {output:?}");
 
     let is_valid = verify(81, output, proof);
-    println!("int to string valid: {}", is_valid);
+    println!("int to string valid: {is_valid}");
 
     let program = guest::compile_string_concat(target_dir);
 
@@ -27,8 +27,8 @@ pub fn main() {
     let now = Instant::now();
     let (output, proof) = prove(20);
     println!("Prover runtime: {} s", now.elapsed().as_secs_f64());
-    println!("string concat output: {:?}", output);
+    println!("string concat output: {output:?}");
 
     let is_valid = verify(20, output, proof);
-    println!("string concat valid: {}", is_valid);
+    println!("string concat valid: {is_valid}");
 }

--- a/jolt-core/benches/binding.rs
+++ b/jolt-core/benches/binding.rs
@@ -35,7 +35,7 @@ fn random_sparse_coeffs<F: JoltField>(
 
 fn benchmark_dense<F: JoltField>(c: &mut Criterion, num_vars: usize) {
     c.bench_function(
-        &format!("DensePolynomial::bind {} variables", num_vars),
+        &format!("DensePolynomial::bind {num_vars} variables"),
         |b| {
             b.iter_with_setup(
                 || {
@@ -60,10 +60,7 @@ fn benchmark_dense<F: JoltField>(c: &mut Criterion, num_vars: usize) {
 
 fn benchmark_dense_batch<F: JoltField>(c: &mut Criterion, num_vars: usize, batch_size: usize) {
     c.bench_function(
-        &format!(
-            "DensePolynomial::bind {} x {} variables",
-            batch_size, num_vars
-        ),
+        &format!("DensePolynomial::bind {batch_size} x {num_vars} variables"),
         |b| {
             b.iter_with_setup(
                 || {
@@ -92,7 +89,7 @@ fn benchmark_dense_batch<F: JoltField>(c: &mut Criterion, num_vars: usize, batch
 
 fn benchmark_dense_interleaved<F: JoltField>(c: &mut Criterion, num_vars: usize) {
     c.bench_function(
-        &format!("DenseInterleavedPolynomial::bind {} variables", num_vars),
+        &format!("DenseInterleavedPolynomial::bind {num_vars} variables"),
         |b| {
             b.iter_with_setup(
                 || {

--- a/jolt-core/benches/commit.rs
+++ b/jolt-core/benches/commit.rs
@@ -31,8 +31,7 @@ where
 {
     assert!(
         percentage_ones <= 100,
-        "Threshold must be between 0 and 100, but got {}",
-        percentage_ones
+        "Threshold must be between 0 and 100, but got {percentage_ones}"
     );
 
     let mut rng = ChaCha20Rng::seed_from_u64(111111u64);
@@ -79,7 +78,7 @@ fn benchmark_commit<PCS, F, ProofTranscript>(
         .into_iter()
         .map(MultilinearPolynomial::from)
         .collect::<Vec<_>>();
-    c.bench_function(&format!("{} Commit: {}% Ones", name, threshold), |b| {
+    c.bench_function(&format!("{name} Commit: {threshold}% Ones"), |b| {
         b.iter(|| {
             PCS::batch_commit(&leaves, &setup);
         });

--- a/jolt-core/benches/compute_cubic.rs
+++ b/jolt-core/benches/compute_cubic.rs
@@ -36,10 +36,7 @@ fn random_sparse_coeffs<F: JoltField>(
 
 fn benchmark_dense_interleaved<F: JoltField>(c: &mut Criterion, num_vars: usize) {
     c.bench_function(
-        &format!(
-            "DenseInterleavedPolynomial::compute_cubic {} variables",
-            num_vars
-        ),
+        &format!("DenseInterleavedPolynomial::compute_cubic {num_vars} variables"),
         |b| {
             b.iter_with_setup(
                 || {

--- a/jolt-core/benches/grand_product.rs
+++ b/jolt-core/benches/grand_product.rs
@@ -43,8 +43,7 @@ where
 {
     assert!(
         percent_ones <= 100,
-        "Threshold must be between 0 and 100, but got {}",
-        percent_ones
+        "Threshold must be between 0 and 100, but got {percent_ones}"
     );
 
     let mut rng = ChaCha20Rng::seed_from_u64(111111u64);

--- a/jolt-core/benches/msm.rs
+++ b/jolt-core/benches/msm.rs
@@ -70,7 +70,7 @@ where
     #[cfg(not(feature = "icicle"))]
     let gpu_bases = None;
 
-    println!("Using max num bits: {}", max_num_bits);
+    println!("Using max num bits: {max_num_bits}");
     (bases, gpu_bases, poly)
 }
 
@@ -85,7 +85,7 @@ where
     #[cfg(feature = "icicle")]
     let id = format!("{} [mode:Icicle]", name);
     #[cfg(not(feature = "icicle"))]
-    let id = format!("{} [mode:JOLT CPU]", name);
+    let id = format!("{name} [mode:JOLT CPU]");
     c.bench_function(&id, |b| {
         b.iter(|| {
             let msm =

--- a/jolt-core/benches/msm_adapter_batch.rs
+++ b/jolt-core/benches/msm_adapter_batch.rs
@@ -151,7 +151,7 @@ fn benchmark_msm_batch<PCS, F, ProofTranscript>(
     #[cfg(feature = "icicle")]
     let id = format!("{} [mode:Icicle]", name);
     #[cfg(not(feature = "icicle"))]
-    let id = format!("{} [mode:JOLT CPU]", name);
+    let id = format!("{name} [mode:JOLT CPU]");
     c.bench_function(&id, |b| {
         b.iter(|| {
             #[cfg(feature = "icicle")]

--- a/jolt-core/benches/msm_batch.rs
+++ b/jolt-core/benches/msm_batch.rs
@@ -127,7 +127,7 @@ fn benchmark_msm_batch<PCS, F, ProofTranscript>(
     #[cfg(feature = "icicle")]
     let id = format!("{} [mode:Icicle]", name);
     #[cfg(not(feature = "icicle"))]
-    let id = format!("{} [mode:JOLT CPU]", name);
+    let id = format!("{name} [mode:JOLT CPU]");
     c.bench_function(&id, |b| {
         b.iter(|| {
             let msm = <G1Projective as VariableBaseMSM>::batch_msm(

--- a/jolt-core/src/benches/bench.rs
+++ b/jolt-core/src/benches/bench.rs
@@ -277,7 +277,7 @@ fn serialize_and_print_size(name: &str, item: &impl ark_serialize::CanonicalSeri
     let file_size_bytes = file.metadata().unwrap().len();
     let file_size_kb = file_size_bytes as f64 / 1024.0;
     let file_size_mb = file_size_kb / 1024.0;
-    println!("{:<30} : {:.3} MB", name, file_size_mb);
+    println!("{name:<30} : {file_size_mb:.3} MB");
 }
 
 fn prove_example<T: Serialize, PCS, F, ProofTranscript>(

--- a/jolt-core/src/host/mod.rs
+++ b/jolt-core/src/host/mod.rs
@@ -167,7 +167,7 @@ impl Program {
     pub fn decode(&self) -> (Vec<ELFInstruction>, Vec<(u64, u8)>) {
         let elf = self.elf.as_ref().unwrap();
         let mut elf_file =
-            File::open(elf).unwrap_or_else(|_| panic!("could not open elf file: {:?}", elf));
+            File::open(elf).unwrap_or_else(|_| panic!("could not open elf file: {elf:?}"));
         let mut elf_contents = Vec::new();
         elf_file.read_to_end(&mut elf_contents).unwrap();
         tracer::decode(&elf_contents)

--- a/jolt-core/src/host/toolchain.rs
+++ b/jolt-core/src/host/toolchain.rs
@@ -160,8 +160,7 @@ fn remove_archive() -> Result<()> {
 fn toolchain_url() -> String {
     let target = target_lexicon::HOST;
     format!(
-        "https://github.com/a16z/rust/releases/download/{}/rust-toolchain-{}.tar.gz",
-        TOOLCHAIN_TAG, target,
+        "https://github.com/a16z/rust/releases/download/{TOOLCHAIN_TAG}/rust-toolchain-{target}.tar.gz",
     )
 }
 

--- a/jolt-core/src/jolt/instruction/div.rs
+++ b/jolt-core/src/jolt/instruction/div.rs
@@ -56,7 +56,7 @@ impl<const WORD_SIZE: usize> VirtualInstructionSequence for DIVInstruction<WORD_
                     (quotient as u64, remainder as u64)
                 }
             }
-            _ => panic!("Unsupported WORD_SIZE: {}", WORD_SIZE),
+            _ => panic!("Unsupported WORD_SIZE: {WORD_SIZE}"),
         };
 
         let q = ADVICEInstruction::<WORD_SIZE>(quotient).lookup_entry();

--- a/jolt-core/src/jolt/instruction/divu.rs
+++ b/jolt-core/src/jolt/instruction/divu.rs
@@ -35,7 +35,7 @@ impl<const WORD_SIZE: usize> VirtualInstructionSequence for DIVUInstruction<WORD
             match WORD_SIZE {
                 32 => u32::MAX as u64,
                 64 => u64::MAX,
-                _ => panic!("Unsupported WORD_SIZE: {}", WORD_SIZE),
+                _ => panic!("Unsupported WORD_SIZE: {WORD_SIZE}"),
             }
         } else {
             x / y
@@ -251,7 +251,7 @@ impl<const WORD_SIZE: usize> VirtualInstructionSequence for DIVUInstruction<WORD
             match WORD_SIZE {
                 32 => u32::MAX as u64,
                 64 => u64::MAX,
-                _ => panic!("Unsupported WORD_SIZE: {}", WORD_SIZE),
+                _ => panic!("Unsupported WORD_SIZE: {WORD_SIZE}"),
             }
         } else {
             x / y

--- a/jolt-core/src/jolt/instruction/lb.rs
+++ b/jolt-core/src/jolt/instruction/lb.rs
@@ -32,7 +32,7 @@ impl<const WORD_SIZE: usize> VirtualInstructionSequence for LBInstruction<WORD_S
         let offset_unsigned = match WORD_SIZE {
             32 => (offset & u32::MAX as i64) as u64,
             64 => offset as u64,
-            _ => panic!("Unsupported WORD_SIZE: {}", WORD_SIZE),
+            _ => panic!("Unsupported WORD_SIZE: {WORD_SIZE}"),
         };
 
         let ram_address = ADDInstruction::<WORD_SIZE>(rs1_val, offset_unsigned).lookup_entry();

--- a/jolt-core/src/jolt/instruction/lbu.rs
+++ b/jolt-core/src/jolt/instruction/lbu.rs
@@ -32,7 +32,7 @@ impl<const WORD_SIZE: usize> VirtualInstructionSequence for LBUInstruction<WORD_
         let offset_unsigned = match WORD_SIZE {
             32 => (offset & u32::MAX as i64) as u64,
             64 => offset as u64,
-            _ => panic!("Unsupported WORD_SIZE: {}", WORD_SIZE),
+            _ => panic!("Unsupported WORD_SIZE: {WORD_SIZE}"),
         };
 
         let ram_address = ADDInstruction::<WORD_SIZE>(rs1_val, offset_unsigned).lookup_entry();

--- a/jolt-core/src/jolt/instruction/lh.rs
+++ b/jolt-core/src/jolt/instruction/lh.rs
@@ -33,7 +33,7 @@ impl<const WORD_SIZE: usize> VirtualInstructionSequence for LHInstruction<WORD_S
         let offset_unsigned = match WORD_SIZE {
             32 => (offset & u32::MAX as i64) as u64,
             64 => offset as u64,
-            _ => panic!("Unsupported WORD_SIZE: {}", WORD_SIZE),
+            _ => panic!("Unsupported WORD_SIZE: {WORD_SIZE}"),
         };
 
         let is_aligned = AssertHalfwordAlignmentInstruction::<WORD_SIZE>(rs1_val, offset_unsigned)

--- a/jolt-core/src/jolt/instruction/lhu.rs
+++ b/jolt-core/src/jolt/instruction/lhu.rs
@@ -33,7 +33,7 @@ impl<const WORD_SIZE: usize> VirtualInstructionSequence for LHUInstruction<WORD_
         let offset_unsigned = match WORD_SIZE {
             32 => (offset & u32::MAX as i64) as u64,
             64 => offset as u64,
-            _ => panic!("Unsupported WORD_SIZE: {}", WORD_SIZE),
+            _ => panic!("Unsupported WORD_SIZE: {WORD_SIZE}"),
         };
 
         let is_aligned = AssertHalfwordAlignmentInstruction::<WORD_SIZE>(rs1_val, offset_unsigned)

--- a/jolt-core/src/jolt/instruction/mulh.rs
+++ b/jolt-core/src/jolt/instruction/mulh.rs
@@ -196,7 +196,7 @@ impl<const WORD_SIZE: usize> VirtualInstructionSequence for MULHInstruction<WORD
                 let result = ((x as i64 as i128) * (y as i64 as i128)) >> 64;
                 result as u64
             }
-            _ => panic!("Unsupported WORD_SIZE: {}", WORD_SIZE),
+            _ => panic!("Unsupported WORD_SIZE: {WORD_SIZE}"),
         }
     }
 }

--- a/jolt-core/src/jolt/instruction/mulhsu.rs
+++ b/jolt-core/src/jolt/instruction/mulhsu.rs
@@ -128,7 +128,7 @@ impl<const WORD_SIZE: usize> VirtualInstructionSequence for MULHSUInstruction<WO
                 let result = ((x as i64 as i128) * (y as i128)) >> 64;
                 result as u64
             }
-            _ => panic!("Unsupported WORD_SIZE: {}", WORD_SIZE),
+            _ => panic!("Unsupported WORD_SIZE: {WORD_SIZE}"),
         }
     }
 }

--- a/jolt-core/src/jolt/instruction/rem.rs
+++ b/jolt-core/src/jolt/instruction/rem.rs
@@ -57,7 +57,7 @@ impl<const WORD_SIZE: usize> VirtualInstructionSequence for REMInstruction<WORD_
                     (quotient as u64, remainder as u64)
                 }
             }
-            _ => panic!("Unsupported WORD_SIZE: {}", WORD_SIZE),
+            _ => panic!("Unsupported WORD_SIZE: {WORD_SIZE}"),
         };
 
         let q = ADVICEInstruction::<WORD_SIZE>(quotient).lookup_entry();
@@ -236,7 +236,7 @@ impl<const WORD_SIZE: usize> VirtualInstructionSequence for REMInstruction<WORD_
                 }
                 remainder as u64
             }
-            _ => panic!("Unsupported WORD_SIZE: {}", WORD_SIZE),
+            _ => panic!("Unsupported WORD_SIZE: {WORD_SIZE}"),
         }
     }
 }

--- a/jolt-core/src/jolt/instruction/remu.rs
+++ b/jolt-core/src/jolt/instruction/remu.rs
@@ -35,7 +35,7 @@ impl<const WORD_SIZE: usize> VirtualInstructionSequence for REMUInstruction<WORD
             match WORD_SIZE {
                 32 => u32::MAX as u64,
                 64 => u64::MAX,
-                _ => panic!("Unsupported WORD_SIZE: {}", WORD_SIZE),
+                _ => panic!("Unsupported WORD_SIZE: {WORD_SIZE}"),
             }
         } else {
             x / y
@@ -228,7 +228,7 @@ impl<const WORD_SIZE: usize> VirtualInstructionSequence for REMUInstruction<WORD
             match WORD_SIZE {
                 32 => (x as u32 % y as u32) as u64,
                 64 => x % y,
-                _ => panic!("Unsupported WORD_SIZE: {}", WORD_SIZE),
+                _ => panic!("Unsupported WORD_SIZE: {WORD_SIZE}"),
             }
         }
     }

--- a/jolt-core/src/jolt/instruction/sb.rs
+++ b/jolt-core/src/jolt/instruction/sb.rs
@@ -34,7 +34,7 @@ impl<const WORD_SIZE: usize> VirtualInstructionSequence for SBInstruction<WORD_S
         let offset_unsigned = match WORD_SIZE {
             32 => (offset & u32::MAX as i64) as u64,
             64 => offset as u64,
-            _ => panic!("Unsupported WORD_SIZE: {}", WORD_SIZE),
+            _ => panic!("Unsupported WORD_SIZE: {WORD_SIZE}"),
         };
 
         let ram_address = ADDInstruction::<WORD_SIZE>(dest, offset_unsigned).lookup_entry();

--- a/jolt-core/src/jolt/instruction/sh.rs
+++ b/jolt-core/src/jolt/instruction/sh.rs
@@ -35,7 +35,7 @@ impl<const WORD_SIZE: usize> VirtualInstructionSequence for SHInstruction<WORD_S
         let offset_unsigned = match WORD_SIZE {
             32 => (offset & u32::MAX as i64) as u64,
             64 => offset as u64,
-            _ => panic!("Unsupported WORD_SIZE: {}", WORD_SIZE),
+            _ => panic!("Unsupported WORD_SIZE: {WORD_SIZE}"),
         };
 
         let is_aligned =

--- a/jolt-core/src/jolt/instruction/virtual_assert_valid_div0.rs
+++ b/jolt-core/src/jolt/instruction/virtual_assert_valid_div0.rs
@@ -65,7 +65,7 @@ impl<const WORD_SIZE: usize> JoltInstruction for AssertValidDiv0Instruction<WORD
             match WORD_SIZE {
                 32 => (quotient == u32::MAX as u64).into(),
                 64 => (quotient == u64::MAX).into(),
-                _ => panic!("Unsupported WORD_SIZE: {}", WORD_SIZE),
+                _ => panic!("Unsupported WORD_SIZE: {WORD_SIZE}"),
             }
         } else {
             1

--- a/jolt-core/src/jolt/instruction/virtual_assert_valid_signed_remainder.rs
+++ b/jolt-core/src/jolt/instruction/virtual_assert_valid_signed_remainder.rs
@@ -121,7 +121,7 @@ impl<const WORD_SIZE: usize> JoltInstruction for AssertValidSignedRemainderInstr
                         .into()
                 }
             }
-            _ => panic!("Unsupported WORD_SIZE: {}", WORD_SIZE),
+            _ => panic!("Unsupported WORD_SIZE: {WORD_SIZE}"),
         }
     }
 

--- a/jolt-core/src/jolt/vm/mod.rs
+++ b/jolt-core/src/jolt/vm/mod.rs
@@ -468,7 +468,7 @@ where
         icicle::icicle_init();
         let trace_length = trace.len();
         let padded_trace_length = trace_length.next_power_of_two();
-        println!("Trace length: {}", trace_length);
+        println!("Trace length: {trace_length}");
 
         F::initialize_lookup_tables(std::mem::take(&mut preprocessing.field));
 

--- a/jolt-core/src/jolt/vm/read_write_memory.rs
+++ b/jolt-core/src/jolt/vm/read_write_memory.rs
@@ -96,7 +96,7 @@ fn remap_address(a: u64, memory_layout: &MemoryLayout) -> u64 {
         // need to be remapped
         a
     } else {
-        panic!("Unexpected address {}", a)
+        panic!("Unexpected address {a}")
     }
 }
 
@@ -352,7 +352,7 @@ impl<F: JoltField> ReadWriteMemoryPolynomials<F> {
                     t_final[a] = timestamp;
                 }
                 MemoryOp::Write(a, v) => {
-                    panic!("Unexpected rs1 MemoryOp::Write({}, {})", a, v);
+                    panic!("Unexpected rs1 MemoryOp::Write({a}, {v})");
                 }
             };
 
@@ -373,13 +373,13 @@ impl<F: JoltField> ReadWriteMemoryPolynomials<F> {
                     t_final[a] = timestamp;
                 }
                 MemoryOp::Write(a, v) => {
-                    panic!("Unexpected rs2 MemoryOp::Write({}, {})", a, v)
+                    panic!("Unexpected rs2 MemoryOp::Write({a}, {v})")
                 }
             };
 
             match step.memory_ops[RD] {
                 MemoryOp::Read(a) => {
-                    panic!("Unexpected rd MemoryOp::Read({})", a)
+                    panic!("Unexpected rd MemoryOp::Read({a})")
                 }
                 MemoryOp::Write(a, v_new) => {
                     assert!(a < REGISTER_COUNT);

--- a/jolt-core/src/lasso/memory_checking.rs
+++ b/jolt-core/src/lasso/memory_checking.rs
@@ -182,8 +182,7 @@ pub trait Initializable<T, Preprocessing>: StructuredPolynomialData<T> + Default
         {
             assert!(
                 std::ptr::eq(ptr, ptr_mut),
-                "Read-write pointer mismatch at index {}",
-                i
+                "Read-write pointer mismatch at index {i}"
             );
         }
 
@@ -201,8 +200,7 @@ pub trait Initializable<T, Preprocessing>: StructuredPolynomialData<T> + Default
         {
             assert!(
                 std::ptr::eq(ptr, ptr_mut),
-                "Init-final pointer mismatch at index {}",
-                i
+                "Init-final pointer mismatch at index {i}"
             );
         }
     }

--- a/jolt-core/src/poly/commitment/hyperkzg.rs
+++ b/jolt-core/src/poly/commitment/hyperkzg.rs
@@ -527,9 +527,7 @@ where
 
         assert!(
             size % CHUNK_SIZE == 0,
-            "CHUNK_SIZE ({}) must evenly divide the size ({})",
-            CHUNK_SIZE,
-            size,
+            "CHUNK_SIZE ({CHUNK_SIZE}) must evenly divide the size ({size})",
         );
 
         let current_chunk = Vec::with_capacity(CHUNK_SIZE);

--- a/jolt-core/src/poly/opening_proof.rs
+++ b/jolt-core/src/poly/opening_proof.rs
@@ -508,8 +508,7 @@ where
                 let prover_commitment = PCS::commit(poly, self.pcs_setup.as_ref().unwrap());
                 assert_eq!(
                     prover_commitment, **commitment,
-                    "commitment mismatch at index {}",
-                    i
+                    "commitment mismatch at index {i}"
                 );
             }
             let batched_poly = MultilinearPolynomial::linear_combination(

--- a/jolt-core/src/r1cs/inputs.rs
+++ b/jolt-core/src/r1cs/inputs.rs
@@ -263,7 +263,7 @@ pub trait ConstraintInput: Clone + Copy + Debug + PartialEq + Sync + Send + 'sta
     fn to_index<const C: usize>(&self) -> usize {
         match Self::flatten::<C>().iter().position(|x| x == self) {
             Some(index) => index,
-            None => panic!("Invalid variant {:?}", self),
+            None => panic!("Invalid variant {self:?}"),
         }
     }
 
@@ -451,7 +451,7 @@ mod tests {
         }) {
             let ref_ptr = aux.get_ref(&jolt_polys) as *const MultilinearPolynomial<Fr>;
             let ref_mut_ptr = aux.get_ref_mut(&mut jolt_polys) as *const MultilinearPolynomial<Fr>;
-            assert_eq!(ref_ptr, ref_mut_ptr, "Pointer mismatch for {:?}", aux);
+            assert_eq!(ref_ptr, ref_mut_ptr, "Pointer mismatch for {aux:?}");
         }
     }
 

--- a/jolt-core/src/subprotocols/grand_product_quarks.rs
+++ b/jolt-core/src/subprotocols/grand_product_quarks.rs
@@ -267,7 +267,7 @@ where
                         transcript,
                         v_len,
                     )
-                    .unwrap_or_else(|e| panic!("quark verify error: {:?}", e))
+                    .unwrap_or_else(|e| panic!("quark verify error: {e:?}"))
             }
             None => {
                 // Otherwise we must check the actual claims and the preset random will be empty.

--- a/jolt-core/src/subprotocols/sparse_grand_product.rs
+++ b/jolt-core/src/subprotocols/sparse_grand_product.rs
@@ -1360,8 +1360,7 @@ mod tests {
         {
             for config in &configs {
                 println!(
-                    "Running test with num_vars = {}, density = {}, batch_size = {}, config = {:?}",
-                    num_vars, density, batch_size, config
+                    "Running test with num_vars = {num_vars}, density = {density}, batch_size = {batch_size}, config = {config:?}"
                 );
                 run_sparse_prove_verify_test(num_vars, density, batch_size, *config);
             }

--- a/jolt-core/src/utils/profiling.rs
+++ b/jolt-core/src/utils/profiling.rs
@@ -36,13 +36,13 @@ pub fn report_memory_usage() {
 
     let memory_usage_map = MEMORY_USAGE_MAP.lock().unwrap();
     for label in memory_usage_map.keys() {
-        eprintln!("  Unclosed memory tracing span: \"{}\"", label);
+        eprintln!("  Unclosed memory tracing span: \"{label}\"");
     }
 
     let memory_delta_map = MEMORY_DELTA_MAP.lock().unwrap();
     for (label, delta) in memory_delta_map.iter() {
         if *delta >= 1.0 {
-            println!("  \"{}\": {:.2} GB", label, delta);
+            println!("  \"{label}\": {delta:.2} GB");
         } else {
             println!("  \"{}\": {:.2} MB", label, delta * 1000.0);
         }
@@ -56,7 +56,7 @@ pub fn print_current_memory_usage(label: &str) {
     if let Some(usage) = memory_stats() {
         let memory_usage_gb = usage.physical_mem as f64 / 1_000_000_000.0;
         if memory_usage_gb >= 1.0 {
-            println!("\"{}\" current memory usage: {} GB", label, memory_usage_gb);
+            println!("\"{label}\" current memory usage: {memory_usage_gb} GB");
         } else {
             println!(
                 "\"{}\" current memory usage: {} MB",
@@ -65,6 +65,6 @@ pub fn print_current_memory_usage(label: &str) {
             );
         }
     } else {
-        println!("Failed to get current memory usage (\"{}\")", label);
+        println!("Failed to get current memory usage (\"{label}\")");
     }
 }

--- a/jolt-sdk/macros/src/lib.rs
+++ b/jolt-sdk/macros/src/lib.rs
@@ -94,13 +94,13 @@ impl MacroBuilder {
 
     fn make_build_prover_fn(&self) -> TokenStream2 {
         let fn_name = self.get_func_name();
-        let build_prover_fn_name = Ident::new(&format!("build_prover_{}", fn_name), fn_name.span());
+        let build_prover_fn_name = Ident::new(&format!("build_prover_{fn_name}"), fn_name.span());
         let prove_output_ty = self.get_prove_output_type();
 
         let input_names = self.func_args.iter().map(|(name, _)| name);
         let input_types = self.func_args.iter().map(|(_, ty)| ty);
         let inputs = &self.func.sig.inputs;
-        let prove_fn_name = Ident::new(&format!("prove_{}", fn_name), fn_name.span());
+        let prove_fn_name = Ident::new(&format!("prove_{fn_name}"), fn_name.span());
         let imports = self.make_imports();
 
         quote! {
@@ -128,7 +128,7 @@ impl MacroBuilder {
     fn make_build_verifier_fn(&self) -> TokenStream2 {
         let fn_name = self.get_func_name();
         let build_verifier_fn_name =
-            Ident::new(&format!("build_verifier_{}", fn_name), fn_name.span());
+            Ident::new(&format!("build_verifier_{fn_name}"), fn_name.span());
 
         let input_types = self.func_args.iter().map(|(_, ty)| ty);
         let output_type: Type = match &self.func.sig.output {
@@ -192,7 +192,7 @@ impl MacroBuilder {
 
         let fn_name = self.get_func_name();
         let fn_name_str = fn_name.to_string();
-        let analyze_fn_name = Ident::new(&format!("analyze_{}", fn_name), fn_name.span());
+        let analyze_fn_name = Ident::new(&format!("analyze_{fn_name}"), fn_name.span());
         let inputs = &self.func.sig.inputs;
         let set_program_args = self.func_args.iter().map(|(name, _)| {
             quote! {
@@ -227,7 +227,7 @@ impl MacroBuilder {
 
         let fn_name = self.get_func_name();
         let fn_name_str = fn_name.to_string();
-        let compile_fn_name = Ident::new(&format!("compile_{}", fn_name), fn_name.span());
+        let compile_fn_name = Ident::new(&format!("compile_{fn_name}"), fn_name.span());
         quote! {
             #[cfg(all(not(target_arch = "wasm32"), not(feature = "guest")))]
             pub fn #compile_fn_name(target_dir: &str) -> jolt::host::Program {
@@ -252,7 +252,7 @@ impl MacroBuilder {
 
         let fn_name = self.get_func_name();
         let preprocess_prover_fn_name =
-            Ident::new(&format!("preprocess_prover_{}", fn_name), fn_name.span());
+            Ident::new(&format!("preprocess_prover_{fn_name}"), fn_name.span());
         quote! {
             #[cfg(all(not(target_arch = "wasm32"), not(feature = "guest")))]
             pub fn #preprocess_prover_fn_name(program: &jolt::host::Program)
@@ -287,7 +287,7 @@ impl MacroBuilder {
 
         let fn_name = self.get_func_name();
         let preprocess_verifier_fn_name =
-            Ident::new(&format!("preprocess_verifier_{}", fn_name), fn_name.span());
+            Ident::new(&format!("preprocess_verifier_{fn_name}"), fn_name.span());
         quote! {
             #[cfg(all(not(target_arch = "wasm32"), not(feature = "guest")))]
             pub fn #preprocess_verifier_fn_name(program: &jolt::host::Program)
@@ -336,7 +336,7 @@ impl MacroBuilder {
         let inputs = &self.func.sig.inputs;
         let imports = self.make_imports();
 
-        let prove_fn_name = syn::Ident::new(&format!("prove_{}", fn_name), fn_name.span());
+        let prove_fn_name = syn::Ident::new(&format!("prove_{fn_name}"), fn_name.span());
         quote! {
             #[cfg(all(not(target_arch = "wasm32"), not(feature = "guest")))]
             pub fn #prove_fn_name(
@@ -634,7 +634,7 @@ impl MacroBuilder {
 
     fn make_wasm_function(&self) -> TokenStream2 {
         let fn_name = self.get_func_name();
-        let verify_wasm_fn_name = Ident::new(&format!("verify_{}", fn_name), fn_name.span());
+        let verify_wasm_fn_name = Ident::new(&format!("verify_{fn_name}"), fn_name.span());
 
         quote! {
             #[wasm_bindgen]

--- a/src/main.rs
+++ b/src/main.rs
@@ -212,8 +212,8 @@ const HOST_MAIN: &str = r#"pub fn main() {
     let (output, proof) = prove_fib(50);
     let is_valid = verify_fib(50, output, proof);
 
-    println!("output: {}", output);
-    println!("valid: {}", is_valid);
+    println!("output: {output}");
+    println!("valid: {is_valid}");
 }
 "#;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -59,51 +59,51 @@ fn create_project(name: String, wasm: bool) {
 
 fn install_toolchain() {
     if let Err(err) = toolchain::install_toolchain() {
-        panic!("toolchain install failed: {}", err);
+        panic!("toolchain install failed: {err}");
     }
     display_welcome();
 }
 
 fn uninstall_toolchain() {
     if let Err(err) = toolchain::uninstall_toolchain() {
-        panic!("toolchain uninstall failed: {}", err);
+        panic!("toolchain uninstall failed: {err}");
     }
 }
 
 fn create_folder_structure(name: &str) -> Result<()> {
     fs::create_dir(name)?;
-    fs::create_dir(format!("{}/src", name))?;
-    fs::create_dir(format!("{}/guest", name))?;
-    fs::create_dir(format!("{}/guest/src", name))?;
+    fs::create_dir(format!("{name}/src"))?;
+    fs::create_dir(format!("{name}/guest"))?;
+    fs::create_dir(format!("{name}/guest/src"))?;
 
     Ok(())
 }
 
 fn create_host_files(name: &str) -> Result<()> {
-    let mut toolchain_file = File::create(format!("{}/rust-toolchain.toml", name))?;
+    let mut toolchain_file = File::create(format!("{name}/rust-toolchain.toml"))?;
     toolchain_file.write_all(RUST_TOOLCHAIN.as_bytes())?;
 
-    let mut gitignore_file = File::create(format!("{}/.gitignore", name))?;
+    let mut gitignore_file = File::create(format!("{name}/.gitignore"))?;
     gitignore_file.write_all(GITIGNORE.as_bytes())?;
 
     let cargo_file_contents = HOST_CARGO_TEMPLATE.replace("{NAME}", name);
-    let mut cargo_file = File::create(format!("{}/Cargo.toml", name))?;
+    let mut cargo_file = File::create(format!("{name}/Cargo.toml"))?;
     cargo_file.write_all(cargo_file_contents.as_bytes())?;
 
-    let mut main_file = File::create(format!("{}/src/main.rs", name))?;
+    let mut main_file = File::create(format!("{name}/src/main.rs"))?;
     main_file.write_all(HOST_MAIN.as_bytes())?;
 
     Ok(())
 }
 
 fn create_guest_files(name: &str) -> Result<()> {
-    let mut cargo_file = File::create(format!("{}/guest/Cargo.toml", name))?;
+    let mut cargo_file = File::create(format!("{name}/guest/Cargo.toml"))?;
     cargo_file.write_all(GUEST_CARGO.as_bytes())?;
 
-    let mut lib_file = File::create(format!("{}/guest/src/lib.rs", name))?;
+    let mut lib_file = File::create(format!("{name}/guest/src/lib.rs"))?;
     lib_file.write_all(GUEST_LIB.as_bytes())?;
 
-    let mut main_file = File::create(format!("{}/guest/src/main.rs", name))?;
+    let mut main_file = File::create(format!("{name}/guest/src/main.rs"))?;
     main_file.write_all(GUEST_MAIN.as_bytes())?;
 
     Ok(())
@@ -118,7 +118,7 @@ fn display_welcome() {
 fn display_greeting() {
     let jolt_logo_ascii = include_str!("ascii/jolt_ascii.ans");
     println!("\n\n\n\n");
-    println!("{}", jolt_logo_ascii);
+    println!("{jolt_logo_ascii}");
     println!("\n\n\n\n");
 
     let prompts = [
@@ -143,7 +143,7 @@ fn display_greeting() {
     ];
     let prompt = prompts.choose(&mut rand::thread_rng()).unwrap();
     println!("\x1B[1mWelcome to Jolt.\x1B[0m");
-    println!("\x1B[3m{}\x1B[0m", prompt);
+    println!("\x1B[3m{prompt}\x1B[0m");
 }
 
 fn display_sysinfo() {

--- a/tracer/src/emulator/cpu.rs
+++ b/tracer/src/emulator/cpu.rs
@@ -277,7 +277,7 @@ impl Cpu {
     /// # Arguments
     /// * `reg` Register number. Must be 0-31
     pub fn read_register(&self, reg: u8) -> i64 {
-        debug_assert!(reg <= 31, "reg must be 0-31. {}", reg);
+        debug_assert!(reg <= 31, "reg must be 0-31. {reg}");
         match reg {
             0 => 0, // 0th register is hardwired zero
             _ => self.x[reg as usize],
@@ -346,10 +346,7 @@ impl Cpu {
                 result
             }
             Err(()) => {
-                panic!(
-                    "Unknown instruction PC:{:x} WORD:{:x}",
-                    instruction_address, original_word
-                );
+                panic!("Unknown instruction PC:{instruction_address:x} WORD:{original_word:x}");
             }
         }
     }
@@ -1442,7 +1439,7 @@ impl Cpu {
         };
 
         let mut s = format!("PC:{:016x} ", self.unsigned_data(self.pc as i64));
-        s += &format!("{:08x} ", original_word);
+        s += &format!("{original_word:08x} ");
         s += &format!("{} ", inst.name);
         s += &format!("{}", (inst.disassemble)(self, word, self.pc, true));
         s
@@ -1752,7 +1749,7 @@ fn parse_format_u(word: u32) -> FormatU {
 }
 
 fn dump_format_u(cpu: &mut Cpu, word: u32, _address: u64, evaluate: bool) -> String {
-    println!("f format: {:x}", word);
+    println!("f format: {word:x}");
     let f = parse_format_u(word);
     let mut s = String::new();
     s += &format!("{}", get_register_name(f.rd));
@@ -1801,7 +1798,7 @@ fn get_register_name(num: usize) -> &'static str {
         29 => "t4",
         30 => "t5",
         31 => "t6",
-        _ => panic!("Unknown register num {}", num),
+        _ => panic!("Unknown register num {num}"),
     }
 }
 

--- a/tracer/src/emulator/device/virtio_block_disk.rs
+++ b/tracer/src/emulator/device/virtio_block_disk.rs
@@ -292,7 +292,7 @@ impl VirtioBlockDisk {
                 if (value & 0x1) == 1 {
                     self.interrupt_status &= !0x1;
                 } else {
-                    panic!("Unknown ack {:X}", value);
+                    panic!("Unknown ack {value:X}");
                 }
             }
             0x10001070 => {
@@ -327,18 +327,15 @@ impl VirtioBlockDisk {
     ) {
         debug_assert!(
             (mem_address % 8) == 0,
-            "Memory address should be eight-byte aligned. {:X}",
-            mem_address
+            "Memory address should be eight-byte aligned. {mem_address:X}"
         );
         debug_assert!(
             (disk_address % 8) == 0,
-            "Disk address should be eight-byte aligned. {:X}",
-            disk_address
+            "Disk address should be eight-byte aligned. {disk_address:X}"
         );
         debug_assert!(
             (length % 8) == 0,
-            "Length should be eight-byte aligned. {:X}",
-            length
+            "Length should be eight-byte aligned. {length:X}"
         );
         for i in 0..(length / 8) {
             let disk_index = ((disk_address + i * 8) >> 3) as usize;
@@ -362,18 +359,15 @@ impl VirtioBlockDisk {
     ) {
         debug_assert!(
             (mem_address % 8) == 0,
-            "Memory address should be eight-byte aligned. {:X}",
-            mem_address
+            "Memory address should be eight-byte aligned. {mem_address:X}"
         );
         debug_assert!(
             (disk_address % 8) == 0,
-            "Disk address should be eight-byte aligned. {:X}",
-            disk_address
+            "Disk address should be eight-byte aligned. {disk_address:X}"
         );
         debug_assert!(
             (length % 8) == 0,
-            "Length should be eight-byte aligned. {:X}",
-            length
+            "Length should be eight-byte aligned. {length:X}"
         );
         for i in 0..(length / 8) {
             let disk_index = ((disk_address + i * 8) >> 3) as usize;

--- a/tracer/src/emulator/elf_analyzer.rs
+++ b/tracer/src/emulator/elf_analyzer.rs
@@ -98,7 +98,7 @@ impl ElfAnalyzer {
         let e_width = match e_class {
             1 => 32,
             2 => 64,
-            _ => panic!("Unknown e_class:{:X}", e_class),
+            _ => panic!("Unknown e_class:{e_class:X}"),
         };
 
         let e_endian = self.read_byte(5);

--- a/tracer/src/emulator/mmu.rs
+++ b/tracer/src/emulator/mmu.rs
@@ -241,23 +241,20 @@ impl Mmu {
             // less then DRAM_BASE and greater then panic => zero_padding region
             assert!(
                 effective_address <= self.jolt_device.memory_layout.termination,
-                "Stack overflow: Attempted to write to 0x{:X}",
-                effective_address
+                "Stack overflow: Attempted to write to 0x{effective_address:X}"
             );
             // less then panic => jolt_device region (i.e. input/output)
             assert!(
                 self.jolt_device.is_output(effective_address)
                     || self.jolt_device.is_panic(effective_address)
                     || self.jolt_device.is_termination(effective_address),
-                "Unknown memory mapping: 0x{:X}",
-                effective_address
+                "Unknown memory mapping: 0x{effective_address:X}"
             );
         } else {
             // greater then memory capacity
             assert!(
                 self.memory.validate_address(effective_address),
-                "Heap overflow: Attempted to write to 0x{:X}",
-                effective_address
+                "Heap overflow: Attempted to write to 0x{effective_address:X}"
             );
         }
     }
@@ -336,8 +333,7 @@ impl Mmu {
     fn load_bytes(&mut self, v_address: u64, width: u64) -> Result<u64, Trap> {
         debug_assert!(
             width == 1 || width == 2 || width == 4 || width == 8,
-            "Width must be 1, 2, 4, or 8. {:X}",
-            width
+            "Width must be 1, 2, 4, or 8. {width:X}"
         );
         match (v_address & 0xfff) <= (0x1000 - width) {
             true => match self.translate_address(v_address, &MemoryAccessType::Read) {
@@ -349,7 +345,7 @@ impl Mmu {
                         2 => Ok(self.load_halfword_raw(p_address) as u64),
                         4 => Ok(self.load_word_raw(p_address) as u64),
                         8 => Ok(self.load_doubleword_raw(p_address)),
-                        _ => panic!("Width must be 1, 2, 4, or 8. {:X}", width),
+                        _ => panic!("Width must be 1, 2, 4, or 8. {width:X}"),
                     }
                 }
                 Err(()) => Err(Trap {
@@ -446,8 +442,7 @@ impl Mmu {
     fn store_bytes(&mut self, v_address: u64, value: u64, width: u64) -> Result<(), Trap> {
         debug_assert!(
             width == 1 || width == 2 || width == 4 || width == 8,
-            "Width must be 1, 2, 4, or 8. {:X}",
-            width
+            "Width must be 1, 2, 4, or 8. {width:X}"
         );
         match (v_address & 0xfff) <= (0x1000 - width) {
             true => match self.translate_address(v_address, &MemoryAccessType::Write) {
@@ -459,7 +454,7 @@ impl Mmu {
                         2 => self.store_halfword_raw(p_address, value as u16),
                         4 => self.store_word_raw(p_address, value as u32),
                         8 => self.store_doubleword_raw(p_address, value),
-                        _ => panic!("Width must be 1, 2, 4, or 8. {:X}", width),
+                        _ => panic!("Width must be 1, 2, 4, or 8. {width:X}"),
                     }
                     Ok(())
                 }
@@ -542,7 +537,7 @@ impl Mmu {
                     if self.jolt_device.is_input(effective_address) {
                         self.jolt_device.load(effective_address)
                     } else {
-                        panic!("Unknown memory mapping {:X}.", effective_address);
+                        panic!("Unknown memory mapping {effective_address:X}.");
                     }
                 }
             },
@@ -569,7 +564,7 @@ impl Mmu {
                     value,
                 });
             } else {
-                panic!("Unknown memory mapping {:X}.", word_address);
+                panic!("Unknown memory mapping {word_address:X}.");
             }
         } else {
             let mut value_bytes = [0u8; 8];
@@ -656,7 +651,7 @@ impl Mmu {
         } else if effective_address % 4 == 0 {
             value | (pre_value & 0xffff0000)
         } else {
-            panic!("Unaligned store {:x}", effective_address);
+            panic!("Unaligned store {effective_address:x}");
         };
 
         self.tracer.push_memory(MemoryState::Write {
@@ -1174,8 +1169,7 @@ impl MemoryWrapper {
     pub fn read_byte(&mut self, p_address: u64) -> u8 {
         debug_assert!(
             p_address >= DRAM_BASE,
-            "Memory address must equals to or bigger than DRAM_BASE. {:X}",
-            p_address
+            "Memory address must equals to or bigger than DRAM_BASE. {p_address:X}"
         );
 
         self.memory.read_byte(p_address - DRAM_BASE)
@@ -1184,8 +1178,7 @@ impl MemoryWrapper {
     pub fn read_halfword(&mut self, p_address: u64) -> u16 {
         debug_assert!(
             p_address >= DRAM_BASE && p_address.wrapping_add(1) >= DRAM_BASE,
-            "Memory address must equals to or bigger than DRAM_BASE. {:X}",
-            p_address
+            "Memory address must equals to or bigger than DRAM_BASE. {p_address:X}"
         );
 
         self.memory.read_halfword(p_address - DRAM_BASE)
@@ -1194,8 +1187,7 @@ impl MemoryWrapper {
     pub fn read_word(&mut self, p_address: u64) -> u32 {
         debug_assert!(
             p_address >= DRAM_BASE && p_address.wrapping_add(3) >= DRAM_BASE,
-            "Memory address must equals to or bigger than DRAM_BASE. {:X}",
-            p_address
+            "Memory address must equals to or bigger than DRAM_BASE. {p_address:X}"
         );
 
         self.memory.read_word(p_address - DRAM_BASE)
@@ -1204,8 +1196,7 @@ impl MemoryWrapper {
     pub fn read_doubleword(&mut self, p_address: u64) -> u64 {
         debug_assert!(
             p_address >= DRAM_BASE && p_address.wrapping_add(7) >= DRAM_BASE,
-            "Memory address must equals to or bigger than DRAM_BASE. {:X}",
-            p_address
+            "Memory address must equals to or bigger than DRAM_BASE. {p_address:X}"
         );
 
         self.memory.read_doubleword(p_address - DRAM_BASE)
@@ -1214,8 +1205,7 @@ impl MemoryWrapper {
     pub fn write_byte(&mut self, p_address: u64, value: u8) {
         debug_assert!(
             p_address >= DRAM_BASE,
-            "Memory address must equals to or bigger than DRAM_BASE. {:X}",
-            p_address
+            "Memory address must equals to or bigger than DRAM_BASE. {p_address:X}"
         );
 
         self.memory.write_byte(p_address - DRAM_BASE, value);
@@ -1224,8 +1214,7 @@ impl MemoryWrapper {
     pub fn write_halfword(&mut self, p_address: u64, value: u16) {
         debug_assert!(
             p_address >= DRAM_BASE && p_address.wrapping_add(1) >= DRAM_BASE,
-            "Memory address must equals to or bigger than DRAM_BASE. {:X}",
-            p_address
+            "Memory address must equals to or bigger than DRAM_BASE. {p_address:X}"
         );
 
         self.memory.write_halfword(p_address - DRAM_BASE, value);
@@ -1234,8 +1223,7 @@ impl MemoryWrapper {
     pub fn write_word(&mut self, p_address: u64, value: u32) {
         debug_assert!(
             p_address >= DRAM_BASE && p_address.wrapping_add(3) >= DRAM_BASE,
-            "Memory address must equals to or bigger than DRAM_BASE. {:X}",
-            p_address
+            "Memory address must equals to or bigger than DRAM_BASE. {p_address:X}"
         );
 
         self.memory.write_word(p_address - DRAM_BASE, value);
@@ -1244,8 +1232,7 @@ impl MemoryWrapper {
     pub fn write_doubleword(&mut self, p_address: u64, value: u64) {
         debug_assert!(
             p_address >= DRAM_BASE && p_address.wrapping_add(7) >= DRAM_BASE,
-            "Memory address must equals to or bigger than DRAM_BASE. {:X}",
-            p_address
+            "Memory address must equals to or bigger than DRAM_BASE. {p_address:X}"
         );
 
         self.memory.write_doubleword(p_address - DRAM_BASE, value);

--- a/tracer/src/emulator/mod.rs
+++ b/tracer/src/emulator/mod.rs
@@ -107,10 +107,10 @@ impl Emulator {
             if endcode != 0 {
                 match endcode {
                     1 => self.put_bytes_to_terminal(
-                        format!("Test Passed with {:X}\n", endcode).as_bytes(),
+                        format!("Test Passed with {endcode:X}\n").as_bytes(),
                     ),
                     _ => self.put_bytes_to_terminal(
-                        format!("Test Failed with {:X}\n", endcode).as_bytes(),
+                        format!("Test Failed with {endcode:X}\n").as_bytes(),
                     ),
                 };
                 break;


### PR DESCRIPTION
This fixes a bunch of clippy errors that emerged in the last 3 weeks, using `clippy`'s automatic `--fix` flag.

It also removes a deprecated action from the CI. I can revert that change or put it in a separate PR since it is adjacent to the direct fixes.