### PR TITLE
feat: add optimized `mul_i128`, change `from_u64`, revert `FixedBase` change

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -226,7 +226,7 @@ dependencies = [
 [[package]]
 name = "ark-ec"
 version = "0.5.0"
-source = "git+https://github.com/a16z/arkworks-algebra?branch=v0.5.0-optimize-mul-u64#b926f92b4f655d8ea7980f09097d51589c1f707a"
+source = "git+https://github.com/a16z/arkworks-algebra?branch=v0.5.0-optimize-mul-u64#4ae5018533f1e757bb321e21927c8bbbf8c27ffc"
 dependencies = [
  "ahash",
  "ark-ff 0.5.0",
@@ -285,7 +285,7 @@ dependencies = [
 [[package]]
 name = "ark-ff"
 version = "0.5.0"
-source = "git+https://github.com/a16z/arkworks-algebra?branch=v0.5.0-optimize-mul-u64#b926f92b4f655d8ea7980f09097d51589c1f707a"
+source = "git+https://github.com/a16z/arkworks-algebra?branch=v0.5.0-optimize-mul-u64#4ae5018533f1e757bb321e21927c8bbbf8c27ffc"
 dependencies = [
  "ark-ff-asm 0.5.0",
  "ark-ff-macros 0.5.0",
@@ -325,7 +325,7 @@ dependencies = [
 [[package]]
 name = "ark-ff-asm"
 version = "0.5.0"
-source = "git+https://github.com/a16z/arkworks-algebra?branch=v0.5.0-optimize-mul-u64#b926f92b4f655d8ea7980f09097d51589c1f707a"
+source = "git+https://github.com/a16z/arkworks-algebra?branch=v0.5.0-optimize-mul-u64#4ae5018533f1e757bb321e21927c8bbbf8c27ffc"
 dependencies = [
  "quote",
  "syn 2.0.101",
@@ -359,7 +359,7 @@ dependencies = [
 [[package]]
 name = "ark-ff-macros"
 version = "0.5.0"
-source = "git+https://github.com/a16z/arkworks-algebra?branch=v0.5.0-optimize-mul-u64#b926f92b4f655d8ea7980f09097d51589c1f707a"
+source = "git+https://github.com/a16z/arkworks-algebra?branch=v0.5.0-optimize-mul-u64#4ae5018533f1e757bb321e21927c8bbbf8c27ffc"
 dependencies = [
  "num-bigint",
  "num-traits",
@@ -371,7 +371,7 @@ dependencies = [
 [[package]]
 name = "ark-poly"
 version = "0.5.0"
-source = "git+https://github.com/a16z/arkworks-algebra?branch=v0.5.0-optimize-mul-u64#b926f92b4f655d8ea7980f09097d51589c1f707a"
+source = "git+https://github.com/a16z/arkworks-algebra?branch=v0.5.0-optimize-mul-u64#4ae5018533f1e757bb321e21927c8bbbf8c27ffc"
 dependencies = [
  "ahash",
  "ark-ff 0.5.0",
@@ -406,7 +406,7 @@ dependencies = [
 [[package]]
 name = "ark-serialize"
 version = "0.5.0"
-source = "git+https://github.com/a16z/arkworks-algebra?branch=v0.5.0-optimize-mul-u64#b926f92b4f655d8ea7980f09097d51589c1f707a"
+source = "git+https://github.com/a16z/arkworks-algebra?branch=v0.5.0-optimize-mul-u64#4ae5018533f1e757bb321e21927c8bbbf8c27ffc"
 dependencies = [
  "ark-serialize-derive 0.5.0 (git+https://github.com/a16z/arkworks-algebra?branch=v0.5.0-optimize-mul-u64)",
  "ark-std 0.5.0",
@@ -430,7 +430,7 @@ dependencies = [
 [[package]]
 name = "ark-serialize-derive"
 version = "0.5.0"
-source = "git+https://github.com/a16z/arkworks-algebra?branch=v0.5.0-optimize-mul-u64#b926f92b4f655d8ea7980f09097d51589c1f707a"
+source = "git+https://github.com/a16z/arkworks-algebra?branch=v0.5.0-optimize-mul-u64#4ae5018533f1e757bb321e21927c8bbbf8c27ffc"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -226,7 +226,7 @@ dependencies = [
 [[package]]
 name = "ark-ec"
 version = "0.5.0"
-source = "git+https://github.com/a16z/arkworks-algebra?branch=v0.5.0-optimize-mul-u64#c4a6537c19254ffab307c674602df22adb1f7d46"
+source = "git+https://github.com/a16z/arkworks-algebra?branch=v0.5.0-optimize-mul-u64#b926f92b4f655d8ea7980f09097d51589c1f707a"
 dependencies = [
  "ahash",
  "ark-ff 0.5.0",
@@ -285,7 +285,7 @@ dependencies = [
 [[package]]
 name = "ark-ff"
 version = "0.5.0"
-source = "git+https://github.com/a16z/arkworks-algebra?branch=v0.5.0-optimize-mul-u64#c4a6537c19254ffab307c674602df22adb1f7d46"
+source = "git+https://github.com/a16z/arkworks-algebra?branch=v0.5.0-optimize-mul-u64#b926f92b4f655d8ea7980f09097d51589c1f707a"
 dependencies = [
  "ark-ff-asm 0.5.0",
  "ark-ff-macros 0.5.0",
@@ -325,7 +325,7 @@ dependencies = [
 [[package]]
 name = "ark-ff-asm"
 version = "0.5.0"
-source = "git+https://github.com/a16z/arkworks-algebra?branch=v0.5.0-optimize-mul-u64#c4a6537c19254ffab307c674602df22adb1f7d46"
+source = "git+https://github.com/a16z/arkworks-algebra?branch=v0.5.0-optimize-mul-u64#b926f92b4f655d8ea7980f09097d51589c1f707a"
 dependencies = [
  "quote",
  "syn 2.0.101",
@@ -359,7 +359,7 @@ dependencies = [
 [[package]]
 name = "ark-ff-macros"
 version = "0.5.0"
-source = "git+https://github.com/a16z/arkworks-algebra?branch=v0.5.0-optimize-mul-u64#c4a6537c19254ffab307c674602df22adb1f7d46"
+source = "git+https://github.com/a16z/arkworks-algebra?branch=v0.5.0-optimize-mul-u64#b926f92b4f655d8ea7980f09097d51589c1f707a"
 dependencies = [
  "num-bigint",
  "num-traits",
@@ -371,7 +371,7 @@ dependencies = [
 [[package]]
 name = "ark-poly"
 version = "0.5.0"
-source = "git+https://github.com/a16z/arkworks-algebra?branch=v0.5.0-optimize-mul-u64#c4a6537c19254ffab307c674602df22adb1f7d46"
+source = "git+https://github.com/a16z/arkworks-algebra?branch=v0.5.0-optimize-mul-u64#b926f92b4f655d8ea7980f09097d51589c1f707a"
 dependencies = [
  "ahash",
  "ark-ff 0.5.0",
@@ -406,7 +406,7 @@ dependencies = [
 [[package]]
 name = "ark-serialize"
 version = "0.5.0"
-source = "git+https://github.com/a16z/arkworks-algebra?branch=v0.5.0-optimize-mul-u64#c4a6537c19254ffab307c674602df22adb1f7d46"
+source = "git+https://github.com/a16z/arkworks-algebra?branch=v0.5.0-optimize-mul-u64#b926f92b4f655d8ea7980f09097d51589c1f707a"
 dependencies = [
  "ark-serialize-derive 0.5.0 (git+https://github.com/a16z/arkworks-algebra?branch=v0.5.0-optimize-mul-u64)",
  "ark-std 0.5.0",
@@ -430,7 +430,7 @@ dependencies = [
 [[package]]
 name = "ark-serialize-derive"
 version = "0.5.0"
-source = "git+https://github.com/a16z/arkworks-algebra?branch=v0.5.0-optimize-mul-u64#c4a6537c19254ffab307c674602df22adb1f7d46"
+source = "git+https://github.com/a16z/arkworks-algebra?branch=v0.5.0-optimize-mul-u64#b926f92b4f655d8ea7980f09097d51589c1f707a"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/jolt-core/src/field/ark.rs
+++ b/jolt-core/src/field/ark.rs
@@ -9,26 +9,24 @@ impl FieldOps for ark_bn254::Fr {}
 impl FieldOps<&ark_bn254::Fr, ark_bn254::Fr> for &ark_bn254::Fr {}
 impl FieldOps<&ark_bn254::Fr, ark_bn254::Fr> for ark_bn254::Fr {}
 
-static mut SMALL_VALUE_LOOKUP_TABLES: [Vec<ark_bn254::Fr>; 4] = [vec![], vec![], vec![], vec![]];
+static mut SMALL_VALUE_LOOKUP_TABLES: [Vec<ark_bn254::Fr>; 2] = [vec![], vec![]];
 
 impl JoltField for ark_bn254::Fr {
     const NUM_BYTES: usize = 32;
-    type SmallValueLookupTables = [Vec<Self>; 4];
+    type SmallValueLookupTables = [Vec<Self>; 2];
 
     fn random<R: rand_core::RngCore>(rng: &mut R) -> Self {
         <Self as UniformRand>::rand(rng)
     }
 
     fn compute_lookup_tables() -> Self::SmallValueLookupTables {
-        // These four lookup tables correspond to the four 16-bit limbs of a u64
+        // These two lookup tables correspond to the two 16-bit limbs of a u64
         let mut lookup_tables = [
-            unsafe_allocate_zero_vec(1 << 16),
-            unsafe_allocate_zero_vec(1 << 16),
             unsafe_allocate_zero_vec(1 << 16),
             unsafe_allocate_zero_vec(1 << 16),
         ];
 
-        for i in 0..4 {
+        for i in 0..2 {
             let bitshift = 16 * i;
             let unit = <Self as ark_ff::PrimeField>::from_u64(1 << bitshift).unwrap();
             lookup_tables[i] = (0..(1 << 16))
@@ -91,20 +89,14 @@ impl JoltField for ark_bn254::Fr {
 
     #[inline]
     fn from_u64(n: u64) -> Self {
-        // TODO(moodlezoup): Using the lookup tables seems to break our tests
-        #[cfg(test)]
-        {
+        // The new `from_u64` is faster than doing 4 lookups & adding them together
+        // but it's slower than doing <=2 lookups & adding them together (if n fits in u16 or u32)
+        if n <= u16::MAX as u64 {
+            <Self as JoltField>::from_u16(n as u16)
+        } else if n <= u32::MAX as u64 {
+            <Self as JoltField>::from_u32(n as u32)
+        } else {
             <Self as ark_ff::PrimeField>::from_u64(n).unwrap()
-        }
-        #[cfg(not(test))]
-        {
-            const BITMASK: u64 = (1 << 16) - 1;
-            unsafe {
-                SMALL_VALUE_LOOKUP_TABLES[0][(n & BITMASK) as usize]
-                    + SMALL_VALUE_LOOKUP_TABLES[1][((n >> 16) & BITMASK) as usize]
-                    + SMALL_VALUE_LOOKUP_TABLES[2][((n >> 32) & BITMASK) as usize]
-                    + SMALL_VALUE_LOOKUP_TABLES[3][((n >> 48) & BITMASK) as usize]
-            }
         }
     }
 

--- a/jolt-core/src/field/ark.rs
+++ b/jolt-core/src/field/ark.rs
@@ -191,6 +191,11 @@ impl JoltField for ark_bn254::Fr {
     fn mul_u64(&self, n: u64) -> Self {
         ark_ff::Fp::mul_u64(*self, n)
     }
+
+    #[inline(always)]
+    fn mul_i128(&self, n: i128) -> Self {
+        ark_ff::Fp::mul_i128(*self, n)
+    }
 }
 
 #[cfg(test)]

--- a/jolt-core/src/field/mod.rs
+++ b/jolt-core/src/field/mod.rs
@@ -79,6 +79,10 @@ pub trait JoltField:
     fn mul_u64(&self, n: u64) -> Self {
         *self * Self::from_u64(n)
     }
+    #[inline(always)]
+    fn mul_i128(&self, n: i128) -> Self {
+        *self * Self::from_i128(n)
+    }
 }
 
 pub trait OptimizedMul<Rhs, Output>: Sized + Mul<Rhs, Output = Output> {

--- a/jolt-core/src/poly/spartan_interleaved_poly.rs
+++ b/jolt-core/src/poly/spartan_interleaved_poly.rs
@@ -314,9 +314,9 @@ impl<F: JoltField> SpartanInterleavedPolynomial<F> {
                     let cz_eval_3 = cz_eval_2 + m_cz;
 
                     // TODO(moodlezoup): optimize
-                    inner_sums.0 += E1_evals.0 * F::from_i128(az.0 * bz.0 - cz.0);
-                    inner_sums.1 += E1_evals.1 * F::from_i128(az_eval_2 * bz_eval_2 - cz_eval_2);
-                    inner_sums.2 += E1_evals.2 * F::from_i128(az_eval_3 * bz_eval_3 - cz_eval_3);
+                    inner_sums.0 += E1_evals.0.mul_i128(az.0 * bz.0 - cz.0);
+                    inner_sums.1 += E1_evals.1.mul_i128(az_eval_2 * bz_eval_2 - cz_eval_2);
+                    inner_sums.2 += E1_evals.2.mul_i128(az_eval_3 * bz_eval_3 - cz_eval_3);
                 }
 
                 eval_point_0 += eq_poly.E2[prev_x2] * inner_sums.0;
@@ -401,7 +401,7 @@ impl<F: JoltField> SpartanInterleavedPolynomial<F> {
                         let (low, high) = (az_coeff.0.unwrap_or(0), az_coeff.1.unwrap_or(0));
                         output_slice[output_index] = (
                             3 * block_index,
-                            F::from_i128(low) + r_i * F::from_i128(high - low),
+                            F::from_i128(low) + r_i.mul_i128(high - low),
                         )
                             .into();
                         output_index += 1;
@@ -410,7 +410,7 @@ impl<F: JoltField> SpartanInterleavedPolynomial<F> {
                         let (low, high) = (bz_coeff.0.unwrap_or(0), bz_coeff.1.unwrap_or(0));
                         output_slice[output_index] = (
                             3 * block_index + 1,
-                            F::from_i128(low) + r_i * F::from_i128(high - low),
+                            F::from_i128(low) + r_i.mul_i128(high - low),
                         )
                             .into();
                         output_index += 1;
@@ -419,7 +419,7 @@ impl<F: JoltField> SpartanInterleavedPolynomial<F> {
                         let (low, high) = (cz_coeff.0.unwrap_or(0), cz_coeff.1.unwrap_or(0));
                         output_slice[output_index] = (
                             3 * block_index + 2,
-                            F::from_i128(low) + r_i * F::from_i128(high - low),
+                            F::from_i128(low) + r_i.mul_i128(high - low),
                         )
                             .into();
                         output_index += 1;

--- a/jolt-evm-verifier/script/Cargo.lock
+++ b/jolt-evm-verifier/script/Cargo.lock
@@ -196,7 +196,7 @@ dependencies = [
 [[package]]
 name = "ark-ec"
 version = "0.5.0"
-source = "git+https://github.com/a16z/arkworks-algebra?branch=v0.5.0-optimize-mul-u64#c4a6537c19254ffab307c674602df22adb1f7d46"
+source = "git+https://github.com/a16z/arkworks-algebra?branch=v0.5.0-optimize-mul-u64#b926f92b4f655d8ea7980f09097d51589c1f707a"
 dependencies = [
  "ahash",
  "ark-ff 0.5.0",
@@ -255,7 +255,7 @@ dependencies = [
 [[package]]
 name = "ark-ff"
 version = "0.5.0"
-source = "git+https://github.com/a16z/arkworks-algebra?branch=v0.5.0-optimize-mul-u64#c4a6537c19254ffab307c674602df22adb1f7d46"
+source = "git+https://github.com/a16z/arkworks-algebra?branch=v0.5.0-optimize-mul-u64#b926f92b4f655d8ea7980f09097d51589c1f707a"
 dependencies = [
  "ark-ff-asm 0.5.0",
  "ark-ff-macros 0.5.0",
@@ -295,7 +295,7 @@ dependencies = [
 [[package]]
 name = "ark-ff-asm"
 version = "0.5.0"
-source = "git+https://github.com/a16z/arkworks-algebra?branch=v0.5.0-optimize-mul-u64#c4a6537c19254ffab307c674602df22adb1f7d46"
+source = "git+https://github.com/a16z/arkworks-algebra?branch=v0.5.0-optimize-mul-u64#b926f92b4f655d8ea7980f09097d51589c1f707a"
 dependencies = [
  "quote",
  "syn 2.0.101",
@@ -329,7 +329,7 @@ dependencies = [
 [[package]]
 name = "ark-ff-macros"
 version = "0.5.0"
-source = "git+https://github.com/a16z/arkworks-algebra?branch=v0.5.0-optimize-mul-u64#c4a6537c19254ffab307c674602df22adb1f7d46"
+source = "git+https://github.com/a16z/arkworks-algebra?branch=v0.5.0-optimize-mul-u64#b926f92b4f655d8ea7980f09097d51589c1f707a"
 dependencies = [
  "num-bigint",
  "num-traits",
@@ -341,7 +341,7 @@ dependencies = [
 [[package]]
 name = "ark-poly"
 version = "0.5.0"
-source = "git+https://github.com/a16z/arkworks-algebra?branch=v0.5.0-optimize-mul-u64#c4a6537c19254ffab307c674602df22adb1f7d46"
+source = "git+https://github.com/a16z/arkworks-algebra?branch=v0.5.0-optimize-mul-u64#b926f92b4f655d8ea7980f09097d51589c1f707a"
 dependencies = [
  "ahash",
  "ark-ff 0.5.0",
@@ -376,7 +376,7 @@ dependencies = [
 [[package]]
 name = "ark-serialize"
 version = "0.5.0"
-source = "git+https://github.com/a16z/arkworks-algebra?branch=v0.5.0-optimize-mul-u64#c4a6537c19254ffab307c674602df22adb1f7d46"
+source = "git+https://github.com/a16z/arkworks-algebra?branch=v0.5.0-optimize-mul-u64#b926f92b4f655d8ea7980f09097d51589c1f707a"
 dependencies = [
  "ark-serialize-derive 0.5.0 (git+https://github.com/a16z/arkworks-algebra?branch=v0.5.0-optimize-mul-u64)",
  "ark-std 0.5.0",
@@ -400,7 +400,7 @@ dependencies = [
 [[package]]
 name = "ark-serialize-derive"
 version = "0.5.0"
-source = "git+https://github.com/a16z/arkworks-algebra?branch=v0.5.0-optimize-mul-u64#c4a6537c19254ffab307c674602df22adb1f7d46"
+source = "git+https://github.com/a16z/arkworks-algebra?branch=v0.5.0-optimize-mul-u64#b926f92b4f655d8ea7980f09097d51589c1f707a"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/jolt-evm-verifier/script/Cargo.lock
+++ b/jolt-evm-verifier/script/Cargo.lock
@@ -196,7 +196,7 @@ dependencies = [
 [[package]]
 name = "ark-ec"
 version = "0.5.0"
-source = "git+https://github.com/a16z/arkworks-algebra?branch=v0.5.0-optimize-mul-u64#b926f92b4f655d8ea7980f09097d51589c1f707a"
+source = "git+https://github.com/a16z/arkworks-algebra?branch=v0.5.0-optimize-mul-u64#4ae5018533f1e757bb321e21927c8bbbf8c27ffc"
 dependencies = [
  "ahash",
  "ark-ff 0.5.0",
@@ -255,7 +255,7 @@ dependencies = [
 [[package]]
 name = "ark-ff"
 version = "0.5.0"
-source = "git+https://github.com/a16z/arkworks-algebra?branch=v0.5.0-optimize-mul-u64#b926f92b4f655d8ea7980f09097d51589c1f707a"
+source = "git+https://github.com/a16z/arkworks-algebra?branch=v0.5.0-optimize-mul-u64#4ae5018533f1e757bb321e21927c8bbbf8c27ffc"
 dependencies = [
  "ark-ff-asm 0.5.0",
  "ark-ff-macros 0.5.0",
@@ -295,7 +295,7 @@ dependencies = [
 [[package]]
 name = "ark-ff-asm"
 version = "0.5.0"
-source = "git+https://github.com/a16z/arkworks-algebra?branch=v0.5.0-optimize-mul-u64#b926f92b4f655d8ea7980f09097d51589c1f707a"
+source = "git+https://github.com/a16z/arkworks-algebra?branch=v0.5.0-optimize-mul-u64#4ae5018533f1e757bb321e21927c8bbbf8c27ffc"
 dependencies = [
  "quote",
  "syn 2.0.101",
@@ -329,7 +329,7 @@ dependencies = [
 [[package]]
 name = "ark-ff-macros"
 version = "0.5.0"
-source = "git+https://github.com/a16z/arkworks-algebra?branch=v0.5.0-optimize-mul-u64#b926f92b4f655d8ea7980f09097d51589c1f707a"
+source = "git+https://github.com/a16z/arkworks-algebra?branch=v0.5.0-optimize-mul-u64#4ae5018533f1e757bb321e21927c8bbbf8c27ffc"
 dependencies = [
  "num-bigint",
  "num-traits",
@@ -341,7 +341,7 @@ dependencies = [
 [[package]]
 name = "ark-poly"
 version = "0.5.0"
-source = "git+https://github.com/a16z/arkworks-algebra?branch=v0.5.0-optimize-mul-u64#b926f92b4f655d8ea7980f09097d51589c1f707a"
+source = "git+https://github.com/a16z/arkworks-algebra?branch=v0.5.0-optimize-mul-u64#4ae5018533f1e757bb321e21927c8bbbf8c27ffc"
 dependencies = [
  "ahash",
  "ark-ff 0.5.0",
@@ -376,7 +376,7 @@ dependencies = [
 [[package]]
 name = "ark-serialize"
 version = "0.5.0"
-source = "git+https://github.com/a16z/arkworks-algebra?branch=v0.5.0-optimize-mul-u64#b926f92b4f655d8ea7980f09097d51589c1f707a"
+source = "git+https://github.com/a16z/arkworks-algebra?branch=v0.5.0-optimize-mul-u64#4ae5018533f1e757bb321e21927c8bbbf8c27ffc"
 dependencies = [
  "ark-serialize-derive 0.5.0 (git+https://github.com/a16z/arkworks-algebra?branch=v0.5.0-optimize-mul-u64)",
  "ark-std 0.5.0",
@@ -400,7 +400,7 @@ dependencies = [
 [[package]]
 name = "ark-serialize-derive"
 version = "0.5.0"
-source = "git+https://github.com/a16z/arkworks-algebra?branch=v0.5.0-optimize-mul-u64#b926f92b4f655d8ea7980f09097d51589c1f707a"
+source = "git+https://github.com/a16z/arkworks-algebra?branch=v0.5.0-optimize-mul-u64#4ae5018533f1e757bb321e21927c8bbbf8c27ffc"
 dependencies = [
  "proc-macro2",
  "quote",


### PR DESCRIPTION
WIP

This PR is downstream of new progress in [v0.5.0-optimize-mul-u64](https://github.com/a16z/arkworks-algebra/tree/v0.5.0-optimize-mul-u64), where we defined `mul_u128` and `mul_i128` using Barrett reduction, similar to `mul_u64`.

The new arkworks version also restores the `FixedBase` trait that is needed for `kzg.rs`. Without it, we got a bench timeout.

Finally, we also change the `from_u64` function for BN254 to call `from_u64` in arkworks instead (if the number fits in u16 or u32 then we call that). The reason is that doing 4 lookups + adding them together is slightly slower than just doing a single `Fr::one().mul_u64(val)`. But of course <=2 lookups is faster.