### PR TITLE
chore: add build script to capture Git commit information

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,49 @@
+use std::path::Path;
+use std::process::Command;
+
+struct CommitInfo {
+    hash: String,
+    short_hash: String,
+    date: String,
+}
+
+fn commit_info_from_git() -> Option<CommitInfo> {
+    if !Path::new(".git").exists() {
+        return None;
+    }
+
+    let output = match Command::new("git")
+        .arg("log")
+        .arg("-1")
+        .arg("--date=short")
+        .arg("--format=%H %h %cd")
+        .arg("--abbrev=9")
+        .output()
+    {
+        Ok(output) if output.status.success() => output,
+        _ => return None,
+    };
+
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let mut parts = stdout.split_whitespace().map(|s| s.to_string());
+
+    Some(CommitInfo {
+        hash: parts.next()?,
+        short_hash: parts.next()?,
+        date: parts.next()?,
+    })
+}
+
+fn commit_info() {
+    let Some(git) = commit_info_from_git() else {
+        return;
+    };
+
+    println!("cargo:rustc-env=GIT_HASH={}", git.hash);
+    println!("cargo:rustc-env=GIT_SHORT_HASH={}", git.short_hash);
+    println!("cargo:rustc-env=GIT_DATE={}", git.date);
+}
+
+fn main() {
+    commit_info();
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,7 +14,7 @@ use build_wasm::{build_wasm, modify_cargo_toml};
 use jolt_core::host::toolchain;
 
 #[derive(Parser)]
-#[command(version, about, long_about = None)]
+#[command(version = version(), about, long_about = None)]
 struct Cli {
     #[command(subcommand)]
     command: Command,
@@ -36,6 +36,17 @@ enum Command {
     UninstallToolchain,
     /// Handles preprocessing and generates WASM compatible files
     BuildWasm,
+}
+
+fn version() -> &'static str {
+    concat!(
+        env!("CARGO_PKG_VERSION"),
+        " (",
+        env!("GIT_SHORT_HASH"),
+        " ",
+        env!("GIT_DATE"),
+        ")"
+    )
 }
 
 fn main() {


### PR DESCRIPTION
This PR introduces a new `build.rs` file that retrieves the latest Git commit hash, short hash, and date, and sets them as environment variables for use in the application. Additionally, the `main.rs` file is updated to include a version function that formats the version string with the Git information.