### PR TITLE
Make the `common` crate `no_std`-compliant

### DIFF
--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -3,10 +3,20 @@ name = "common"
 version = "0.2.0"
 edition = "2021"
 
+[features]
+default = ["std"]
+std = [
+    "ark-serialize/std",
+    "serde/std",
+    "serde_json/std",
+    "strum/std",
+    "syn/full",
+]
+
 [dependencies]
-ark-serialize = { version = "0.5.0", features = ["derive"] }
-serde = { version = "1.0.193", features = ["derive"] }
-serde_json = "1.0.108"
+ark-serialize = { version = "0.5.0", features = ["derive"], default-features = false }
+serde = { version = "1.0.193", features = ["derive"], default-features = false }
+serde_json = { version = "1.0.108", features = ["alloc"], default-features = false }
 strum_macros = "0.26.4"
-strum = "0.26.3"
-syn = { version = "1.0", features = ["full"] }
+strum = { version = "0.26.3", default-features = false }
+syn = { version = "1.0", optional = true }

--- a/common/src/attributes.rs
+++ b/common/src/attributes.rs
@@ -1,6 +1,9 @@
+#[cfg(feature = "std")]
 use std::collections::HashMap;
+#[cfg(feature = "std")]
 use syn::{Lit, Meta, MetaNameValue, NestedMeta};
 
+#[cfg(feature = "std")]
 use crate::constants::{
     DEFAULT_MAX_INPUT_SIZE, DEFAULT_MAX_OUTPUT_SIZE, DEFAULT_MEMORY_SIZE, DEFAULT_STACK_SIZE,
 };
@@ -13,6 +16,7 @@ pub struct Attributes {
     pub max_output_size: u64,
 }
 
+#[cfg(feature = "std")]
 pub fn parse_attributes(attr: &Vec<NestedMeta>) -> Attributes {
     let mut attributes = HashMap::<_, u64>::new();
     let mut wasm = false;

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -1,3 +1,8 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+
 pub mod attributes;
 pub mod constants;
 pub mod rv_trace;

--- a/common/src/rv_trace.rs
+++ b/common/src/rv_trace.rs
@@ -1,4 +1,9 @@
-use std::str::FromStr;
+#[cfg(not(feature = "std"))]
+use alloc::{
+    string::{String, ToString},
+    vec::Vec,
+};
+use core::str::FromStr;
 
 use crate::constants::{MEMORY_OPS_PER_INSTRUCTION, RAM_START_ADDRESS, REGISTER_COUNT};
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
@@ -400,7 +405,9 @@ impl RVTraceRow {
 }
 
 // Reference: https://www.cs.sfu.ca/~ashriram/Courses/CS295/assets/notebooks/RISCV/RISCV_CARD.pdf
-#[derive(Debug, PartialEq, Eq, Clone, Copy, FromRepr, Serialize, Deserialize, Hash)]
+#[derive(
+    Debug, PartialEq, Eq, Clone, Copy, FromRepr, Serialize, Deserialize, Hash, PartialOrd, Ord,
+)]
 #[repr(u8)]
 #[allow(non_camel_case_types)]
 pub enum RV32IM {
@@ -581,6 +588,7 @@ impl JoltDevice {
 
     pub fn store(&mut self, address: u64, value: u8) {
         if address == self.memory_layout.panic {
+            #[cfg(feature = "std")]
             println!("GUEST PANIC");
             self.panic = true;
             return;


### PR DESCRIPTION
This is Step 1 in a long line of steps towards making `jolt` `no_std` compliant.