### PR TITLE
Feat: Optimize SLLI, SRLI, SRAI

### DIFF
--- a/jolt-core/src/jolt/instruction/mod.rs
+++ b/jolt-core/src/jolt/instruction/mod.rs
@@ -122,6 +122,7 @@ impl InstructionLookup<32> for RV32IMInstruction {
             RV32IMInstruction::AssertValidUnsignedRemainder(instr) => instr.lookup_table(),
             RV32IMInstruction::Move(instr) => instr.lookup_table(),
             RV32IMInstruction::Movsign(instr) => instr.lookup_table(),
+            RV32IMInstruction::MULI(instr) => instr.lookup_table(),
             RV32IMInstruction::Pow2(instr) => instr.lookup_table(),
             RV32IMInstruction::Pow2I(instr) => instr.lookup_table(),
             RV32IMInstruction::ShiftRightBitmask(instr) => instr.lookup_table(),
@@ -176,6 +177,7 @@ impl InstructionFlags for RV32IMInstruction {
             RV32IMInstruction::AssertValidUnsignedRemainder(instr) => instr.circuit_flags(),
             RV32IMInstruction::Move(instr) => instr.circuit_flags(),
             RV32IMInstruction::Movsign(instr) => instr.circuit_flags(),
+            RV32IMInstruction::MULI(instr) => instr.circuit_flags(),
             RV32IMInstruction::Pow2(instr) => instr.circuit_flags(),
             RV32IMInstruction::Pow2I(instr) => instr.circuit_flags(),
             RV32IMInstruction::ShiftRightBitmask(instr) => instr.circuit_flags(),
@@ -229,6 +231,7 @@ impl<const WORD_SIZE: usize> InstructionLookup<WORD_SIZE> for RV32IMCycle {
             RV32IMCycle::AssertValidUnsignedRemainder(cycle) => cycle.instruction.lookup_table(),
             RV32IMCycle::Move(cycle) => cycle.instruction.lookup_table(),
             RV32IMCycle::Movsign(cycle) => cycle.instruction.lookup_table(),
+            RV32IMCycle::MULI(cycle) => cycle.instruction.lookup_table(),
             RV32IMCycle::Pow2(cycle) => cycle.instruction.lookup_table(),
             RV32IMCycle::Pow2I(cycle) => cycle.instruction.lookup_table(),
             RV32IMCycle::ShiftRightBitmask(cycle) => cycle.instruction.lookup_table(),
@@ -290,6 +293,9 @@ impl<const WORD_SIZE: usize> LookupQuery<WORD_SIZE> for RV32IMCycle {
             }
             RV32IMCycle::Move(cycle) => LookupQuery::<WORD_SIZE>::to_instruction_inputs(cycle),
             RV32IMCycle::Movsign(cycle) => LookupQuery::<WORD_SIZE>::to_instruction_inputs(cycle),
+            RV32IMCycle::MULI(cycle) => {
+                LookupQuery::<WORD_SIZE>::to_instruction_inputs(cycle)
+            }
             RV32IMCycle::Pow2(cycle) => LookupQuery::<WORD_SIZE>::to_instruction_inputs(cycle),
             RV32IMCycle::Pow2I(cycle) => LookupQuery::<WORD_SIZE>::to_instruction_inputs(cycle),
             RV32IMCycle::ShiftRightBitmask(cycle) => {
@@ -357,6 +363,7 @@ impl<const WORD_SIZE: usize> LookupQuery<WORD_SIZE> for RV32IMCycle {
             }
             RV32IMCycle::Move(cycle) => LookupQuery::<WORD_SIZE>::to_lookup_operands(cycle),
             RV32IMCycle::Movsign(cycle) => LookupQuery::<WORD_SIZE>::to_lookup_operands(cycle),
+            RV32IMCycle::MULI(cycle) => LookupQuery::<WORD_SIZE>::to_lookup_operands(cycle),
             RV32IMCycle::Pow2(cycle) => LookupQuery::<WORD_SIZE>::to_lookup_operands(cycle),
             RV32IMCycle::Pow2I(cycle) => LookupQuery::<WORD_SIZE>::to_lookup_operands(cycle),
             RV32IMCycle::ShiftRightBitmask(cycle) => {
@@ -420,6 +427,7 @@ impl<const WORD_SIZE: usize> LookupQuery<WORD_SIZE> for RV32IMCycle {
             }
             RV32IMCycle::Move(cycle) => LookupQuery::<WORD_SIZE>::to_lookup_output(cycle),
             RV32IMCycle::Movsign(cycle) => LookupQuery::<WORD_SIZE>::to_lookup_output(cycle),
+            RV32IMCycle::MULI(cycle) => LookupQuery::<WORD_SIZE>::to_lookup_output(cycle),
             RV32IMCycle::Pow2(cycle) => LookupQuery::<WORD_SIZE>::to_lookup_output(cycle),
             RV32IMCycle::Pow2I(cycle) => LookupQuery::<WORD_SIZE>::to_lookup_output(cycle),
             RV32IMCycle::ShiftRightBitmask(cycle) => {
@@ -471,6 +479,7 @@ pub mod virtual_assert_valid_signed_remainder;
 pub mod virtual_assert_valid_unsigned_remainder;
 pub mod virtual_move;
 pub mod virtual_movsign;
+pub mod virtual_muli;
 pub mod virtual_pow2;
 pub mod virtual_pow2i;
 pub mod virtual_shift_right_bitmask;

--- a/jolt-core/src/jolt/instruction/mod.rs
+++ b/jolt-core/src/jolt/instruction/mod.rs
@@ -128,7 +128,9 @@ impl InstructionLookup<32> for RV32IMInstruction {
             RV32IMInstruction::ShiftRightBitmask(instr) => instr.lookup_table(),
             RV32IMInstruction::ShiftRightBitmaskI(instr) => instr.lookup_table(),
             RV32IMInstruction::VirtualSRA(instr) => instr.lookup_table(),
+            RV32IMInstruction::VirtualSRAI(instr) => instr.lookup_table(),
             RV32IMInstruction::VirtualSRL(instr) => instr.lookup_table(),
+            RV32IMInstruction::VirtualSRLI(instr) => instr.lookup_table(),
             _ => panic!("Unexpected instruction {:?}", self),
         }
     }
@@ -183,7 +185,9 @@ impl InstructionFlags for RV32IMInstruction {
             RV32IMInstruction::ShiftRightBitmask(instr) => instr.circuit_flags(),
             RV32IMInstruction::ShiftRightBitmaskI(instr) => instr.circuit_flags(),
             RV32IMInstruction::VirtualSRA(instr) => instr.circuit_flags(),
+            RV32IMInstruction::VirtualSRAI(instr) => instr.circuit_flags(),
             RV32IMInstruction::VirtualSRL(instr) => instr.circuit_flags(),
+            RV32IMInstruction::VirtualSRLI(instr) => instr.circuit_flags(),
             _ => panic!("Unexpected instruction {:?}", self),
         }
     }
@@ -237,7 +241,9 @@ impl<const WORD_SIZE: usize> InstructionLookup<WORD_SIZE> for RV32IMCycle {
             RV32IMCycle::ShiftRightBitmask(cycle) => cycle.instruction.lookup_table(),
             RV32IMCycle::ShiftRightBitmaskI(cycle) => cycle.instruction.lookup_table(),
             RV32IMCycle::VirtualSRA(cycle) => cycle.instruction.lookup_table(),
+            RV32IMCycle::VirtualSRAI(cycle) => cycle.instruction.lookup_table(),
             RV32IMCycle::VirtualSRL(cycle) => cycle.instruction.lookup_table(),
+            RV32IMCycle::VirtualSRLI(cycle) => cycle.instruction.lookup_table(),
             _ => panic!("Unexpected instruction {:?}", self),
         }
     }
@@ -307,7 +313,13 @@ impl<const WORD_SIZE: usize> LookupQuery<WORD_SIZE> for RV32IMCycle {
             RV32IMCycle::VirtualSRA(cycle) => {
                 LookupQuery::<WORD_SIZE>::to_instruction_inputs(cycle)
             }
+            RV32IMCycle::VirtualSRAI(cycle) => {
+                LookupQuery::<WORD_SIZE>::to_instruction_inputs(cycle)
+            }
             RV32IMCycle::VirtualSRL(cycle) => {
+                LookupQuery::<WORD_SIZE>::to_instruction_inputs(cycle)
+            }
+            RV32IMCycle::VirtualSRLI(cycle) => {
                 LookupQuery::<WORD_SIZE>::to_instruction_inputs(cycle)
             }
             _ => panic!("Unexpected instruction {:?}", self),
@@ -373,7 +385,9 @@ impl<const WORD_SIZE: usize> LookupQuery<WORD_SIZE> for RV32IMCycle {
                 LookupQuery::<WORD_SIZE>::to_lookup_operands(cycle)
             }
             RV32IMCycle::VirtualSRA(cycle) => LookupQuery::<WORD_SIZE>::to_lookup_operands(cycle),
+            RV32IMCycle::VirtualSRAI(cycle) => LookupQuery::<WORD_SIZE>::to_lookup_operands(cycle),
             RV32IMCycle::VirtualSRL(cycle) => LookupQuery::<WORD_SIZE>::to_lookup_operands(cycle),
+            RV32IMCycle::VirtualSRLI(cycle) => LookupQuery::<WORD_SIZE>::to_lookup_operands(cycle),
             _ => panic!("Unexpected instruction {:?}", self),
         }
     }
@@ -437,7 +451,9 @@ impl<const WORD_SIZE: usize> LookupQuery<WORD_SIZE> for RV32IMCycle {
                 LookupQuery::<WORD_SIZE>::to_lookup_output(cycle)
             }
             RV32IMCycle::VirtualSRA(cycle) => LookupQuery::<WORD_SIZE>::to_lookup_output(cycle),
+            RV32IMCycle::VirtualSRAI(cycle) => LookupQuery::<WORD_SIZE>::to_lookup_output(cycle),
             RV32IMCycle::VirtualSRL(cycle) => LookupQuery::<WORD_SIZE>::to_lookup_output(cycle),
+            RV32IMCycle::VirtualSRLI(cycle) => LookupQuery::<WORD_SIZE>::to_lookup_output(cycle),
             _ => panic!("Unexpected instruction {:?}", self),
         }
     }
