### PR TITLE
feat: add Gruen's optimization for dense interleaved polynomial (draft)

### DIFF
--- a/jolt-core/src/poly/dense_interleaved_poly.rs
+++ b/jolt-core/src/poly/dense_interleaved_poly.rs
@@ -14,7 +14,7 @@ use rayon::{prelude::*, slice::Chunks};
 #[cfg(test)]
 use super::dense_mlpoly::DensePolynomial;
 use super::{
-    split_eq_poly::{SplitEqPolynomial, NewSplitEqPolynomial},
+    split_eq_poly::{NewSplitEqPolynomial, SplitEqPolynomial},
     unipoly::{CompressedUniPoly, UniPoly},
 };
 
@@ -354,7 +354,11 @@ impl<F: JoltField, ProofTranscript: Transcript> BatchedCubicSumcheck<F, ProofTra
 // New implementation with Gruen's optimization
 impl<F: JoltField> DenseInterleavedPolynomial<F> {
     #[tracing::instrument(skip_all, name = "DenseInterleavedPolynomial::compute_cubic_new")]
-    pub fn compute_cubic_new(&self, eq_poly: &NewSplitEqPolynomial<F>, previous_round_claim: F) -> UniPoly<F> {
+    pub fn compute_cubic_new(
+        &self,
+        eq_poly: &NewSplitEqPolynomial<F>,
+        previous_round_claim: F,
+    ) -> UniPoly<F> {
         // We use the Dao-Thaler optimization for the EQ polynomial, so there are two cases we
         // must handle.
 
@@ -525,7 +529,7 @@ impl<F: JoltField> DenseInterleavedPolynomial<F> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::poly::split_eq_poly::{SplitEqPolynomial, NewSplitEqPolynomial};
+    use crate::poly::split_eq_poly::{NewSplitEqPolynomial, SplitEqPolynomial};
     use crate::subprotocols::sumcheck::BatchedCubicSumcheck;
     use crate::utils::transcript::KeccakTranscript;
     use ark_bn254::Fr;

--- a/jolt-core/src/poly/dense_interleaved_poly.rs
+++ b/jolt-core/src/poly/dense_interleaved_poly.rs
@@ -476,7 +476,7 @@ impl<F: JoltField> DenseInterleavedPolynomial<F> {
         let mut cubic_polys: Vec<CompressedUniPoly<F>> = Vec::new();
 
         for i in 0..num_rounds {
-            println!("Starting sumcheck round {}", i);
+            println!("Starting sumcheck round {i}");
             // #[cfg(test)]
             // self.sumcheck_sanity_check(eq_poly, previous_claim);
 

--- a/jolt-core/src/poly/dense_interleaved_poly.rs
+++ b/jolt-core/src/poly/dense_interleaved_poly.rs
@@ -2,15 +2,21 @@ use crate::{
     field::JoltField,
     subprotocols::{
         grand_product::BatchedGrandProductLayer,
-        sumcheck::{BatchedCubicSumcheck, Bindable},
+        sumcheck::{BatchedCubicSumcheck, Bindable, SumcheckInstanceProof},
     },
-    utils::{thread::unsafe_allocate_zero_vec, transcript::Transcript},
+    utils::{
+        thread::unsafe_allocate_zero_vec,
+        transcript::{AppendToTranscript, Transcript},
+    },
 };
 use rayon::{prelude::*, slice::Chunks};
 
 #[cfg(test)]
 use super::dense_mlpoly::DensePolynomial;
-use super::{split_eq_poly::SplitEqPolynomial, unipoly::UniPoly};
+use super::{
+    split_eq_poly::{SplitEqPolynomial, NewSplitEqPolynomial},
+    unipoly::{CompressedUniPoly, UniPoly},
+};
 
 /// Represents a single layer of a grand product circuit.
 ///
@@ -195,7 +201,7 @@ impl<F: JoltField, ProofTranscript: Transcript> BatchedCubicSumcheck<F, ProofTra
     }
 
     /// We want to compute the evaluations of the following univariate cubic polynomial at
-    /// points {0, 1, 2, 3}:
+    /// points `x in {0, 1, \infty}`:
     ///     Σ eq(r, x) * left(x) * right(x)
     /// where the inner summation is over all but the "least significant bit" of the multilinear
     /// polynomials `eq`, `left`, and `right`. We denote this "least significant" variable x_b.
@@ -212,6 +218,7 @@ impl<F: JoltField, ProofTranscript: Transcript> BatchedCubicSumcheck<F, ProofTra
     fn compute_cubic(&self, eq_poly: &SplitEqPolynomial<F>, previous_round_claim: F) -> UniPoly<F> {
         // We use the Dao-Thaler optimization for the EQ polynomial, so there are two cases we
         // must handle. For details, refer to Section 2.2 of https://eprint.iacr.org/2024/1210.pdf
+
         let cubic_evals = if eq_poly.E1_len == 1 {
             // If `eq_poly.E1` has been fully bound, we compute the cubic polynomial as we
             // would without the Dao-Thaler optimization, using the standard linear-time
@@ -283,6 +290,7 @@ impl<F: JoltField, ProofTranscript: Transcript> BatchedCubicSumcheck<F, ProofTra
                 .collect();
 
             let chunk_size = (self.len.next_power_of_two() / eq_poly.E2_len).max(1);
+
             eq_poly.E2[..eq_poly.E2_len]
                 .par_iter()
                 .zip(self.par_chunks(chunk_size))
@@ -343,12 +351,187 @@ impl<F: JoltField, ProofTranscript: Transcript> BatchedCubicSumcheck<F, ProofTra
     }
 }
 
+// New implementation with Gruen's optimization
+impl<F: JoltField> DenseInterleavedPolynomial<F> {
+    #[tracing::instrument(skip_all, name = "DenseInterleavedPolynomial::compute_cubic_new")]
+    pub fn compute_cubic_new(&self, eq_poly: &NewSplitEqPolynomial<F>, previous_round_claim: F) -> UniPoly<F> {
+        // We use the Dao-Thaler optimization for the EQ polynomial, so there are two cases we
+        // must handle.
+
+        // For details, refer to Section 3.6.1 of the Twist & Shout paper
+        // https://eprint.iacr.org/2025/105.pdf, which is a slight refinement of Section 2.2 of
+        // https://eprint.iacr.org/2024/1210.pdf
+
+        // From that paper, we have the equation: s_i(X) = eq(r_i, X) * t_i(X)
+        // We will compute the evaluations at zero and infinity of t_i(X), which recall (when `i=0`) is:
+        // `t_0(X) = \sum_x2 E2[x2] * (\sum_x1 E1[x1] * \prod_k ((1 - X) * P_k(0 || x1 || x2) + X * P_k(1 || x1 || x2)))`
+        // (here "evaluation at infinity" is just the quadratic coefficient of t_i(X))
+
+        let quadratic_evals = if eq_poly.E1_len() == 1 {
+            // If `eq_poly.E1` has been fully bound, we compute the cubic polynomial as
+            // \sum_x2 E2[x2] * \prod_k ((1 - j) * P_k(r || 0 || x2) + j * P_k(r || 1 || x2))
+            self.par_chunks(4)
+                .zip(eq_poly.E2_current())
+                .map(|(layer_chunk, eq_chunk)| {
+                    let left = (
+                        *layer_chunk.first().unwrap_or(&F::zero()),
+                        *layer_chunk.get(2).unwrap_or(&F::zero()),
+                    );
+                    let right = (
+                        *layer_chunk.get(1).unwrap_or(&F::zero()),
+                        *layer_chunk.get(3).unwrap_or(&F::zero()),
+                    );
+
+                    let left_eval_infty = left.1 - left.0;
+                    let right_eval_infty = right.1 - right.0;
+
+                    (
+                        *eq_chunk * left.0 * right.0,
+                        *eq_chunk * left_eval_infty * right_eval_infty,
+                    )
+                })
+                .reduce(
+                    || (F::zero(), F::zero()),
+                    |sum, evals| (sum.0 + evals.0, sum.1 + evals.1),
+                )
+        } else {
+            // If `eq_poly.E1` has NOT been fully bound, we compute the cubic polynomial
+            // using the nested summation approach
+            //
+            // Note, however, that we reverse the inner/outer summation compared to the
+            // description in the paper. I.e. instead of:
+            //
+            // \sum_x1 E1[x1] * (\sum_x2 E2[x2] * \prod_k ((1 - j) * P_k(0 || x1 || x2) + j * P_k(1 || x1 || x2)))
+            //
+            // we do:
+            //
+            // \sum_x2 E2[x2] * (\sum_x1 E1[x1] * \prod_k ((1 - j) * P_k(0 || x1 || x2) + j * P_k(1 || x1 || x2)))
+            //
+            // because it has better memory locality.
+            // (note also that we are doing the binding in the opposite order, i.e. the correct formula should be P_k(x2 || x1 || 0))
+
+            let chunk_size = (self.len.next_power_of_two() / eq_poly.E2_len()).max(1);
+
+            eq_poly
+                .E2_current()
+                .par_iter()
+                .zip(self.par_chunks(chunk_size))
+                .map(|(E2_eval, P_x2)| {
+                    // The for-loop below corresponds to the inner sum:
+                    // \sum_x1 E1[x1] * \prod_k ((1 - j) * P_k(0 || x1 || x2) + j * P_k(1 || x1 || x2))
+                    let mut inner_sum = (F::zero(), F::zero());
+                    for (E1_evals, P_chunk) in eq_poly.E1_current().iter().zip(P_x2.chunks(4)) {
+                        let left = (
+                            *P_chunk.first().unwrap_or(&F::zero()),
+                            *P_chunk.get(2).unwrap_or(&F::zero()),
+                        );
+                        let right = (
+                            *P_chunk.get(1).unwrap_or(&F::zero()),
+                            *P_chunk.get(3).unwrap_or(&F::zero()),
+                        );
+                        let left_eval_infty = left.1 - left.0;
+                        let right_eval_infty = right.1 - right.0;
+
+                        inner_sum.0 += *E1_evals * left.0 * right.0;
+                        inner_sum.1 += *E1_evals * left_eval_infty * right_eval_infty;
+                    }
+
+                    // Multiply the inner sum by E2[x2]
+                    (*E2_eval * inner_sum.0, *E2_eval * inner_sum.1)
+                })
+                .reduce(
+                    || (F::zero(), F::zero()),
+                    |sum, evals| (sum.0 + evals.0, sum.1 + evals.1),
+                )
+        };
+
+        let scalar_times_w_i = eq_poly.current_scalar * eq_poly.w[eq_poly.current_index - 1];
+
+        UniPoly::from_linear_times_quadratic_with_hint(
+            // The coefficients of `eq(w[(n - i)..], r[..i]) * eq(w[n - i - 1], X)`
+            [
+                eq_poly.current_scalar - scalar_times_w_i,
+                scalar_times_w_i + scalar_times_w_i - eq_poly.current_scalar,
+            ],
+            quadratic_evals.0,
+            quadratic_evals.1,
+            previous_round_claim,
+        )
+    }
+
+    pub fn prove_sumcheck_new<ProofTranscript: Transcript>(
+        &mut self,
+        eq_poly: &mut NewSplitEqPolynomial<F>,
+        claim: &F,
+        transcript: &mut ProofTranscript,
+    ) -> (SumcheckInstanceProof<F, ProofTranscript>, Vec<F>, (F, F)) {
+        let num_rounds = eq_poly.get_num_vars();
+
+        let mut previous_claim = *claim;
+        let mut r: Vec<F> = Vec::new();
+        let mut cubic_polys: Vec<CompressedUniPoly<F>> = Vec::new();
+
+        for i in 0..num_rounds {
+            println!("Starting sumcheck round {}", i);
+            // #[cfg(test)]
+            // self.sumcheck_sanity_check(eq_poly, previous_claim);
+
+            let start_cubic_poly_time = std::time::Instant::now();
+
+            let cubic_poly = self.compute_cubic_new(eq_poly, previous_claim);
+
+            let end_cubic_poly_time = std::time::Instant::now();
+            println!(
+                "Time taken for computing cubic poly in total for new method: {:?}",
+                end_cubic_poly_time.duration_since(start_cubic_poly_time)
+            );
+
+            let compressed_poly = cubic_poly.compress();
+            // append the prover's message to the transcript
+            compressed_poly.append_to_transcript(transcript);
+            // derive the verifier's challenge for the next round
+            let r_j = transcript.challenge_scalar();
+
+            r.push(r_j);
+            // bind polynomials to verifier's challenge
+            self.bind(r_j);
+
+            let start_bind_time = std::time::Instant::now();
+            eq_poly.bind(r_j);
+            let bind_time = std::time::Instant::now();
+            println!(
+                "Time taken for binding new eq poly: {:?}",
+                bind_time.duration_since(start_bind_time)
+            );
+
+            previous_claim = cubic_poly.evaluate(&r_j);
+            cubic_polys.push(compressed_poly);
+        }
+
+        // #[cfg(test)]
+        // self.sumcheck_sanity_check(eq_poly, previous_claim);
+
+        debug_assert_eq!(eq_poly.len(), 1);
+
+        (
+            SumcheckInstanceProof::new(cubic_polys),
+            r,
+            // self.final_claims(),
+            (F::zero(), F::zero()),
+        )
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::poly::split_eq_poly::{SplitEqPolynomial, NewSplitEqPolynomial};
+    use crate::subprotocols::sumcheck::BatchedCubicSumcheck;
+    use crate::utils::transcript::KeccakTranscript;
     use ark_bn254::Fr;
-    use ark_std::test_rng;
+    use ark_std::{test_rng, UniformRand};
     use itertools::Itertools;
+    use std::time::Instant;
 
     #[test]
     fn interleave_uninterleave() {
@@ -426,6 +609,150 @@ mod tests {
                     .iter()
                     .collect::<Vec<_>>()
             );
+        }
+    }
+
+    #[test]
+    fn run_sumcheck() {
+        let mut rng = test_rng();
+        for log_size in [8] {
+            let size = 1 << (log_size + 1);
+            let values: Vec<_> = (0..size).map(|_| Fr::rand(&mut rng)).collect();
+            let mut poly = DenseInterleavedPolynomial::new(values);
+
+            let w: Vec<_> = (0..log_size).map(|_| Fr::rand(&mut rng)).collect();
+
+            let mut eq_poly = SplitEqPolynomial::new(&w);
+            let mut new_eq_poly = NewSplitEqPolynomial::new(&w);
+
+            let (left, right) = poly.uninterleave();
+            let merged_eq = eq_poly.merge();
+
+            // Claim for the 0-th round
+            let previous_round_claim: Fr = left
+                .iter()
+                .zip(right.iter())
+                .zip(merged_eq.evals_ref().iter())
+                .map(|((l, r), eq)| *eq * l * r)
+                .sum();
+
+            let mut transcript = KeccakTranscript::new(b"cubic");
+
+            let _cubic_sumcheck = BatchedCubicSumcheck::<Fr, KeccakTranscript>::prove_sumcheck(
+                &mut poly,
+                &previous_round_claim,
+                &mut eq_poly,
+                &mut transcript,
+            );
+
+            let _cubic_sumcheck_new = DenseInterleavedPolynomial::<Fr>::prove_sumcheck_new(
+                &mut poly,
+                &mut new_eq_poly,
+                &previous_round_claim,
+                &mut transcript,
+            );
+        }
+    }
+
+    #[test]
+    fn compute_cubic_compare() {
+        let mut rng = test_rng();
+
+        // Create test data with various sizes
+        for log_size in [15, 17, 19] {
+            let size = 1 << (log_size + 1);
+            // Create a random polynomial
+            let values: Vec<_> = (0..size).map(|_| Fr::rand(&mut rng)).collect();
+            let mut poly = DenseInterleavedPolynomial::new(values);
+
+            // Create random challenges for both EQ polynomial types
+            let w: Vec<_> = (0..log_size).map(|_| Fr::rand(&mut rng)).collect();
+
+            // Create both types of EQ polynomials
+            let mut eq_poly = SplitEqPolynomial::new(&w);
+            let mut new_eq_poly = NewSplitEqPolynomial::new(&w);
+
+            let (left, right) = poly.uninterleave();
+            let merged_eq = eq_poly.merge();
+            // Claim for the 0-th round
+            let mut previous_round_claim: Fr = left
+                .iter()
+                .zip(right.iter())
+                .zip(merged_eq.evals_ref().iter())
+                .map(|((l, r), eq)| *eq * l * r)
+                .sum();
+
+            // Time the methods
+            let start = Instant::now();
+
+            // Compute using both methods
+            let cubic_result = BatchedCubicSumcheck::<Fr, KeccakTranscript>::compute_cubic(
+                &poly,
+                &eq_poly,
+                previous_round_claim,
+            );
+
+            let end_first = Instant::now();
+            println!(
+                "Time taken for the old method: {:?}",
+                end_first.duration_since(start)
+            );
+
+            let cubic_new_result = poly.compute_cubic_new(&new_eq_poly, previous_round_claim);
+
+            let end_second = Instant::now();
+            println!(
+                "Time taken for new method: {:?}",
+                end_second.duration_since(end_first)
+            );
+
+            // Compare the results
+            assert_eq!(
+                cubic_result, cubic_new_result,
+                "compute_cubic and compute_cubic_new produced different results for size {}",
+                size
+            );
+
+            // Also test after binding
+            if size > 4 {
+                let r_bind = Fr::rand(&mut rng);
+                poly.bind(r_bind);
+
+                let start_bound = Instant::now();
+
+                previous_round_claim = cubic_result.evaluate(&r_bind);
+
+                eq_poly.bind(r_bind);
+                let bound_cubic_result =
+                    BatchedCubicSumcheck::<Fr, KeccakTranscript>::compute_cubic(
+                        &poly,
+                        &eq_poly,
+                        previous_round_claim,
+                    );
+
+                let end_first_bound = Instant::now();
+                println!(
+                    "Time taken for old method to bind and prove next: {:?}",
+                    end_first_bound.duration_since(start_bound)
+                );
+
+                new_eq_poly.bind(r_bind);
+                let bound_cubic_new_result =
+                    poly.compute_cubic_new(&new_eq_poly, previous_round_claim);
+
+                let end_second_bound = Instant::now();
+                println!(
+                    "Time taken for new method after binding: {:?}",
+                    end_second_bound.duration_since(end_first_bound)
+                );
+
+                assert_eq!(
+                    bound_cubic_result,
+                    bound_cubic_new_result,
+                    "After binding, compute_cubic and compute_cubic_new produced different results for size {}",
+                    size
+                );
+            }
         }
     }
 }

--- a/jolt-core/src/poly/eq_poly.rs
+++ b/jolt-core/src/poly/eq_poly.rs
@@ -26,11 +26,23 @@ impl<F: JoltField> EqPolynomial<F> {
     }
 
     #[tracing::instrument(skip_all, name = "EqPolynomial::evals")]
+    /// Computes the table of coefficients: `{eq(r, x) for all x in {0, 1}^n}`
     pub fn evals(r: &[F]) -> Vec<F> {
         match r.len() {
             0..=PARALLEL_THRESHOLD => Self::evals_serial(r, None),
             _ => Self::evals_parallel(r, None),
         }
+    }
+
+    #[tracing::instrument(skip_all, name = "EqPolynomial::evals_cached")]
+    /// Computes the table of coefficients like `evals`, but also caches the intermediate results
+    ///
+    /// In other words, computes `{eq(r[i..], x) for all x in {0, 1}^{n - i}}` and for all `i in
+    /// 0..r.len()`.
+    pub fn evals_cached(r: &[F]) -> Vec<Vec<F>> {
+        // TODO: implement parallel version (it seems more difficult to parallelize all the
+        // intermediate results)
+        Self::evals_serial_cached(r, None)
     }
 
     /// Computes the table of coefficients:
@@ -52,8 +64,58 @@ impl<F: JoltField> EqPolynomial<F> {
         evals
     }
 
+    /// Computes the table of coefficients like `evals_serial`, but also caches the intermediate results.
+    ///
+    /// Returns a vector of vectors, where the `j`th vector contains the coefficients for the polynomial
+    /// `eq(r[..j], x)` for all `x in {0, 1}^{j}`.
+    ///
+    /// Performance seems at most 10% worse than `evals_serial`
+    fn evals_serial_cached(r: &[F], scaling_factor: Option<F>) -> Vec<Vec<F>> {
+        let mut evals: Vec<Vec<F>> = (0..r.len() + 1)
+            .map(|i| vec![scaling_factor.unwrap_or(F::one()); 1 << i])
+            .collect();
+        let mut size = 1;
+        for j in 0..r.len() {
+            size *= 2;
+            for i in (0..size).rev().step_by(2) {
+                let scalar = evals[j][i / 2];
+                evals[j + 1][i] = scalar * r[j];
+                evals[j + 1][i - 1] = scalar - evals[j + 1][i];
+            }
+        }
+        evals
+    }
+
+    /// Computes the table of coefficients like `evals_serial`, but also caches the intermediate
+    /// results. This binds `r` in the reverse order compared to `evals_serial_cached`.
+    ///
+    /// Concretely, this returns a vector of vectors, where the `(n -j)`th vector contains the
+    /// coefficients for the polynomial `eq(r[j..], x)` for all `x in {0, 1}^{n - j}`.
+    ///
+    /// Performance seems at most 10% worse than `evals_serial`
+    #[allow(dead_code)]
+    fn evals_serial_cached_rev(r: &[F], scaling_factor: Option<F>) -> Vec<Vec<F>> {
+        let rev_r = r.iter().rev().collect::<Vec<_>>();
+        let mut evals: Vec<Vec<F>> = (0..r.len() + 1)
+            .map(|i| vec![scaling_factor.unwrap_or(F::one()); 1 << i])
+            .collect();
+        let mut size = 1;
+        for j in 0..r.len() {
+            for i in 0..size {
+                let scalar = evals[j][i];
+                let multiple = 1 << j;
+                evals[j + 1][i + multiple] = scalar * rev_r[j];
+                evals[j + 1][i] = scalar - evals[j + 1][i + multiple];
+            }
+            size *= 2;
+        }
+        evals
+    }
+
     /// Computes the table of coefficients:
-    ///     scaling_factor * eq(r, x) for all x in {0, 1}^n
+    ///
+    ///     `scaling_factor * eq(r, x) for all x in {0, 1}^n`,
+    ///
     /// computing biggest layers of the dynamic programming tree in parallel.
     #[tracing::instrument(skip_all, "EqPolynomial::evals_parallel")]
     pub fn evals_parallel(r: &[F], scaling_factor: Option<F>) -> Vec<F> {
@@ -157,5 +219,62 @@ impl<F: JoltField> EqPlusOnePolynomial<F> {
         }
 
         (eq_evals, eq_plus_one_evals)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ark_bn254::Fr;
+    use ark_std::test_rng;
+    use std::time::Instant;
+
+    #[test]
+    /// Test that the results of running `evals_serial`, `evals_parallel`, and `evals_serial_cached`
+    /// (taking the last vector) are the same (and also benchmark them)
+    fn test_evals() {
+        let mut rng = test_rng();
+        for len in 5..22 {
+            let r = (0..len).map(|_| Fr::random(&mut rng)).collect::<Vec<_>>();
+            let start = Instant::now();
+            let evals_serial = EqPolynomial::evals_serial(&r, None);
+            let end_first = Instant::now();
+            let evals_parallel = EqPolynomial::evals_parallel(&r, None);
+            let end_second = Instant::now();
+            let evals_serial_cached = EqPolynomial::evals_serial_cached(&r, None);
+            let end_third = Instant::now();
+            println!(
+                "len: {}, Time taken to compute evals_serial: {:?}",
+                len,
+                end_first - start
+            );
+            println!(
+                "len: {}, Time taken to compute evals_parallel: {:?}",
+                len,
+                end_second - end_first
+            );
+            println!(
+                "len: {}, Time taken to compute evals_serial_cached: {:?}",
+                len,
+                end_third - end_second
+            );
+            assert_eq!(evals_serial, evals_parallel);
+            assert_eq!(evals_serial, *evals_serial_cached.last().unwrap());
+        }
+    }
+
+    #[test]
+    /// Test that the `i`th vector of `evals_serial_cached` is equivalent to
+    /// `evals(&r[..i])`, for all `i`.
+    fn test_evals_cached() {
+        let mut rng = test_rng();
+        for len in 2..22 {
+            let r = (0..len).map(|_| Fr::random(&mut rng)).collect::<Vec<_>>();
+            let evals_serial_cached = EqPolynomial::evals_serial_cached(&r, None);
+            for i in 0..len {
+                let evals = EqPolynomial::evals(&r[..i]);
+                assert_eq!(evals_serial_cached[i], evals);
+            }
+        }
     }
 }

--- a/jolt-core/src/poly/split_eq_poly.rs
+++ b/jolt-core/src/poly/split_eq_poly.rs
@@ -5,12 +5,141 @@ use super::dense_mlpoly::DensePolynomial;
 use crate::{field::JoltField, poly::eq_poly::EqPolynomial};
 
 #[derive(Debug, Clone, PartialEq)]
+/// A struct holding the equality polynomial evaluations for use in sum-check, when incorporating
+/// both the Gruen and Dao-Thaler optimizations.
+///
+/// For the `i = 0..n`-th round of sum-check, we want the following invariants:
+///
+/// - `current_index = n - i` (where `n = w.len()`)
+/// - `current_scalar = eq(w[(n - i)..],r[..i])`
+/// - `E2.last().unwrap() = [eq(w[..min(i, n/2)], x) for all x in {0, 1}^{n - min(i, n/2)}]`
+/// - If `i < n/2`, then `E1.last().unwrap() = [eq(w[n/2..(n/2 + i + 1)], x) for all x in {0,
+///   1}^{n/2 - i - 1}]`; else `E1` is empty
+///
+/// Note: all current applications of `SplitEqPolynomial` use the `LowToHigh` binding order. This
+/// means that we are iterating over `w` in the reverse order: `w.len()` down to `0`.
+pub struct NewSplitEqPolynomial<F> {
+    pub(crate) current_index: usize,
+    pub(crate) current_scalar: F,
+    pub(crate) w: Vec<F>,
+    pub(crate) E1: Vec<Vec<F>>,
+    pub(crate) E2: Vec<Vec<F>>,
+}
+
+/// Old struct for equality polynomial, without Gruen's optimization
 pub struct SplitEqPolynomial<F> {
     num_vars: usize,
     pub(crate) E1: Vec<F>,
     pub(crate) E1_len: usize,
     pub(crate) E2: Vec<F>,
     pub(crate) E2_len: usize,
+}
+
+impl<F: JoltField> NewSplitEqPolynomial<F> {
+    #[tracing::instrument(skip_all, name = "NewSplitEqPolynomial::new")]
+    pub fn new(w: &[F]) -> Self {
+        let m = w.len() / 2;
+        //   w = [w2, w1, w_last]
+        //        ↑   ↑    ↑
+        //        |   |    |
+        //        |   |    last element
+        //        |   second half of remaining elements (for E1)
+        //        first half of remaining elements (for E2)
+        let (_, wprime) = w.split_last().unwrap();
+        let (w2, w1) = wprime.split_at(m);
+        let (E2, E1) = rayon::join(
+            || EqPolynomial::evals_cached(w2),
+            || EqPolynomial::evals_cached(w1),
+        );
+        Self {
+            current_index: w.len(),
+            current_scalar: F::one(),
+            w: w.to_vec(),
+            E1,
+            E2,
+        }
+    }
+
+    pub fn get_num_vars(&self) -> usize {
+        self.w.len()
+    }
+
+    pub fn len(&self) -> usize {
+        1 << self.current_index
+    }
+
+    pub fn E1_len(&self) -> usize {
+        self.E1.last().unwrap().len()
+    }
+
+    pub fn E2_len(&self) -> usize {
+        self.E2.last().unwrap().len()
+    }
+
+    /// Return the last vector from `E1` as a slice
+    pub fn E1_current(&self) -> &[F] {
+        self.E1.last().unwrap()
+    }
+
+    pub fn to_E1_old(&self) -> Vec<F> {
+        if self.current_index > self.w.len() / 2 {
+            let wi = self.w[self.current_index - 1];
+            let E1_old_odd: Vec<F> = self
+                .E1
+                .last()
+                .unwrap()
+                .iter()
+                .map(|x| *x * (F::one() - wi))
+                .collect();
+            let E1_old_even: Vec<F> = self.E1.last().unwrap().iter().map(|x| *x * wi).collect();
+            // Interleave the two vectors
+            let mut E1_old = vec![];
+            for i in 0..E1_old_odd.len() {
+                E1_old.push(E1_old_odd[i]);
+                E1_old.push(E1_old_even[i]);
+            }
+            E1_old
+        } else {
+            // println!("Don't expect to call this");
+            vec![self.current_scalar; 1]
+        }
+    }
+
+    /// Return the last vector from `E2` as a slice
+    pub fn E2_current(&self) -> &[F] {
+        self.E2.last().unwrap()
+    }
+
+    #[tracing::instrument(skip_all, name = "NewSplitEqPolynomial::bind")]
+    pub fn bind(&mut self, r: F) {
+        // multiply `current_scalar` by `eq(w[i], r) = (1 - w[i]) * (1 - r) + w[i] * r`
+        self.current_scalar *= F::one() - self.w[self.current_index - 1] - r
+            + self.w[self.current_index - 1] * r
+            + self.w[self.current_index - 1] * r;
+        // decrement `current_index`
+        self.current_index -= 1;
+        // pop the last vector from `E1` or `E2` (since we don't need it anymore)
+        if self.w.len() / 2 < self.current_index {
+            self.E1.pop();
+        } else if 0 < self.current_index {
+            self.E2.pop();
+        }
+        // println!(
+        //     "current_index: {}, E1_len: {}, E2_len: {}",
+        //     self.current_index,
+        //     self.E1.len(),
+        //     self.E2.len()
+        // );
+    }
+
+    #[cfg(test)]
+    pub fn merge(&self) -> DensePolynomial<F> {
+        let evals = EqPolynomial::evals(&self.w[..self.current_index])
+            .iter()
+            .map(|x| *x * self.current_scalar)
+            .collect();
+        DensePolynomial::new(evals)
+    }
 }
 
 impl<F: JoltField> SplitEqPolynomial<F> {
@@ -93,14 +222,14 @@ mod tests {
 
     #[test]
     fn bind() {
-        const NUM_VARS: usize = 9;
+        const NUM_VARS: usize = 10;
         let mut rng = test_rng();
         let w: Vec<Fr> = std::iter::repeat_with(|| Fr::random(&mut rng))
             .take(NUM_VARS)
             .collect();
 
         let mut regular_eq = DensePolynomial::new(EqPolynomial::evals(&w));
-        let mut split_eq = SplitEqPolynomial::new(&w);
+        let mut split_eq = NewSplitEqPolynomial::new(&w);
         assert_eq!(regular_eq, split_eq.merge());
 
         for _ in 0..NUM_VARS {
@@ -110,6 +239,65 @@ mod tests {
 
             let merged = split_eq.merge();
             assert_eq!(regular_eq.Z[..regular_eq.len()], merged.Z[..merged.len()]);
+        }
+    }
+
+    #[test]
+    fn equal_old_and_new_split_eq() {
+        const NUM_VARS: usize = 15;
+        let mut rng = test_rng();
+        let w: Vec<Fr> = std::iter::repeat_with(|| Fr::random(&mut rng))
+            .take(NUM_VARS)
+            .collect();
+
+        let mut old_split_eq = SplitEqPolynomial::new(&w);
+        let mut new_split_eq = NewSplitEqPolynomial::new(&w);
+
+        assert_eq!(old_split_eq.get_num_vars(), new_split_eq.get_num_vars());
+        assert_eq!(old_split_eq.len(), new_split_eq.len());
+        assert_eq!(old_split_eq.E1, *new_split_eq.to_E1_old());
+        assert_eq!(old_split_eq.E2, *new_split_eq.E2.last().unwrap());
+        assert_eq!(old_split_eq.merge(), new_split_eq.merge());
+        // Show that they are the same after binding
+        for i in (0..NUM_VARS).rev() {
+            let r = Fr::random(&mut rng);
+            old_split_eq.bind(r);
+            new_split_eq.bind(r);
+            assert_eq!(old_split_eq.merge(), new_split_eq.merge());
+            if NUM_VARS / 2 < i {
+                assert_eq!(old_split_eq.E1_len, new_split_eq.E1_len() * 2);
+                assert_eq!(old_split_eq.E2_len, new_split_eq.E2_len());
+            } else if i > 0 {
+                assert_eq!(old_split_eq.E1_len, new_split_eq.E1_len());
+                assert_eq!(old_split_eq.E2_len, new_split_eq.E2_len() * 2);
+            }
+        }
+    }
+
+    #[test]
+    fn bench_old_and_new_split_eq() {
+        let mut rng = test_rng();
+        for num_vars in 5..30 {
+            let w: Vec<Fr> = std::iter::repeat_with(|| Fr::random(&mut rng))
+                .take(num_vars)
+                .collect();
+            println!("Testing for {} variables", num_vars);
+
+            let start_old_split_eq_time = std::time::Instant::now();
+            let _old_split_eq = SplitEqPolynomial::new(&w);
+            let end_old_split_eq_time = std::time::Instant::now();
+            println!(
+                "Time taken for creating old split eq: {:?}",
+                end_old_split_eq_time.duration_since(start_old_split_eq_time)
+            );
+
+            let start_new_split_eq_time = std::time::Instant::now();
+            let _new_split_eq = NewSplitEqPolynomial::new(&w);
+            let end_new_split_eq_time = std::time::Instant::now();
+            println!(
+                "Time taken for creating new split eq: {:?}",
+                end_new_split_eq_time.duration_since(start_new_split_eq_time)
+            );
         }
     }
 }

--- a/jolt-core/src/poly/unipoly.rs
+++ b/jolt-core/src/poly/unipoly.rs
@@ -32,6 +32,7 @@ impl<F: JoltField> UniPoly<F> {
         UniPoly { coeffs }
     }
 
+    /// Interpolate a polynomial from its evaluations at the points 0, 1, 2, ..., n-1.
     pub fn from_evals(evals: &[F]) -> Self {
         UniPoly {
             coeffs: Self::vandermonde_interpolation(evals),
@@ -213,6 +214,41 @@ impl<F: JoltField> UniPoly<F> {
 
     pub fn shift_coefficients(&mut self, rhs: &F) {
         self.coeffs.par_iter_mut().for_each(|c| *c += *rhs);
+    }
+
+    /// This function computes a cubic polynomial s(X), given the following conditions:
+    /// - s(X) = l(X) * t(X), where l(X) is linear and t(X) is quadratic,
+    /// - l(X) = a + bX is given by l(0) = a and l(\infty) = b,
+    /// - t(X) = c + dX + eX^2 is given by t(0) = c and t(\infty) = e (but d is missing),
+    /// - s(0) + s(1) = hint,
+    ///
+    /// This is used in the optimized sum-check evaluation with split eq polynomial.
+    pub fn from_linear_times_quadratic_with_hint(
+        linear_coeffs: [F; 2],
+        quadratic_coeff_0: F,
+        quadratic_coeff_2: F,
+        hint: F,
+    ) -> Self {
+        let linear_eval_one = linear_coeffs[0] + linear_coeffs[1];
+
+        let cubic_coeff_0 = linear_coeffs[0] * quadratic_coeff_0;
+
+        // Compute the linear coefficient of the quadratic polynomial from the hint
+        // Given that s(0) + s(1) = hint, we can rewrite this as:
+        // a * c + (a + b) * (c + d + e) = hint, which means we can solve for d as:
+        // d = (hint - a * c) / (a + b) - c - e
+        let quadratic_coeff_1 =
+            (hint - cubic_coeff_0) / linear_eval_one - quadratic_coeff_0 - quadratic_coeff_2;
+
+        // Now derive the coefficients of the cubic polynomial from the evaluations
+        // We have s(X) = (a + bX) * (c + dX + eX^2) = ac + (ad + bc)X + (ae + bd)X^2 + beX^3
+        let coeffs = [
+            cubic_coeff_0,
+            linear_coeffs[0] * quadratic_coeff_1 + linear_coeffs[1] * quadratic_coeff_0,
+            linear_coeffs[0] * quadratic_coeff_2 + linear_coeffs[1] * quadratic_coeff_1,
+            linear_coeffs[1] * quadratic_coeff_2,
+        ];
+        Self::from_coeff(coeffs.to_vec())
     }
 }
 
@@ -436,5 +472,28 @@ mod tests {
                 }
             }
         }
+    }
+
+    #[test]
+    fn test_from_linear_times_quadratic_with_hint() {
+        // polynomial is s(x) = (x + 1) * (x^2 + 2x + 3) = x^3 + 3x^2 + 5x + 3
+        // hint = s(0) + s(1) = 3 + (1 + 3 + 5 + 3) = 15
+        let linear_coeffs = [Fr::from_u64(1u64), Fr::from_u64(1u64)];
+        let quadratic_coeff_0 = Fr::from_u64(3u64);
+        let quadratic_coeff_2 = Fr::from_u64(1u64);
+        let true_poly = UniPoly::from_coeff(vec![
+            Fr::from_u64(3u64),
+            Fr::from_u64(5u64),
+            Fr::from_u64(3u64),
+            Fr::from_u64(1u64),
+        ]);
+        let hint = Fr::from_u64(15u64);
+        let poly = UniPoly::from_linear_times_quadratic_with_hint(
+            linear_coeffs,
+            quadratic_coeff_0,
+            quadratic_coeff_2,
+            hint,
+        );
+        assert_eq!(poly.coeffs, true_poly.coeffs);
     }
 }


### PR DESCRIPTION
This **draft** PR implements Gruen's optimization for one particular protocol in `dense_interleaved_poly.rs`.

The point is to introduce the new `SplitEqPolynomial` type tailored to Gruen's optimization, and demonstrate the decrease in evaluation points needed (we only need evals at 0 and infinity, instead of at 0, 2, and 3).

The new changes are all marked as `new`. In particular, we have `compute_cubic_new` being the new version with Gruen's optimization.

There are three more targets for optimization: `sparse_interleaved_poly`, `sparse_grand_product`, and `spartan_interleaved_poly`. All three are more complicated than `dense_interleaved_poly`. I tried changing them in a different branch (https://github.com/quangvdao/jolt/tree/gruen-optimization), but was not successful in debugging to yield the same result as the old method.

Thus, I put the core of the changes in this branch so that people can look at it. I have tested the new implementation of `dense_interleaved_poly` to be the same as the old one, at least for certain cases (should definitely do more testing).
