### PR TITLE
Fix broken link in GKR documentation

### DIFF
--- a/book/src/background/gkr.md
+++ b/book/src/background/gkr.md
@@ -33,4 +33,4 @@ where
 $$
 g^{(i)}_z(p) = \widetilde{\text{eq}}_{s_i}(z, p) \cdot \widetilde{V}_{i+1}(p,0) \cdot \widetilde{V}_{i+1}(p,1)
 $$
-GKR is utilized in [memory-checking](./memory-checking.html) for the multi-set permutation check.
+GKR is utilized in [memory-checking](./memory-checking.md) for the multi-set permutation check.


### PR DESCRIPTION
Changed the link to memory-checking from .html to .md extension in the GKR background documentation to fix the broken reference and ensure proper navigation between documentation files.