@@ -485,7 +501,9 @@ pub mod virtual_pow2i;
 pub mod virtual_shift_right_bitmask;
 pub mod virtual_shift_right_bitmaski;
 pub mod virtual_sra;
+pub mod virtual_srai;
 pub mod virtual_srl;
+pub mod virtual_srli;
 pub mod xor;
 pub mod xori;
 

--- a/jolt-core/src/jolt/instruction/virtual_muli.rs
+++ b/jolt-core/src/jolt/instruction/virtual_muli.rs
@@ -1,0 +1,80 @@
+use tracer::instruction::{virtual_muli::VirtualMULI, RISCVCycle};
+
+use crate::jolt::lookup_table::range_check::RangeCheckTable;
+use crate::jolt::lookup_table::LookupTables;
+
+use super::{CircuitFlags, InstructionFlags, InstructionLookup, LookupQuery, NUM_CIRCUIT_FLAGS};
+
+impl<const WORD_SIZE: usize> InstructionLookup<WORD_SIZE> for VirtualMULI {
+    fn lookup_table(&self) -> Option<LookupTables<WORD_SIZE>> {
+        Some(RangeCheckTable.into())
+    }
+}
+
+impl InstructionFlags for VirtualMULI {
+    fn circuit_flags(&self) -> [bool; NUM_CIRCUIT_FLAGS] {
+        let mut flags = [false; NUM_CIRCUIT_FLAGS];
+        flags[CircuitFlags::LeftOperandIsRs1Value as usize] = true;
+        flags[CircuitFlags::RightOperandIsImm as usize] = true;
+        flags[CircuitFlags::MultiplyOperands as usize] = true;
+        flags[CircuitFlags::WriteLookupOutputToRD as usize] = true;
+        flags[CircuitFlags::Virtual as usize] = self.virtual_sequence_remaining.is_some();
+        flags[CircuitFlags::DoNotUpdatePC as usize] =
+            self.virtual_sequence_remaining.unwrap_or(0) != 0;
+        flags
+    }
+}
+
+impl<const WORD_SIZE: usize> LookupQuery<WORD_SIZE> for RISCVCycle<VirtualMULI> {
+    fn to_lookup_operands(&self) -> (u64, u64) {
+        let (x, y) = LookupQuery::<WORD_SIZE>::to_instruction_inputs(self);
+        (0, x * y as u64)
+    }
+
+    fn to_lookup_index(&self) -> u64 {
+        LookupQuery::<WORD_SIZE>::to_lookup_operands(self).1
+    }
+
+    fn to_instruction_inputs(&self) -> (u64, i64) {
+        match WORD_SIZE {
+            #[cfg(test)]
+            8 => (
+                self.register_state.rs1 as u8 as u64,
+                self.instruction.operands.imm as u8 as i64,
+            ),
+            32 => (
+                self.register_state.rs1 as u32 as u64,
+                self.instruction.operands.imm as u32 as i64,
+            ),
+            64 => (
+                self.register_state.rs1,
+                self.instruction.operands.imm as i64,
+            ),
+            _ => panic!("{WORD_SIZE}-bit word size is unsupported"),
+        }
+    }
+
+    fn to_lookup_output(&self) -> u64 {
+        let (x, y) = LookupQuery::<WORD_SIZE>::to_instruction_inputs(self);
+        match WORD_SIZE {
+            #[cfg(test)]
+            8 => (x as i8).wrapping_mul(y as i8) as u8 as u64,
+            32 => (x as i32).wrapping_mul(y as i32) as u32 as u64,
+            64 => (x as i64).wrapping_mul(y as i64) as u64,
+            _ => panic!("{WORD_SIZE}-bit word size is unsupported"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::jolt::instruction::test::materialize_entry_test;
+
+    use super::*;
+    use ark_bn254::Fr;
+
+    #[test]
+    fn materialize_entry() {
+        materialize_entry_test::<Fr, VirtualMULI>();
+    }
+}

--- a/jolt-core/src/jolt/instruction/virtual_srai.rs
+++ b/jolt-core/src/jolt/instruction/virtual_srai.rs
@@ -1,0 +1,64 @@
+use tracer::instruction::{virtual_srai::VirtualSRAI, RISCVCycle};
+
+use crate::jolt::lookup_table::{virtual_sra::VirtualSRATable, LookupTables};
+
+use super::{CircuitFlags, InstructionFlags, InstructionLookup, LookupQuery, NUM_CIRCUIT_FLAGS};
+
+impl<const WORD_SIZE: usize> InstructionLookup<WORD_SIZE> for VirtualSRAI {
+    fn lookup_table(&self) -> Option<LookupTables<WORD_SIZE>> {
+        Some(VirtualSRATable.into())
+    }
+}
+
+impl InstructionFlags for VirtualSRAI {
+    fn circuit_flags(&self) -> [bool; NUM_CIRCUIT_FLAGS] {
+        let mut flags = [false; NUM_CIRCUIT_FLAGS];
+        flags[CircuitFlags::LeftOperandIsRs1Value as usize] = true;
+        flags[CircuitFlags::RightOperandIsImm as usize] = true;
+        flags[CircuitFlags::WriteLookupOutputToRD as usize] = true;
+        flags[CircuitFlags::Virtual as usize] = self.virtual_sequence_remaining.is_some();
+        flags[CircuitFlags::DoNotUpdatePC as usize] =
+            self.virtual_sequence_remaining.unwrap_or(0) != 0;
+        flags
+    }
+}
+
+impl<const WORD_SIZE: usize> LookupQuery<WORD_SIZE> for RISCVCycle<VirtualSRAI> {
+    fn to_instruction_inputs(&self) -> (u64, i64) {
+        (self.register_state.rs1, self.instruction.operands.imm as i64)
+    }
+
+    fn to_lookup_output(&self) -> u64 {
+        use crate::subprotocols::sparse_dense_shout::LookupBits;
+        let (x, y) = LookupQuery::<WORD_SIZE>::to_instruction_inputs(self);
+        let mut x = LookupBits::new(x as u64, WORD_SIZE);
+        let mut y = LookupBits::new(y as u64, WORD_SIZE);
+
+        let sign_bit = if x.leading_ones() == 0 { 0 } else { 1 };
+        let mut entry = 0;
+        let mut sign_extension = 0;
+        for i in 0..WORD_SIZE {
+            let x_i = x.pop_msb() as u64;
+            let y_i = y.pop_msb() as u64;
+            entry *= 1 + y_i;
+            entry += x_i * y_i;
+            if i != 0 {
+                sign_extension += (1 << i) * (1 - y_i);
+            }
+        }
+        entry + sign_bit * sign_extension
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::jolt::instruction::test::materialize_entry_test;
+
+    use super::*;
+    use ark_bn254::Fr;
+
+    #[test]
+    fn materialize_entry() {
+        materialize_entry_test::<Fr, VirtualSRAI>();
+    }
+}

--- a/jolt-core/src/jolt/instruction/virtual_srli.rs
+++ b/jolt-core/src/jolt/instruction/virtual_srli.rs
@@ -1,0 +1,59 @@
+use tracer::instruction::{virtual_srli::VirtualSRLI, RISCVCycle};
+
+use crate::jolt::lookup_table::{virtual_srl::VirtualSRLTable, LookupTables};
+
+use super::{CircuitFlags, InstructionFlags, InstructionLookup, LookupQuery, NUM_CIRCUIT_FLAGS};
+
+impl<const WORD_SIZE: usize> InstructionLookup<WORD_SIZE> for VirtualSRLI {
+    fn lookup_table(&self) -> Option<LookupTables<WORD_SIZE>> {
+        Some(VirtualSRLTable.into())
+    }
+}
+
+impl InstructionFlags for VirtualSRLI {
+    fn circuit_flags(&self) -> [bool; NUM_CIRCUIT_FLAGS] {
+        let mut flags = [false; NUM_CIRCUIT_FLAGS];
+        flags[CircuitFlags::LeftOperandIsRs1Value as usize] = true;
+        flags[CircuitFlags::RightOperandIsImm as usize] = true;
+        flags[CircuitFlags::WriteLookupOutputToRD as usize] = true;
+        flags[CircuitFlags::Virtual as usize] = self.virtual_sequence_remaining.is_some();
+        flags[CircuitFlags::DoNotUpdatePC as usize] =
+            self.virtual_sequence_remaining.unwrap_or(0) != 0;
+        flags
+    }
+}
+
+impl<const WORD_SIZE: usize> LookupQuery<WORD_SIZE> for RISCVCycle<VirtualSRLI> {
+    fn to_instruction_inputs(&self) -> (u64, i64) {
+        (self.register_state.rs1, self.instruction.operands.imm as i64)
+    }
+
+    fn to_lookup_output(&self) -> u64 {
+        use crate::subprotocols::sparse_dense_shout::LookupBits;
+        let (x, y) = LookupQuery::<WORD_SIZE>::to_instruction_inputs(self);
+        let mut x = LookupBits::new(x as u64, WORD_SIZE);
+        let mut y = LookupBits::new(y as u64, WORD_SIZE);
+
+        let mut entry = 0;
+        for _ in 0..WORD_SIZE {
+            let x_i = x.pop_msb();
+            let y_i = y.pop_msb();
+            entry *= 1 + y_i as u64;
+            entry += (x_i * y_i) as u64;
+        }
+        entry
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::jolt::instruction::test::materialize_entry_test;
+
+    use super::*;
+    use ark_bn254::Fr;
+
+    #[test]
+    fn materialize_entry() {
+        materialize_entry_test::<Fr, VirtualSRLI>();
+    }
+}

--- a/jolt-core/src/r1cs/constraints.rs
+++ b/jolt-core/src/r1cs/constraints.rs
@@ -1,3 +1,5 @@
+use std::ops::Add;
+
 use crate::{field::JoltField, jolt::instruction::CircuitFlags};
 
 use super::{
@@ -165,8 +167,8 @@ impl<F: JoltField> R1CSConstraints<F> for JoltRV32IMConstraints {
         //     assert!(RightLookupOperand == Rs1Value * Rs2Value)
         // }
         cs.constrain_prod(
-            JoltR1CSInputs::Rs1Value,
-            JoltR1CSInputs::Rs2Value,
+            JoltR1CSInputs::RightInstructionInput,
+            JoltR1CSInputs::LeftInstructionInput,
             JoltR1CSInputs::Product,
         );
         cs.constrain_eq_conditional(

--- a/jolt-core/src/r1cs/inputs.rs
+++ b/jolt-core/src/r1cs/inputs.rs
@@ -234,7 +234,10 @@ impl JoltR1CSInputs {
             JoltR1CSInputs::Product => {
                 let coeffs: Vec<u64> = trace
                     .par_iter()
-                    .map(|cycle| cycle.rs1_read().1 * cycle.rs2_read().1)
+                    .map(|cycle| {
+                        LookupQuery::<32>::to_instruction_inputs(cycle).0
+                            * LookupQuery::<32>::to_instruction_inputs(cycle).1 as u64
+                    })
                     .collect();
                 coeffs.into()
             }

--- a/jolt-core/src/subprotocols/sparse_dense_shout.rs
+++ b/jolt-core/src/subprotocols/sparse_dense_shout.rs
@@ -768,7 +768,9 @@ mod tests {
             RV32IMCycle::ShiftRightBitmask(cycle) => cycle.random(rng).into(),
             RV32IMCycle::ShiftRightBitmaskI(cycle) => cycle.random(rng).into(),
             RV32IMCycle::VirtualSRA(cycle) => cycle.random(rng).into(),
+            RV32IMCycle::VirtualSRAI(cycle) => cycle.random(rng).into(),
             RV32IMCycle::VirtualSRL(cycle) => cycle.random(rng).into(),
+            RV32IMCycle::VirtualSRLI(cycle) => cycle.random(rng).into(),
             _ => RV32IMCycle::NoOp,
         }
     }
@@ -1030,9 +1032,19 @@ mod tests {
     fn test_virtualsra() {
         test_sparse_dense_shout(Some(RV32IMCycle::VirtualSRA(Default::default())));
     }
+    
+    #[test]
+    fn test_virtualsrai() {
+        test_sparse_dense_shout(Some(RV32IMCycle::VirtualSRAI(Default::default())));
+    }
 
     #[test]
     fn test_virtualsrl() {
         test_sparse_dense_shout(Some(RV32IMCycle::VirtualSRL(Default::default())));
+    }
+    
+    #[test]
+    fn test_virtualsrli() {
+        test_sparse_dense_shout(Some(RV32IMCycle::VirtualSRLI(Default::default())));
     }
 }

--- a/jolt-core/src/subprotocols/sparse_dense_shout.rs
+++ b/jolt-core/src/subprotocols/sparse_dense_shout.rs
@@ -762,6 +762,7 @@ mod tests {
             RV32IMCycle::AssertValidUnsignedRemainder(cycle) => cycle.random(rng).into(),
             RV32IMCycle::Move(cycle) => cycle.random(rng).into(),
             RV32IMCycle::Movsign(cycle) => cycle.random(rng).into(),
+            RV32IMCycle::MULI(cycle) => cycle.random(rng).into(),
             RV32IMCycle::Pow2(cycle) => cycle.random(rng).into(),
             RV32IMCycle::Pow2I(cycle) => cycle.random(rng).into(),
             RV32IMCycle::ShiftRightBitmask(cycle) => cycle.random(rng).into(),
@@ -998,6 +999,11 @@ mod tests {
     #[test]
     fn test_movsign() {
         test_sparse_dense_shout(Some(RV32IMCycle::Movsign(Default::default())));
+    }
+    
+    #[test]
+    fn test_muli() {
+        test_sparse_dense_shout(Some(RV32IMCycle::MULI(Default::default())));
     }
 
     #[test]

--- a/tracer/src/instruction/format/format_virtual_i.rs
+++ b/tracer/src/instruction/format/format_virtual_i.rs
@@ -1,0 +1,73 @@
+use crate::emulator::cpu::Cpu;
+use common::constants::REGISTER_COUNT;
+use rand::rngs::StdRng;
+use rand::RngCore;
+use serde::{Deserialize, Serialize};
+use std::fmt::Debug;
+
+use super::{
+    normalize_register_value, InstructionFormat, InstructionRegisterState, NormalizedOperands,
+};
+
+#[derive(Default, Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+pub struct FormatVirtualI {
+    pub rd: usize,
+    pub rs1: usize,
+    pub imm: u64,
+}
+
+#[derive(Default, Debug, Copy, Clone, Serialize, Deserialize)]
+pub struct RegisterStateFormatVirtualI {
+    pub rd: (u64, u64), // (old_value, new_value)
+    pub rs1: u64,
+}
+
+impl InstructionRegisterState for RegisterStateFormatVirtualI {
+    fn random(rng: &mut StdRng) -> Self {
+        Self {
+            rd: (rng.next_u64(), rng.next_u64()),
+            rs1: rng.next_u64(),
+        }
+    }
+
+    fn rs1_value(&self) -> u64 {
+        self.rs1
+    }
+
+    fn rd_values(&self) -> (u64, u64) {
+        self.rd
+    }
+}
+
+impl InstructionFormat for FormatVirtualI {
+    type RegisterState = RegisterStateFormatVirtualI;
+
+    fn parse(_: u32) -> Self {
+        unimplemented!("virtual instruction")
+    }
+
+    fn capture_pre_execution_state(&self, state: &mut Self::RegisterState, cpu: &mut Cpu) {
+        state.rs1 = normalize_register_value(cpu.x[self.rs1], &cpu.xlen);
+        state.rd.0 = normalize_register_value(cpu.x[self.rd], &cpu.xlen);
+    }
+
+    fn capture_post_execution_state(&self, state: &mut Self::RegisterState, cpu: &mut Cpu) {
+        state.rd.1 = normalize_register_value(cpu.x[self.rd], &cpu.xlen);
+    }
+
+    fn random(rng: &mut StdRng) -> Self {
+        Self {
+            imm: rng.next_u64(),
+            rd: (rng.next_u64() % REGISTER_COUNT) as usize,
+            rs1: (rng.next_u64() % REGISTER_COUNT) as usize,
+        }
+    }
+    fn normalize(&self) -> NormalizedOperands {
+        NormalizedOperands {
+            rs1: self.rs1,
+            rs2: 0,
+            rd: self.rd,
+            imm: self.imm as i64,
+        }
+    }
+}

--- a/tracer/src/instruction/format/format_virtual_r.rs
+++ b/tracer/src/instruction/format/format_virtual_r.rs
@@ -10,20 +10,20 @@ use super::{
 };
 
 #[derive(Default, Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
-pub struct FormatVirtualRightShift {
+pub struct FormatVirtualR {
     pub rd: usize,
     pub rs1: usize,
     pub rs2: usize,
 }
 
 #[derive(Default, Debug, Copy, Clone, Serialize, Deserialize)]
-pub struct RegisterStateVirtualRightShift {
+pub struct RegisterStateVirtualR {
     pub rd: (u64, u64), // (old_value, new_value)
     pub rs1: u64,
     pub rs2: u64,
 }
 
-impl InstructionRegisterState for RegisterStateVirtualRightShift {
+impl InstructionRegisterState for RegisterStateVirtualR {
     fn random(rng: &mut StdRng) -> Self {
         let shift = rng.next_u32() % 64;
         let ones: u64 = (1 << shift) - 1;
@@ -48,8 +48,8 @@ impl InstructionRegisterState for RegisterStateVirtualRightShift {
     }
 }
 
-impl InstructionFormat for FormatVirtualRightShift {
-    type RegisterState = RegisterStateVirtualRightShift;
+impl InstructionFormat for FormatVirtualR {
+    type RegisterState = RegisterStateVirtualR;
 
     fn parse(_: u32) -> Self {
         unimplemented!("virtual instruction")

--- a/tracer/src/instruction/format/mod.rs
+++ b/tracer/src/instruction/format/mod.rs
@@ -12,7 +12,7 @@ pub mod format_s;
 pub mod format_u;
 pub mod format_virtual_halfword_alignment;
 pub mod format_virtual_i;
-pub mod format_virtual_right_shift;
+pub mod format_virtual_r;
 
 #[derive(Default)]
 pub struct NormalizedOperands {

--- a/tracer/src/instruction/format/mod.rs
+++ b/tracer/src/instruction/format/mod.rs
@@ -11,6 +11,7 @@ pub mod format_r;
 pub mod format_s;
 pub mod format_u;
 pub mod format_virtual_halfword_alignment;
+pub mod format_virtual_i;
 pub mod format_virtual_right_shift;
 
 #[derive(Default)]

--- a/tracer/src/instruction/lb.rs
+++ b/tracer/src/instruction/lb.rs
@@ -94,7 +94,7 @@ impl VirtualInstructionSequence for LB {
                 rs1: self.operands.rs1,
                 imm: self.operands.imm as u32 as u64, // TODO(moodlezoup): this only works for Xlen = 32
             },
-            virtual_sequence_remaining: Some(8),
+            virtual_sequence_remaining: Some(7),
         };
         sequence.push(add.into());
 
@@ -105,7 +105,7 @@ impl VirtualInstructionSequence for LB {
                 rs1: v_address,
                 imm: -4i64 as u32 as u64, // TODO(moodlezoup): this only works for Xlen = 32
             },
-            virtual_sequence_remaining: Some(7),
+            virtual_sequence_remaining: Some(6),
         };
         sequence.push(andi.into());
 
@@ -116,7 +116,7 @@ impl VirtualInstructionSequence for LB {
                 rs1: v_word_address,
                 imm: 0,
             },
-            virtual_sequence_remaining: Some(6),
+            virtual_sequence_remaining: Some(5),
         };
         sequence.push(lw.into());
 
@@ -127,7 +127,7 @@ impl VirtualInstructionSequence for LB {
                 rs1: v_address,
                 imm: 3,
             },
-            virtual_sequence_remaining: Some(5),
+            virtual_sequence_remaining: Some(4),
         };
         sequence.push(xori.into());
 
@@ -138,7 +138,7 @@ impl VirtualInstructionSequence for LB {
                 rs1: v_shift,
                 imm: 3,
             },
-            virtual_sequence_remaining: Some(4),
+            virtual_sequence_remaining: Some(3),
         };
         sequence.extend(slli.virtual_sequence().into_iter());
 
@@ -149,7 +149,7 @@ impl VirtualInstructionSequence for LB {
                 rs1: v_word,
                 rs2: v_shift,
             },
-            virtual_sequence_remaining: Some(3),
+            virtual_sequence_remaining: Some(2),
         };
         sequence.extend(sll.virtual_sequence().into_iter());
 
@@ -160,7 +160,7 @@ impl VirtualInstructionSequence for LB {
                 rs1: self.operands.rd,
                 imm: 24,
             },
-            virtual_sequence_remaining: Some(1),
+            virtual_sequence_remaining: Some(0),
         };
         sequence.extend(srai.virtual_sequence().into_iter());
 

--- a/tracer/src/instruction/lb.rs
+++ b/tracer/src/instruction/lb.rs
@@ -94,7 +94,7 @@ impl VirtualInstructionSequence for LB {
                 rs1: self.operands.rs1,
                 imm: self.operands.imm as u32 as u64, // TODO(moodlezoup): this only works for Xlen = 32
             },
-            virtual_sequence_remaining: Some(9),
+            virtual_sequence_remaining: Some(8),
         };
         sequence.push(add.into());
 
@@ -105,7 +105,7 @@ impl VirtualInstructionSequence for LB {
                 rs1: v_address,
                 imm: -4i64 as u32 as u64, // TODO(moodlezoup): this only works for Xlen = 32
             },
-            virtual_sequence_remaining: Some(8),
+            virtual_sequence_remaining: Some(7),
         };
         sequence.push(andi.into());
 
@@ -116,7 +116,7 @@ impl VirtualInstructionSequence for LB {
                 rs1: v_word_address,
                 imm: 0,
             },
-            virtual_sequence_remaining: Some(7),
+            virtual_sequence_remaining: Some(6),
         };
         sequence.push(lw.into());
 
@@ -127,7 +127,7 @@ impl VirtualInstructionSequence for LB {
                 rs1: v_address,
                 imm: 3,
             },
-            virtual_sequence_remaining: Some(6),
+            virtual_sequence_remaining: Some(5),
         };
         sequence.push(xori.into());
 
@@ -138,7 +138,7 @@ impl VirtualInstructionSequence for LB {
                 rs1: v_shift,
                 imm: 3,
             },
-            virtual_sequence_remaining: Some(5),
+            virtual_sequence_remaining: Some(4),
         };
         sequence.extend(slli.virtual_sequence().into_iter());
 

--- a/tracer/src/instruction/lbu.rs
+++ b/tracer/src/instruction/lbu.rs
@@ -94,7 +94,7 @@ impl VirtualInstructionSequence for LBU {
                 rs1: self.operands.rs1,
                 imm: self.operands.imm as u32 as u64, // TODO(moodlezoup): this only works for Xlen = 32
             },
-            virtual_sequence_remaining: Some(9),
+            virtual_sequence_remaining: Some(8),
         };
         sequence.push(add.into());
 
@@ -105,7 +105,7 @@ impl VirtualInstructionSequence for LBU {
                 rs1: v_address,
                 imm: -4i64 as u32 as u64, // TODO(moodlezoup): this only works for Xlen = 32
             },
-            virtual_sequence_remaining: Some(8),
+            virtual_sequence_remaining: Some(7),
         };
         sequence.push(andi.into());
 
@@ -116,7 +116,7 @@ impl VirtualInstructionSequence for LBU {
                 rs1: v_word_address,
                 imm: 0,
             },
-            virtual_sequence_remaining: Some(7),
+            virtual_sequence_remaining: Some(6),
         };
         sequence.push(lw.into());
 
@@ -127,7 +127,7 @@ impl VirtualInstructionSequence for LBU {
                 rs1: v_address,
                 imm: 3,
             },
-            virtual_sequence_remaining: Some(6),
+            virtual_sequence_remaining: Some(5),
         };
         sequence.push(xori.into());
 
@@ -138,7 +138,7 @@ impl VirtualInstructionSequence for LBU {
                 rs1: v_shift,
                 imm: 3,
             },
-            virtual_sequence_remaining: Some(5),
+            virtual_sequence_remaining: Some(4),
         };
         sequence.extend(slli.virtual_sequence().into_iter());
 

