### PR TITLE
refactor: remove associated_type_defaults feature flag

### DIFF
--- a/jolt-core/src/field/mod.rs
+++ b/jolt-core/src/field/mod.rs
@@ -45,7 +45,7 @@ pub trait JoltField:
     /// conversion of small primitive integers (e.g. `u16` values) into field elements. For example,
     /// the arkworks BN254 scalar field requires a conversion into Montgomery form, which naively
     /// requires a field multiplication, but can instead be looked up.
-    type SmallValueLookupTables: Clone + Default + CanonicalSerialize + CanonicalDeserialize = ();
+    type SmallValueLookupTables: Clone + Default + CanonicalSerialize + CanonicalDeserialize;
 
     fn random<R: rand_core::RngCore>(rng: &mut R) -> Self;
     /// Computes the small-value lookup tables.

--- a/jolt-core/src/jolt/vm/bytecode.rs
+++ b/jolt-core/src/jolt/vm/bytecode.rs
@@ -16,6 +16,7 @@ use crate::lasso::memory_checking::{
 use crate::poly::commitment::commitment_scheme::CommitmentScheme;
 use crate::poly::compact_polynomial::{CompactPolynomial, SmallScalar};
 use crate::poly::multilinear_polynomial::{MultilinearPolynomial, PolynomialEvaluation};
+use crate::subprotocols::grand_product::BatchedDenseGrandProduct;
 use common::constants::{BYTES_PER_INSTRUCTION, RAM_START_ADDRESS};
 use common::rv_trace::ELFInstruction;
 
@@ -479,9 +480,14 @@ where
     PCS: CommitmentScheme<ProofTranscript, Field = F>,
     ProofTranscript: Transcript,
 {
+    type ReadWriteGrandProduct = BatchedDenseGrandProduct<F>;
+    type InitFinalGrandProduct = BatchedDenseGrandProduct<F>;
+
     type Polynomials = BytecodePolynomials<F>;
     type Openings = BytecodeOpenings<F>;
     type Commitments = BytecodeCommitments<PCS, ProofTranscript>;
+    type ExogenousOpenings = NoExogenousOpenings;
+
     type Preprocessing = BytecodePreprocessing<F>;
 
     // [virtual_address, elf_address, opcode, rd, rs1, rs2, imm, t]

--- a/jolt-core/src/jolt/vm/instruction_lookups.rs
+++ b/jolt-core/src/jolt/vm/instruction_lookups.rs
@@ -3,7 +3,7 @@ use crate::poly::multilinear_polynomial::{
     BindingOrder, MultilinearPolynomial, PolynomialBinding, PolynomialEvaluation,
 };
 use crate::poly::opening_proof::{ProverOpeningAccumulator, VerifierOpeningAccumulator};
-use crate::subprotocols::grand_product::BatchedGrandProduct;
+use crate::subprotocols::grand_product::{BatchedDenseGrandProduct, BatchedGrandProduct};
 use crate::subprotocols::sparse_grand_product::ToggledBatchedGrandProduct;
 use crate::utils::thread::unsafe_allocate_zero_vec;
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
@@ -167,10 +167,12 @@ where
     ProofTranscript: Transcript,
 {
     type ReadWriteGrandProduct = ToggledBatchedGrandProduct<F>;
+    type InitFinalGrandProduct = BatchedDenseGrandProduct<F>;
 
     type Polynomials = InstructionLookupPolynomials<F>;
     type Openings = InstructionLookupOpenings<F>;
     type Commitments = InstructionLookupCommitments<PCS, ProofTranscript>;
+    type ExogenousOpenings = NoExogenousOpenings;
 
     type Preprocessing = InstructionLookupsPreprocessing<C, F>;
 

--- a/jolt-core/src/jolt/vm/read_write_memory.rs
+++ b/jolt-core/src/jolt/vm/read_write_memory.rs
@@ -6,6 +6,7 @@ use crate::lasso::memory_checking::{
 use crate::poly::compact_polynomial::{CompactPolynomial, SmallScalar};
 use crate::poly::multilinear_polynomial::{MultilinearPolynomial, PolynomialEvaluation};
 use crate::poly::opening_proof::{ProverOpeningAccumulator, VerifierOpeningAccumulator};
+use crate::subprotocols::grand_product::BatchedDenseGrandProduct;
 use crate::utils::thread::unsafe_allocate_zero_vec;
 use rayon::prelude::*;
 #[cfg(test)]
@@ -501,12 +502,15 @@ where
     PCS: CommitmentScheme<ProofTranscript, Field = F>,
     ProofTranscript: Transcript,
 {
+    type ReadWriteGrandProduct = BatchedDenseGrandProduct<F>;
+    type InitFinalGrandProduct = BatchedDenseGrandProduct<F>;
+
     type Polynomials = ReadWriteMemoryPolynomials<F>;
     type Openings = ReadWriteMemoryOpenings<F>;
     type Commitments = ReadWriteMemoryCommitments<PCS, ProofTranscript>;
-    type Preprocessing = ReadWriteMemoryPreprocessing;
-
     type ExogenousOpenings = RegisterAddressOpenings<F>;
+
+    type Preprocessing = ReadWriteMemoryPreprocessing;
 
     // (a, v, t)
     type MemoryTuple = (F, F, F);

--- a/jolt-core/src/jolt/vm/timestamp_range_check.rs
+++ b/jolt-core/src/jolt/vm/timestamp_range_check.rs
@@ -269,14 +269,18 @@ where
     PCS: CommitmentScheme<ProofTranscript, Field = F>,
     ProofTranscript: Transcript,
 {
+    type ReadWriteGrandProduct = BatchedDenseGrandProduct<F>;
+    // Init/final grand products are batched together with read/write grand products
+    type InitFinalGrandProduct = NoopGrandProduct;
+
     type Polynomials = TimestampRangeCheckPolynomials<F>;
     type Openings = TimestampRangeCheckOpenings<F>;
     type Commitments = TimestampRangeCheckCommitments<PCS, ProofTranscript>;
     type ExogenousOpenings = ReadTimestampOpenings<F>;
-    type MemoryTuple = (F, F); // a = v for all range check tuples
 
-    // Init/final grand products are batched together with read/write grand products
-    type InitFinalGrandProduct = NoopGrandProduct;
+    type Preprocessing = NoPreprocessing;
+
+    type MemoryTuple = (F, F); // a = v for all range check tuples
 
     fn prove_memory_checking(
         _: &PCS::Setup,

--- a/jolt-core/src/lasso/memory_checking.rs
+++ b/jolt-core/src/lasso/memory_checking.rs
@@ -12,9 +12,7 @@ use crate::utils::thread::drop_in_background_thread;
 use crate::utils::transcript::Transcript;
 use crate::{
     poly::commitment::commitment_scheme::CommitmentScheme,
-    subprotocols::grand_product::{
-        BatchedDenseGrandProduct, BatchedGrandProduct, BatchedGrandProductProof,
-    },
+    subprotocols::grand_product::{BatchedGrandProduct, BatchedGrandProductProof},
 };
 
 use crate::field::JoltField;
@@ -216,20 +214,18 @@ where
     ProofTranscript: Transcript,
     Self: Sync,
 {
-    type ReadWriteGrandProduct: BatchedGrandProduct<F, PCS, ProofTranscript> + Send + 'static =
-        BatchedDenseGrandProduct<F>;
-    type InitFinalGrandProduct: BatchedGrandProduct<F, PCS, ProofTranscript> + Send + 'static =
-        BatchedDenseGrandProduct<F>;
+    type ReadWriteGrandProduct: BatchedGrandProduct<F, PCS, ProofTranscript> + Send + 'static;
+    type InitFinalGrandProduct: BatchedGrandProduct<F, PCS, ProofTranscript> + Send + 'static;
 
     type Polynomials: StructuredPolynomialData<MultilinearPolynomial<F>>;
     type Openings: StructuredPolynomialData<F> + Sync + Initializable<F, Self::Preprocessing>;
     type Commitments: StructuredPolynomialData<PCS::Commitment>;
-    type ExogenousOpenings: ExogenousOpenings<F> + Sync = NoExogenousOpenings;
+    type ExogenousOpenings: ExogenousOpenings<F> + Sync;
 
-    type Preprocessing = NoPreprocessing;
+    type Preprocessing;
 
     /// The data associated with each memory slot. A triple (a, v, t) by default.
-    type MemoryTuple: Copy + Clone = (F, F, F);
+    type MemoryTuple: Copy + Clone;
 
     #[tracing::instrument(skip_all, name = "MemoryCheckingProver::prove_memory_checking")]
     /// Generates a memory checking proof for the given committed polynomials.

--- a/jolt-core/src/lasso/surge.rs
+++ b/jolt-core/src/lasso/surge.rs
@@ -6,6 +6,7 @@ use crate::{
         multilinear_polynomial::{MultilinearPolynomial, PolynomialEvaluation},
         opening_proof::{ProverOpeningAccumulator, VerifierOpeningAccumulator},
     },
+    subprotocols::grand_product::BatchedDenseGrandProduct,
 };
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use rayon::iter::{IntoParallelIterator, IntoParallelRefIterator, ParallelIterator};
@@ -101,10 +102,18 @@ where
     Instruction: JoltInstruction + Default + Sync,
     PCS: CommitmentScheme<ProofTranscript, Field = F>,
 {
+    type ReadWriteGrandProduct = BatchedDenseGrandProduct<F>;
+    type InitFinalGrandProduct = BatchedDenseGrandProduct<F>;
+
     type Polynomials = SurgePolynomials<F>;
     type Openings = SurgeOpenings<F>;
     type Commitments = SurgeCommitments<PCS, ProofTranscript>;
+    type ExogenousOpenings = NoExogenousOpenings;
+
     type Preprocessing = SurgePreprocessing<F, Instruction, C, M>;
+
+    /// The data associated with each memory slot. A triple (a, v, t) by default.
+    type MemoryTuple = (F, F, F); // (a, v, t)
 
     fn fingerprint(inputs: &(F, F, F), gamma: &F, tau: &F) -> F {
         let (a, v, t) = *inputs;

--- a/jolt-core/src/lib.rs
+++ b/jolt-core/src/lib.rs
@@ -1,4 +1,3 @@
-#![feature(associated_type_defaults)]
 #![allow(non_snake_case)]
 #![allow(incomplete_features)]
 #![allow(long_running_const_eval)]


### PR DESCRIPTION
This commit removes the associated_type_defaults feature flag and makes all associated types explicit in the codebase. The changes include:

- Remove #![feature(associated_type_defaults)] from lib.rs
- Remove default value (= ()) from JoltField::SmallValueLookupTables
- Remove default values from MemoryCheckingProver associated types:
  - ReadWriteGrandProduct
  - InitFinalGrandProduct
  - ExogenousOpenings
  - Preprocessing
  - MemoryTuple
- Make all implementations of MemoryCheckingProver explicitly specify their associated types
- Reorder associated type declarations for better readability

These changes make the code more explicit and remove the dependency on the unstable associated_type_defaults feature, improving compatibility with stable Rust.