### PR TITLE
feat: instruction macro

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3861,6 +3861,7 @@ dependencies = [
  "derive_more 2.0.1",
  "fnv",
  "object 0.32.2",
+ "paste",
  "rand 0.7.3",
  "serde",
  "serde_json",

--- a/tracer/Cargo.toml
+++ b/tracer/Cargo.toml
@@ -28,3 +28,4 @@ strum = "0.26.3"
 rand = "0.7.3"
 
 common = { path = "../common" }
+paste = "1.0.15"

--- a/tracer/src/instruction/add.rs
+++ b/tracer/src/instruction/add.rs
@@ -1,48 +1,22 @@
 use serde::{Deserialize, Serialize};
 
-use crate::emulator::cpu::Cpu;
+use crate::{declare_riscv_instr, emulator::cpu::Cpu};
 
 use super::{
     format::{format_r::FormatR, InstructionFormat},
     RISCVInstruction, RISCVTrace,
 };
 
-#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
-pub struct ADD {
-    pub address: u64,
-    pub operands: FormatR,
-    /// If this instruction is part of a "virtual sequence" (see Section 6.2 of the
-    /// Jolt paper), then this contains the number of virtual instructions after this
-    /// one in the sequence. I.e. if this is the last instruction in the sequence,
-    /// `virtual_sequence_remaining` will be Some(0); if this is the penultimate instruction
-    /// in the sequence, `virtual_sequence_remaining` will be Some(1); etc.
-    pub virtual_sequence_remaining: Option<usize>,
-}
+declare_riscv_instr!(
+    name   = ADD,
+    mask   = 0xfe00707f,
+    match  = 0x00000033,
+    format = FormatR,
+    ram    = ()
+);
 
-impl RISCVInstruction for ADD {
-    const MASK: u32 = 0xfe00707f;
-    const MATCH: u32 = 0x00000033;
-
-    type Format = FormatR;
-    type RAMAccess = ();
-
-    fn operands(&self) -> &Self::Format {
-        &self.operands
-    }
-
-    fn new(word: u32, address: u64, validate: bool) -> Self {
-        if validate {
-            debug_assert_eq!(word & Self::MASK, Self::MATCH);
-        }
-
-        Self {
-            address,
-            operands: FormatR::parse(word),
-            virtual_sequence_remaining: None,
-        }
-    }
-
-    fn execute(&self, cpu: &mut Cpu, _: &mut Self::RAMAccess) {
+impl ADD {
+    fn exec(&self, cpu: &mut Cpu, _: &mut <ADD as RISCVInstruction>::RAMAccess) {
         cpu.x[self.operands.rd] =
             cpu.sign_extend(cpu.x[self.operands.rs1].wrapping_add(cpu.x[self.operands.rs2]));
     }

--- a/tracer/src/instruction/addi.rs
+++ b/tracer/src/instruction/addi.rs
@@ -1,48 +1,22 @@
 use serde::{Deserialize, Serialize};
 
-use crate::emulator::cpu::Cpu;
+use crate::{declare_riscv_instr, emulator::cpu::Cpu};
 
 use super::{
     format::{format_i::FormatI, normalize_imm, InstructionFormat},
     RISCVInstruction, RISCVTrace,
 };
 
-#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
-pub struct ADDI {
-    pub address: u64,
-    pub operands: FormatI,
-    /// If this instruction is part of a "virtual sequence" (see Section 6.2 of the
-    /// Jolt paper), then this contains the number of virtual instructions after this
-    /// one in the sequence. I.e. if this is the last instruction in the sequence,
-    /// `virtual_sequence_remaining` will be Some(0); if this is the penultimate instruction
-    /// in the sequence, `virtual_sequence_remaining` will be Some(1); etc.
-    pub virtual_sequence_remaining: Option<usize>,
-}
+declare_riscv_instr!(
+    name   = ADDI,
+    mask   = 0x0000707f,
+    match  = 0x00000013,
+    format = FormatI,
+    ram    = ()
+);
 
-impl RISCVInstruction for ADDI {
-    const MASK: u32 = 0x0000707f;
-    const MATCH: u32 = 0x00000013;
-
-    type Format = FormatI;
-    type RAMAccess = ();
-
-    fn operands(&self) -> &Self::Format {
-        &self.operands
-    }
-
-    fn new(word: u32, address: u64, validate: bool) -> Self {
-        if validate {
-            debug_assert_eq!(word & Self::MASK, Self::MATCH);
-        }
-
-        Self {
-            address,
-            operands: FormatI::parse(word),
-            virtual_sequence_remaining: None,
-        }
-    }
-
-    fn execute(&self, cpu: &mut Cpu, _: &mut Self::RAMAccess) {
+impl ADDI {
+    fn exec(&self, cpu: &mut Cpu, _: &mut <ADDI as RISCVInstruction>::RAMAccess) {
         cpu.x[self.operands.rd] = cpu
             .sign_extend(cpu.x[self.operands.rs1].wrapping_add(normalize_imm(self.operands.imm)));
     }

--- a/tracer/src/instruction/and.rs
+++ b/tracer/src/instruction/and.rs
@@ -1,48 +1,22 @@
 use serde::{Deserialize, Serialize};
 
-use crate::emulator::cpu::Cpu;
+use crate::{declare_riscv_instr, emulator::cpu::Cpu};
 
 use super::{
     format::{format_r::FormatR, InstructionFormat},
     RISCVInstruction, RISCVTrace,
 };
 
-#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
-pub struct AND {
-    pub address: u64,
-    pub operands: FormatR,
-    /// If this instruction is part of a "virtual sequence" (see Section 6.2 of the
-    /// Jolt paper), then this contains the number of virtual instructions after this
-    /// one in the sequence. I.e. if this is the last instruction in the sequence,
-    /// `virtual_sequence_remaining` will be Some(0); if this is the penultimate instruction
-    /// in the sequence, `virtual_sequence_remaining` will be Some(1); etc.
-    pub virtual_sequence_remaining: Option<usize>,
-}
+declare_riscv_instr!(
+    name   = AND,
+    mask   = 0xfe00707f,
+    match  = 0x00007033,
+    format = FormatR,
+    ram    = ()
+);
 
-impl RISCVInstruction for AND {
-    const MASK: u32 = 0xfe00707f;
-    const MATCH: u32 = 0x00007033;
-
-    type Format = FormatR;
-    type RAMAccess = ();
-
-    fn operands(&self) -> &Self::Format {
-        &self.operands
-    }
-
-    fn new(word: u32, address: u64, validate: bool) -> Self {
-        if validate {
-            debug_assert_eq!(word & Self::MASK, Self::MATCH);
-        }
-
-        Self {
-            address,
-            operands: FormatR::parse(word),
-            virtual_sequence_remaining: None,
-        }
-    }
-
-    fn execute(&self, cpu: &mut Cpu, _: &mut Self::RAMAccess) {
+impl AND {
+    fn exec(&self, cpu: &mut Cpu, _: &mut <AND as RISCVInstruction>::RAMAccess) {
         cpu.x[self.operands.rd] =
             cpu.sign_extend(cpu.x[self.operands.rs1] & cpu.x[self.operands.rs2]);
     }

--- a/tracer/src/instruction/andi.rs
+++ b/tracer/src/instruction/andi.rs
@@ -1,48 +1,22 @@
 use serde::{Deserialize, Serialize};
 
-use crate::emulator::cpu::Cpu;
+use crate::{declare_riscv_instr, emulator::cpu::Cpu};
 
 use super::{
     format::{format_i::FormatI, normalize_imm, InstructionFormat},
     RISCVInstruction, RISCVTrace,
 };
 
-#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
-pub struct ANDI {
-    pub address: u64,
-    pub operands: FormatI,
-    /// If this instruction is part of a "virtual sequence" (see Section 6.2 of the
-    /// Jolt paper), then this contains the number of virtual instructions after this
-    /// one in the sequence. I.e. if this is the last instruction in the sequence,
-    /// `virtual_sequence_remaining` will be Some(0); if this is the penultimate instruction
-    /// in the sequence, `virtual_sequence_remaining` will be Some(1); etc.
-    pub virtual_sequence_remaining: Option<usize>,
-}
+declare_riscv_instr!(
+    name   = ANDI,
+    mask   = 0x0000707f,
+    match  = 0x00007013,
+    format = FormatI,
+    ram    = ()
+);
 
-impl RISCVInstruction for ANDI {
-    const MASK: u32 = 0x0000707f;
-    const MATCH: u32 = 0x00007013;
-
-    type Format = FormatI;
-    type RAMAccess = ();
-
-    fn operands(&self) -> &Self::Format {
-        &self.operands
-    }
-
-    fn new(word: u32, address: u64, validate: bool) -> Self {
-        if validate {
-            debug_assert_eq!(word & Self::MASK, Self::MATCH);
-        }
-
-        Self {
-            address,
-            operands: FormatI::parse(word),
-            virtual_sequence_remaining: None,
-        }
-    }
-
-    fn execute(&self, cpu: &mut Cpu, _: &mut Self::RAMAccess) {
+impl ANDI {
+    fn exec(&self, cpu: &mut Cpu, _: &mut <ANDI as RISCVInstruction>::RAMAccess) {
         cpu.x[self.operands.rd] =
             cpu.sign_extend(cpu.x[self.operands.rs1] & normalize_imm(self.operands.imm));
     }

--- a/tracer/src/instruction/auipc.rs
+++ b/tracer/src/instruction/auipc.rs
@@ -1,48 +1,22 @@
 use serde::{Deserialize, Serialize};
 
-use crate::emulator::cpu::Cpu;
+use crate::{declare_riscv_instr, emulator::cpu::Cpu};
 
 use super::{
     format::{format_u::FormatU, normalize_imm, InstructionFormat},
     RISCVInstruction, RISCVTrace,
 };
 
-#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
-pub struct AUIPC {
-    pub address: u64,
-    pub operands: FormatU,
-    /// If this instruction is part of a "virtual sequence" (see Section 6.2 of the
-    /// Jolt paper), then this contains the number of virtual instructions after this
-    /// one in the sequence. I.e. if this is the last instruction in the sequence,
-    /// `virtual_sequence_remaining` will be Some(0); if this is the penultimate instruction
-    /// in the sequence, `virtual_sequence_remaining` will be Some(1); etc.
-    pub virtual_sequence_remaining: Option<usize>,
-}
+declare_riscv_instr!(
+    name   = AUIPC,
+    mask   = 0x0000007f,
+    match  = 0x00000017,
+    format = FormatU,
+    ram    = ()
+);
 
-impl RISCVInstruction for AUIPC {
-    const MASK: u32 = 0x0000007f;
-    const MATCH: u32 = 0x00000017;
-
-    type Format = FormatU;
-    type RAMAccess = ();
-
-    fn operands(&self) -> &Self::Format {
-        &self.operands
-    }
-
-    fn new(word: u32, address: u64, validate: bool) -> Self {
-        if validate {
-            debug_assert_eq!(word & Self::MASK, Self::MATCH);
-        }
-
-        Self {
-            address,
-            operands: FormatU::parse(word),
-            virtual_sequence_remaining: None,
-        }
-    }
-
-    fn execute(&self, cpu: &mut Cpu, _: &mut Self::RAMAccess) {
+impl AUIPC {
+    fn exec(&self, cpu: &mut Cpu, _: &mut <AUIPC as RISCVInstruction>::RAMAccess) {
         cpu.x[self.operands.rd] =
             cpu.sign_extend(self.address as i64 + normalize_imm(self.operands.imm));
     }

--- a/tracer/src/instruction/beq.rs
+++ b/tracer/src/instruction/beq.rs
@@ -1,48 +1,22 @@
 use serde::{Deserialize, Serialize};
 
-use crate::emulator::cpu::Cpu;
+use crate::{declare_riscv_instr, emulator::cpu::Cpu};
 
 use super::{
     format::{format_b::FormatB, InstructionFormat},
     RISCVInstruction, RISCVTrace,
 };
 
-#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
-pub struct BEQ {
-    pub address: u64,
-    pub operands: FormatB,
-    /// If this instruction is part of a "virtual sequence" (see Section 6.2 of the
-    /// Jolt paper), then this contains the number of virtual instructions after this
-    /// one in the sequence. I.e. if this is the last instruction in the sequence,
-    /// `virtual_sequence_remaining` will be Some(0); if this is the penultimate instruction
-    /// in the sequence, `virtual_sequence_remaining` will be Some(1); etc.
-    pub virtual_sequence_remaining: Option<usize>,
-}
+declare_riscv_instr!(
+    name   = BEQ,
+    mask   = 0x0000707f,
+    match  = 0x00000063,
+    format = FormatB,
+    ram    = ()
+);
 
-impl RISCVInstruction for BEQ {
-    const MASK: u32 = 0x0000707f;
-    const MATCH: u32 = 0x00000063;
-
-    type Format = FormatB;
-    type RAMAccess = ();
-
-    fn operands(&self) -> &Self::Format {
-        &self.operands
-    }
-
-    fn new(word: u32, address: u64, validate: bool) -> Self {
-        if validate {
-            debug_assert_eq!(word & Self::MASK, Self::MATCH);
-        }
-
-        Self {
-            address,
-            operands: FormatB::parse(word),
-            virtual_sequence_remaining: None,
-        }
-    }
-
-    fn execute(&self, cpu: &mut Cpu, _: &mut Self::RAMAccess) {
+impl BEQ {
+    fn exec(&self, cpu: &mut Cpu, _: &mut <BEQ as RISCVInstruction>::RAMAccess) {
         if cpu.sign_extend(cpu.x[self.operands.rs1]) == cpu.sign_extend(cpu.x[self.operands.rs2]) {
             cpu.pc = (self.address as i64 + self.operands.imm) as u64;
         }

--- a/tracer/src/instruction/bge.rs
+++ b/tracer/src/instruction/bge.rs
@@ -1,48 +1,22 @@
 use serde::{Deserialize, Serialize};
 
-use crate::emulator::cpu::Cpu;
+use crate::{declare_riscv_instr, emulator::cpu::Cpu};
 
 use super::{
     format::{format_b::FormatB, InstructionFormat},
     RISCVInstruction, RISCVTrace,
 };
 
-#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
-pub struct BGE {
-    pub address: u64,
-    pub operands: FormatB,
-    /// If this instruction is part of a "virtual sequence" (see Section 6.2 of the
-    /// Jolt paper), then this contains the number of virtual instructions after this
-    /// one in the sequence. I.e. if this is the last instruction in the sequence,
-    /// `virtual_sequence_remaining` will be Some(0); if this is the penultimate instruction
-    /// in the sequence, `virtual_sequence_remaining` will be Some(1); etc.
-    pub virtual_sequence_remaining: Option<usize>,
-}
+declare_riscv_instr!(
+    name   = BGE,
+    mask   = 0x0000707f,
+    match  = 0x00005063,
+    format = FormatB,
+    ram    = ()
+);
 
-impl RISCVInstruction for BGE {
-    const MASK: u32 = 0x0000707f;
-    const MATCH: u32 = 0x00005063;
-
-    type Format = FormatB;
-    type RAMAccess = ();
-
-    fn operands(&self) -> &Self::Format {
-        &self.operands
-    }
-
-    fn new(word: u32, address: u64, validate: bool) -> Self {
-        if validate {
-            debug_assert_eq!(word & Self::MASK, Self::MATCH);
-        }
-
-        Self {
-            address,
-            operands: FormatB::parse(word),
-            virtual_sequence_remaining: None,
-        }
-    }
-
-    fn execute(&self, cpu: &mut Cpu, _: &mut Self::RAMAccess) {
+impl BGE {
+    fn exec(&self, cpu: &mut Cpu, _: &mut <BGE as RISCVInstruction>::RAMAccess) {
         if cpu.sign_extend(cpu.x[self.operands.rs1]) >= cpu.sign_extend(cpu.x[self.operands.rs2]) {
             cpu.pc = (self.address as i64 + self.operands.imm) as u64;
         }

--- a/tracer/src/instruction/bgeu.rs
+++ b/tracer/src/instruction/bgeu.rs
@@ -1,48 +1,22 @@
 use serde::{Deserialize, Serialize};
 
-use crate::emulator::cpu::Cpu;
+use crate::{declare_riscv_instr, emulator::cpu::Cpu};
 
 use super::{
     format::{format_b::FormatB, InstructionFormat},
     RISCVInstruction, RISCVTrace,
 };
 
-#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
-pub struct BGEU {
-    pub address: u64,
-    pub operands: FormatB,
-    /// If this instruction is part of a "virtual sequence" (see Section 6.2 of the
-    /// Jolt paper), then this contains the number of virtual instructions after this
-    /// one in the sequence. I.e. if this is the last instruction in the sequence,
-    /// `virtual_sequence_remaining` will be Some(0); if this is the penultimate instruction
-    /// in the sequence, `virtual_sequence_remaining` will be Some(1); etc.
-    pub virtual_sequence_remaining: Option<usize>,
-}
+declare_riscv_instr!(
+    name   = BGEU,
+    mask   = 0x0000707f,
+    match  = 0x00007063,
+    format = FormatB,
+    ram    = ()
+);
 
-impl RISCVInstruction for BGEU {
-    const MASK: u32 = 0x0000707f;
-    const MATCH: u32 = 0x00007063;
-
-    type Format = FormatB;
-    type RAMAccess = ();
-
-    fn operands(&self) -> &Self::Format {
-        &self.operands
-    }
-
-    fn new(word: u32, address: u64, validate: bool) -> Self {
-        if validate {
-            debug_assert_eq!(word & Self::MASK, Self::MATCH);
-        }
-
-        Self {
-            address,
-            operands: FormatB::parse(word),
-            virtual_sequence_remaining: None,
-        }
-    }
-
-    fn execute(&self, cpu: &mut Cpu, _: &mut Self::RAMAccess) {
+impl BGEU {
+    fn exec(&self, cpu: &mut Cpu, _: &mut <BGEU as RISCVInstruction>::RAMAccess) {
         if cpu.unsigned_data(cpu.x[self.operands.rs1])
             >= cpu.unsigned_data(cpu.x[self.operands.rs2])
         {

--- a/tracer/src/instruction/blt.rs
+++ b/tracer/src/instruction/blt.rs
@@ -1,48 +1,22 @@
 use serde::{Deserialize, Serialize};
 
-use crate::emulator::cpu::Cpu;
+use crate::{declare_riscv_instr, emulator::cpu::Cpu};
 
 use super::{
     format::{format_b::FormatB, InstructionFormat},
     RISCVInstruction, RISCVTrace,
 };
 
-#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
-pub struct BLT {
-    pub address: u64,
-    pub operands: FormatB,
-    /// If this instruction is part of a "virtual sequence" (see Section 6.2 of the
-    /// Jolt paper), then this contains the number of virtual instructions after this
-    /// one in the sequence. I.e. if this is the last instruction in the sequence,
-    /// `virtual_sequence_remaining` will be Some(0); if this is the penultimate instruction
-    /// in the sequence, `virtual_sequence_remaining` will be Some(1); etc.
-    pub virtual_sequence_remaining: Option<usize>,
-}
+declare_riscv_instr!(
+    name   = BLT,
+    mask   = 0x0000707f,
+    match  = 0x00004063,
+    format = FormatB,
+    ram    = ()
+);
 
-impl RISCVInstruction for BLT {
-    const MASK: u32 = 0x0000707f;
-    const MATCH: u32 = 0x00004063;
-
-    type Format = FormatB;
-    type RAMAccess = ();
-
-    fn operands(&self) -> &Self::Format {
-        &self.operands
-    }
-
-    fn new(word: u32, address: u64, validate: bool) -> Self {
-        if validate {
-            debug_assert_eq!(word & Self::MASK, Self::MATCH);
-        }
-
-        Self {
-            address,
-            operands: FormatB::parse(word),
-            virtual_sequence_remaining: None,
-        }
-    }
-
-    fn execute(&self, cpu: &mut Cpu, _: &mut Self::RAMAccess) {
+impl BLT {
+    fn exec(&self, cpu: &mut Cpu, _: &mut <BLT as RISCVInstruction>::RAMAccess) {
         if cpu.sign_extend(cpu.x[self.operands.rs1]) < cpu.sign_extend(cpu.x[self.operands.rs2]) {
             cpu.pc = (self.address as i64 + self.operands.imm) as u64;
         }

--- a/tracer/src/instruction/bltu.rs
+++ b/tracer/src/instruction/bltu.rs
@@ -1,48 +1,22 @@
 use serde::{Deserialize, Serialize};
 
-use crate::emulator::cpu::Cpu;
+use crate::{declare_riscv_instr, emulator::cpu::Cpu};
 
 use super::{
     format::{format_b::FormatB, InstructionFormat},
     RISCVInstruction, RISCVTrace,
 };
 
-#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
-pub struct BLTU {
-    pub address: u64,
-    pub operands: FormatB,
-    /// If this instruction is part of a "virtual sequence" (see Section 6.2 of the
-    /// Jolt paper), then this contains the number of virtual instructions after this
-    /// one in the sequence. I.e. if this is the last instruction in the sequence,
-    /// `virtual_sequence_remaining` will be Some(0); if this is the penultimate instruction
-    /// in the sequence, `virtual_sequence_remaining` will be Some(1); etc.
-    pub virtual_sequence_remaining: Option<usize>,
-}
+declare_riscv_instr!(
+    name   = BLTU,
+    mask   = 0x0000707f,
+    match  = 0x00006063,
+    format = FormatB,
+    ram    = ()
+);
 
-impl RISCVInstruction for BLTU {
-    const MASK: u32 = 0x0000707f;
-    const MATCH: u32 = 0x00006063;
-
-    type Format = FormatB;
-    type RAMAccess = ();
-
-    fn operands(&self) -> &Self::Format {
-        &self.operands
-    }
-
-    fn new(word: u32, address: u64, validate: bool) -> Self {
-        if validate {
-            debug_assert_eq!(word & Self::MASK, Self::MATCH);
-        }
-
-        Self {
-            address,
-            operands: FormatB::parse(word),
-            virtual_sequence_remaining: None,
-        }
-    }
-
-    fn execute(&self, cpu: &mut Cpu, _: &mut Self::RAMAccess) {
+impl BLTU {
+    fn exec(&self, cpu: &mut Cpu, _: &mut <BLTU as RISCVInstruction>::RAMAccess) {
         if cpu.unsigned_data(cpu.x[self.operands.rs1]) < cpu.unsigned_data(cpu.x[self.operands.rs2])
         {
             cpu.pc = (self.address as i64 + self.operands.imm) as u64;

--- a/tracer/src/instruction/bne.rs
+++ b/tracer/src/instruction/bne.rs
@@ -1,48 +1,22 @@
 use serde::{Deserialize, Serialize};
 
-use crate::emulator::cpu::Cpu;
+use crate::{declare_riscv_instr, emulator::cpu::Cpu};
 
 use super::{
     format::{format_b::FormatB, InstructionFormat},
     RISCVInstruction, RISCVTrace,
 };
 
-#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
-pub struct BNE {
-    pub address: u64,
-    pub operands: FormatB,
-    /// If this instruction is part of a "virtual sequence" (see Section 6.2 of the
-    /// Jolt paper), then this contains the number of virtual instructions after this
-    /// one in the sequence. I.e. if this is the last instruction in the sequence,
-    /// `virtual_sequence_remaining` will be Some(0); if this is the penultimate instruction
-    /// in the sequence, `virtual_sequence_remaining` will be Some(1); etc.
-    pub virtual_sequence_remaining: Option<usize>,
-}
+declare_riscv_instr!(
+    name   = BNE,
+    mask   = 0x0000707f,
+    match  = 0x00001063,
+    format = FormatB,
+    ram    = ()
+);
 
-impl RISCVInstruction for BNE {
-    const MASK: u32 = 0x0000707f;
-    const MATCH: u32 = 0x00001063;
-
-    type Format = FormatB;
-    type RAMAccess = ();
-
-    fn operands(&self) -> &Self::Format {
-        &self.operands
-    }
-
-    fn new(word: u32, address: u64, validate: bool) -> Self {
-        if validate {
-            debug_assert_eq!(word & Self::MASK, Self::MATCH);
-        }
-
-        Self {
-            address,
-            operands: FormatB::parse(word),
-            virtual_sequence_remaining: None,
-        }
-    }
-
-    fn execute(&self, cpu: &mut Cpu, _: &mut Self::RAMAccess) {
+impl BNE {
+    fn exec(&self, cpu: &mut Cpu, _: &mut <BNE as RISCVInstruction>::RAMAccess) {
         if cpu.sign_extend(cpu.x[self.operands.rs1]) != cpu.sign_extend(cpu.x[self.operands.rs2]) {
             cpu.pc = (self.address as i64 + self.operands.imm) as u64;
         }

--- a/tracer/src/instruction/div.rs
+++ b/tracer/src/instruction/div.rs
@@ -24,7 +24,7 @@ use super::{
 declare_riscv_instr!(
     name   = DIV,
     mask   = 0xfe00707f,
-    match  = 0x02005033,
+    match  = 0x02004033,
     format = FormatR,
     ram    = ()
 );

--- a/tracer/src/instruction/divu.rs
+++ b/tracer/src/instruction/divu.rs
@@ -1,7 +1,10 @@
 use common::constants::virtual_register_index;
 use serde::{Deserialize, Serialize};
 
-use crate::emulator::cpu::{Cpu, Xlen};
+use crate::{
+    declare_riscv_instr,
+    emulator::cpu::{Cpu, Xlen},
+};
 
 use super::{
     add::ADD,
@@ -18,42 +21,16 @@ use super::{
     RISCVInstruction, RISCVTrace, RV32IMInstruction, VirtualInstructionSequence,
 };
 
-#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
-pub struct DIVU {
-    pub address: u64,
-    pub operands: FormatR,
-    /// If this instruction is part of a "virtual sequence" (see Section 6.2 of the
-    /// Jolt paper), then this contains the number of virtual instructions after this
-    /// one in the sequence. I.e. if this is the last instruction in the sequence,
-    /// `virtual_sequence_remaining` will be Some(0); if this is the penultimate instruction
-    /// in the sequence, `virtual_sequence_remaining` will be Some(1); etc.
-    pub virtual_sequence_remaining: Option<usize>,
-}
+declare_riscv_instr!(
+    name   = DIVU,
+    mask   = 0xfe00707f,
+    match  = 0x02005033,
+    format = FormatR,
+    ram    = ()
+);
 
-impl RISCVInstruction for DIVU {
-    const MASK: u32 = 0xfe00707f;
-    const MATCH: u32 = 0x02005033;
-
-    type Format = FormatR;
-    type RAMAccess = ();
-
-    fn operands(&self) -> &Self::Format {
-        &self.operands
-    }
-
-    fn new(word: u32, address: u64, validate: bool) -> Self {
-        if validate {
-            debug_assert_eq!(word & Self::MASK, Self::MATCH);
-        }
-
-        Self {
-            address,
-            operands: FormatR::parse(word),
-            virtual_sequence_remaining: None,
-        }
-    }
-
-    fn execute(&self, cpu: &mut Cpu, _: &mut Self::RAMAccess) {
+impl DIVU {
+    fn exec(&self, cpu: &mut Cpu, _: &mut <DIVU as RISCVInstruction>::RAMAccess) {
         let dividend = cpu.unsigned_data(cpu.x[self.operands.rs1]);
         let divisor = cpu.unsigned_data(cpu.x[self.operands.rs2]);
         if divisor == 0 {

--- a/tracer/src/instruction/ecall.rs
+++ b/tracer/src/instruction/ecall.rs
@@ -1,52 +1,30 @@
-//! ECALL (SYSTEM 0x0000_0073) — currently only serves for Jolt-cycle tracking.
+//! ECALL (SYSTEM 0x0000_0073) — currently only serves for Jolt cycle-tracking.
 //! Although, this will be used for "pseudo-precompiles"
-//!
-//! It retires like a normal instruction; there is **no trap** because the
-//! emulator has an early-exit path in `Cpu::handle_trap` that consumes the
-//! marker.  From the ISA-level point of view we therefore treat it as a
-//! “no-op”.
 
 use serde::{Deserialize, Serialize};
 
-use crate::emulator::cpu::{Cpu, PrivilegeMode, Trap, TrapType};
+use crate::{
+    declare_riscv_instr,
+    emulator::cpu::{Cpu, PrivilegeMode, Trap, TrapType},
+};
 
 use super::{
     format::{format_i::FormatI, InstructionFormat},
     RISCVInstruction, RISCVTrace,
 };
 
-#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
-pub struct ECALL {
-    pub address: u64,
-    pub operands: FormatI,
-    pub virtual_sequence_remaining: Option<usize>,
-}
+declare_riscv_instr!(
+    name   = ECALL,
+    mask   = 0xffff_ffff,
+    match  = 0x0000_0073,
+    format = FormatI,
+    ram    = ()
+);
 
-impl RISCVInstruction for ECALL {
-    const MASK: u32 = 0xffff_ffff;
-    const MATCH: u32 = 0x0000_0073; // ECALL opcode
-
-    type Format = FormatI;
-    type RAMAccess = ();
-
-    fn operands(&self) -> &Self::Format {
-        &self.operands
-    }
-
-    fn new(word: u32, address: u64, validate: bool) -> Self {
-        if validate {
-            debug_assert_eq!(word, Self::MATCH);
-        }
-        Self {
-            address,
-            operands: FormatI::parse(word),
-            virtual_sequence_remaining: None,
-        }
-    }
-
+impl ECALL {
     /// **No architectural effects**
     /// Signals to emulator to record cycles through early exit of trap
-    fn execute(&self, cpu: &mut Cpu, _: &mut Self::RAMAccess) {
+    fn exec(&self, cpu: &mut Cpu, _: &mut <ECALL as RISCVInstruction>::RAMAccess) {
         let trap_type = match cpu.privilege_mode {
             PrivilegeMode::User => TrapType::EnvironmentCallFromUMode,
             PrivilegeMode::Supervisor => TrapType::EnvironmentCallFromSMode,

--- a/tracer/src/instruction/fence.rs
+++ b/tracer/src/instruction/fence.rs
@@ -1,48 +1,22 @@
 use serde::{Deserialize, Serialize};
 
-use crate::emulator::cpu::Cpu;
+use crate::{declare_riscv_instr, emulator::cpu::Cpu};
 
 use super::{
     format::{format_i::FormatI, InstructionFormat},
     RISCVInstruction, RISCVTrace,
 };
 
-#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
-pub struct FENCE {
-    pub address: u64,
-    pub operands: FormatI,
-    /// If this instruction is part of a "virtual sequence" (see Section 6.2 of the
-    /// Jolt paper), then this contains the number of virtual instructions after this
-    /// one in the sequence. I.e. if this is the last instruction in the sequence,
-    /// `virtual_sequence_remaining` will be Some(0); if this is the penultimate instruction
-    /// in the sequence, `virtual_sequence_remaining` will be Some(1); etc.
-    pub virtual_sequence_remaining: Option<usize>,
-}
+declare_riscv_instr!(
+    name   = FENCE,
+    mask   = 0x0000707f,
+    match  = 0x0000000f,
+    format = FormatI,
+    ram    = ()
+);
 
-impl RISCVInstruction for FENCE {
-    const MASK: u32 = 0x0000707f;
-    const MATCH: u32 = 0x0000000f;
-
-    type Format = FormatI;
-    type RAMAccess = ();
-
-    fn operands(&self) -> &Self::Format {
-        &self.operands
-    }
-
-    fn new(word: u32, address: u64, validate: bool) -> Self {
-        if validate {
-            debug_assert_eq!(word & Self::MASK, Self::MATCH);
-        }
-
-        Self {
-            address,
-            operands: FormatI::parse(word),
-            virtual_sequence_remaining: None,
-        }
-    }
-
-    fn execute(&self, _: &mut Cpu, _: &mut Self::RAMAccess) {
+impl FENCE {
+    fn exec(&self, _: &mut Cpu, _: &mut <FENCE as RISCVInstruction>::RAMAccess) {
         // no-op
     }
 }

--- a/tracer/src/instruction/instruction_macros.rs
+++ b/tracer/src/instruction/instruction_macros.rs
@@ -1,0 +1,69 @@
+use super::format;
+
+#[macro_export]
+macro_rules! declare_riscv_instr {
+    (
+      name    = $name:ident,
+      mask    = $mask:expr,
+      match   = $match_:expr,
+      format  = $format:ty,
+      ram     = $ram:ty
+      $(, is_virtual = $virt:tt)?
+        $(,)?
+  ) => {
+        #[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
+        pub struct $name {
+            pub address: u64,
+            pub operands: $format,
+            pub virtual_sequence_remaining: Option<usize>,
+        }
+
+        impl $crate::instruction::RISCVInstruction for $name {
+            const MASK: u32 = $mask;
+            const MATCH: u32 = $match_;
+
+            type Format = $format;
+            type RAMAccess = $ram;
+
+            fn operands(&self) -> &Self::Format {
+                &self.operands
+            }
+
+            fn new(word: u32, address: u64, validate: bool) -> Self {
+              if declare_riscv_instr!(@is_virtual $( $virt )?) {
+                    panic!(
+                        "virtual instruction `{}` cannot be built from a machine word",
+                        stringify!($name)
+                    );
+                }
+                if validate {
+                    debug_assert_eq!(word & Self::MASK, Self::MATCH);
+                }
+                Self {
+                    address,
+                    operands: <$format>::parse(word),
+                    virtual_sequence_remaining: None,
+                }
+            }
+
+            fn random(rng: &mut rand::rngs::StdRng) -> Self {
+                Self {
+                    address: rand::RngCore::next_u64(rng),
+                    operands: <$format>::random(rng),
+                    virtual_sequence_remaining: None,
+                }
+            }
+
+            fn execute(&self, cpu: &mut Cpu, ram: &mut Self::RAMAccess) {
+                self.exec(cpu, ram)
+            }
+        }
+    };
+
+    (@is_virtual true) => {
+        true
+    };
+    (@is_virtual) => {
+        false
+    };
+}

--- a/tracer/src/instruction/jal.rs
+++ b/tracer/src/instruction/jal.rs
@@ -1,48 +1,22 @@
 use serde::{Deserialize, Serialize};
 
-use crate::emulator::cpu::Cpu;
+use crate::{declare_riscv_instr, emulator::cpu::Cpu};
 
 use super::{
     format::{format_j::FormatJ, normalize_imm, InstructionFormat},
     RISCVInstruction, RISCVTrace,
 };
 
-#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
-pub struct JAL {
-    pub address: u64,
-    pub operands: FormatJ,
-    /// If this instruction is part of a "virtual sequence" (see Section 6.2 of the
-    /// Jolt paper), then this contains the number of virtual instructions after this
-    /// one in the sequence. I.e. if this is the last instruction in the sequence,
-    /// `virtual_sequence_remaining` will be Some(0); if this is the penultimate instruction
-    /// in the sequence, `virtual_sequence_remaining` will be Some(1); etc.
-    pub virtual_sequence_remaining: Option<usize>,
-}
+declare_riscv_instr!(
+    name   = JAL,
+    mask   = 0x0000_007f,
+    match  = 0x0000_006f,
+    format = FormatJ,
+    ram    = ()
+);
 
-impl RISCVInstruction for JAL {
-    const MASK: u32 = 0x0000007f;
-    const MATCH: u32 = 0x0000006f;
-
-    type Format = FormatJ;
-    type RAMAccess = ();
-
-    fn operands(&self) -> &Self::Format {
-        &self.operands
-    }
-
-    fn new(word: u32, address: u64, validate: bool) -> Self {
-        if validate {
-            debug_assert_eq!(word & Self::MASK, Self::MATCH);
-        }
-
-        Self {
-            address,
-            operands: FormatJ::parse(word),
-            virtual_sequence_remaining: None,
-        }
-    }
-
-    fn execute(&self, cpu: &mut Cpu, _: &mut Self::RAMAccess) {
+impl JAL {
+    fn exec(&self, cpu: &mut Cpu, _: &mut <JAL as RISCVInstruction>::RAMAccess) {
         if self.operands.rd != 0 {
             cpu.x[self.operands.rd] = cpu.sign_extend(cpu.pc as i64);
         }

--- a/tracer/src/instruction/jalr.rs
+++ b/tracer/src/instruction/jalr.rs
@@ -1,48 +1,22 @@
 use serde::{Deserialize, Serialize};
 
-use crate::emulator::cpu::Cpu;
+use crate::{declare_riscv_instr, emulator::cpu::Cpu};
 
 use super::{
     format::{format_i::FormatI, InstructionFormat},
     RISCVInstruction, RISCVTrace,
 };
 
-#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
-pub struct JALR {
-    pub address: u64,
-    pub operands: FormatI,
-    /// If this instruction is part of a "virtual sequence" (see Section 6.2 of the
-    /// Jolt paper), then this contains the number of virtual instructions after this
-    /// one in the sequence. I.e. if this is the last instruction in the sequence,
-    /// `virtual_sequence_remaining` will be Some(0); if this is the penultimate instruction
-    /// in the sequence, `virtual_sequence_remaining` will be Some(1); etc.
-    pub virtual_sequence_remaining: Option<usize>,
-}
+declare_riscv_instr!(
+    name   = JALR,
+    mask   = 0x0000707f,
+    match  = 0x00000067,
+    format = FormatI,
+    ram    = ()
+);
 
-impl RISCVInstruction for JALR {
-    const MASK: u32 = 0x0000707f;
-    const MATCH: u32 = 0x00000067;
-
-    type Format = FormatI;
-    type RAMAccess = ();
-
-    fn operands(&self) -> &Self::Format {
-        &self.operands
-    }
-
-    fn new(word: u32, address: u64, validate: bool) -> Self {
-        if validate {
-            debug_assert_eq!(word & Self::MASK, Self::MATCH);
-        }
-
-        Self {
-            address,
-            operands: FormatI::parse(word),
-            virtual_sequence_remaining: None,
-        }
-    }
-
-    fn execute(&self, cpu: &mut Cpu, _: &mut Self::RAMAccess) {
+impl JALR {
+    fn exec(&self, cpu: &mut Cpu, _: &mut <JALR as RISCVInstruction>::RAMAccess) {
         let tmp = cpu.sign_extend(cpu.pc as i64);
         cpu.pc = (cpu.x[self.operands.rs1] as u64).wrapping_add(self.operands.imm as u64);
         if self.operands.rd != 0 {

--- a/tracer/src/instruction/lbu.rs
+++ b/tracer/src/instruction/lbu.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-use crate::emulator::cpu::Cpu;
+use crate::{declare_riscv_instr, emulator::cpu::Cpu};
 
 use super::andi::ANDI;
 use super::format::format_load::FormatLoad;
@@ -19,42 +19,16 @@ use super::{
     RISCVInstruction, RISCVTrace,
 };
 
-#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
-pub struct LBU {
-    pub address: u64,
-    pub operands: FormatLoad,
-    /// If this instruction is part of a "virtual sequence" (see Section 6.2 of the
-    /// Jolt paper), then this contains the number of virtual instructions after this
-    /// one in the sequence. I.e. if this is the last instruction in the sequence,
-    /// `virtual_sequence_remaining` will be Some(0); if this is the penultimate instruction
-    /// in the sequence, `virtual_sequence_remaining` will be Some(1); etc.
-    pub virtual_sequence_remaining: Option<usize>,
-}
+declare_riscv_instr!(
+    name   = LBU,
+    mask   = 0x0000707f,
+    match  = 0x00004003,
+    format = FormatLoad,
+    ram    = RAMRead
+);
 
-impl RISCVInstruction for LBU {
-    const MASK: u32 = 0x0000707f;
-    const MATCH: u32 = 0x00004003;
-
-    type Format = FormatLoad;
-    type RAMAccess = RAMRead;
-
-    fn operands(&self) -> &Self::Format {
-        &self.operands
-    }
-
-    fn new(word: u32, address: u64, validate: bool) -> Self {
-        if validate {
-            assert_eq!(word & Self::MASK, Self::MATCH);
-        }
-
-        Self {
-            address,
-            operands: FormatLoad::parse(word),
-            virtual_sequence_remaining: None,
-        }
-    }
-
-    fn execute(&self, cpu: &mut Cpu, ram_access: &mut Self::RAMAccess) {
+impl LBU {
+    fn exec(&self, cpu: &mut Cpu, ram_access: &mut <LBU as RISCVInstruction>::RAMAccess) {
         cpu.x[self.operands.rd] = match cpu
             .mmu
             .load(cpu.x[self.operands.rs1].wrapping_add(self.operands.imm) as u64)

--- a/tracer/src/instruction/lh.rs
+++ b/tracer/src/instruction/lh.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-use crate::emulator::cpu::Cpu;
+use crate::{declare_riscv_instr, emulator::cpu::Cpu};
 
 use super::andi::ANDI;
 use super::format::format_load::FormatLoad;
@@ -21,42 +21,16 @@ use super::{
     RISCVInstruction, RISCVTrace,
 };
 
-#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
-pub struct LH {
-    pub address: u64,
-    pub operands: FormatLoad,
-    /// If this instruction is part of a "virtual sequence" (see Section 6.2 of the
-    /// Jolt paper), then this contains the number of virtual instructions after this
-    /// one in the sequence. I.e. if this is the last instruction in the sequence,
-    /// `virtual_sequence_remaining` will be Some(0); if this is the penultimate instruction
-    /// in the sequence, `virtual_sequence_remaining` will be Some(1); etc.
-    pub virtual_sequence_remaining: Option<usize>,
-}
+declare_riscv_instr!(
+    name   = LH,
+    mask   = 0x0000707f,
+    match  = 0x00001003,
+    format = FormatLoad,
+    ram    = RAMRead
+);
 
-impl RISCVInstruction for LH {
-    const MASK: u32 = 0x0000707f;
-    const MATCH: u32 = 0x00001003;
-
-    type Format = FormatLoad;
-    type RAMAccess = RAMRead;
-
-    fn operands(&self) -> &Self::Format {
-        &self.operands
-    }
-
-    fn new(word: u32, address: u64, validate: bool) -> Self {
-        if validate {
-            assert_eq!(word & Self::MASK, Self::MATCH);
-        }
-
-        Self {
-            address,
-            operands: FormatLoad::parse(word),
-            virtual_sequence_remaining: None,
-        }
-    }
-
-    fn execute(&self, cpu: &mut Cpu, ram_access: &mut Self::RAMAccess) {
+impl LH {
+    fn exec(&self, cpu: &mut Cpu, ram_access: &mut <LH as RISCVInstruction>::RAMAccess) {
         cpu.x[self.operands.rd] = match cpu
             .mmu
             .load_halfword(cpu.x[self.operands.rs1].wrapping_add(self.operands.imm) as u64)

--- a/tracer/src/instruction/lhu.rs
+++ b/tracer/src/instruction/lhu.rs
@@ -25,7 +25,7 @@ use super::{
 declare_riscv_instr!(
     name   = LHU,
     mask   = 0x0000707f,
-    match  = 0x00001003,
+    match  = 0x00005003,
     format = FormatLoad,
     ram    = RAMRead
 );

--- a/tracer/src/instruction/lhu.rs
+++ b/tracer/src/instruction/lhu.rs
@@ -1,5 +1,6 @@
 use serde::{Deserialize, Serialize};
 
+use crate::declare_riscv_instr;
 use crate::emulator::cpu::Cpu;
 
 use super::andi::ANDI;
@@ -21,42 +22,16 @@ use super::{
     RISCVInstruction, RISCVTrace,
 };
 
-#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
-pub struct LHU {
-    pub address: u64,
-    pub operands: FormatLoad,
-    /// If this instruction is part of a "virtual sequence" (see Section 6.2 of the
-    /// Jolt paper), then this contains the number of virtual instructions after this
-    /// one in the sequence. I.e. if this is the last instruction in the sequence,
-    /// `virtual_sequence_remaining` will be Some(0); if this is the penultimate instruction
-    /// in the sequence, `virtual_sequence_remaining` will be Some(1); etc.
-    pub virtual_sequence_remaining: Option<usize>,
-}
+declare_riscv_instr!(
+    name   = LHU,
+    mask   = 0x0000707f,
+    match  = 0x00001003,
+    format = FormatLoad,
+    ram    = RAMRead
+);
 
-impl RISCVInstruction for LHU {
-    const MASK: u32 = 0x0000707f;
-    const MATCH: u32 = 0x00005003;
-
-    type Format = FormatLoad;
-    type RAMAccess = RAMRead;
-
-    fn operands(&self) -> &Self::Format {
-        &self.operands
-    }
-
-    fn new(word: u32, address: u64, validate: bool) -> Self {
-        if validate {
-            assert_eq!(word & Self::MASK, Self::MATCH);
-        }
-
-        Self {
-            address,
-            operands: FormatLoad::parse(word),
-            virtual_sequence_remaining: None,
-        }
-    }
-
-    fn execute(&self, cpu: &mut Cpu, ram_access: &mut Self::RAMAccess) {
+impl LHU {
+    fn exec(&self, cpu: &mut Cpu, ram_access: &mut <LHU as RISCVInstruction>::RAMAccess) {
         cpu.x[self.operands.rd] = match cpu
             .mmu
             .load_halfword(cpu.x[self.operands.rs1].wrapping_add(self.operands.imm) as u64)

--- a/tracer/src/instruction/lui.rs
+++ b/tracer/src/instruction/lui.rs
@@ -1,48 +1,22 @@
 use serde::{Deserialize, Serialize};
 
-use crate::emulator::cpu::Cpu;
+use crate::{declare_riscv_instr, emulator::cpu::Cpu};
 
 use super::{
     format::{format_u::FormatU, InstructionFormat},
     RISCVInstruction, RISCVTrace,
 };
 
-#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
-pub struct LUI {
-    pub address: u64,
-    pub operands: FormatU,
-    /// If this instruction is part of a "virtual sequence" (see Section 6.2 of the
-    /// Jolt paper), then this contains the number of virtual instructions after this
-    /// one in the sequence. I.e. if this is the last instruction in the sequence,
-    /// `virtual_sequence_remaining` will be Some(0); if this is the penultimate instruction
-    /// in the sequence, `virtual_sequence_remaining` will be Some(1); etc.
-    pub virtual_sequence_remaining: Option<usize>,
-}
+declare_riscv_instr!(
+    name   = LUI,
+    mask   = 0x0000007f,
+    match  = 0x00000037,
+    format = FormatU,
+    ram    = ()
+);
 
-impl RISCVInstruction for LUI {
-    const MASK: u32 = 0x0000007f;
-    const MATCH: u32 = 0x00000037;
-
-    type Format = FormatU;
-    type RAMAccess = ();
-
-    fn operands(&self) -> &Self::Format {
-        &self.operands
-    }
-
-    fn new(word: u32, address: u64, validate: bool) -> Self {
-        if validate {
-            debug_assert_eq!(word & Self::MASK, Self::MATCH);
-        }
-
-        Self {
-            address,
-            operands: FormatU::parse(word),
-            virtual_sequence_remaining: None,
-        }
-    }
-
-    fn execute(&self, cpu: &mut Cpu, _: &mut Self::RAMAccess) {
+impl LUI {
+    fn exec(&self, cpu: &mut Cpu, _: &mut <LUI as RISCVInstruction>::RAMAccess) {
         cpu.x[self.operands.rd] = self.operands.imm as i64;
     }
 }

--- a/tracer/src/instruction/lw.rs
+++ b/tracer/src/instruction/lw.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-use crate::emulator::cpu::Cpu;
+use crate::{declare_riscv_instr, emulator::cpu::Cpu};
 
 use super::RAMRead;
 
@@ -9,42 +9,16 @@ use super::{
     RISCVInstruction, RISCVTrace,
 };
 
-#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
-pub struct LW {
-    pub address: u64,
-    pub operands: FormatLoad,
-    /// If this instruction is part of a "virtual sequence" (see Section 6.2 of the
-    /// Jolt paper), then this contains the number of virtual instructions after this
-    /// one in the sequence. I.e. if this is the last instruction in the sequence,
-    /// `virtual_sequence_remaining` will be Some(0); if this is the penultimate instruction
-    /// in the sequence, `virtual_sequence_remaining` will be Some(1); etc.
-    pub virtual_sequence_remaining: Option<usize>,
-}
+declare_riscv_instr!(
+    name   = LW,
+    mask   = 0x0000707f,
+    match  = 0x00002003,
+    format = FormatLoad,
+    ram    = RAMRead
+);
 
-impl RISCVInstruction for LW {
-    const MASK: u32 = 0x0000707f;
-    const MATCH: u32 = 0x00002003;
-
-    type Format = FormatLoad;
-    type RAMAccess = RAMRead;
-
-    fn operands(&self) -> &Self::Format {
-        &self.operands
-    }
-
-    fn new(word: u32, address: u64, validate: bool) -> Self {
-        if validate {
-            assert_eq!(word & Self::MASK, Self::MATCH);
-        }
-
-        Self {
-            address,
-            operands: FormatLoad::parse(word),
-            virtual_sequence_remaining: None,
-        }
-    }
-
-    fn execute(&self, cpu: &mut Cpu, ram_access: &mut Self::RAMAccess) {
+impl LW {
+    fn exec(&self, cpu: &mut Cpu, ram_access: &mut <LW as RISCVInstruction>::RAMAccess) {
         cpu.x[self.operands.rd] = match cpu
             .mmu
             .load_word(cpu.x[self.operands.rs1].wrapping_add(self.operands.imm) as u64)

--- a/tracer/src/instruction/mod.rs
+++ b/tracer/src/instruction/mod.rs
@@ -77,6 +77,8 @@ use format::{InstructionFormat, InstructionRegisterState, NormalizedOperands};
 
 pub mod format;
 
+pub mod instruction_macros;
+
 pub mod add;
 pub mod addi;
 pub mod and;

--- a/tracer/src/instruction/mul.rs
+++ b/tracer/src/instruction/mul.rs
@@ -1,48 +1,22 @@
 use serde::{Deserialize, Serialize};
 
-use crate::emulator::cpu::Cpu;
+use crate::{declare_riscv_instr, emulator::cpu::Cpu};
 
 use super::{
     format::{format_r::FormatR, InstructionFormat},
     RISCVInstruction, RISCVTrace,
 };
 
-#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
-pub struct MUL {
-    pub address: u64,
-    pub operands: FormatR,
-    /// If this instruction is part of a "virtual sequence" (see Section 6.2 of the
-    /// Jolt paper), then this contains the number of virtual instructions after this
-    /// one in the sequence. I.e. if this is the last instruction in the sequence,
-    /// `virtual_sequence_remaining` will be Some(0); if this is the penultimate instruction
-    /// in the sequence, `virtual_sequence_remaining` will be Some(1); etc.
-    pub virtual_sequence_remaining: Option<usize>,
-}
+declare_riscv_instr!(
+    name   = MUL,
+    mask   = 0xfe00707f,
+    match  = 0x02000033,
+    format = FormatR,
+    ram    = ()
+);
 
-impl RISCVInstruction for MUL {
-    const MASK: u32 = 0xfe00707f;
-    const MATCH: u32 = 0x02000033;
-
-    type Format = FormatR;
-    type RAMAccess = ();
-
-    fn operands(&self) -> &Self::Format {
-        &self.operands
-    }
-
-    fn new(word: u32, address: u64, validate: bool) -> Self {
-        if validate {
-            debug_assert_eq!(word & Self::MASK, Self::MATCH);
-        }
-
-        Self {
-            address,
-            operands: FormatR::parse(word),
-            virtual_sequence_remaining: None,
-        }
-    }
-
-    fn execute(&self, cpu: &mut Cpu, _: &mut Self::RAMAccess) {
+impl MUL {
+    fn exec(&self, cpu: &mut Cpu, _: &mut <MUL as RISCVInstruction>::RAMAccess) {
         cpu.x[self.operands.rd] =
             cpu.sign_extend(cpu.x[self.operands.rs1].wrapping_mul(cpu.x[self.operands.rs2]));
     }

--- a/tracer/src/instruction/mulh.rs
+++ b/tracer/src/instruction/mulh.rs
@@ -1,7 +1,10 @@
 use common::constants::virtual_register_index;
 use serde::{Deserialize, Serialize};
 
-use crate::emulator::cpu::{Cpu, Xlen};
+use crate::{
+    declare_riscv_instr,
+    emulator::cpu::{Cpu, Xlen},
+};
 
 use super::{
     add::ADD,
@@ -12,42 +15,16 @@ use super::{
     RISCVInstruction, RISCVTrace, RV32IMInstruction, VirtualInstructionSequence,
 };
 
-#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
-pub struct MULH {
-    pub address: u64,
-    pub operands: FormatR,
-    /// If this instruction is part of a "virtual sequence" (see Section 6.2 of the
-    /// Jolt paper), then this contains the number of virtual instructions after this
-    /// one in the sequence. I.e. if this is the last instruction in the sequence,
-    /// `virtual_sequence_remaining` will be Some(0); if this is the penultimate instruction
-    /// in the sequence, `virtual_sequence_remaining` will be Some(1); etc.
-    pub virtual_sequence_remaining: Option<usize>,
-}
+declare_riscv_instr!(
+    name   = MULH,
+    mask   = 0xfe00707f,
+    match  = 0x02001033,
+    format = FormatR,
+    ram    = ()
+);
 
-impl RISCVInstruction for MULH {
-    const MASK: u32 = 0xfe00707f;
-    const MATCH: u32 = 0x02001033;
-
-    type Format = FormatR;
-    type RAMAccess = ();
-
-    fn operands(&self) -> &Self::Format {
-        &self.operands
-    }
-
-    fn new(word: u32, address: u64, validate: bool) -> Self {
-        if validate {
-            debug_assert_eq!(word & Self::MASK, Self::MATCH);
-        }
-
-        Self {
-            address,
-            operands: FormatR::parse(word),
-            virtual_sequence_remaining: None,
-        }
-    }
-
-    fn execute(&self, cpu: &mut Cpu, _: &mut Self::RAMAccess) {
+impl MULH {
+    fn exec(&self, cpu: &mut Cpu, _: &mut <MULH as RISCVInstruction>::RAMAccess) {
         cpu.x[self.operands.rd] = match cpu.xlen {
             Xlen::Bit32 => {
                 cpu.sign_extend((cpu.x[self.operands.rs1] * cpu.x[self.operands.rs2]) >> 32)

--- a/tracer/src/instruction/mulhsu.rs
+++ b/tracer/src/instruction/mulhsu.rs
@@ -1,7 +1,10 @@
 use common::constants::virtual_register_index;
 use serde::{Deserialize, Serialize};
 
-use crate::emulator::cpu::{Cpu, Xlen};
+use crate::{
+    declare_riscv_instr,
+    emulator::cpu::{Cpu, Xlen},
+};
 
 use super::{
     add::ADD,
@@ -11,42 +14,16 @@ use super::{
     RISCVInstruction, RISCVTrace, RV32IMInstruction, VirtualInstructionSequence,
 };
 
-#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
-pub struct MULHSU {
-    pub address: u64,
-    pub operands: FormatR,
-    /// If this instruction is part of a "virtual sequence" (see Section 6.2 of the
-    /// Jolt paper), then this contains the number of virtual instructions after this
-    /// one in the sequence. I.e. if this is the last instruction in the sequence,
-    /// `virtual_sequence_remaining` will be Some(0); if this is the penultimate instruction
-    /// in the sequence, `virtual_sequence_remaining` will be Some(1); etc.
-    pub virtual_sequence_remaining: Option<usize>,
-}
+declare_riscv_instr!(
+    name   = MULHSU,
+    mask   = 0xfe00707f,
+    match  = 0x02002033,
+    format = FormatR,
+    ram    = ()
+);
 
-impl RISCVInstruction for MULHSU {
-    const MASK: u32 = 0xfe00707f;
-    const MATCH: u32 = 0x02002033;
-
-    type Format = FormatR;
-    type RAMAccess = ();
-
-    fn operands(&self) -> &Self::Format {
-        &self.operands
-    }
-
-    fn new(word: u32, address: u64, validate: bool) -> Self {
-        if validate {
-            debug_assert_eq!(word & Self::MASK, Self::MATCH);
-        }
-
-        Self {
-            address,
-            operands: FormatR::parse(word),
-            virtual_sequence_remaining: None,
-        }
-    }
-
-    fn execute(&self, cpu: &mut Cpu, _: &mut Self::RAMAccess) {
+impl MULHSU {
+    fn exec(&self, cpu: &mut Cpu, _: &mut <MULHSU as RISCVInstruction>::RAMAccess) {
         cpu.x[self.operands.rd] = match cpu.xlen {
             Xlen::Bit32 => cpu.sign_extend(
                 ((cpu.x[self.operands.rs1] as i64)

--- a/tracer/src/instruction/mulhu.rs
+++ b/tracer/src/instruction/mulhu.rs
@@ -1,48 +1,25 @@
 use serde::{Deserialize, Serialize};
 
-use crate::emulator::cpu::{Cpu, Xlen};
+use crate::{
+    declare_riscv_instr,
+    emulator::cpu::{Cpu, Xlen},
+};
 
 use super::{
     format::{format_r::FormatR, InstructionFormat},
     RISCVInstruction, RISCVTrace,
 };
 
-#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
-pub struct MULHU {
-    pub address: u64,
-    pub operands: FormatR,
-    /// If this instruction is part of a "virtual sequence" (see Section 6.2 of the
-    /// Jolt paper), then this contains the number of virtual instructions after this
-    /// one in the sequence. I.e. if this is the last instruction in the sequence,
-    /// `virtual_sequence_remaining` will be Some(0); if this is the penultimate instruction
-    /// in the sequence, `virtual_sequence_remaining` will be Some(1); etc.
-    pub virtual_sequence_remaining: Option<usize>,
-}
+declare_riscv_instr!(
+    name   = MULHU,
+    mask   = 0xfe00707f,
+    match  = 0x02003033,
+    format = FormatR,
+    ram    = ()
+);
 
-impl RISCVInstruction for MULHU {
-    const MASK: u32 = 0xfe00707f;
-    const MATCH: u32 = 0x02003033;
-
-    type Format = FormatR;
-    type RAMAccess = ();
-
-    fn operands(&self) -> &Self::Format {
-        &self.operands
-    }
-
-    fn new(word: u32, address: u64, validate: bool) -> Self {
-        if validate {
-            debug_assert_eq!(word & Self::MASK, Self::MATCH);
-        }
-
-        Self {
-            address,
-            operands: FormatR::parse(word),
-            virtual_sequence_remaining: None,
-        }
-    }
-
-    fn execute(&self, cpu: &mut Cpu, _: &mut Self::RAMAccess) {
+impl MULHU {
+    fn exec(&self, cpu: &mut Cpu, _: &mut <MULHU as RISCVInstruction>::RAMAccess) {
         cpu.x[self.operands.rd] = match cpu.xlen {
             Xlen::Bit32 => cpu.sign_extend(
                 (((cpu.x[self.operands.rs1] as u32 as u64)

--- a/tracer/src/instruction/or.rs
+++ b/tracer/src/instruction/or.rs
@@ -1,48 +1,22 @@
 use serde::{Deserialize, Serialize};
 
-use crate::emulator::cpu::Cpu;
+use crate::{declare_riscv_instr, emulator::cpu::Cpu};
 
 use super::{
     format::{format_r::FormatR, InstructionFormat},
     RISCVInstruction, RISCVTrace,
 };
 
-#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
-pub struct OR {
-    pub address: u64,
-    pub operands: FormatR,
-    /// If this instruction is part of a "virtual sequence" (see Section 6.2 of the
-    /// Jolt paper), then this contains the number of virtual instructions after this
-    /// one in the sequence. I.e. if this is the last instruction in the sequence,
-    /// `virtual_sequence_remaining` will be Some(0); if this is the penultimate instruction
-    /// in the sequence, `virtual_sequence_remaining` will be Some(1); etc.
-    pub virtual_sequence_remaining: Option<usize>,
-}
+declare_riscv_instr!(
+    name   = OR,
+    mask   = 0xfe00707f,
+    match  = 0x00006033,
+    format = FormatR,
+    ram    = ()
+);
 
-impl RISCVInstruction for OR {
-    const MASK: u32 = 0xfe00707f;
-    const MATCH: u32 = 0x00006033;
-
-    type Format = FormatR;
-    type RAMAccess = ();
-
-    fn operands(&self) -> &Self::Format {
-        &self.operands
-    }
-
-    fn new(word: u32, address: u64, validate: bool) -> Self {
-        if validate {
-            debug_assert_eq!(word & Self::MASK, Self::MATCH);
-        }
-
-        Self {
-            address,
-            operands: FormatR::parse(word),
-            virtual_sequence_remaining: None,
-        }
-    }
-
-    fn execute(&self, cpu: &mut Cpu, _: &mut Self::RAMAccess) {
+impl OR {
+    fn exec(&self, cpu: &mut Cpu, _: &mut <OR as RISCVInstruction>::RAMAccess) {
         cpu.x[self.operands.rd] =
             cpu.sign_extend(cpu.x[self.operands.rs1] | cpu.x[self.operands.rs2]);
     }

--- a/tracer/src/instruction/ori.rs
+++ b/tracer/src/instruction/ori.rs
@@ -1,48 +1,22 @@
 use serde::{Deserialize, Serialize};
 
-use crate::emulator::cpu::Cpu;
+use crate::{declare_riscv_instr, emulator::cpu::Cpu};
 
 use super::{
     format::{format_i::FormatI, normalize_imm, InstructionFormat},
     RISCVInstruction, RISCVTrace,
 };
 
-#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
-pub struct ORI {
-    pub address: u64,
-    pub operands: FormatI,
-    /// If this instruction is part of a "virtual sequence" (see Section 6.2 of the
-    /// Jolt paper), then this contains the number of virtual instructions after this
-    /// one in the sequence. I.e. if this is the last instruction in the sequence,
-    /// `virtual_sequence_remaining` will be Some(0); if this is the penultimate instruction
-    /// in the sequence, `virtual_sequence_remaining` will be Some(1); etc.
-    pub virtual_sequence_remaining: Option<usize>,
-}
+declare_riscv_instr!(
+    name   = ORI,
+    mask   = 0x0000707f,
+    match  = 0x00006013,
+    format = FormatI,
+    ram    = ()
+);
 
-impl RISCVInstruction for ORI {
-    const MASK: u32 = 0x0000707f;
-    const MATCH: u32 = 0x00006013;
-
-    type Format = FormatI;
-    type RAMAccess = ();
-
-    fn operands(&self) -> &Self::Format {
-        &self.operands
-    }
-
-    fn new(word: u32, address: u64, validate: bool) -> Self {
-        if validate {
-            debug_assert_eq!(word & Self::MASK, Self::MATCH);
-        }
-
-        Self {
-            address,
-            operands: FormatI::parse(word),
-            virtual_sequence_remaining: None,
-        }
-    }
-
-    fn execute(&self, cpu: &mut Cpu, _: &mut Self::RAMAccess) {
+impl ORI {
+    fn exec(&self, cpu: &mut Cpu, _: &mut <ORI as RISCVInstruction>::RAMAccess) {
         cpu.x[self.operands.rd] =
             cpu.sign_extend(cpu.x[self.operands.rs1] | normalize_imm(self.operands.imm));
     }

--- a/tracer/src/instruction/rem.rs
+++ b/tracer/src/instruction/rem.rs
@@ -1,7 +1,10 @@
 use common::constants::virtual_register_index;
 use serde::{Deserialize, Serialize};
 
-use crate::emulator::cpu::{Cpu, Xlen};
+use crate::{
+    declare_riscv_instr,
+    emulator::cpu::{Cpu, Xlen},
+};
 
 use super::{
     add::ADD,
@@ -17,42 +20,16 @@ use super::{
     RISCVInstruction, RISCVTrace, RV32IMInstruction, VirtualInstructionSequence,
 };
 
-#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
-pub struct REM {
-    pub address: u64,
-    pub operands: FormatR,
-    /// If this instruction is part of a "virtual sequence" (see Section 6.2 of the
-    /// Jolt paper), then this contains the number of virtual instructions after this
-    /// one in the sequence. I.e. if this is the last instruction in the sequence,
-    /// `virtual_sequence_remaining` will be Some(0); if this is the penultimate instruction
-    /// in the sequence, `virtual_sequence_remaining` will be Some(1); etc.
-    pub virtual_sequence_remaining: Option<usize>,
-}
+declare_riscv_instr!(
+    name   = REM,
+    mask   = 0xfe00707f,
+    match  = 0x02006033,
+    format = FormatR,
+    ram    = ()
+);
 
-impl RISCVInstruction for REM {
-    const MASK: u32 = 0xfe00707f;
-    const MATCH: u32 = 0x02006033;
-
-    type Format = FormatR;
-    type RAMAccess = ();
-
-    fn operands(&self) -> &Self::Format {
-        &self.operands
-    }
-
-    fn new(word: u32, address: u64, validate: bool) -> Self {
-        if validate {
-            debug_assert_eq!(word & Self::MASK, Self::MATCH);
-        }
-
-        Self {
-            address,
-            operands: FormatR::parse(word),
-            virtual_sequence_remaining: None,
-        }
-    }
-
-    fn execute(&self, cpu: &mut Cpu, _: &mut Self::RAMAccess) {
+impl REM {
+    fn exec(&self, cpu: &mut Cpu, _: &mut <REM as RISCVInstruction>::RAMAccess) {
         let dividend = cpu.x[self.operands.rs1];
         let divisor = cpu.x[self.operands.rs2];
         if divisor == 0 {

--- a/tracer/src/instruction/remu.rs
+++ b/tracer/src/instruction/remu.rs
@@ -1,7 +1,10 @@
 use common::constants::virtual_register_index;
 use serde::{Deserialize, Serialize};
 
-use crate::emulator::cpu::{Cpu, Xlen};
+use crate::{
+    declare_riscv_instr,
+    emulator::cpu::{Cpu, Xlen},
+};
 
 use super::{
     add::ADD,
@@ -18,42 +21,16 @@ use super::{
     RISCVInstruction, RISCVTrace, RV32IMInstruction, VirtualInstructionSequence,
 };
 
-#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
-pub struct REMU {
-    pub address: u64,
-    pub operands: FormatR,
-    /// If this instruction is part of a "virtual sequence" (see Section 6.2 of the
-    /// Jolt paper), then this contains the number of virtual instructions after this
-    /// one in the sequence. I.e. if this is the last instruction in the sequence,
-    /// `virtual_sequence_remaining` will be Some(0); if this is the penultimate instruction
-    /// in the sequence, `virtual_sequence_remaining` will be Some(1); etc.
-    pub virtual_sequence_remaining: Option<usize>,
-}
+declare_riscv_instr!(
+    name   = REMU,
+    mask   = 0xfe00707f,
+    match  = 0x02007033,
+    format = FormatR,
+    ram    = ()
+);
 
-impl RISCVInstruction for REMU {
-    const MASK: u32 = 0xfe00707f;
-    const MATCH: u32 = 0x02007033;
-
-    type Format = FormatR;
-    type RAMAccess = ();
-
-    fn operands(&self) -> &Self::Format {
-        &self.operands
-    }
-
-    fn new(word: u32, address: u64, validate: bool) -> Self {
-        if validate {
-            debug_assert_eq!(word & Self::MASK, Self::MATCH);
-        }
-
-        Self {
-            address,
-            operands: FormatR::parse(word),
-            virtual_sequence_remaining: None,
-        }
-    }
-
-    fn execute(&self, cpu: &mut Cpu, _: &mut Self::RAMAccess) {
+impl REMU {
+    fn exec(&self, cpu: &mut Cpu, _: &mut <REMU as RISCVInstruction>::RAMAccess) {
         let dividend = cpu.unsigned_data(cpu.x[self.operands.rs1]);
         let divisor = cpu.unsigned_data(cpu.x[self.operands.rs2]);
         cpu.x[self.operands.rd] = match divisor {

--- a/tracer/src/instruction/sb.rs
+++ b/tracer/src/instruction/sb.rs
@@ -1,7 +1,7 @@
 use common::constants::virtual_register_index;
 use serde::{Deserialize, Serialize};
 
-use crate::emulator::cpu::Cpu;
+use crate::{declare_riscv_instr, emulator::cpu::Cpu};
 
 use super::addi::ADDI;
 use super::and::AND;
@@ -21,42 +21,16 @@ use super::{
     RISCVInstruction, RISCVTrace,
 };
 
-#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
-pub struct SB {
-    pub address: u64,
-    pub operands: FormatS,
-    /// If this instruction is part of a "virtual sequence" (see Section 6.2 of the
-    /// Jolt paper), then this contains the number of virtual instructions after this
-    /// one in the sequence. I.e. if this is the last instruction in the sequence,
-    /// `virtual_sequence_remaining` will be Some(0); if this is the penultimate instruction
-    /// in the sequence, `virtual_sequence_remaining` will be Some(1); etc.
-    pub virtual_sequence_remaining: Option<usize>,
-}
+declare_riscv_instr!(
+    name   = SB,
+    mask   = 0x0000707f,
+    match  = 0x00000023,
+    format = FormatS,
+    ram    = RAMWrite
+);
 
-impl RISCVInstruction for SB {
-    const MASK: u32 = 0x0000707f;
-    const MATCH: u32 = 0x00000023;
-
-    type Format = FormatS;
-    type RAMAccess = RAMWrite;
-
-    fn operands(&self) -> &Self::Format {
-        &self.operands
-    }
-
-    fn new(word: u32, address: u64, validate: bool) -> Self {
-        if validate {
-            assert_eq!(word & Self::MASK, Self::MATCH);
-        }
-
-        Self {
-            address,
-            operands: FormatS::parse(word),
-            virtual_sequence_remaining: None,
-        }
-    }
-
-    fn execute(&self, cpu: &mut Cpu, ram_access: &mut Self::RAMAccess) {
+impl SB {
+    fn exec(&self, cpu: &mut Cpu, ram_access: &mut <SB as RISCVInstruction>::RAMAccess) {
         *ram_access = cpu
             .mmu
             .store(

--- a/tracer/src/instruction/sh.rs
+++ b/tracer/src/instruction/sh.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-use crate::emulator::cpu::Cpu;
+use crate::{declare_riscv_instr, emulator::cpu::Cpu};
 
 use super::addi::ADDI;
 use super::and::AND;
@@ -27,42 +27,16 @@ use super::{
     RISCVInstruction, RISCVTrace,
 };
 
-#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
-pub struct SH {
-    pub address: u64,
-    pub operands: FormatS,
-    /// If this instruction is part of a "virtual sequence" (see Section 6.2 of the
-    /// Jolt paper), then this contains the number of virtual instructions after this
-    /// one in the sequence. I.e. if this is the last instruction in the sequence,
-    /// `virtual_sequence_remaining` will be Some(0); if this is the penultimate instruction
-    /// in the sequence, `virtual_sequence_remaining` will be Some(1); etc.
-    pub virtual_sequence_remaining: Option<usize>,
-}
+declare_riscv_instr!(
+    name   = SH,
+    mask   = 0x0000707f,
+    match  = 0x00001023,
+    format = FormatS,
+    ram    = RAMWrite
+);
 
-impl RISCVInstruction for SH {
-    const MASK: u32 = 0x0000707f;
-    const MATCH: u32 = 0x00001023;
-
-    type Format = FormatS;
-    type RAMAccess = RAMWrite;
-
-    fn operands(&self) -> &Self::Format {
-        &self.operands
-    }
-
-    fn new(word: u32, address: u64, validate: bool) -> Self {
-        if validate {
-            assert_eq!(word & Self::MASK, Self::MATCH);
-        }
-
-        Self {
-            address,
-            operands: FormatS::parse(word),
-            virtual_sequence_remaining: None,
-        }
-    }
-
-    fn execute(&self, cpu: &mut Cpu, ram_access: &mut Self::RAMAccess) {
+impl SH {
+    fn exec(&self, cpu: &mut Cpu, ram_access: &mut <SH as RISCVInstruction>::RAMAccess) {
         *ram_access = cpu
             .mmu
             .store_halfword(

--- a/tracer/src/instruction/sll.rs
+++ b/tracer/src/instruction/sll.rs
@@ -1,7 +1,10 @@
 use common::constants::virtual_register_index;
 use serde::{Deserialize, Serialize};
 
-use crate::emulator::cpu::{Cpu, Xlen};
+use crate::{
+    declare_riscv_instr,
+    emulator::cpu::{Cpu, Xlen},
+};
 
 use super::{
     format::{format_i::FormatI, format_r::FormatR, InstructionFormat},
@@ -10,42 +13,16 @@ use super::{
     RISCVInstruction, RISCVTrace, RV32IMInstruction, VirtualInstructionSequence,
 };
 
-#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
-pub struct SLL {
-    pub address: u64,
-    pub operands: FormatR,
-    /// If this instruction is part of a "virtual sequence" (see Section 6.2 of the
-    /// Jolt paper), then this contains the number of virtual instructions after this
-    /// one in the sequence. I.e. if this is the last instruction in the sequence,
-    /// `virtual_sequence_remaining` will be Some(0); if this is the penultimate instruction
-    /// in the sequence, `virtual_sequence_remaining` will be Some(1); etc.
-    pub virtual_sequence_remaining: Option<usize>,
-}
+declare_riscv_instr!(
+    name   = SLL,
+    mask   = 0xfe00707f,
+    match  = 0x00001033,
+    format = FormatR,
+    ram    = ()
+);
 
-impl RISCVInstruction for SLL {
-    const MASK: u32 = 0xfe00707f;
-    const MATCH: u32 = 0x00001033;
-
-    type Format = FormatR;
-    type RAMAccess = ();
-
-    fn operands(&self) -> &Self::Format {
-        &self.operands
-    }
-
-    fn new(word: u32, address: u64, validate: bool) -> Self {
-        if validate {
-            debug_assert_eq!(word & Self::MASK, Self::MATCH);
-        }
-
-        Self {
-            address,
-            operands: FormatR::parse(word),
-            virtual_sequence_remaining: None,
-        }
-    }
-
-    fn execute(&self, cpu: &mut Cpu, _: &mut Self::RAMAccess) {
+impl SLL {
+    fn exec(&self, cpu: &mut Cpu, _: &mut <SLL as RISCVInstruction>::RAMAccess) {
         let mask = match cpu.xlen {
             Xlen::Bit32 => 0x1f,
             Xlen::Bit64 => 0x3f,

--- a/tracer/src/instruction/slli.rs
+++ b/tracer/src/instruction/slli.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 use crate::{
+    declare_riscv_instr,
     emulator::cpu::{Cpu, Xlen},
     instruction::virtual_muli::VirtualMULI,
 };
@@ -10,42 +11,16 @@ use super::{
     RISCVInstruction, RISCVTrace, RV32IMInstruction, VirtualInstructionSequence,
 };
 
-#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
-pub struct SLLI {
-    pub address: u64,
-    pub operands: FormatI,
-    /// If this instruction is part of a "virtual sequence" (see Section 6.2 of the
-    /// Jolt paper), then this contains the number of virtual instructions after this
-    /// one in the sequence. I.e. if this is the last instruction in the sequence,
-    /// `virtual_sequence_remaining` will be Some(0); if this is the penultimate instruction
-    /// in the sequence, `virtual_sequence_remaining` will be Some(1); etc.
-    pub virtual_sequence_remaining: Option<usize>,
-}
+declare_riscv_instr!(
+    name   = SLLI,
+    mask   = 0xfc00707f,
+    match  = 0x00001013,
+    format = FormatI,
+    ram    = ()
+);
 
-impl RISCVInstruction for SLLI {
-    const MASK: u32 = 0xfc00707f;
-    const MATCH: u32 = 0x00001013;
-
-    type Format = FormatI;
-    type RAMAccess = ();
-
-    fn operands(&self) -> &Self::Format {
-        &self.operands
-    }
-
-    fn new(word: u32, address: u64, validate: bool) -> Self {
-        if validate {
-            debug_assert_eq!(word & Self::MASK, Self::MATCH);
-        }
-
-        Self {
-            address,
-            operands: FormatI::parse(word),
-            virtual_sequence_remaining: None,
-        }
-    }
-
-    fn execute(&self, cpu: &mut Cpu, _: &mut Self::RAMAccess) {
+impl SLLI {
+    fn exec(&self, cpu: &mut Cpu, _: &mut <SLLI as RISCVInstruction>::RAMAccess) {
         let mask = match cpu.xlen {
             Xlen::Bit32 => 0x1f,
             Xlen::Bit64 => 0x3f,

--- a/tracer/src/instruction/slt.rs
+++ b/tracer/src/instruction/slt.rs
@@ -1,48 +1,22 @@
 use serde::{Deserialize, Serialize};
 
-use crate::emulator::cpu::Cpu;
+use crate::{declare_riscv_instr, emulator::cpu::Cpu};
 
 use super::{
     format::{format_r::FormatR, InstructionFormat},
     RISCVInstruction, RISCVTrace,
 };
 
-#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
-pub struct SLT {
-    pub address: u64,
-    pub operands: FormatR,
-    /// If this instruction is part of a "virtual sequence" (see Section 6.2 of the
-    /// Jolt paper), then this contains the number of virtual instructions after this
-    /// one in the sequence. I.e. if this is the last instruction in the sequence,
-    /// `virtual_sequence_remaining` will be Some(0); if this is the penultimate instruction
-    /// in the sequence, `virtual_sequence_remaining` will be Some(1); etc.
-    pub virtual_sequence_remaining: Option<usize>,
-}
+declare_riscv_instr!(
+    name   = SLT,
+    mask   = 0xfe00707f,
+    match  = 0x00002033,
+    format = FormatR,
+    ram    = ()
+);
 
-impl RISCVInstruction for SLT {
-    const MASK: u32 = 0xfe00707f;
-    const MATCH: u32 = 0x00002033;
-
-    type Format = FormatR;
-    type RAMAccess = ();
-
-    fn operands(&self) -> &Self::Format {
-        &self.operands
-    }
-
-    fn new(word: u32, address: u64, validate: bool) -> Self {
-        if validate {
-            debug_assert_eq!(word & Self::MASK, Self::MATCH);
-        }
-
-        Self {
-            address,
-            operands: FormatR::parse(word),
-            virtual_sequence_remaining: None,
-        }
-    }
-
-    fn execute(&self, cpu: &mut Cpu, _: &mut Self::RAMAccess) {
+impl SLT {
+    fn exec(&self, cpu: &mut Cpu, _: &mut <SLT as RISCVInstruction>::RAMAccess) {
         cpu.x[self.operands.rd] = match cpu.x[self.operands.rs1] < cpu.x[self.operands.rs2] {
             true => 1,
             false => 0,

--- a/tracer/src/instruction/slti.rs
+++ b/tracer/src/instruction/slti.rs
@@ -1,48 +1,22 @@
 use serde::{Deserialize, Serialize};
 
-use crate::emulator::cpu::Cpu;
+use crate::{declare_riscv_instr, emulator::cpu::Cpu};
 
 use super::{
     format::{format_i::FormatI, normalize_imm, InstructionFormat},
     RISCVInstruction, RISCVTrace,
 };
 
-#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
-pub struct SLTI {
-    pub address: u64,
-    pub operands: FormatI,
-    /// If this instruction is part of a "virtual sequence" (see Section 6.2 of the
-    /// Jolt paper), then this contains the number of virtual instructions after this
-    /// one in the sequence. I.e. if this is the last instruction in the sequence,
-    /// `virtual_sequence_remaining` will be Some(0); if this is the penultimate instruction
-    /// in the sequence, `virtual_sequence_remaining` will be Some(1); etc.
-    pub virtual_sequence_remaining: Option<usize>,
-}
+declare_riscv_instr!(
+    name   = SLTI,
+    mask   = 0x0000707f,
+    match  = 0x00002013,
+    format = FormatI,
+    ram    = ()
+);
 
-impl RISCVInstruction for SLTI {
-    const MASK: u32 = 0x0000707f;
-    const MATCH: u32 = 0x00002013;
-
-    type Format = FormatI;
-    type RAMAccess = ();
-
-    fn operands(&self) -> &Self::Format {
-        &self.operands
-    }
-
-    fn new(word: u32, address: u64, validate: bool) -> Self {
-        if validate {
-            debug_assert_eq!(word & Self::MASK, Self::MATCH);
-        }
-
-        Self {
-            address,
-            operands: FormatI::parse(word),
-            virtual_sequence_remaining: None,
-        }
-    }
-
-    fn execute(&self, cpu: &mut Cpu, _: &mut Self::RAMAccess) {
+impl SLTI {
+    fn exec(&self, cpu: &mut Cpu, _: &mut <SLTI as RISCVInstruction>::RAMAccess) {
         cpu.x[self.operands.rd] = match cpu.x[self.operands.rs1] < normalize_imm(self.operands.imm)
         {
             true => 1,

--- a/tracer/src/instruction/sltiu.rs
+++ b/tracer/src/instruction/sltiu.rs
@@ -1,48 +1,22 @@
 use serde::{Deserialize, Serialize};
 
-use crate::emulator::cpu::Cpu;
+use crate::{declare_riscv_instr, emulator::cpu::Cpu};
 
 use super::{
     format::{format_i::FormatI, normalize_imm, InstructionFormat},
     RISCVInstruction, RISCVTrace,
 };
 
-#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
-pub struct SLTIU {
-    pub address: u64,
-    pub operands: FormatI,
-    /// If this instruction is part of a "virtual sequence" (see Section 6.2 of the
-    /// Jolt paper), then this contains the number of virtual instructions after this
-    /// one in the sequence. I.e. if this is the last instruction in the sequence,
-    /// `virtual_sequence_remaining` will be Some(0); if this is the penultimate instruction
-    /// in the sequence, `virtual_sequence_remaining` will be Some(1); etc.
-    pub virtual_sequence_remaining: Option<usize>,
-}
+declare_riscv_instr!(
+    name   = SLTIU,
+    mask   = 0x0000707f,
+    match  = 0x00003013,
+    format = FormatI,
+    ram    = ()
+);
 
-impl RISCVInstruction for SLTIU {
-    const MASK: u32 = 0x0000707f;
-    const MATCH: u32 = 0x00003013;
-
-    type Format = FormatI;
-    type RAMAccess = ();
-
-    fn operands(&self) -> &Self::Format {
-        &self.operands
-    }
-
-    fn new(word: u32, address: u64, validate: bool) -> Self {
-        if validate {
-            debug_assert_eq!(word & Self::MASK, Self::MATCH);
-        }
-
-        Self {
-            address,
-            operands: FormatI::parse(word),
-            virtual_sequence_remaining: None,
-        }
-    }
-
-    fn execute(&self, cpu: &mut Cpu, _: &mut Self::RAMAccess) {
+impl SLTIU {
+    fn exec(&self, cpu: &mut Cpu, _: &mut <SLTIU as RISCVInstruction>::RAMAccess) {
         cpu.x[self.operands.rd] = match cpu.unsigned_data(cpu.x[self.operands.rs1])
             < cpu.unsigned_data(normalize_imm(self.operands.imm))
         {

--- a/tracer/src/instruction/sltu.rs
+++ b/tracer/src/instruction/sltu.rs
@@ -1,48 +1,22 @@
 use serde::{Deserialize, Serialize};
 
-use crate::emulator::cpu::Cpu;
+use crate::{declare_riscv_instr, emulator::cpu::Cpu};
 
 use super::{
     format::{format_r::FormatR, InstructionFormat},
     RISCVInstruction, RISCVTrace,
 };
 
-#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
-pub struct SLTU {
-    pub address: u64,
-    pub operands: FormatR,
-    /// If this instruction is part of a "virtual sequence" (see Section 6.2 of the
-    /// Jolt paper), then this contains the number of virtual instructions after this
-    /// one in the sequence. I.e. if this is the last instruction in the sequence,
-    /// `virtual_sequence_remaining` will be Some(0); if this is the penultimate instruction
-    /// in the sequence, `virtual_sequence_remaining` will be Some(1); etc.
-    pub virtual_sequence_remaining: Option<usize>,
-}
+declare_riscv_instr!(
+    name   = SLTU,
+    mask   = 0xfe00707f,
+    match  = 0x00003033,
+    format = FormatR,
+    ram    = ()
+);
 
-impl RISCVInstruction for SLTU {
-    const MASK: u32 = 0xfe00707f;
-    const MATCH: u32 = 0x00003033;
-
-    type Format = FormatR;
-    type RAMAccess = ();
-
-    fn operands(&self) -> &Self::Format {
-        &self.operands
-    }
-
-    fn new(word: u32, address: u64, validate: bool) -> Self {
-        if validate {
-            debug_assert_eq!(word & Self::MASK, Self::MATCH);
-        }
-
-        Self {
-            address,
-            operands: FormatR::parse(word),
-            virtual_sequence_remaining: None,
-        }
-    }
-
-    fn execute(&self, cpu: &mut Cpu, _: &mut Self::RAMAccess) {
+impl SLTU {
+    fn exec(&self, cpu: &mut Cpu, _: &mut <SLTU as RISCVInstruction>::RAMAccess) {
         cpu.x[self.operands.rd] = match cpu.unsigned_data(cpu.x[self.operands.rs1])
             < cpu.unsigned_data(cpu.x[self.operands.rs2])
         {

--- a/tracer/src/instruction/sra.rs
+++ b/tracer/src/instruction/sra.rs
@@ -1,7 +1,10 @@
 use common::constants::virtual_register_index;
 use serde::{Deserialize, Serialize};
 
-use crate::emulator::cpu::{Cpu, Xlen};
+use crate::{
+    declare_riscv_instr,
+    emulator::cpu::{Cpu, Xlen},
+};
 
 use super::{
     format::{
@@ -13,42 +16,16 @@ use super::{
     RISCVInstruction, RISCVTrace, RV32IMInstruction, VirtualInstructionSequence,
 };
 
-#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
-pub struct SRA {
-    pub address: u64,
-    pub operands: FormatR,
-    /// If this instruction is part of a "virtual sequence" (see Section 6.2 of the
-    /// Jolt paper), then this contains the number of virtual instructions after this
-    /// one in the sequence. I.e. if this is the last instruction in the sequence,
-    /// `virtual_sequence_remaining` will be Some(0); if this is the penultimate instruction
-    /// in the sequence, `virtual_sequence_remaining` will be Some(1); etc.
-    pub virtual_sequence_remaining: Option<usize>,
-}
+declare_riscv_instr!(
+    name   = SRA,
+    mask   = 0xfe00707f,
+    match  = 0x40005033,
+    format = FormatR,
+    ram    = ()
+);
 
-impl RISCVInstruction for SRA {
-    const MASK: u32 = 0xfe00707f;
-    const MATCH: u32 = 0x40005033;
-
-    type Format = FormatR;
-    type RAMAccess = ();
-
-    fn operands(&self) -> &Self::Format {
-        &self.operands
-    }
-
-    fn new(word: u32, address: u64, validate: bool) -> Self {
-        if validate {
-            debug_assert_eq!(word & Self::MASK, Self::MATCH);
-        }
-
-        Self {
-            address,
-            operands: FormatR::parse(word),
-            virtual_sequence_remaining: None,
-        }
-    }
-
-    fn execute(&self, cpu: &mut Cpu, _: &mut Self::RAMAccess) {
+impl SRA {
+    fn exec(&self, cpu: &mut Cpu, _: &mut <SRA as RISCVInstruction>::RAMAccess) {
         let mask = match cpu.xlen {
             Xlen::Bit32 => 0x1f,
             Xlen::Bit64 => 0x3f,

--- a/tracer/src/instruction/srai.rs
+++ b/tracer/src/instruction/srai.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 use crate::{
+    declare_riscv_instr,
     emulator::cpu::{Cpu, Xlen},
     instruction::{
         format::format_virtual_right_shift_i::FormatVirtualRightShiftI, virtual_srai::VirtualSRAI,
@@ -12,42 +13,16 @@ use super::{
     RISCVInstruction, RISCVTrace, RV32IMInstruction, VirtualInstructionSequence,
 };
 
-#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
-pub struct SRAI {
-    pub address: u64,
-    pub operands: FormatI,
-    /// If this instruction is part of a "virtual sequence" (see Section 6.2 of the
-    /// Jolt paper), then this contains the number of virtual instructions after this
-    /// one in the sequence. I.e. if this is the last instruction in the sequence,
-    /// `virtual_sequence_remaining` will be Some(0); if this is the penultimate instruction
-    /// in the sequence, `virtual_sequence_remaining` will be Some(1); etc.
-    pub virtual_sequence_remaining: Option<usize>,
-}
+declare_riscv_instr!(
+    name   = SRAI,
+    mask   = 0xfc00707f,
+    match  = 0x40005013,
+    format = FormatI,
+    ram    = ()
+);
 
-impl RISCVInstruction for SRAI {
-    const MASK: u32 = 0xfc00707f;
-    const MATCH: u32 = 0x40005013;
-
-    type Format = FormatI;
-    type RAMAccess = ();
-
-    fn operands(&self) -> &Self::Format {
-        &self.operands
-    }
-
-    fn new(word: u32, address: u64, validate: bool) -> Self {
-        if validate {
-            debug_assert_eq!(word & Self::MASK, Self::MATCH);
-        }
-
-        Self {
-            address,
-            operands: FormatI::parse(word),
-            virtual_sequence_remaining: None,
-        }
-    }
-
-    fn execute(&self, cpu: &mut Cpu, _: &mut Self::RAMAccess) {
+impl SRAI {
+    fn exec(&self, cpu: &mut Cpu, _: &mut <SRAI as RISCVInstruction>::RAMAccess) {
         let mask = match cpu.xlen {
             Xlen::Bit32 => 0x1f,
             Xlen::Bit64 => 0x3f,

--- a/tracer/src/instruction/srl.rs
+++ b/tracer/src/instruction/srl.rs
@@ -1,7 +1,10 @@
 use common::constants::virtual_register_index;
 use serde::{Deserialize, Serialize};
 
-use crate::emulator::cpu::{Cpu, Xlen};
+use crate::{
+    declare_riscv_instr,
+    emulator::cpu::{Cpu, Xlen},
+};
 
 use super::{
     format::{
@@ -13,42 +16,16 @@ use super::{
     RISCVInstruction, RISCVTrace, RV32IMInstruction, VirtualInstructionSequence,
 };
 
-#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
-pub struct SRL {
-    pub address: u64,
-    pub operands: FormatR,
-    /// If this instruction is part of a "virtual sequence" (see Section 6.2 of the
-    /// Jolt paper), then this contains the number of virtual instructions after this
-    /// one in the sequence. I.e. if this is the last instruction in the sequence,
-    /// `virtual_sequence_remaining` will be Some(0); if this is the penultimate instruction
-    /// in the sequence, `virtual_sequence_remaining` will be Some(1); etc.
-    pub virtual_sequence_remaining: Option<usize>,
-}
+declare_riscv_instr!(
+    name   = SRL,
+    mask   = 0xfe00707f,
+    match  = 0x00005033,
+    format = FormatR,
+    ram    = ()
+);
 
-impl RISCVInstruction for SRL {
-    const MASK: u32 = 0xfe00707f;
-    const MATCH: u32 = 0x00005033;
-
-    type Format = FormatR;
-    type RAMAccess = ();
-
-    fn operands(&self) -> &Self::Format {
-        &self.operands
-    }
-
-    fn new(word: u32, address: u64, validate: bool) -> Self {
-        if validate {
-            debug_assert_eq!(word & Self::MASK, Self::MATCH);
-        }
-
-        Self {
-            address,
-            operands: FormatR::parse(word),
-            virtual_sequence_remaining: None,
-        }
-    }
-
-    fn execute(&self, cpu: &mut Cpu, _: &mut Self::RAMAccess) {
+impl SRL {
+    fn exec(&self, cpu: &mut Cpu, _: &mut <SRL as RISCVInstruction>::RAMAccess) {
         let mask = match cpu.xlen {
             Xlen::Bit32 => 0x1f,
             Xlen::Bit64 => 0x3f,

--- a/tracer/src/instruction/srli.rs
+++ b/tracer/src/instruction/srli.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 use crate::{
+    declare_riscv_instr,
     emulator::cpu::{Cpu, Xlen},
     instruction::{
         format::format_virtual_right_shift_i::FormatVirtualRightShiftI, virtual_srli::VirtualSRLI,
@@ -12,42 +13,16 @@ use super::{
     RISCVInstruction, RISCVTrace, RV32IMInstruction, VirtualInstructionSequence,
 };
 
-#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
-pub struct SRLI {
-    pub address: u64,
-    pub operands: FormatI,
-    /// If this instruction is part of a "virtual sequence" (see Section 6.2 of the
-    /// Jolt paper), then this contains the number of virtual instructions after this
-    /// one in the sequence. I.e. if this is the last instruction in the sequence,
-    /// `virtual_sequence_remaining` will be Some(0); if this is the penultimate instruction
-    /// in the sequence, `virtual_sequence_remaining` will be Some(1); etc.
-    pub virtual_sequence_remaining: Option<usize>,
-}
+declare_riscv_instr!(
+    name   = SRLI,
+    mask   = 0xfc00707f,
+    match  = 0x00005013,
+    format = FormatI,
+    ram    = ()
+);
 
-impl RISCVInstruction for SRLI {
-    const MASK: u32 = 0xfc00707f;
-    const MATCH: u32 = 0x00005013;
-
-    type Format = FormatI;
-    type RAMAccess = ();
-
-    fn operands(&self) -> &Self::Format {
-        &self.operands
-    }
-
-    fn new(word: u32, address: u64, validate: bool) -> Self {
-        if validate {
-            debug_assert_eq!(word & Self::MASK, Self::MATCH);
-        }
-
-        Self {
-            address,
-            operands: FormatI::parse(word),
-            virtual_sequence_remaining: None,
-        }
-    }
-
-    fn execute(&self, cpu: &mut Cpu, _: &mut Self::RAMAccess) {
+impl SRLI {
+    fn exec(&self, cpu: &mut Cpu, _: &mut <SRLI as RISCVInstruction>::RAMAccess) {
         let mask = match cpu.xlen {
             Xlen::Bit32 => 0x1f,
             Xlen::Bit64 => 0x3f,

--- a/tracer/src/instruction/sub.rs
+++ b/tracer/src/instruction/sub.rs
@@ -1,48 +1,22 @@
 use serde::{Deserialize, Serialize};
 
-use crate::emulator::cpu::Cpu;
+use crate::{declare_riscv_instr, emulator::cpu::Cpu};
 
 use super::{
     format::{format_r::FormatR, InstructionFormat},
     RISCVInstruction, RISCVTrace,
 };
 
-#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
-pub struct SUB {
-    pub address: u64,
-    pub operands: FormatR,
-    /// If this instruction is part of a "virtual sequence" (see Section 6.2 of the
-    /// Jolt paper), then this contains the number of virtual instructions after this
-    /// one in the sequence. I.e. if this is the last instruction in the sequence,
-    /// `virtual_sequence_remaining` will be Some(0); if this is the penultimate instruction
-    /// in the sequence, `virtual_sequence_remaining` will be Some(1); etc.
-    pub virtual_sequence_remaining: Option<usize>,
-}
+declare_riscv_instr!(
+    name   = SUB,
+    mask   = 0xfe00707f,
+    match  = 0x40000033,
+    format = FormatR,
+    ram    = ()
+);
 
-impl RISCVInstruction for SUB {
-    const MASK: u32 = 0xfe00707f;
-    const MATCH: u32 = 0x40000033;
-
-    type Format = FormatR;
-    type RAMAccess = ();
-
-    fn operands(&self) -> &Self::Format {
-        &self.operands
-    }
-
-    fn new(word: u32, address: u64, validate: bool) -> Self {
-        if validate {
-            debug_assert_eq!(word & Self::MASK, Self::MATCH);
-        }
-
-        Self {
-            address,
-            operands: FormatR::parse(word),
-            virtual_sequence_remaining: None,
-        }
-    }
-
-    fn execute(&self, cpu: &mut Cpu, _: &mut Self::RAMAccess) {
+impl SUB {
+    fn exec(&self, cpu: &mut Cpu, _: &mut <SUB as RISCVInstruction>::RAMAccess) {
         cpu.x[self.operands.rd] =
             cpu.sign_extend(cpu.x[self.operands.rs1].wrapping_sub(cpu.x[self.operands.rs2]));
     }

--- a/tracer/src/instruction/sw.rs
+++ b/tracer/src/instruction/sw.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-use crate::emulator::cpu::Cpu;
+use crate::{declare_riscv_instr, emulator::cpu::Cpu};
 
 use super::RAMWrite;
 
@@ -9,42 +9,16 @@ use super::{
     RISCVInstruction, RISCVTrace,
 };
 
-#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
-pub struct SW {
-    pub address: u64,
-    pub operands: FormatS,
-    /// If this instruction is part of a "virtual sequence" (see Section 6.2 of the
-    /// Jolt paper), then this contains the number of virtual instructions after this
-    /// one in the sequence. I.e. if this is the last instruction in the sequence,
-    /// `virtual_sequence_remaining` will be Some(0); if this is the penultimate instruction
-    /// in the sequence, `virtual_sequence_remaining` will be Some(1); etc.
-    pub virtual_sequence_remaining: Option<usize>,
-}
+declare_riscv_instr!(
+    name   = SW,
+    mask   = 0x0000707f,
+    match  = 0x00002023,
+    format = FormatS,
+    ram    = RAMWrite
+);
 
-impl RISCVInstruction for SW {
-    const MASK: u32 = 0x0000707f;
-    const MATCH: u32 = 0x00002023;
-
-    type Format = FormatS;
-    type RAMAccess = RAMWrite;
-
-    fn operands(&self) -> &Self::Format {
-        &self.operands
-    }
-
-    fn new(word: u32, address: u64, validate: bool) -> Self {
-        if validate {
-            assert_eq!(word & Self::MASK, Self::MATCH);
-        }
-
-        Self {
-            address,
-            operands: FormatS::parse(word),
-            virtual_sequence_remaining: None,
-        }
-    }
-
-    fn execute(&self, cpu: &mut Cpu, ram_access: &mut Self::RAMAccess) {
+impl SW {
+    fn exec(&self, cpu: &mut Cpu, ram_access: &mut <SW as RISCVInstruction>::RAMAccess) {
         *ram_access = cpu
             .mmu
             .store_word(

--- a/tracer/src/instruction/virtual_advice.rs
+++ b/tracer/src/instruction/virtual_advice.rs
@@ -8,6 +8,7 @@ use super::{
     RISCVInstruction, RISCVTrace,
 };
 
+// Special case for VirtualAdvice as it has an extra 'advice' field
 #[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
 pub struct VirtualAdvice {
     pub address: u64,
@@ -33,7 +34,7 @@ impl RISCVInstruction for VirtualAdvice {
     }
 
     fn new(_: u32, _: u64, _: bool) -> Self {
-        unimplemented!("virtual instruction")
+        panic!("virtual instruction `VirtualAdvice` cannot be built from a machine word");
     }
 
     fn random(rng: &mut StdRng) -> Self {

--- a/tracer/src/instruction/virtual_assert_eq.rs
+++ b/tracer/src/instruction/virtual_assert_eq.rs
@@ -1,49 +1,23 @@
-use rand::{rngs::StdRng, RngCore};
 use serde::{Deserialize, Serialize};
 
-use crate::emulator::cpu::Cpu;
+use crate::{declare_riscv_instr, emulator::cpu::Cpu};
 
 use super::{
     format::{format_b::FormatB, InstructionFormat},
     RISCVInstruction, RISCVTrace,
 };
 
-#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
-pub struct VirtualAssertEQ {
-    pub address: u64,
-    pub operands: FormatB,
-    /// If this instruction is part of a "virtual sequence" (see Section 6.2 of the
-    /// Jolt paper), then this contains the number of virtual instructions after this
-    /// one in the sequence. I.e. if this is the last instruction in the sequence,
-    /// `virtual_sequence_remaining` will be Some(0); if this is the penultimate instruction
-    /// in the sequence, `virtual_sequence_remaining` will be Some(1); etc.
-    pub virtual_sequence_remaining: Option<usize>,
-}
+declare_riscv_instr!(
+    name = VirtualAssertEQ,
+    mask = 0,
+    match = 0,
+    format = FormatB,
+    ram = (),
+    is_virtual = true
+);
 
-impl RISCVInstruction for VirtualAssertEQ {
-    const MASK: u32 = 0; // Virtual
-    const MATCH: u32 = 0; // Virtual
-
-    type Format = FormatB;
-    type RAMAccess = ();
-
-    fn operands(&self) -> &Self::Format {
-        &self.operands
-    }
-
-    fn new(_: u32, _: u64, _: bool) -> Self {
-        unimplemented!("virtual instruction")
-    }
-
-    fn random(rng: &mut StdRng) -> Self {
-        Self {
-            address: rng.next_u64(),
-            operands: FormatB::random(rng),
-            virtual_sequence_remaining: None,
-        }
-    }
-
-    fn execute(&self, cpu: &mut Cpu, _: &mut Self::RAMAccess) {
+impl VirtualAssertEQ {
+    fn exec(&self, cpu: &mut Cpu, _: &mut <VirtualAssertEQ as RISCVInstruction>::RAMAccess) {
         assert_eq!(cpu.x[self.operands.rs1], cpu.x[self.operands.rs2]);
     }
 }

--- a/tracer/src/instruction/virtual_assert_halfword_alignment.rs
+++ b/tracer/src/instruction/virtual_assert_halfword_alignment.rs
@@ -1,49 +1,27 @@
-use rand::{rngs::StdRng, RngCore};
 use serde::{Deserialize, Serialize};
 
-use crate::emulator::cpu::Cpu;
+use crate::{declare_riscv_instr, emulator::cpu::Cpu};
 
 use super::{
     format::{format_virtual_halfword_alignment::HalfwordAlignFormat, InstructionFormat},
     RISCVInstruction, RISCVTrace,
 };
 
-#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
-pub struct VirtualAssertHalfwordAlignment {
-    pub address: u64,
-    pub operands: HalfwordAlignFormat,
-    /// If this instruction is part of a "virtual sequence" (see Section 6.2 of the
-    /// Jolt paper), then this contains the number of virtual instructions after this
-    /// one in the sequence. I.e. if this is the last instruction in the sequence,
-    /// `virtual_sequence_remaining` will be Some(0); if this is the penultimate instruction
-    /// in the sequence, `virtual_sequence_remaining` will be Some(1); etc.
-    pub virtual_sequence_remaining: Option<usize>,
-}
+declare_riscv_instr!(
+    name = VirtualAssertHalfwordAlignment,
+    mask = 0,
+    match = 0,
+    format = HalfwordAlignFormat,
+    ram = (),
+    is_virtual = true
+);
 
-impl RISCVInstruction for VirtualAssertHalfwordAlignment {
-    const MASK: u32 = 0; // Virtual
-    const MATCH: u32 = 0; // Virtual
-
-    type Format = HalfwordAlignFormat;
-    type RAMAccess = ();
-
-    fn operands(&self) -> &Self::Format {
-        &self.operands
-    }
-
-    fn new(_: u32, _: u64, _: bool) -> Self {
-        unimplemented!("virtual instruction")
-    }
-
-    fn random(rng: &mut StdRng) -> Self {
-        Self {
-            address: rng.next_u64(),
-            operands: HalfwordAlignFormat::random(rng),
-            virtual_sequence_remaining: None,
-        }
-    }
-
-    fn execute(&self, cpu: &mut Cpu, _: &mut Self::RAMAccess) {
+impl VirtualAssertHalfwordAlignment {
+    fn exec(
+        &self,
+        cpu: &mut Cpu,
+        _: &mut <VirtualAssertHalfwordAlignment as RISCVInstruction>::RAMAccess,
+    ) {
         let address = cpu.x[self.operands.rs1] + self.operands.imm;
         assert!(
             address & 1 == 0,

--- a/tracer/src/instruction/virtual_assert_lte.rs
+++ b/tracer/src/instruction/virtual_assert_lte.rs
@@ -1,49 +1,23 @@
-use rand::{rngs::StdRng, RngCore};
 use serde::{Deserialize, Serialize};
 
-use crate::emulator::cpu::Cpu;
+use crate::{declare_riscv_instr, emulator::cpu::Cpu};
 
 use super::{
     format::{format_b::FormatB, InstructionFormat},
     RISCVInstruction, RISCVTrace,
 };
 
-#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
-pub struct VirtualAssertLTE {
-    pub address: u64,
-    pub operands: FormatB,
-    /// If this instruction is part of a "virtual sequence" (see Section 6.2 of the
-    /// Jolt paper), then this contains the number of virtual instructions after this
-    /// one in the sequence. I.e. if this is the last instruction in the sequence,
-    /// `virtual_sequence_remaining` will be Some(0); if this is the penultimate instruction
-    /// in the sequence, `virtual_sequence_remaining` will be Some(1); etc.
-    pub virtual_sequence_remaining: Option<usize>,
-}
+declare_riscv_instr!(
+    name = VirtualAssertLTE,
+    mask = 0,
+    match = 0,
+    format = FormatB,
+    ram = (),
+    is_virtual = true
+);
 
-impl RISCVInstruction for VirtualAssertLTE {
-    const MASK: u32 = 0; // Virtual
-    const MATCH: u32 = 0; // Virtual
-
-    type Format = FormatB;
-    type RAMAccess = ();
-
-    fn operands(&self) -> &Self::Format {
-        &self.operands
-    }
-
-    fn new(_: u32, _: u64, _: bool) -> Self {
-        unimplemented!("virtual instruction")
-    }
-
-    fn random(rng: &mut StdRng) -> Self {
-        Self {
-            address: rng.next_u64(),
-            operands: FormatB::random(rng),
-            virtual_sequence_remaining: None,
-        }
-    }
-
-    fn execute(&self, cpu: &mut Cpu, _: &mut Self::RAMAccess) {
+impl VirtualAssertLTE {
+    fn exec(&self, cpu: &mut Cpu, _: &mut <VirtualAssertLTE as RISCVInstruction>::RAMAccess) {
         assert!(cpu.x[self.operands.rs1] as u64 <= cpu.x[self.operands.rs2] as u64);
     }
 }

--- a/tracer/src/instruction/virtual_assert_valid_div0.rs
+++ b/tracer/src/instruction/virtual_assert_valid_div0.rs
@@ -1,49 +1,26 @@
-use rand::{rngs::StdRng, RngCore};
 use serde::{Deserialize, Serialize};
 
-use crate::emulator::cpu::{Cpu, Xlen};
+use crate::{
+    declare_riscv_instr,
+    emulator::cpu::{Cpu, Xlen},
+};
 
 use super::{
     format::{format_b::FormatB, InstructionFormat},
     RISCVInstruction, RISCVTrace,
 };
 
-#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
-pub struct VirtualAssertValidDiv0 {
-    pub address: u64,
-    pub operands: FormatB,
-    /// If this instruction is part of a "virtual sequence" (see Section 6.2 of the
-    /// Jolt paper), then this contains the number of virtual instructions after this
-    /// one in the sequence. I.e. if this is the last instruction in the sequence,
-    /// `virtual_sequence_remaining` will be Some(0); if this is the penultimate instruction
-    /// in the sequence, `virtual_sequence_remaining` will be Some(1); etc.
-    pub virtual_sequence_remaining: Option<usize>,
-}
+declare_riscv_instr!(
+    name = VirtualAssertValidDiv0,
+    mask = 0,
+    match = 0,
+    format = FormatB,
+    ram = (),
+    is_virtual = true
+);
 
-impl RISCVInstruction for VirtualAssertValidDiv0 {
-    const MASK: u32 = 0; // Virtual
-    const MATCH: u32 = 0; // Virtual
-
-    type Format = FormatB;
-    type RAMAccess = ();
-
-    fn operands(&self) -> &Self::Format {
-        &self.operands
-    }
-
-    fn new(_: u32, _: u64, _: bool) -> Self {
-        unimplemented!("virtual instruction")
-    }
-
-    fn random(rng: &mut StdRng) -> Self {
-        Self {
-            address: rng.next_u64(),
-            operands: FormatB::random(rng),
-            virtual_sequence_remaining: None,
-        }
-    }
-
-    fn execute(&self, cpu: &mut Cpu, _: &mut Self::RAMAccess) {
+impl VirtualAssertValidDiv0 {
+    fn exec(&self, cpu: &mut Cpu, _: &mut <VirtualAssertValidDiv0 as RISCVInstruction>::RAMAccess) {
         let divisor = cpu.x[self.operands.rs1];
         let quotient = cpu.x[self.operands.rs2];
         match cpu.xlen {

--- a/tracer/src/instruction/virtual_assert_valid_signed_remainder.rs
+++ b/tracer/src/instruction/virtual_assert_valid_signed_remainder.rs
@@ -1,49 +1,30 @@
-use rand::{rngs::StdRng, RngCore};
 use serde::{Deserialize, Serialize};
 
-use crate::emulator::cpu::{Cpu, Xlen};
+use crate::{
+    declare_riscv_instr,
+    emulator::cpu::{Cpu, Xlen},
+};
 
 use super::{
     format::{format_b::FormatB, InstructionFormat},
     RISCVInstruction, RISCVTrace,
 };
 
-#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
-pub struct VirtualAssertValidSignedRemainder {
-    pub address: u64,
-    pub operands: FormatB,
-    /// If this instruction is part of a "virtual sequence" (see Section 6.2 of the
-    /// Jolt paper), then this contains the number of virtual instructions after this
-    /// one in the sequence. I.e. if this is the last instruction in the sequence,
-    /// `virtual_sequence_remaining` will be Some(0); if this is the penultimate instruction
-    /// in the sequence, `virtual_sequence_remaining` will be Some(1); etc.
-    pub virtual_sequence_remaining: Option<usize>,
-}
+declare_riscv_instr!(
+    name = VirtualAssertValidSignedRemainder,
+    mask = 0,
+    match = 0,
+    format = FormatB,
+    ram = (),
+    is_virtual = true
+);
 
-impl RISCVInstruction for VirtualAssertValidSignedRemainder {
-    const MASK: u32 = 0; // Virtual
-    const MATCH: u32 = 0; // Virtual
-
-    type Format = FormatB;
-    type RAMAccess = ();
-
-    fn operands(&self) -> &Self::Format {
-        &self.operands
-    }
-
-    fn new(_: u32, _: u64, _: bool) -> Self {
-        unimplemented!("virtual instruction")
-    }
-
-    fn random(rng: &mut StdRng) -> Self {
-        Self {
-            address: rng.next_u64(),
-            operands: FormatB::random(rng),
-            virtual_sequence_remaining: None,
-        }
-    }
-
-    fn execute(&self, cpu: &mut Cpu, _: &mut Self::RAMAccess) {
+impl VirtualAssertValidSignedRemainder {
+    fn exec(
+        &self,
+        cpu: &mut Cpu,
+        _: &mut <VirtualAssertValidSignedRemainder as RISCVInstruction>::RAMAccess,
+    ) {
         match cpu.xlen {
             Xlen::Bit32 => {
                 let remainder = cpu.x[self.operands.rs1] as i32;

--- a/tracer/src/instruction/virtual_assert_valid_unsigned_remainder.rs
+++ b/tracer/src/instruction/virtual_assert_valid_unsigned_remainder.rs
@@ -1,49 +1,30 @@
-use rand::{rngs::StdRng, RngCore};
 use serde::{Deserialize, Serialize};
 
-use crate::emulator::cpu::{Cpu, Xlen};
+use crate::{
+    declare_riscv_instr,
+    emulator::cpu::{Cpu, Xlen},
+};
 
 use super::{
     format::{format_b::FormatB, InstructionFormat},
     RISCVInstruction, RISCVTrace,
 };
 
-#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
-pub struct VirtualAssertValidUnsignedRemainder {
-    pub address: u64,
-    pub operands: FormatB,
-    /// If this instruction is part of a "virtual sequence" (see Section 6.2 of the
-    /// Jolt paper), then this contains the number of virtual instructions after this
-    /// one in the sequence. I.e. if this is the last instruction in the sequence,
-    /// `virtual_sequence_remaining` will be Some(0); if this is the penultimate instruction
-    /// in the sequence, `virtual_sequence_remaining` will be Some(1); etc.
-    pub virtual_sequence_remaining: Option<usize>,
-}
+declare_riscv_instr!(
+    name = VirtualAssertValidUnsignedRemainder,
+    mask = 0,
+    match = 0,
+    format = FormatB,
+    ram = (),
+    is_virtual = true
+);
 
-impl RISCVInstruction for VirtualAssertValidUnsignedRemainder {
-    const MASK: u32 = 0; // Virtual
-    const MATCH: u32 = 0; // Virtual
-
-    type Format = FormatB;
-    type RAMAccess = ();
-
-    fn operands(&self) -> &Self::Format {
-        &self.operands
-    }
-
-    fn new(_: u32, _: u64, _: bool) -> Self {
-        unimplemented!("virtual instruction")
-    }
-
-    fn random(rng: &mut StdRng) -> Self {
-        Self {
-            address: rng.next_u64(),
-            operands: FormatB::random(rng),
-            virtual_sequence_remaining: None,
-        }
-    }
-
-    fn execute(&self, cpu: &mut Cpu, _: &mut Self::RAMAccess) {
+impl VirtualAssertValidUnsignedRemainder {
+    fn exec(
+        &self,
+        cpu: &mut Cpu,
+        _: &mut <VirtualAssertValidUnsignedRemainder as RISCVInstruction>::RAMAccess,
+    ) {
         match cpu.xlen {
             Xlen::Bit32 => {
                 let remainder = cpu.x[self.operands.rs1] as i32 as u32;

--- a/tracer/src/instruction/virtual_move.rs
+++ b/tracer/src/instruction/virtual_move.rs
@@ -1,49 +1,23 @@
-use rand::{rngs::StdRng, RngCore};
 use serde::{Deserialize, Serialize};
 
-use crate::emulator::cpu::Cpu;
+use crate::{declare_riscv_instr, emulator::cpu::Cpu};
 
 use super::{
     format::{format_i::FormatI, InstructionFormat},
     RISCVInstruction, RISCVTrace,
 };
 
-#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
-pub struct VirtualMove {
-    pub address: u64,
-    pub operands: FormatI,
-    /// If this instruction is part of a "virtual sequence" (see Section 6.2 of the
-    /// Jolt paper), then this contains the number of virtual instructions after this
-    /// one in the sequence. I.e. if this is the last instruction in the sequence,
-    /// `virtual_sequence_remaining` will be Some(0); if this is the penultimate instruction
-    /// in the sequence, `virtual_sequence_remaining` will be Some(1); etc.
-    pub virtual_sequence_remaining: Option<usize>,
-}
+declare_riscv_instr!(
+    name = VirtualMove,
+    mask = 0,
+    match = 0,
+    format = FormatI,
+    ram = (),
+    is_virtual = true
+);
 
-impl RISCVInstruction for VirtualMove {
-    const MASK: u32 = 0; // Virtual
-    const MATCH: u32 = 0; // Virtual
-
-    type Format = FormatI;
-    type RAMAccess = ();
-
-    fn operands(&self) -> &Self::Format {
-        &self.operands
-    }
-
-    fn new(_: u32, _: u64, _: bool) -> Self {
-        unimplemented!("virtual instruction")
-    }
-
-    fn random(rng: &mut StdRng) -> Self {
-        Self {
-            address: rng.next_u64(),
-            operands: FormatI::random(rng),
-            virtual_sequence_remaining: None,
-        }
-    }
-
-    fn execute(&self, cpu: &mut Cpu, _: &mut Self::RAMAccess) {
+impl VirtualMove {
+    fn exec(&self, cpu: &mut Cpu, _: &mut <VirtualMove as RISCVInstruction>::RAMAccess) {
         cpu.x[self.operands.rd] = cpu.x[self.operands.rs1];
     }
 }

--- a/tracer/src/instruction/virtual_movsign.rs
+++ b/tracer/src/instruction/virtual_movsign.rs
@@ -1,24 +1,14 @@
-use rand::{rngs::StdRng, RngCore};
 use serde::{Deserialize, Serialize};
 
-use crate::emulator::cpu::{Cpu, Xlen};
+use crate::{
+    declare_riscv_instr,
+    emulator::cpu::{Cpu, Xlen},
+};
 
 use super::{
     format::{format_i::FormatI, InstructionFormat},
     RISCVInstruction, RISCVTrace,
 };
-
-#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
-pub struct VirtualMovsign {
-    pub address: u64,
-    pub operands: FormatI,
-    /// If this instruction is part of a "virtual sequence" (see Section 6.2 of the
-    /// Jolt paper), then this contains the number of virtual instructions after this
-    /// one in the sequence. I.e. if this is the last instruction in the sequence,
-    /// `virtual_sequence_remaining` will be Some(0); if this is the penultimate instruction
-    /// in the sequence, `virtual_sequence_remaining` will be Some(1); etc.
-    pub virtual_sequence_remaining: Option<usize>,
-}
 
 // Constants for 32-bit and 64-bit word sizes
 const ALL_ONES_32: u64 = 0xFFFF_FFFF;
@@ -26,30 +16,17 @@ const ALL_ONES_64: u64 = 0xFFFF_FFFF_FFFF_FFFF;
 const SIGN_BIT_32: u64 = 0x8000_0000;
 const SIGN_BIT_64: u64 = 0x8000_0000_0000_0000;
 
-impl RISCVInstruction for VirtualMovsign {
-    const MASK: u32 = 0; // Virtual
-    const MATCH: u32 = 0; // Virtual
+declare_riscv_instr!(
+    name = VirtualMovsign,
+    mask = 0,
+    match = 0,
+    format = FormatI,
+    ram = (),
+    is_virtual = true
+);
 
-    type Format = FormatI;
-    type RAMAccess = ();
-
-    fn operands(&self) -> &Self::Format {
-        &self.operands
-    }
-
-    fn new(_: u32, _: u64, _: bool) -> Self {
-        unimplemented!("virtual instruction")
-    }
-
-    fn random(rng: &mut StdRng) -> Self {
-        Self {
-            address: rng.next_u64(),
-            operands: FormatI::random(rng),
-            virtual_sequence_remaining: None,
-        }
-    }
-
-    fn execute(&self, cpu: &mut Cpu, _: &mut Self::RAMAccess) {
+impl VirtualMovsign {
+    fn exec(&self, cpu: &mut Cpu, _: &mut <VirtualMovsign as RISCVInstruction>::RAMAccess) {
         let val = cpu.x[self.operands.rs1] as u64;
         cpu.x[self.operands.rd] = match cpu.xlen {
             Xlen::Bit32 => {

--- a/tracer/src/instruction/virtual_muli.rs
+++ b/tracer/src/instruction/virtual_muli.rs
@@ -1,7 +1,7 @@
-use rand::{rngs::StdRng, RngCore};
 use serde::{Deserialize, Serialize};
 
 use crate::{
+    declare_riscv_instr,
     emulator::cpu::Cpu,
     instruction::{
         format::{format_i::FormatI, InstructionFormat},
@@ -9,42 +9,17 @@ use crate::{
     },
 };
 
-#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
-pub struct VirtualMULI {
-    pub address: u64,
-    pub operands: FormatI,
-    /// If this instruction is part of a "virtual sequence" (see Section 6.2 of the
-    /// Jolt paper), then this contains the number of virtual instructions after this
-    /// one in the sequence. I.e. if this is the last instruction in the sequence,
-    /// `virtual_sequence_remaining` will be Some(0); if this is the penultimate instruction
-    /// in the sequence, `virtual_sequence_remaining` will be Some(1); etc.
-    pub virtual_sequence_remaining: Option<usize>,
-}
+declare_riscv_instr!(
+    name = VirtualMULI,
+    mask = 0,
+    match = 0,
+    format = FormatI,
+    ram = (),
+    is_virtual = true
+);
 
-impl RISCVInstruction for VirtualMULI {
-    const MASK: u32 = 0; // Virtual
-    const MATCH: u32 = 0; // Virtual
-
-    type Format = FormatI;
-    type RAMAccess = ();
-
-    fn operands(&self) -> &Self::Format {
-        &self.operands
-    }
-
-    fn new(_: u32, _: u64, _: bool) -> Self {
-        unimplemented!("virtual instruction")
-    }
-
-    fn random(rng: &mut StdRng) -> Self {
-        Self {
-            address: rng.next_u64(),
-            operands: FormatI::random(rng),
-            virtual_sequence_remaining: None,
-        }
-    }
-
-    fn execute(&self, cpu: &mut Cpu, _: &mut Self::RAMAccess) {
+impl VirtualMULI {
+    fn exec(&self, cpu: &mut Cpu, _: &mut <VirtualMULI as RISCVInstruction>::RAMAccess) {
         cpu.x[self.operands.rd] =
             cpu.sign_extend(cpu.x[self.operands.rs1].wrapping_mul(self.operands.imm as i64))
     }

--- a/tracer/src/instruction/virtual_pow2.rs
+++ b/tracer/src/instruction/virtual_pow2.rs
@@ -1,49 +1,26 @@
-use rand::{rngs::StdRng, RngCore};
 use serde::{Deserialize, Serialize};
 
-use crate::emulator::cpu::{Cpu, Xlen};
+use crate::{
+    declare_riscv_instr,
+    emulator::cpu::{Cpu, Xlen},
+};
 
 use super::{
     format::{format_i::FormatI, InstructionFormat},
     RISCVInstruction, RISCVTrace,
 };
 
-#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
-pub struct VirtualPow2 {
-    pub address: u64,
-    pub operands: FormatI,
-    /// If this instruction is part of a "virtual sequence" (see Section 6.2 of the
-    /// Jolt paper), then this contains the number of virtual instructions after this
-    /// one in the sequence. I.e. if this is the last instruction in the sequence,
-    /// `virtual_sequence_remaining` will be Some(0); if this is the penultimate instruction
-    /// in the sequence, `virtual_sequence_remaining` will be Some(1); etc.
-    pub virtual_sequence_remaining: Option<usize>,
-}
+declare_riscv_instr!(
+    name = VirtualPow2,
+    mask = 0,
+    match = 0,
+    format = FormatI,
+    ram = (),
+    is_virtual = true
+);
 
-impl RISCVInstruction for VirtualPow2 {
-    const MASK: u32 = 0; // Virtual
-    const MATCH: u32 = 0; // Virtual
-
-    type Format = FormatI;
-    type RAMAccess = ();
-
-    fn operands(&self) -> &Self::Format {
-        &self.operands
-    }
-
-    fn new(_: u32, _: u64, _: bool) -> Self {
-        unimplemented!("virtual instruction")
-    }
-
-    fn random(rng: &mut StdRng) -> Self {
-        Self {
-            address: rng.next_u64(),
-            operands: FormatI::random(rng),
-            virtual_sequence_remaining: None,
-        }
-    }
-
-    fn execute(&self, cpu: &mut Cpu, _: &mut Self::RAMAccess) {
+impl VirtualPow2 {
+    fn exec(&self, cpu: &mut Cpu, _: &mut <VirtualPow2 as RISCVInstruction>::RAMAccess) {
         match cpu.xlen {
             Xlen::Bit32 => cpu.x[self.operands.rd] = 1 << (cpu.x[self.operands.rs1] as u64 % 32),
             Xlen::Bit64 => cpu.x[self.operands.rd] = 1 << (cpu.x[self.operands.rs1] as u64 % 64),

--- a/tracer/src/instruction/virtual_pow2i.rs
+++ b/tracer/src/instruction/virtual_pow2i.rs
@@ -1,49 +1,26 @@
-use rand::{rngs::StdRng, RngCore};
 use serde::{Deserialize, Serialize};
 
-use crate::emulator::cpu::{Cpu, Xlen};
+use crate::{
+    declare_riscv_instr,
+    emulator::cpu::{Cpu, Xlen},
+};
 
 use super::{
     format::{format_j::FormatJ, InstructionFormat},
     RISCVInstruction, RISCVTrace,
 };
 
-#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
-pub struct VirtualPow2I {
-    pub address: u64,
-    pub operands: FormatJ,
-    /// If this instruction is part of a "virtual sequence" (see Section 6.2 of the
-    /// Jolt paper), then this contains the number of virtual instructions after this
-    /// one in the sequence. I.e. if this is the last instruction in the sequence,
-    /// `virtual_sequence_remaining` will be Some(0); if this is the penultimate instruction
-    /// in the sequence, `virtual_sequence_remaining` will be Some(1); etc.
-    pub virtual_sequence_remaining: Option<usize>,
-}
+declare_riscv_instr!(
+    name = VirtualPow2I,
+    mask = 0,
+    match = 0,
+    format = FormatJ,
+    ram = (),
+    is_virtual = true
+);
 
-impl RISCVInstruction for VirtualPow2I {
-    const MASK: u32 = 0; // Virtual
-    const MATCH: u32 = 0; // Virtual
-
-    type Format = FormatJ;
-    type RAMAccess = ();
-
-    fn operands(&self) -> &Self::Format {
-        &self.operands
-    }
-
-    fn new(_: u32, _: u64, _: bool) -> Self {
-        unimplemented!("virtual instruction")
-    }
-
-    fn random(rng: &mut StdRng) -> Self {
-        Self {
-            address: rng.next_u64(),
-            operands: FormatJ::random(rng),
-            virtual_sequence_remaining: None,
-        }
-    }
-
-    fn execute(&self, cpu: &mut Cpu, _: &mut Self::RAMAccess) {
+impl VirtualPow2I {
+    fn exec(&self, cpu: &mut Cpu, _: &mut <VirtualPow2I as RISCVInstruction>::RAMAccess) {
         match cpu.xlen {
             Xlen::Bit32 => cpu.x[self.operands.rd] = 1 << (self.operands.imm as u64) % 32,
             Xlen::Bit64 => cpu.x[self.operands.rd] = 1 << (self.operands.imm as u64) % 64,

--- a/tracer/src/instruction/virtual_shift_right_bitmask.rs
+++ b/tracer/src/instruction/virtual_shift_right_bitmask.rs
@@ -1,49 +1,30 @@
-use rand::{rngs::StdRng, RngCore};
 use serde::{Deserialize, Serialize};
 
-use crate::emulator::cpu::{Cpu, Xlen};
+use crate::{
+    declare_riscv_instr,
+    emulator::cpu::{Cpu, Xlen},
+};
 
 use super::{
     format::{format_i::FormatI, InstructionFormat},
     RISCVInstruction, RISCVTrace,
 };
 
-#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
-pub struct VirtualShiftRightBitmask {
-    pub address: u64,
-    pub operands: FormatI,
-    /// If this instruction is part of a "virtual sequence" (see Section 6.2 of the
-    /// Jolt paper), then this contains the number of virtual instructions after this
-    /// one in the sequence. I.e. if this is the last instruction in the sequence,
-    /// `virtual_sequence_remaining` will be Some(0); if this is the penultimate instruction
-    /// in the sequence, `virtual_sequence_remaining` will be Some(1); etc.
-    pub virtual_sequence_remaining: Option<usize>,
-}
+declare_riscv_instr!(
+    name = VirtualShiftRightBitmask,
+    mask = 0,
+    match = 0,
+    format = FormatI,
+    ram = (),
+    is_virtual = true
+);
 
-impl RISCVInstruction for VirtualShiftRightBitmask {
-    const MASK: u32 = 0; // Virtual
-    const MATCH: u32 = 0; // Virtual
-
-    type Format = FormatI;
-    type RAMAccess = ();
-
-    fn operands(&self) -> &Self::Format {
-        &self.operands
-    }
-
-    fn new(_: u32, _: u64, _: bool) -> Self {
-        unimplemented!("virtual instruction")
-    }
-
-    fn random(rng: &mut StdRng) -> Self {
-        Self {
-            address: rng.next_u64(),
-            operands: FormatI::random(rng),
-            virtual_sequence_remaining: None,
-        }
-    }
-
-    fn execute(&self, cpu: &mut Cpu, _: &mut Self::RAMAccess) {
+impl VirtualShiftRightBitmask {
+    fn exec(
+        &self,
+        cpu: &mut Cpu,
+        _: &mut <VirtualShiftRightBitmask as RISCVInstruction>::RAMAccess,
+    ) {
         match cpu.xlen {
             Xlen::Bit32 => {
                 let shift = cpu.x[self.operands.rs1] as u64 % 32;

--- a/tracer/src/instruction/virtual_shift_right_bitmaski.rs
+++ b/tracer/src/instruction/virtual_shift_right_bitmaski.rs
@@ -1,49 +1,30 @@
-use rand::{rngs::StdRng, RngCore};
 use serde::{Deserialize, Serialize};
 
-use crate::emulator::cpu::{Cpu, Xlen};
+use crate::{
+    declare_riscv_instr,
+    emulator::cpu::{Cpu, Xlen},
+};
 
 use super::{
     format::{format_j::FormatJ, InstructionFormat},
     RISCVInstruction, RISCVTrace,
 };
 
-#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
-pub struct VirtualShiftRightBitmaskI {
-    pub address: u64,
-    pub operands: FormatJ,
-    /// If this instruction is part of a "virtual sequence" (see Section 6.2 of the
-    /// Jolt paper), then this contains the number of virtual instructions after this
-    /// one in the sequence. I.e. if this is the last instruction in the sequence,
-    /// `virtual_sequence_remaining` will be Some(0); if this is the penultimate instruction
-    /// in the sequence, `virtual_sequence_remaining` will be Some(1); etc.
-    pub virtual_sequence_remaining: Option<usize>,
-}
+declare_riscv_instr!(
+    name = VirtualShiftRightBitmaskI,
+    mask = 0,
+    match = 0,
+    format = FormatJ,
+    ram = (),
+    is_virtual = true
+);
 
-impl RISCVInstruction for VirtualShiftRightBitmaskI {
-    const MASK: u32 = 0; // Virtual
-    const MATCH: u32 = 0; // Virtual
-
-    type Format = FormatJ;
-    type RAMAccess = ();
-
-    fn operands(&self) -> &Self::Format {
-        &self.operands
-    }
-
-    fn new(_: u32, _: u64, _: bool) -> Self {
-        unimplemented!("virtual instruction")
-    }
-
-    fn random(rng: &mut StdRng) -> Self {
-        Self {
-            address: rng.next_u64(),
-            operands: FormatJ::random(rng),
-            virtual_sequence_remaining: None,
-        }
-    }
-
-    fn execute(&self, cpu: &mut Cpu, _: &mut Self::RAMAccess) {
+impl VirtualShiftRightBitmaskI {
+    fn exec(
+        &self,
+        cpu: &mut Cpu,
+        _: &mut <VirtualShiftRightBitmaskI as RISCVInstruction>::RAMAccess,
+    ) {
         match cpu.xlen {
             Xlen::Bit32 => {
                 let shift = self.operands.imm as u64 % 32;

--- a/tracer/src/instruction/virtual_sra.rs
+++ b/tracer/src/instruction/virtual_sra.rs
@@ -1,49 +1,23 @@
-use rand::{rngs::StdRng, RngCore};
 use serde::{Deserialize, Serialize};
 
-use crate::emulator::cpu::Cpu;
+use crate::{declare_riscv_instr, emulator::cpu::Cpu};
 
 use super::{
     format::{format_virtual_right_shift_r::FormatVirtualRightShiftR, InstructionFormat},
     RISCVInstruction, RISCVTrace,
 };
 
-#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
-pub struct VirtualSRA {
-    pub address: u64,
-    pub operands: FormatVirtualRightShiftR,
-    /// If this instruction is part of a "virtual sequence" (see Section 6.2 of the
-    /// Jolt paper), then this contains the number of virtual instructions after this
-    /// one in the sequence. I.e. if this is the last instruction in the sequence,
-    /// `virtual_sequence_remaining` will be Some(0); if this is the penultimate instruction
-    /// in the sequence, `virtual_sequence_remaining` will be Some(1); etc.
-    pub virtual_sequence_remaining: Option<usize>,
-}
+declare_riscv_instr!(
+    name = VirtualSRA,
+    mask = 0,
+    match = 0,
+    format = FormatVirtualRightShiftR,
+    ram = (),
+    is_virtual = true
+);
 
-impl RISCVInstruction for VirtualSRA {
-    const MASK: u32 = 0; // Virtual
-    const MATCH: u32 = 0; // Virtual
-
-    type Format = FormatVirtualRightShiftR;
-    type RAMAccess = ();
-
-    fn operands(&self) -> &Self::Format {
-        &self.operands
-    }
-
-    fn new(_: u32, _: u64, _: bool) -> Self {
-        unimplemented!("virtual instruction")
-    }
-
-    fn random(rng: &mut StdRng) -> Self {
-        Self {
-            address: rng.next_u64(),
-            operands: FormatVirtualRightShiftR::random(rng),
-            virtual_sequence_remaining: None,
-        }
-    }
-
-    fn execute(&self, cpu: &mut Cpu, _: &mut Self::RAMAccess) {
+impl VirtualSRA {
+    fn exec(&self, cpu: &mut Cpu, _: &mut <VirtualSRA as RISCVInstruction>::RAMAccess) {
         let shift = cpu.x[self.operands.rs2].trailing_zeros();
         cpu.x[self.operands.rd] = cpu.sign_extend(cpu.x[self.operands.rs1].wrapping_shr(shift));
     }

--- a/tracer/src/instruction/virtual_srai.rs
+++ b/tracer/src/instruction/virtual_srai.rs
@@ -1,48 +1,23 @@
-use rand::{rngs::StdRng, RngCore};
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    emulator::cpu::Cpu, instruction::format::format_virtual_right_shift_i::FormatVirtualRightShiftI,
+    declare_riscv_instr, emulator::cpu::Cpu,
+    instruction::format::format_virtual_right_shift_i::FormatVirtualRightShiftI,
 };
 
 use super::{format::InstructionFormat, RISCVInstruction, RISCVTrace};
 
-#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
-pub struct VirtualSRAI {
-    pub address: u64,
-    pub operands: FormatVirtualRightShiftI,
-    /// If this instruction is part of a "virtual sequence" (see Section 6.2 of the
-    /// Jolt paper), then this contains the number of virtual instructions after this
-    /// one in the sequence. I.e. if this is the last instruction in the sequence,
-    /// `virtual_sequence_remaining` will be Some(0); if this is the penultimate instruction
-    /// in the sequence, `virtual_sequence_remaining` will be Some(1); etc.
-    pub virtual_sequence_remaining: Option<usize>,
-}
+declare_riscv_instr!(
+    name = VirtualSRAI,
+    mask = 0,
+    match = 0,
+    format = FormatVirtualRightShiftI,
+    ram = (),
+    is_virtual = true
+);
 
-impl RISCVInstruction for VirtualSRAI {
-    const MASK: u32 = 0; // Virtual
-    const MATCH: u32 = 0; // Virtual
-
-    type Format = FormatVirtualRightShiftI;
-    type RAMAccess = ();
-
-    fn operands(&self) -> &Self::Format {
-        &self.operands
-    }
-
-    fn new(_: u32, _: u64, _: bool) -> Self {
-        unimplemented!("virtual instruction")
-    }
-
-    fn random(rng: &mut StdRng) -> Self {
-        Self {
-            address: rng.next_u64(),
-            operands: FormatVirtualRightShiftI::random(rng),
-            virtual_sequence_remaining: None,
-        }
-    }
-
-    fn execute(&self, cpu: &mut Cpu, _: &mut Self::RAMAccess) {
+impl VirtualSRAI {
+    fn exec(&self, cpu: &mut Cpu, _: &mut <VirtualSRAI as RISCVInstruction>::RAMAccess) {
         let shift = self.operands.imm.trailing_zeros();
         cpu.x[self.operands.rd] = cpu.sign_extend(cpu.x[self.operands.rs1].wrapping_shr(shift));
     }

--- a/tracer/src/instruction/virtual_srl.rs
+++ b/tracer/src/instruction/virtual_srl.rs
@@ -1,49 +1,23 @@
-use rand::{rngs::StdRng, RngCore};
 use serde::{Deserialize, Serialize};
 
-use crate::emulator::cpu::Cpu;
+use crate::{declare_riscv_instr, emulator::cpu::Cpu};
 
 use super::{
     format::{format_virtual_right_shift_r::FormatVirtualRightShiftR, InstructionFormat},
     RISCVInstruction, RISCVTrace,
 };
 
-#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
-pub struct VirtualSRL {
-    pub address: u64,
-    pub operands: FormatVirtualRightShiftR,
-    /// If this instruction is part of a "virtual sequence" (see Section 6.2 of the
-    /// Jolt paper), then this contains the number of virtual instructions after this
-    /// one in the sequence. I.e. if this is the last instruction in the sequence,
-    /// `virtual_sequence_remaining` will be Some(0); if this is the penultimate instruction
-    /// in the sequence, `virtual_sequence_remaining` will be Some(1); etc.
-    pub virtual_sequence_remaining: Option<usize>,
-}
+declare_riscv_instr!(
+    name = VirtualSRL,
+    mask = 0,
+    match = 0,
+    format = FormatVirtualRightShiftR,
+    ram = (),
+    is_virtual = true
+);
 
-impl RISCVInstruction for VirtualSRL {
-    const MASK: u32 = 0; // Virtual
-    const MATCH: u32 = 0; // Virtual
-
-    type Format = FormatVirtualRightShiftR;
-    type RAMAccess = ();
-
-    fn operands(&self) -> &Self::Format {
-        &self.operands
-    }
-
-    fn new(_: u32, _: u64, _: bool) -> Self {
-        unimplemented!("virtual instruction")
-    }
-
-    fn random(rng: &mut StdRng) -> Self {
-        Self {
-            address: rng.next_u64(),
-            operands: FormatVirtualRightShiftR::random(rng),
-            virtual_sequence_remaining: None,
-        }
-    }
-
-    fn execute(&self, cpu: &mut Cpu, _: &mut Self::RAMAccess) {
+impl VirtualSRL {
+    fn exec(&self, cpu: &mut Cpu, _: &mut <VirtualSRL as RISCVInstruction>::RAMAccess) {
         let shift = cpu.x[self.operands.rs2].trailing_zeros();
         cpu.x[self.operands.rd] = cpu.sign_extend(
             cpu.unsigned_data(cpu.x[self.operands.rs1])

--- a/tracer/src/instruction/virtual_srli.rs
+++ b/tracer/src/instruction/virtual_srli.rs
@@ -1,48 +1,23 @@
-use rand::{rngs::StdRng, RngCore};
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    emulator::cpu::Cpu, instruction::format::format_virtual_right_shift_i::FormatVirtualRightShiftI,
+    declare_riscv_instr, emulator::cpu::Cpu,
+    instruction::format::format_virtual_right_shift_i::FormatVirtualRightShiftI,
 };
 
 use super::{format::InstructionFormat, RISCVInstruction, RISCVTrace};
 
-#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
-pub struct VirtualSRLI {
-    pub address: u64,
-    pub operands: FormatVirtualRightShiftI,
-    /// If this instruction is part of a "virtual sequence" (see Section 6.2 of the
-    /// Jolt paper), then this contains the number of virtual instructions after this
-    /// one in the sequence. I.e. if this is the last instruction in the sequence,
-    /// `virtual_sequence_remaining` will be Some(0); if this is the penultimate instruction
-    /// in the sequence, `virtual_sequence_remaining` will be Some(1); etc.
-    pub virtual_sequence_remaining: Option<usize>,
-}
+declare_riscv_instr!(
+    name = VirtualSRLI,
+    mask = 0,
+    match = 0,
+    format = FormatVirtualRightShiftI,
+    ram = (),
+    is_virtual = true
+);
 
-impl RISCVInstruction for VirtualSRLI {
-    const MASK: u32 = 0; // Virtual
-    const MATCH: u32 = 0; // Virtual
-
-    type Format = FormatVirtualRightShiftI;
-    type RAMAccess = ();
-
-    fn operands(&self) -> &Self::Format {
-        &self.operands
-    }
-
-    fn new(_: u32, _: u64, _: bool) -> Self {
-        unimplemented!("virtual instruction")
-    }
-
-    fn random(rng: &mut StdRng) -> Self {
-        Self {
-            address: rng.next_u64(),
-            operands: FormatVirtualRightShiftI::random(rng),
-            virtual_sequence_remaining: None,
-        }
-    }
-
-    fn execute(&self, cpu: &mut Cpu, _: &mut Self::RAMAccess) {
+impl VirtualSRLI {
+    fn exec(&self, cpu: &mut Cpu, _: &mut <VirtualSRLI as RISCVInstruction>::RAMAccess) {
         let shift = self.operands.imm.trailing_zeros();
         cpu.x[self.operands.rd] = cpu.sign_extend(
             cpu.unsigned_data(cpu.x[self.operands.rs1])

--- a/tracer/src/instruction/xor.rs
+++ b/tracer/src/instruction/xor.rs
@@ -1,48 +1,22 @@
 use serde::{Deserialize, Serialize};
 
-use crate::emulator::cpu::Cpu;
+use crate::{declare_riscv_instr, emulator::cpu::Cpu};
 
 use super::{
     format::{format_r::FormatR, InstructionFormat},
     RISCVInstruction, RISCVTrace,
 };
 
-#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
-pub struct XOR {
-    pub address: u64,
-    pub operands: FormatR,
-    /// If this instruction is part of a "virtual sequence" (see Section 6.2 of the
-    /// Jolt paper), then this contains the number of virtual instructions after this
-    /// one in the sequence. I.e. if this is the last instruction in the sequence,
-    /// `virtual_sequence_remaining` will be Some(0); if this is the penultimate instruction
-    /// in the sequence, `virtual_sequence_remaining` will be Some(1); etc.
-    pub virtual_sequence_remaining: Option<usize>,
-}
+declare_riscv_instr!(
+    name   = XOR,
+    mask   = 0xfe00707f,
+    match  = 0x00004033,
+    format = FormatR,
+    ram    = ()
+);
 
-impl RISCVInstruction for XOR {
-    const MASK: u32 = 0xfe00707f;
-    const MATCH: u32 = 0x00004033;
-
-    type Format = FormatR;
-    type RAMAccess = ();
-
-    fn operands(&self) -> &Self::Format {
-        &self.operands
-    }
-
-    fn new(word: u32, address: u64, validate: bool) -> Self {
-        if validate {
-            debug_assert_eq!(word & Self::MASK, Self::MATCH);
-        }
-
-        Self {
-            address,
-            operands: FormatR::parse(word),
-            virtual_sequence_remaining: None,
-        }
-    }
-
-    fn execute(&self, cpu: &mut Cpu, _: &mut Self::RAMAccess) {
+impl XOR {
+    fn exec(&self, cpu: &mut Cpu, _: &mut <XOR as RISCVInstruction>::RAMAccess) {
         cpu.x[self.operands.rd] =
             cpu.sign_extend(cpu.x[self.operands.rs1] ^ cpu.x[self.operands.rs2]);
     }

--- a/tracer/src/instruction/xori.rs
+++ b/tracer/src/instruction/xori.rs
@@ -1,48 +1,22 @@
 use serde::{Deserialize, Serialize};
 
-use crate::emulator::cpu::Cpu;
+use crate::{declare_riscv_instr, emulator::cpu::Cpu};
 
 use super::{
     format::{format_i::FormatI, normalize_imm, InstructionFormat},
     RISCVInstruction, RISCVTrace,
 };
 
-#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
-pub struct XORI {
-    pub address: u64,
-    pub operands: FormatI,
-    /// If this instruction is part of a "virtual sequence" (see Section 6.2 of the
-    /// Jolt paper), then this contains the number of virtual instructions after this
-    /// one in the sequence. I.e. if this is the last instruction in the sequence,
-    /// `virtual_sequence_remaining` will be Some(0); if this is the penultimate instruction
-    /// in the sequence, `virtual_sequence_remaining` will be Some(1); etc.
-    pub virtual_sequence_remaining: Option<usize>,
-}
+declare_riscv_instr!(
+    name   = XORI,
+    mask   = 0x0000707f,
+    match  = 0x00004013,
+    format = FormatI,
+    ram    = ()
+);
 
-impl RISCVInstruction for XORI {
-    const MASK: u32 = 0x0000707f;
-    const MATCH: u32 = 0x00004013;
-
-    type Format = FormatI;
-    type RAMAccess = ();
-
-    fn operands(&self) -> &Self::Format {
-        &self.operands
-    }
-
-    fn new(word: u32, address: u64, validate: bool) -> Self {
-        if validate {
-            debug_assert_eq!(word & Self::MASK, Self::MATCH);
-        }
-
-        Self {
-            address,
-            operands: FormatI::parse(word),
-            virtual_sequence_remaining: None,
-        }
-    }
-
-    fn execute(&self, cpu: &mut Cpu, _: &mut Self::RAMAccess) {
+impl XORI {
+    fn exec(&self, cpu: &mut Cpu, _: &mut <XORI as RISCVInstruction>::RAMAccess) {
         cpu.x[self.operands.rd] =
             cpu.sign_extend(cpu.x[self.operands.rs1] ^ normalize_imm(self.operands.imm));
     }


### PR DESCRIPTION
- adds a `declare_riscv_instr!` macro under the tracer crate, which heavily reduces the amount of code repetition for instructions
- A future task would be to do a similar macro for the instructions `mod.rs`, since there is a large amount of repetition there (without using `enum_dispatch`?)