--- a/tracer/src/instruction/lbu.rs
+++ b/tracer/src/instruction/lbu.rs
@@ -94,7 +94,7 @@ impl VirtualInstructionSequence for LBU {
                 rs1: self.operands.rs1,
                 imm: self.operands.imm as u32 as u64, // TODO(moodlezoup): this only works for Xlen = 32
             },
-            virtual_sequence_remaining: Some(8),
+            virtual_sequence_remaining: Some(7),
         };
         sequence.push(add.into());
 
@@ -105,7 +105,7 @@ impl VirtualInstructionSequence for LBU {
                 rs1: v_address,
                 imm: -4i64 as u32 as u64, // TODO(moodlezoup): this only works for Xlen = 32
             },
-            virtual_sequence_remaining: Some(7),
+            virtual_sequence_remaining: Some(6),
         };
         sequence.push(andi.into());
 
@@ -116,7 +116,7 @@ impl VirtualInstructionSequence for LBU {
                 rs1: v_word_address,
                 imm: 0,
             },
-            virtual_sequence_remaining: Some(6),
+            virtual_sequence_remaining: Some(5),
         };
         sequence.push(lw.into());
 
@@ -127,7 +127,7 @@ impl VirtualInstructionSequence for LBU {
                 rs1: v_address,
                 imm: 3,
             },
