### PR TITLE
fix: use paste crate to resolve enum_dispatch inner scope issue

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2004,6 +2004,7 @@ dependencies = [
  "num-integer",
  "num-traits",
  "once_cell",
+ "paste",
  "postcard",
  "rand 0.7.3",
  "rand_chacha 0.3.1",

--- a/jolt-core/Cargo.toml
+++ b/jolt-core/Cargo.toml
@@ -88,6 +88,7 @@ alloy-sol-types = "0.7.6"
 once_cell = "1.19.0"
 rand_distr = "0.4.3"
 anyhow = "1.0.97"
+paste = "1.0.15"
 
 [dev-dependencies]
 criterion = { version = "0.5.1", features = ["html_reports"] }

--- a/jolt-core/src/jolt/vm/rv32i_vm.rs
+++ b/jolt-core/src/jolt/vm/rv32i_vm.rs
@@ -14,6 +14,7 @@ use crate::r1cs::inputs::JoltR1CSInputs;
 use ark_bn254::{Bn254, Fr};
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use enum_dispatch::enum_dispatch;
+use paste::paste;
 use rand::{prelude::StdRng, RngCore};
 use serde::{Deserialize, Serialize};
 use std::any::TypeId;
@@ -44,12 +45,14 @@ use crate::poly::commitment::commitment_scheme::CommitmentScheme;
 /// are callable on the enum type via enum_dispatch.
 macro_rules! instruction_set {
     ($enum_name:ident, $($alias:ident: $struct:ty),+) => {
-        #[allow(non_camel_case_types)]
-        #[repr(u8)]
-        #[derive(Copy, Clone, Debug, PartialEq, EnumIter, EnumCountMacro, Serialize, Deserialize)]
-        #[enum_dispatch(JoltInstruction)]
-        pub enum $enum_name {
-            $($alias($struct)),+
+        paste! {
+            #[allow(non_camel_case_types)]
+            #[repr(u8)]
+            #[derive(Copy, Clone, Debug, PartialEq, EnumIter, EnumCountMacro, Serialize, Deserialize)]
+            #[enum_dispatch(JoltInstruction)]
+            pub enum $enum_name {
+                $([<$alias>]($struct)),+
+            }
         }
         impl JoltInstructionSet for $enum_name {}
         impl $enum_name {
@@ -77,11 +80,13 @@ macro_rules! instruction_set {
 /// are callable on the enum type via enum_dispatch.
 macro_rules! subtable_enum {
     ($enum_name:ident, $($alias:ident: $struct:ty),+) => {
-        #[allow(non_camel_case_types)]
-        #[repr(u8)]
-        #[enum_dispatch(LassoSubtable<F>)]
-        #[derive(EnumCountMacro, EnumIter)]
-        pub enum $enum_name<F: JoltField> { $($alias($struct)),+ }
+        paste! {
+            #[allow(non_camel_case_types)]
+            #[repr(u8)]
+            #[enum_dispatch(LassoSubtable<F>)]
+            #[derive(EnumCountMacro, EnumIter)]
+            pub enum $enum_name<F: JoltField> { $([<$alias>]($struct)),+ }
+        }
         impl<F: JoltField> From<SubtableId> for $enum_name<F> {
           fn from(subtable_id: SubtableId) -> Self {
             $(


### PR DESCRIPTION
The error "cannot find value `inner` in this scope" occurs because enum_dispatch
creates an inner identifier during macro expansion, but it's not properly scoped.
The paste crate helps by creating hygienic identifiers during macro expansion,
ensuring the inner value is available in the correct scope.

This is a more robust solution than relying on trait definition order, as it
properly handles macro hygiene and identifier scoping.