### PR TITLE
Make `tracer` `no_std` compatible

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -507,7 +507,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "miniz_oxide",
- "object 0.36.7",
+ "object",
  "rustc-demangle",
  "windows-targets 0.52.6",
 ]
@@ -1272,20 +1272,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
-name = "flate2"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ced92e76e966ca2fd84c8f7aa01a4aea65b0eb6648d72f7c8f3e2764a67fece"
-dependencies = [
- "crc32fast",
- "miniz_oxide",
-]
-
-[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "foreign-types"
@@ -1473,6 +1469,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84b26c544d002229e640969970a2e74021aadf6e2f96372b9c58eff97de08eb3"
 dependencies = [
  "allocator-api2",
+ "foldhash",
 ]
 
 [[package]]
@@ -2393,21 +2390,13 @@ checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "object"
-version = "0.32.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6a622008b6e321afc04970976f62ee297fdbaa6f95318ca343e3eebb9648441"
-dependencies = [
- "flate2",
- "memchr",
- "ruzstd",
-]
-
-[[package]]
-name = "object"
 version = "0.36.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
 dependencies = [
+ "crc32fast",
+ "hashbrown",
+ "indexmap",
  "memchr",
 ]
 
@@ -3171,17 +3160,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ruzstd"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58c4eb8a81997cf040a091d1f7e1938aeab6749d3a0dfa73af43cdc32393483d"
-dependencies = [
- "byteorder",
- "derive_more",
- "twox-hash",
-]
-
-[[package]]
 name = "ryu"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3836,7 +3814,7 @@ version = "0.2.0"
 dependencies = [
  "common",
  "fnv",
- "object 0.32.2",
+ "object",
  "tracing",
 ]
 
@@ -3913,16 +3891,6 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
-
-[[package]]
-name = "twox-hash"
-version = "1.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
-dependencies = [
- "cfg-if",
- "static_assertions",
-]
 
 [[package]]
 name = "typenum"

--- a/jolt-core/src/host/mod.rs
+++ b/jolt-core/src/host/mod.rs
@@ -177,9 +177,18 @@ impl Program {
     #[tracing::instrument(skip_all, name = "Program::trace")]
     pub fn trace(&mut self, inputs: &[u8]) -> (JoltDevice, Vec<JoltTraceStep<RV32I>>) {
         self.build(DEFAULT_TARGET_DIR);
-        let elf = self.elf.clone().unwrap();
-        let (raw_trace, io_device) =
-            tracer::trace(&elf, inputs, self.max_input_size, self.max_output_size);
+        let elf = self.elf.as_ref().unwrap();
+        let mut elf_file =
+            File::open(elf).unwrap_or_else(|_| panic!("could not open elf file: {elf:?}"));
+        let mut elf_contents = Vec::new();
+        elf_file.read_to_end(&mut elf_contents).unwrap();
+
+        let (raw_trace, io_device) = tracer::trace(
+            elf_contents,
+            inputs,
+            self.max_input_size,
+            self.max_output_size,
+        );
 
         let trace: Vec<_> = raw_trace
             .into_par_iter()
@@ -216,7 +225,17 @@ impl Program {
     pub fn trace_analyze<F: JoltField>(mut self, inputs: &[u8]) -> ProgramSummary {
         self.build(DEFAULT_TARGET_DIR);
         let elf = self.elf.as_ref().unwrap();
-        let (raw_trace, _) = tracer::trace(elf, inputs, self.max_input_size, self.max_output_size);
+        let mut elf_file =
+            File::open(elf).unwrap_or_else(|_| panic!("could not open elf file: {elf:?}"));
+        let mut elf_contents = Vec::new();
+        elf_file.read_to_end(&mut elf_contents).unwrap();
+
+        let (raw_trace, _) = tracer::trace(
+            elf_contents,
+            inputs,
+            self.max_input_size,
+            self.max_output_size,
+        );
 
         let (bytecode, memory_init) = self.decode();
         let (io_device, processed_trace) = self.trace(inputs);

--- a/tracer/Cargo.toml
+++ b/tracer/Cargo.toml
@@ -15,9 +15,18 @@ homepage = "https://github.com/a16z/jolt/README.md"
 repository = "https://github.com/a16z/jolt"
 edition = "2021"
 
-[dependencies]
-fnv = "1.0.7"
-object = "0.32.1"
-tracing = "0.1.37"
+[features]
+default = ["std"]
+std = [
+    "common/std",
+    "fnv/std",
+    "object/std",
+    "tracing/std",
+]
 
-common = { path = "../common" }
+[dependencies]
+fnv = { version = "1.0.7", default-features = false }
+object = { version = "0.36.7", features = ["build_core", "elf"], default-features = false }
+tracing = { version = "0.1.41", features = ["attributes"], default-features = false }
+
+common = { path = "../common", default-features = false }

--- a/tracer/src/emulator/default_terminal.rs
+++ b/tracer/src/emulator/default_terminal.rs
@@ -1,5 +1,8 @@
 use super::terminal::Terminal;
 
+#[cfg(not(feature = "std"))]
+use alloc::{vec, vec::Vec};
+
 /// Standard `Terminal`.
 pub struct DefaultTerminal {
     input_data: Vec<u8>,

--- a/tracer/src/emulator/device/uart.rs
+++ b/tracer/src/emulator/device/uart.rs
@@ -1,5 +1,8 @@
 use crate::emulator::terminal::Terminal;
 
+#[cfg(not(feature = "std"))]
+use alloc::boxed::Box;
+
 const IER_RXINT_BIT: u8 = 0x1;
 const IER_THREINT_BIT: u8 = 0x2;
 

--- a/tracer/src/emulator/device/virtio_block_disk.rs
+++ b/tracer/src/emulator/device/virtio_block_disk.rs
@@ -1,5 +1,8 @@
 use crate::emulator::mmu::MemoryWrapper;
 
+#[cfg(not(feature = "std"))]
+use alloc::{vec, vec::Vec};
+
 // Based on Virtual I/O Device (VIRTIO) Version 1.1
 // https://docs.oasis-open.org/virtio/virtio/v1.1/csprd01/virtio-v1.1-csprd01.html
 

--- a/tracer/src/emulator/elf_analyzer.rs
+++ b/tracer/src/emulator/elf_analyzer.rs
@@ -1,6 +1,12 @@
 extern crate fnv;
 
+#[cfg(feature = "std")]
 use self::fnv::FnvHashMap;
+#[cfg(not(feature = "std"))]
+use alloc::collections::btree_map::BTreeMap as FnvHashMap;
+
+#[cfg(not(feature = "std"))]
+use alloc::{string::String, vec::Vec};
 
 /// ELF header
 pub struct Header {

--- a/tracer/src/emulator/memory.rs
+++ b/tracer/src/emulator/memory.rs
@@ -1,3 +1,6 @@
+#[cfg(not(feature = "std"))]
+use alloc::{vec, vec::Vec};
+
 /// Emulates main memory.
 pub struct Memory {
     /// Memory content

--- a/tracer/src/emulator/mmu.rs
+++ b/tracer/src/emulator/mmu.rs
@@ -6,12 +6,21 @@ const DTB_SIZE: usize = 0xfe0;
 
 extern crate fnv;
 
+#[cfg(not(feature = "std"))]
+use alloc::rc::Rc;
+#[cfg(feature = "std")]
 use std::rc::Rc;
 
 use crate::trace::Tracer;
 use common::rv_trace::{JoltDevice, MemoryState};
 
+#[cfg(feature = "std")]
 use self::fnv::FnvHashMap;
+#[cfg(not(feature = "std"))]
+use alloc::collections::btree_map::BTreeMap as FnvHashMap;
+
+#[cfg(not(feature = "std"))]
+use alloc::{boxed::Box, vec, vec::Vec};
 
 use super::cpu::{get_privilege_mode, PrivilegeMode, Trap, TrapType, Xlen};
 use super::device::clint::Clint;

--- a/tracer/src/emulator/mod.rs
+++ b/tracer/src/emulator/mod.rs
@@ -4,7 +4,19 @@ const PROGRAM_MEMORY_CAPACITY: u64 = 1024 * 1024 * 128; // big enough to run Lin
 
 extern crate fnv;
 
+#[cfg(feature = "std")]
 use self::fnv::FnvHashMap;
+#[cfg(not(feature = "std"))]
+use alloc::collections::btree_map::BTreeMap as FnvHashMap;
+
+#[cfg(not(feature = "std"))]
+use alloc::{
+    boxed::Box,
+    format,
+    string::{String, ToString},
+    vec,
+    vec::Vec,
+};
 
 pub mod cpu;
 pub mod default_terminal;
@@ -89,6 +101,7 @@ impl Emulator {
     /// * Displays the result message (pass/fail) to terminal
     pub fn run_test(&mut self) {
         // @TODO: Send this message to terminal?
+        #[cfg(feature = "std")]
         println!("This elf file seems riscv-tests elf file. Running in test mode.");
         loop {
             let disas = self.cpu.disassemble_next_instruction();

--- a/tracer/src/lib.rs
+++ b/tracer/src/lib.rs
@@ -1,7 +1,12 @@
+#![cfg_attr(not(feature = "std"), no_std)]
 #![allow(dead_code)]
 #![allow(clippy::legacy_numeric_constants)]
 
-use std::{fs::File, io::Read, path::PathBuf};
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+
+#[cfg(not(feature = "std"))]
+use alloc::{boxed::Box, vec::Vec};
 
 use common::{self, constants::RAM_START_ADDRESS};
 use emulator::{
@@ -24,7 +29,7 @@ use crate::decode::decode_raw;
 
 #[tracing::instrument(skip_all)]
 pub fn trace(
-    elf: &PathBuf,
+    elf_contents: Vec<u8>,
     inputs: &[u8],
     input_size: u64,
     output_size: u64,
@@ -36,11 +41,6 @@ pub fn trace(
     let mut jolt_device = JoltDevice::new(input_size, output_size);
     jolt_device.inputs = inputs.to_vec();
     emulator.get_mut_cpu().get_mut_mmu().jolt_device = jolt_device;
-
-    let mut elf_file = File::open(elf).unwrap();
-
-    let mut elf_contents = Vec::new();
-    elf_file.read_to_end(&mut elf_contents).unwrap();
 
     emulator.setup_program(elf_contents);
 

--- a/tracer/src/trace.rs
+++ b/tracer/src/trace.rs
@@ -1,8 +1,11 @@
-use std::cell::RefCell;
+use core::cell::RefCell;
 
 use common::rv_trace::{ELFInstruction, MemoryState, RVTraceRow, RegisterState};
 
 use crate::emulator::cpu::Xlen;
+
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
 
 pub struct Tracer {
     pub rows: RefCell<Vec<RVTraceRow>>,


### PR DESCRIPTION
This requires a slight change to the API that is exposed to `jolt-core`: The `trace` function no longer takes a `PathBuf` (since that's not available in a `no_std` environment) and instead takes the elf contents as a `Vec<u8>`. This requires a slight change to the `jolt-core` `host` module to make that API change compatible.