-            virtual_sequence_remaining: Some(5),
+            virtual_sequence_remaining: Some(4),
         };
         sequence.push(xori.into());
 
@@ -138,7 +138,7 @@ impl VirtualInstructionSequence for LBU {
                 rs1: v_shift,
                 imm: 3,
             },
-            virtual_sequence_remaining: Some(4),
+            virtual_sequence_remaining: Some(3),
         };
         sequence.extend(slli.virtual_sequence().into_iter());
 
@@ -149,7 +149,7 @@ impl VirtualInstructionSequence for LBU {
                 rs1: v_word,
                 rs2: v_shift,
             },
-            virtual_sequence_remaining: Some(3),
+            virtual_sequence_remaining: Some(2),
         };
         sequence.extend(sll.virtual_sequence().into_iter());
 
@@ -160,7 +160,7 @@ impl VirtualInstructionSequence for LBU {
                 rs1: self.operands.rd,
                 imm: 24,
             },
-            virtual_sequence_remaining: Some(1),
+            virtual_sequence_remaining: Some(0),
         };
         sequence.extend(srli.virtual_sequence().into_iter());
 

--- a/tracer/src/instruction/lh.rs
+++ b/tracer/src/instruction/lh.rs
@@ -95,7 +95,7 @@ impl VirtualInstructionSequence for LH {
                 rs1: self.operands.rs1,
                 imm: self.operands.imm,
             },
-            virtual_sequence_remaining: Some(9),
+            virtual_sequence_remaining: Some(8),
         };
         sequence.push(alignment_check.into());
 
@@ -106,7 +106,7 @@ impl VirtualInstructionSequence for LH {
                 rs1: self.operands.rs1,
                 imm: self.operands.imm as u32 as u64, // TODO(moodlezoup): this only works for Xlen = 32
             },
-            virtual_sequence_remaining: Some(8),
+            virtual_sequence_remaining: Some(7),
         };
         sequence.push(add.into());
 
@@ -117,7 +117,7 @@ impl VirtualInstructionSequence for LH {
                 rs1: v_address,
                 imm: -4i64 as u32 as u64, // TODO(moodlezoup): this only works for Xlen = 32
             },
-            virtual_sequence_remaining: Some(7),
+            virtual_sequence_remaining: Some(6),
         };
         sequence.push(andi.into());
 
@@ -128,7 +128,7 @@ impl VirtualInstructionSequence for LH {
                 rs1: v_word_address,
                 imm: 0,
             },
-            virtual_sequence_remaining: Some(6),
+            virtual_sequence_remaining: Some(5),
         };
         sequence.push(lw.into());
 
@@ -139,7 +139,7 @@ impl VirtualInstructionSequence for LH {
                 rs1: v_address,
                 imm: 2,
             },
-            virtual_sequence_remaining: Some(5),
+            virtual_sequence_remaining: Some(4),
         };
         sequence.push(xori.into());
 
@@ -150,7 +150,7 @@ impl VirtualInstructionSequence for LH {
                 rs1: v_shift,
                 imm: 3,
             },
-            virtual_sequence_remaining: Some(4),
+            virtual_sequence_remaining: Some(3),
         };
         sequence.extend(slli.virtual_sequence().into_iter());
 
@@ -161,7 +161,7 @@ impl VirtualInstructionSequence for LH {
                 rs1: v_word,
                 rs2: v_shift,
             },
-            virtual_sequence_remaining: Some(3),
+            virtual_sequence_remaining: Some(2),
         };
         sequence.extend(sll.virtual_sequence().into_iter());
 
@@ -172,7 +172,7 @@ impl VirtualInstructionSequence for LH {
                 rs1: self.operands.rd,
                 imm: 16,
             },
-            virtual_sequence_remaining: Some(1),
+            virtual_sequence_remaining: Some(0),
         };
         sequence.extend(srai.virtual_sequence().into_iter());
 

--- a/tracer/src/instruction/lh.rs
+++ b/tracer/src/instruction/lh.rs
@@ -95,7 +95,7 @@ impl VirtualInstructionSequence for LH {
                 rs1: self.operands.rs1,
                 imm: self.operands.imm,
             },
-            virtual_sequence_remaining: Some(10),
+            virtual_sequence_remaining: Some(9),
         };
         sequence.push(alignment_check.into());
 
@@ -106,7 +106,7 @@ impl VirtualInstructionSequence for LH {
                 rs1: self.operands.rs1,
                 imm: self.operands.imm as u32 as u64, // TODO(moodlezoup): this only works for Xlen = 32
             },
-            virtual_sequence_remaining: Some(9),
+            virtual_sequence_remaining: Some(8),
         };
         sequence.push(add.into());
 
@@ -117,7 +117,7 @@ impl VirtualInstructionSequence for LH {
                 rs1: v_address,
                 imm: -4i64 as u32 as u64, // TODO(moodlezoup): this only works for Xlen = 32
             },
-            virtual_sequence_remaining: Some(8),
+            virtual_sequence_remaining: Some(7),
         };
         sequence.push(andi.into());
 
@@ -128,7 +128,7 @@ impl VirtualInstructionSequence for LH {
                 rs1: v_word_address,
                 imm: 0,
             },
-            virtual_sequence_remaining: Some(7),
+            virtual_sequence_remaining: Some(6),
         };
         sequence.push(lw.into());
 
@@ -139,7 +139,7 @@ impl VirtualInstructionSequence for LH {
                 rs1: v_address,
                 imm: 2,
             },
-            virtual_sequence_remaining: Some(6),
+            virtual_sequence_remaining: Some(5),
         };
         sequence.push(xori.into());
 
@@ -150,7 +150,7 @@ impl VirtualInstructionSequence for LH {
                 rs1: v_shift,
                 imm: 3,
             },
-            virtual_sequence_remaining: Some(5),
+            virtual_sequence_remaining: Some(4),
         };
         sequence.extend(slli.virtual_sequence().into_iter());
 

--- a/tracer/src/instruction/lhu.rs
+++ b/tracer/src/instruction/lhu.rs
@@ -95,7 +95,7 @@ impl VirtualInstructionSequence for LHU {
                 rs1: self.operands.rs1,
                 imm: self.operands.imm,
             },
-            virtual_sequence_remaining: Some(10),
+            virtual_sequence_remaining: Some(9),
         };
         sequence.push(assert_alignment.into());
 
@@ -106,7 +106,7 @@ impl VirtualInstructionSequence for LHU {
                 rs1: self.operands.rs1,
                 imm: self.operands.imm as u32 as u64, // TODO(moodlezoup): this only works for Xlen = 32
             },
-            virtual_sequence_remaining: Some(9),
+            virtual_sequence_remaining: Some(8),
         };
         sequence.push(add.into());
 
@@ -117,7 +117,7 @@ impl VirtualInstructionSequence for LHU {
                 rs1: v_address,
                 imm: -4i64 as u32 as u64, // TODO(moodlezoup): this only works for Xlen = 32
             },
-            virtual_sequence_remaining: Some(8),
+            virtual_sequence_remaining: Some(7),
         };
         sequence.push(andi.into());
 
@@ -128,7 +128,7 @@ impl VirtualInstructionSequence for LHU {
                 rs1: v_word_address,
                 imm: 0,
             },
-            virtual_sequence_remaining: Some(7),
+            virtual_sequence_remaining: Some(6),
         };
         sequence.push(lw.into());
 
@@ -139,7 +139,7 @@ impl VirtualInstructionSequence for LHU {
                 rs1: v_address,
                 imm: 2,
             },
-            virtual_sequence_remaining: Some(6),
+            virtual_sequence_remaining: Some(5),
         };
         sequence.push(xori.into());
 
@@ -150,7 +150,7 @@ impl VirtualInstructionSequence for LHU {
                 rs1: v_shift,
                 imm: 3,
             },
-            virtual_sequence_remaining: Some(5),
+            virtual_sequence_remaining: Some(4),
         };
         sequence.extend(slli.virtual_sequence().into_iter());
 

--- a/tracer/src/instruction/lhu.rs
+++ b/tracer/src/instruction/lhu.rs
@@ -95,7 +95,7 @@ impl VirtualInstructionSequence for LHU {
                 rs1: self.operands.rs1,
                 imm: self.operands.imm,
             },
-            virtual_sequence_remaining: Some(9),
+            virtual_sequence_remaining: Some(8),
         };
         sequence.push(assert_alignment.into());
 
@@ -106,7 +106,7 @@ impl VirtualInstructionSequence for LHU {
                 rs1: self.operands.rs1,
                 imm: self.operands.imm as u32 as u64, // TODO(moodlezoup): this only works for Xlen = 32
             },
-            virtual_sequence_remaining: Some(8),
+            virtual_sequence_remaining: Some(7),
         };
         sequence.push(add.into());
 
@@ -117,7 +117,7 @@ impl VirtualInstructionSequence for LHU {
                 rs1: v_address,
                 imm: -4i64 as u32 as u64, // TODO(moodlezoup): this only works for Xlen = 32
             },
-            virtual_sequence_remaining: Some(7),
+            virtual_sequence_remaining: Some(6),
         };
         sequence.push(andi.into());
 
@@ -128,7 +128,7 @@ impl VirtualInstructionSequence for LHU {
                 rs1: v_word_address,
                 imm: 0,
             },
-            virtual_sequence_remaining: Some(6),
+            virtual_sequence_remaining: Some(5),
         };
         sequence.push(lw.into());
 
@@ -139,7 +139,7 @@ impl VirtualInstructionSequence for LHU {
                 rs1: v_address,
                 imm: 2,
             },
-            virtual_sequence_remaining: Some(5),
+            virtual_sequence_remaining: Some(4),
         };
         sequence.push(xori.into());
 
@@ -150,7 +150,7 @@ impl VirtualInstructionSequence for LHU {
                 rs1: v_shift,
                 imm: 3,
             },
-            virtual_sequence_remaining: Some(4),
+            virtual_sequence_remaining: Some(3),
         };
         sequence.extend(slli.virtual_sequence().into_iter());
 
@@ -161,7 +161,7 @@ impl VirtualInstructionSequence for LHU {
                 rs1: v_word,
                 rs2: v_shift,
             },
-            virtual_sequence_remaining: Some(3),
+            virtual_sequence_remaining: Some(2),
         };
         sequence.extend(sll.virtual_sequence().into_iter());
 
@@ -172,7 +172,7 @@ impl VirtualInstructionSequence for LHU {
                 rs1: self.operands.rd,
                 imm: 16,
             },
-            virtual_sequence_remaining: Some(1),
+            virtual_sequence_remaining: Some(0),
         };
         sequence.extend(srli.virtual_sequence().into_iter());
 

--- a/tracer/src/instruction/sb.rs
+++ b/tracer/src/instruction/sb.rs
@@ -96,7 +96,7 @@ impl VirtualInstructionSequence for SB {
                 rs1: self.operands.rs1,
                 imm: self.operands.imm as u32 as u64, // TODO(moodlezoup): this only works for Xlen = 32
             },
-            virtual_sequence_remaining: Some(13),
+            virtual_sequence_remaining: Some(12),
         };
         sequence.push(add.into());
 
@@ -107,7 +107,7 @@ impl VirtualInstructionSequence for SB {
                 rs1: v_address,
                 imm: -4i64 as u32 as u64, // TODO(moodlezoup): this only works for Xlen = 32
             },
-            virtual_sequence_remaining: Some(12),
+            virtual_sequence_remaining: Some(11),
         };
         sequence.push(andi.into());
 
@@ -118,7 +118,7 @@ impl VirtualInstructionSequence for SB {
                 rs1: v_word_address,
                 imm: 0,
             },
-            virtual_sequence_remaining: Some(11),
+            virtual_sequence_remaining: Some(10),
         };
         sequence.push(lw.into());
 
@@ -129,7 +129,7 @@ impl VirtualInstructionSequence for SB {
                 rs1: v_address,
                 imm: 3,
             },
-            virtual_sequence_remaining: Some(10),
+            virtual_sequence_remaining: Some(9),
         };
         sequence.extend(slli.virtual_sequence());
 

--- a/tracer/src/instruction/sh.rs
+++ b/tracer/src/instruction/sh.rs
@@ -101,7 +101,7 @@ impl VirtualInstructionSequence for SH {
                 rs1: self.operands.rs1,
                 imm: self.operands.imm,
             },
-            virtual_sequence_remaining: Some(14),
+            virtual_sequence_remaining: Some(13),
         };
         sequence.push(align_check.into());
 
@@ -112,7 +112,7 @@ impl VirtualInstructionSequence for SH {
                 rs1: self.operands.rs1,
                 imm: self.operands.imm as u32 as u64, // TODO(moodlezoup): this only works for Xlen = 32
             },
-            virtual_sequence_remaining: Some(13),
+            virtual_sequence_remaining: Some(12),
         };
         sequence.push(add.into());
 
@@ -123,7 +123,7 @@ impl VirtualInstructionSequence for SH {
                 rs1: v_address,
                 imm: -4i64 as u32 as u64, // TODO(moodlezoup): this only works for Xlen = 32
             },
-            virtual_sequence_remaining: Some(12),
+            virtual_sequence_remaining: Some(11),
         };
         sequence.push(andi.into());
 
@@ -134,7 +134,7 @@ impl VirtualInstructionSequence for SH {
                 rs1: v_word_address,
                 imm: 0,
             },
-            virtual_sequence_remaining: Some(11),
+            virtual_sequence_remaining: Some(10),
         };
         sequence.push(lw.into());
 
@@ -145,7 +145,7 @@ impl VirtualInstructionSequence for SH {
                 rs1: v_address,
                 imm: 3,
             },
-            virtual_sequence_remaining: Some(10),
+            virtual_sequence_remaining: Some(9),
         };
         sequence.extend(slli.virtual_sequence().into_iter());
 

--- a/tracer/src/instruction/slli.rs
+++ b/tracer/src/instruction/slli.rs
@@ -74,6 +74,7 @@ impl VirtualInstructionSequence for SLLI {
             operands: FormatI {
                 rd: self.operands.rd,
                 rs1: self.operands.rs1,
+                // HACK: supposed to be % 32 or % 64 for 64-bit mode
                 imm: (1 << ((self.operands.imm as u64) % 32)),
             },
             virtual_sequence_remaining: Some(virtual_sequence_remaining),

--- a/tracer/src/instruction/slli.rs
+++ b/tracer/src/instruction/slli.rs
@@ -74,7 +74,7 @@ impl VirtualInstructionSequence for SLLI {
             operands: FormatI {
                 rd: self.operands.rd,
                 rs1: self.operands.rs1,
-                // HACK: supposed to be % 32 or % 64 for 64-bit mode
+                // TODO: this only works for Xlen = 32
                 imm: (1 << ((self.operands.imm as u64) % 32)),
             },
             virtual_sequence_remaining: Some(virtual_sequence_remaining),

--- a/tracer/src/instruction/slli.rs
+++ b/tracer/src/instruction/slli.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     emulator::cpu::{Cpu, Xlen},
-    instruction::virtual_muli::VirtualMULI,
+    instruction::{format::format_virtual_i::FormatVirtualI, virtual_muli::VirtualMULI},
 };
 
 use super::{
@@ -71,7 +71,7 @@ impl VirtualInstructionSequence for SLLI {
 
         let mul = RV32IMInstruction::MULI(VirtualMULI {
             address: self.address,
-            operands: FormatI {
+            operands: FormatVirtualI {
                 rd: self.operands.rd,
                 rs1: self.operands.rs1,
                 // TODO: this only works for Xlen = 32

--- a/tracer/src/instruction/sra.rs
+++ b/tracer/src/instruction/sra.rs
@@ -5,7 +5,7 @@ use crate::emulator::cpu::{Cpu, Xlen};
 
 use super::{
     format::{
-        format_i::FormatI, format_r::FormatR, format_virtual_right_shift::FormatVirtualRightShift,
+        format_i::FormatI, format_r::FormatR, format_virtual_r::FormatVirtualR,
         InstructionFormat,
     },
     virtual_shift_right_bitmask::VirtualShiftRightBitmask,
@@ -89,7 +89,7 @@ impl VirtualInstructionSequence for SRA {
 
         let sra = VirtualSRA {
             address: self.address,
-            operands: FormatVirtualRightShift {
+            operands: FormatVirtualR {
                 rd: self.operands.rd,
                 rs1: self.operands.rs1,
                 rs2: v_bitmask,

--- a/tracer/src/instruction/srai.rs
+++ b/tracer/src/instruction/srai.rs
@@ -1,15 +1,12 @@
-use common::constants::virtual_register_index;
 use serde::{Deserialize, Serialize};
 
-use crate::emulator::cpu::{Cpu, Xlen};
+use crate::{
+    emulator::cpu::{Cpu, Xlen},
+    instruction::{format::format_virtual_i::FormatVirtualI, virtual_srai::VirtualSRAI},
+};
 
 use super::{
-    format::{
-        format_i::FormatI, format_j::FormatJ, format_virtual_right_shift::FormatVirtualRightShift,
-        InstructionFormat,
-    },
-    virtual_shift_right_bitmaski::VirtualShiftRightBitmaskI,
-    virtual_sra::VirtualSRA,
+    format::{format_i::FormatI, InstructionFormat},
     RISCVInstruction, RISCVTrace, RV32IMInstruction, VirtualInstructionSequence,
 };
 
@@ -69,29 +66,20 @@ impl RISCVTrace for SRAI {
 
 impl VirtualInstructionSequence for SRAI {
     fn virtual_sequence(&self) -> Vec<RV32IMInstruction> {
-        // Virtual registers used in sequence
-        let v_bitmask = virtual_register_index(6) as usize;
-
-        let mut virtual_sequence_remaining = self.virtual_sequence_remaining.unwrap_or(1);
+        let virtual_sequence_remaining = self.virtual_sequence_remaining.unwrap_or(0);
         let mut sequence = vec![];
 
-        let bitmask = VirtualShiftRightBitmaskI {
-            address: self.address,
-            operands: FormatJ {
-                rd: v_bitmask,
-                imm: self.operands.imm,
-            },
-            virtual_sequence_remaining: Some(virtual_sequence_remaining),
-        };
-        sequence.push(bitmask.into());
-        virtual_sequence_remaining -= 1;
+        // TODO: this only works for Xlen = 32
+        let shift = self.operands.imm % 32;
+        let ones = (1u64 << (32 - shift)) - 1;
+        let bitmask = ones << shift;
 
-        let sra = VirtualSRA {
+        let sra = VirtualSRAI {
             address: self.address,
-            operands: FormatVirtualRightShift {
+            operands: FormatVirtualI {
                 rd: self.operands.rd,
                 rs1: self.operands.rs1,
-                rs2: v_bitmask,
+                imm: bitmask,
             },
             virtual_sequence_remaining: Some(virtual_sequence_remaining),
         };

--- a/tracer/src/instruction/srl.rs
+++ b/tracer/src/instruction/srl.rs
@@ -5,7 +5,7 @@ use crate::emulator::cpu::{Cpu, Xlen};
 
 use super::{
     format::{
-        format_i::FormatI, format_r::FormatR, format_virtual_right_shift::FormatVirtualRightShift,
+        format_i::FormatI, format_r::FormatR, format_virtual_r::FormatVirtualR,
         InstructionFormat,
     },
     virtual_shift_right_bitmask::VirtualShiftRightBitmask,
@@ -91,7 +91,7 @@ impl VirtualInstructionSequence for SRL {
 
         let srl = VirtualSRL {
             address: self.address,
-            operands: FormatVirtualRightShift {
+            operands: FormatVirtualR {
                 rd: self.operands.rd,
                 rs1: self.operands.rs1,
                 rs2: v_bitmask,

--- a/tracer/src/instruction/virtual_muli.rs
+++ b/tracer/src/instruction/virtual_muli.rs
@@ -3,15 +3,13 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     emulator::cpu::Cpu,
-    instruction::format::format_i::FormatI,
-    instruction::format::InstructionFormat,
-    instruction::{RISCVInstruction, RISCVTrace},
+    instruction::{format::{format_virtual_i::FormatVirtualI, InstructionFormat}, RISCVInstruction, RISCVTrace},
 };
 
 #[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
 pub struct VirtualMULI {
     pub address: u64,
-    pub operands: FormatI,
+    pub operands: FormatVirtualI,
     /// If this instruction is part of a "virtual sequence" (see Section 6.2 of the
     /// Jolt paper), then this contains the number of virtual instructions after this
     /// one in the sequence. I.e. if this is the last instruction in the sequence,
@@ -24,7 +22,7 @@ impl RISCVInstruction for VirtualMULI {
     const MASK: u32 = 0; // Virtual
     const MATCH: u32 = 0; // Virtual
 
-    type Format = FormatI;
+    type Format = FormatVirtualI;
     type RAMAccess = ();
 
     fn operands(&self) -> &Self::Format {
@@ -38,7 +36,7 @@ impl RISCVInstruction for VirtualMULI {
     fn random(rng: &mut StdRng) -> Self {
         Self {
             address: rng.next_u64(),
-            operands: FormatI::random(rng),
+            operands: FormatVirtualI::random(rng),
             virtual_sequence_remaining: None,
         }
     }

--- a/tracer/src/instruction/virtual_muli.rs
+++ b/tracer/src/instruction/virtual_muli.rs
@@ -1,0 +1,52 @@
+use rand::{rngs::StdRng, RngCore};
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    emulator::cpu::Cpu,
+    instruction::format::format_i::FormatI,
+    instruction::format::InstructionFormat,
+    instruction::{RISCVInstruction, RISCVTrace},
+};
+
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
+pub struct VirtualMULI {
+    pub address: u64,
+    pub operands: FormatI,
+    /// If this instruction is part of a "virtual sequence" (see Section 6.2 of the
+    /// Jolt paper), then this contains the number of virtual instructions after this
+    /// one in the sequence. I.e. if this is the last instruction in the sequence,
+    /// `virtual_sequence_remaining` will be Some(0); if this is the penultimate instruction
+    /// in the sequence, `virtual_sequence_remaining` will be Some(1); etc.
+    pub virtual_sequence_remaining: Option<usize>,
+}
+
+impl RISCVInstruction for VirtualMULI {
+    const MASK: u32 = 0; // Virtual
+    const MATCH: u32 = 0; // Virtual
+
+    type Format = FormatI;
+    type RAMAccess = ();
+
+    fn operands(&self) -> &Self::Format {
+        &self.operands
+    }
+
+    fn new(_: u32, _: u64, _: bool) -> Self {
+        unimplemented!("virtual instruction")
+    }
+
+    fn random(rng: &mut StdRng) -> Self {
+        Self {
+            address: rng.next_u64(),
+            operands: FormatI::random(rng),
+            virtual_sequence_remaining: None,
+        }
+    }
+
+    fn execute(&self, cpu: &mut Cpu, _: &mut Self::RAMAccess) {
+        cpu.x[self.operands.rd] =
+            cpu.sign_extend(cpu.x[self.operands.rs1].wrapping_mul(self.operands.imm as i64))
+    }
+}
+
+impl RISCVTrace for VirtualMULI {}

--- a/tracer/src/instruction/virtual_sra.rs
+++ b/tracer/src/instruction/virtual_sra.rs
@@ -4,14 +4,14 @@ use serde::{Deserialize, Serialize};
 use crate::emulator::cpu::Cpu;
 
 use super::{
-    format::{format_virtual_right_shift::FormatVirtualRightShift, InstructionFormat},
+    format::{format_virtual_r::FormatVirtualR, InstructionFormat},
     RISCVInstruction, RISCVTrace,
 };
 
 #[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
 pub struct VirtualSRA {
     pub address: u64,
-    pub operands: FormatVirtualRightShift,
+    pub operands: FormatVirtualR,
     /// If this instruction is part of a "virtual sequence" (see Section 6.2 of the
     /// Jolt paper), then this contains the number of virtual instructions after this
     /// one in the sequence. I.e. if this is the last instruction in the sequence,
@@ -24,7 +24,7 @@ impl RISCVInstruction for VirtualSRA {
     const MASK: u32 = 0; // Virtual
     const MATCH: u32 = 0; // Virtual
 
-    type Format = FormatVirtualRightShift;
+    type Format = FormatVirtualR;
     type RAMAccess = ();
 
     fn operands(&self) -> &Self::Format {
@@ -38,7 +38,7 @@ impl RISCVInstruction for VirtualSRA {
     fn random(rng: &mut StdRng) -> Self {
         Self {
             address: rng.next_u64(),
-            operands: FormatVirtualRightShift::random(rng),
+            operands: FormatVirtualR::random(rng),
             virtual_sequence_remaining: None,
         }
     }

--- a/tracer/src/instruction/virtual_srai.rs
+++ b/tracer/src/instruction/virtual_srai.rs
@@ -1,0 +1,49 @@
+use rand::{rngs::StdRng, RngCore};
+use serde::{Deserialize, Serialize};
+
+use crate::{emulator::cpu::Cpu, instruction::format::format_virtual_i::FormatVirtualI};
+
+use super::{format::InstructionFormat, RISCVInstruction, RISCVTrace};
+
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
+pub struct VirtualSRAI {
+    pub address: u64,
+    pub operands: FormatVirtualI,
+    /// If this instruction is part of a "virtual sequence" (see Section 6.2 of the
+    /// Jolt paper), then this contains the number of virtual instructions after this
+    /// one in the sequence. I.e. if this is the last instruction in the sequence,
+    /// `virtual_sequence_remaining` will be Some(0); if this is the penultimate instruction
+    /// in the sequence, `virtual_sequence_remaining` will be Some(1); etc.
+    pub virtual_sequence_remaining: Option<usize>,
+}
+
+impl RISCVInstruction for VirtualSRAI {
+    const MASK: u32 = 0; // Virtual
+    const MATCH: u32 = 0; // Virtual
+
+    type Format = FormatVirtualI;
+    type RAMAccess = ();
+
+    fn operands(&self) -> &Self::Format {
+        &self.operands
+    }
+
+    fn new(_: u32, _: u64, _: bool) -> Self {
+        unimplemented!("virtual instruction")
+    }
+
+    fn random(rng: &mut StdRng) -> Self {
+        Self {
+            address: rng.next_u64(),
+            operands: FormatVirtualI::random(rng),
+            virtual_sequence_remaining: None,
+        }
+    }
+
+    fn execute(&self, cpu: &mut Cpu, _: &mut Self::RAMAccess) {
+        let shift = self.operands.imm.trailing_zeros();
+        cpu.x[self.operands.rd] = cpu.sign_extend(cpu.x[self.operands.rs1].wrapping_shr(shift));
+    }
+}
+
+impl RISCVTrace for VirtualSRAI {}

--- a/tracer/src/instruction/virtual_srl.rs
+++ b/tracer/src/instruction/virtual_srl.rs
@@ -4,14 +4,14 @@ use serde::{Deserialize, Serialize};
 use crate::emulator::cpu::Cpu;
 
 use super::{
-    format::{format_virtual_right_shift::FormatVirtualRightShift, InstructionFormat},
+    format::{format_virtual_r::FormatVirtualR, InstructionFormat},
     RISCVInstruction, RISCVTrace,
 };
 
 #[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
 pub struct VirtualSRL {
     pub address: u64,
-    pub operands: FormatVirtualRightShift,
+    pub operands: FormatVirtualR,
     /// If this instruction is part of a "virtual sequence" (see Section 6.2 of the
     /// Jolt paper), then this contains the number of virtual instructions after this
     /// one in the sequence. I.e. if this is the last instruction in the sequence,
@@ -24,7 +24,7 @@ impl RISCVInstruction for VirtualSRL {
     const MASK: u32 = 0; // Virtual
     const MATCH: u32 = 0; // Virtual
 
-    type Format = FormatVirtualRightShift;
+    type Format = FormatVirtualR;
     type RAMAccess = ();
 
     fn operands(&self) -> &Self::Format {
@@ -38,7 +38,7 @@ impl RISCVInstruction for VirtualSRL {
     fn random(rng: &mut StdRng) -> Self {
         Self {
             address: rng.next_u64(),
-            operands: FormatVirtualRightShift::random(rng),
+            operands: FormatVirtualR::random(rng),
             virtual_sequence_remaining: None,
         }
     }

--- a/tracer/src/instruction/virtual_srli.rs
+++ b/tracer/src/instruction/virtual_srli.rs
@@ -1,0 +1,52 @@
+use rand::{rngs::StdRng, RngCore};
+use serde::{Deserialize, Serialize};
+
+use crate::{emulator::cpu::Cpu, instruction::format::format_virtual_i::FormatVirtualI};
+
+use super::{format::InstructionFormat, RISCVInstruction, RISCVTrace};
+
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
+pub struct VirtualSRLI {
+    pub address: u64,
+    pub operands: FormatVirtualI,
+    /// If this instruction is part of a "virtual sequence" (see Section 6.2 of the
+    /// Jolt paper), then this contains the number of virtual instructions after this
+    /// one in the sequence. I.e. if this is the last instruction in the sequence,
+    /// `virtual_sequence_remaining` will be Some(0); if this is the penultimate instruction
+    /// in the sequence, `virtual_sequence_remaining` will be Some(1); etc.
+    pub virtual_sequence_remaining: Option<usize>,
+}
+
+impl RISCVInstruction for VirtualSRLI {
+    const MASK: u32 = 0; // Virtual
+    const MATCH: u32 = 0; // Virtual
+
+    type Format = FormatVirtualI;
+    type RAMAccess = ();
+
+    fn operands(&self) -> &Self::Format {
+        &self.operands
+    }
+
+    fn new(_: u32, _: u64, _: bool) -> Self {
+        unimplemented!("virtual instruction")
+    }
+
+    fn random(rng: &mut StdRng) -> Self {
+        Self {
+            address: rng.next_u64(),
+            operands: FormatVirtualI::random(rng),
+            virtual_sequence_remaining: None,
+        }
+    }
+
+    fn execute(&self, cpu: &mut Cpu, _: &mut Self::RAMAccess) {
+        let shift = self.operands.imm.trailing_zeros();
+        cpu.x[self.operands.rd] = cpu.sign_extend(
+            cpu.unsigned_data(cpu.x[self.operands.rs1])
+                .wrapping_shr(shift) as i64,
+        );
+    }
+}
+
+impl RISCVTrace for VirtualSRLI {}


### PR DESCRIPTION
Linear issue 104

Optimizes SLLI, SRLI, SRAI, by replacing this instruction by a virtual instruction with precalculated `imm` field.

Important for review, product constraint now accesses left and right instruction inputs instead of `rs1` and `rs2`. This is needed for MULI instruction.

TODOs (not in this PR):
- Support for 64 bits inside of `VirtualInstructionSequence` implementations
- We should consider removing the hardcoded virtual instruction enumeration (such as in load and store instructions).