### PR TITLE
feat: implement gruen's optimization & more for spartan

### DIFF
--- a/jolt-core/src/msm/icicle/mod.rs
+++ b/jolt-core/src/msm/icicle/mod.rs
@@ -83,23 +83,15 @@ pub fn total_memory_bits() -> usize {
     #[cfg(feature = "icicle")]
     if let Ok((total_bytes, _)) = icicle_runtime::get_available_memory() {
         // If icicle is enabled and memory is available, return the total memory in bits.
-        return total_bytes.checked_mul(BITS_PER_BYTE).unwrap_or(usize::MAX);
+        return total_bytes.saturating_mul(BITS_PER_BYTE);
     }
 
     // Fallback to system memory if icicle is unavailable or not enabled.
     #[cfg(not(target_arch = "wasm32"))]
     if let Ok(mem_info) = sys_info::mem_info() {
-        return (mem_info.total as usize * BYTES_PER_KB)
-            .checked_mul(BITS_PER_BYTE)
-            .unwrap_or(usize::MAX);
+        return (mem_info.total as usize * BYTES_PER_KB).saturating_mul(BITS_PER_BYTE);
     }
 
     // Fallback to "default" memory if system memory retrieval fails.
-    DEFAULT_MEM_GB
-        .checked_mul(
-            BYTES_PER_GB
-                .checked_mul(BITS_PER_BYTE)
-                .unwrap_or(usize::MAX),
-        )
-        .unwrap_or(usize::MAX)
+    DEFAULT_MEM_GB.saturating_mul(BYTES_PER_GB.saturating_mul(BITS_PER_BYTE))
 }

--- a/jolt-core/src/poly/commitment/bmmtv/hyperbmmtv.rs
+++ b/jolt-core/src/poly/commitment/bmmtv/hyperbmmtv.rs
@@ -156,7 +156,7 @@ where
         polys.push(poly.into());
         for i in 0..ell - 1 {
             let previous_poly: &UniPoly<P::ScalarField> = &polys[i];
-            let Pi_len = previous_poly.len() / 2;
+            let Pi_len = previous_poly.coeffs.len() / 2;
             let mut Pi = vec![P::ScalarField::zero(); Pi_len];
             let x = point[ell - i - 1];
 
@@ -170,7 +170,7 @@ where
         }
 
         assert_eq!(polys.len(), ell);
-        assert_eq!(polys[ell - 1].len(), 2);
+        assert_eq!(polys[ell - 1].coeffs.len(), 2);
 
         // We do not need to commit to the first polynomial as it is already committed.
 

--- a/jolt-core/src/poly/commitment/bmmtv/poly_commit.rs
+++ b/jolt-core/src/poly/commitment/bmmtv/poly_commit.rs
@@ -231,7 +231,7 @@ where
         srs: &KZGProverKey<P>,
         polynomial: &UnivariatePolynomial<P::ScalarField>,
     ) -> Result<(PairingOutput<P>, Vec<P::G1>), Error> {
-        let bivariate_degrees = Self::bivariate_degrees(polynomial.len() - 1);
+        let bivariate_degrees = Self::bivariate_degrees(polynomial.coeffs.len() - 1);
         BivariatePolynomialCommitment::<P, ProofTranscript>::commit(
             srs,
             &Self::bivariate_form(bivariate_degrees, polynomial),
@@ -245,7 +245,7 @@ where
         point: &P::ScalarField,
         transcript: &mut ProofTranscript,
     ) -> Result<OpeningProof<P>, Error> {
-        let (x_degree, y_degree) = Self::bivariate_degrees(polynomial.len() - 1);
+        let (x_degree, y_degree) = Self::bivariate_degrees(polynomial.coeffs.len() - 1);
         let y = *point;
         let x = point.pow(vec![(y_degree + 1) as u64]);
         BivariatePolynomialCommitment::<P, ProofTranscript>::open(

--- a/jolt-core/src/poly/eq_poly.rs
+++ b/jolt-core/src/poly/eq_poly.rs
@@ -26,11 +26,23 @@ impl<F: JoltField> EqPolynomial<F> {
     }
 
     #[tracing::instrument(skip_all, name = "EqPolynomial::evals")]
+    /// Computes the table of coefficients: `{eq(r, x) for all x in {0, 1}^n}`
     pub fn evals(r: &[F]) -> Vec<F> {
         match r.len() {
             0..=PARALLEL_THRESHOLD => Self::evals_serial(r, None),
             _ => Self::evals_parallel(r, None),
         }
+    }
+
+    #[tracing::instrument(skip_all, name = "EqPolynomial::evals_cached")]
+    /// Computes the table of coefficients like `evals`, but also caches the intermediate results
+    ///
+    /// In other words, computes `{eq(r[i..], x) for all x in {0, 1}^{n - i}}` and for all `i in
+    /// 0..r.len()`.
+    pub fn evals_cached(r: &[F]) -> Vec<Vec<F>> {
+        // TODO: implement parallel version (it seems more difficult to parallelize all the
+        // intermediate results)
+        Self::evals_serial_cached(r, None)
     }
 
     /// Computes the table of coefficients:
@@ -52,8 +64,58 @@ impl<F: JoltField> EqPolynomial<F> {
         evals
     }
 
+    /// Computes the table of coefficients like `evals_serial`, but also caches the intermediate results.
+    ///
+    /// Returns a vector of vectors, where the `j`th vector contains the coefficients for the polynomial
+    /// `eq(r[..j], x)` for all `x in {0, 1}^{j}`.
+    ///
+    /// Performance seems at most 10% worse than `evals_serial`
+    fn evals_serial_cached(r: &[F], scaling_factor: Option<F>) -> Vec<Vec<F>> {
+        let mut evals: Vec<Vec<F>> = (0..r.len() + 1)
+            .map(|i| vec![scaling_factor.unwrap_or(F::one()); 1 << i])
+            .collect();
+        let mut size = 1;
+        for j in 0..r.len() {
+            size *= 2;
+            for i in (0..size).rev().step_by(2) {
+                let scalar = evals[j][i / 2];
+                evals[j + 1][i] = scalar * r[j];
+                evals[j + 1][i - 1] = scalar - evals[j + 1][i];
+            }
+        }
+        evals
+    }
+
+    /// Computes the table of coefficients like `evals_serial`, but also caches the intermediate
+    /// results. This binds `r` in the reverse order compared to `evals_serial_cached`.
+    ///
+    /// Concretely, this returns a vector of vectors, where the `(n -j)`th vector contains the
+    /// coefficients for the polynomial `eq(r[j..], x)` for all `x in {0, 1}^{n - j}`.
+    ///
+    /// Performance seems at most 10% worse than `evals_serial`
+    #[allow(dead_code)]
+    fn evals_serial_cached_rev(r: &[F], scaling_factor: Option<F>) -> Vec<Vec<F>> {
+        let rev_r = r.iter().rev().collect::<Vec<_>>();
+        let mut evals: Vec<Vec<F>> = (0..r.len() + 1)
+            .map(|i| vec![scaling_factor.unwrap_or(F::one()); 1 << i])
+            .collect();
+        let mut size = 1;
+        for j in 0..r.len() {
+            for i in 0..size {
+                let scalar = evals[j][i];
+                let multiple = 1 << j;
+                evals[j + 1][i + multiple] = scalar * rev_r[j];
+                evals[j + 1][i] = scalar - evals[j + 1][i + multiple];
+            }
+            size *= 2;
+        }
+        evals
+    }
+
     /// Computes the table of coefficients:
-    ///     scaling_factor * eq(r, x) for all x in {0, 1}^n
+    ///
+    ///     `scaling_factor * eq(r, x) for all x in {0, 1}^n`,
+    ///
     /// computing biggest layers of the dynamic programming tree in parallel.
     #[tracing::instrument(skip_all, "EqPolynomial::evals_parallel")]
     pub fn evals_parallel(r: &[F], scaling_factor: Option<F>) -> Vec<F> {
@@ -157,5 +219,62 @@ impl<F: JoltField> EqPlusOnePolynomial<F> {
         }
 
         (eq_evals, eq_plus_one_evals)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ark_bn254::Fr;
+    use ark_std::test_rng;
+    use std::time::Instant;
+
+    #[test]
+    /// Test that the results of running `evals_serial`, `evals_parallel`, and `evals_serial_cached`
+    /// (taking the last vector) are the same (and also benchmark them)
+    fn test_evals() {
+        let mut rng = test_rng();
+        for len in 5..22 {
+            let r = (0..len).map(|_| Fr::random(&mut rng)).collect::<Vec<_>>();
+            let start = Instant::now();
+            let evals_serial = EqPolynomial::evals_serial(&r, None);
+            let end_first = Instant::now();
+            let evals_parallel = EqPolynomial::evals_parallel(&r, None);
+            let end_second = Instant::now();
+            let evals_serial_cached = EqPolynomial::evals_serial_cached(&r, None);
+            let end_third = Instant::now();
+            println!(
+                "len: {}, Time taken to compute evals_serial: {:?}",
+                len,
+                end_first - start
+            );
+            println!(
+                "len: {}, Time taken to compute evals_parallel: {:?}",
+                len,
+                end_second - end_first
+            );
+            println!(
+                "len: {}, Time taken to compute evals_serial_cached: {:?}",
+                len,
+                end_third - end_second
+            );
+            assert_eq!(evals_serial, evals_parallel);
+            assert_eq!(evals_serial, *evals_serial_cached.last().unwrap());
+        }
+    }
+
+    #[test]
+    /// Test that the `i`th vector of `evals_serial_cached` is equivalent to
+    /// `evals(&r[..i])`, for all `i`.
+    fn test_evals_cached() {
+        let mut rng = test_rng();
+        for len in 2..22 {
+            let r = (0..len).map(|_| Fr::random(&mut rng)).collect::<Vec<_>>();
+            let evals_serial_cached = EqPolynomial::evals_serial_cached(&r, None);
+            for i in 0..len {
+                let evals = EqPolynomial::evals(&r[..i]);
+                assert_eq!(evals_serial_cached[i], evals);
+            }
+        }
     }
 }

--- a/jolt-core/src/poly/eq_poly.rs
+++ b/jolt-core/src/poly/eq_poly.rs
@@ -40,8 +40,7 @@ impl<F: JoltField> EqPolynomial<F> {
     /// In other words, computes `{eq(r[i..], x) for all x in {0, 1}^{n - i}}` and for all `i in
     /// 0..r.len()`.
     pub fn evals_cached(r: &[F]) -> Vec<Vec<F>> {
-        // TODO: implement parallel version (it seems more difficult to parallelize all the
-        // intermediate results)
+        // TODO: implement parallel version & determine switchover point
         Self::evals_serial_cached(r, None)
     }
 

--- a/jolt-core/src/poly/spartan_interleaved_poly.rs
+++ b/jolt-core/src/poly/spartan_interleaved_poly.rs
@@ -478,15 +478,15 @@ impl<F: JoltField> SpartanInterleavedPolynomial<F> {
             }
             // Compare the underlying Z vectors directly after ensuring lengths match.
             assert_eq!(
-                az_bound.Z, az_for_test.Z,
+                &az_bound.Z[..az_for_test.len()], &az_for_test.Z[..az_for_test.len()],
                 "Az polynomial data mismatch after binding"
             );
             assert_eq!(
-                bz_bound.Z, bz_for_test.Z,
+                &bz_bound.Z[..bz_for_test.len()], &bz_for_test.Z[..bz_for_test.len()],
                 "Bz polynomial data mismatch after binding"
             );
             assert_eq!(
-                cz_bound.Z, cz_for_test.Z,
+                &cz_bound.Z[..cz_for_test.len()], &cz_for_test.Z[..cz_for_test.len()],
                 "Cz polynomial data mismatch after binding"
             );
         }

--- a/jolt-core/src/poly/spartan_interleaved_poly.rs
+++ b/jolt-core/src/poly/spartan_interleaved_poly.rs
@@ -44,30 +44,14 @@ impl<F: JoltField> SpartanInterleavedPolynomial<F> {
         flattened_polynomials: &[&MultilinearPolynomial<F>], // N variables of (S steps)
         padded_num_constraints: usize,
     ) -> Self {
-        let outer_span = tracing::info_span!("SpartanInterleavedPolynomial::new_body");
-        let _outer_guard = outer_span.enter();
-
-        let var_setup_span = tracing::debug_span!("old_new_variable_setup");
-        let _var_setup_guard = var_setup_span.enter();
-
         let num_steps = flattened_polynomials[0].len();
 
         let num_chunks = rayon::current_num_threads().next_power_of_two() * 16;
         let chunk_size = num_steps.div_ceil(num_chunks);
 
-        drop(_var_setup_guard);
-
-        let main_coeff_compute_span = tracing::info_span!("old_new_main_coefficient_computation");
-        let _main_coeff_compute_guard = main_coeff_compute_span.enter();
-
-        let par_iter_span = tracing::debug_span!("old_new_flat_map_iter_computation");
-        let _par_iter_guard = par_iter_span.enter();
         let unbound_coeffs_shards_iter = (0..num_chunks)
             .into_par_iter()
             .map(|chunk_index| {
-                let chunk_task_span = tracing::debug_span!("old_new_chunk_task", chunk_idx = chunk_index);
-                let _chunk_task_guard = chunk_task_span.enter();
-
                 let mut coeffs = Vec::with_capacity(chunk_size * padded_num_constraints * 3);
                 for step_index in chunk_size * chunk_index..chunk_size * (chunk_index + 1) {
                     // Uniform constraints
@@ -180,15 +164,8 @@ impl<F: JoltField> SpartanInterleavedPolynomial<F> {
 
                 Arc::new(coeffs)
             });
-        drop(_par_iter_guard);
-
-        let collect_span = tracing::info_span!("old_new_collect_unbound_coeffs");
-        let _collect_guard = collect_span.enter();
         let unbound_coeffs_shards: Vec<Arc<Vec<SparseCoefficient<i128>>>> =
             unbound_coeffs_shards_iter.collect();
-        drop(_collect_guard);
-        
-        drop(_main_coeff_compute_guard);
 
         #[cfg(test)]
         {
@@ -201,7 +178,8 @@ impl<F: JoltField> SpartanInterleavedPolynomial<F> {
                         assert!(
                             coeff.index > prev_index,
                             "Indices not monotonically increasing in shard: prev {}, current {}",
-                            prev_index, coeff.index
+                            prev_index,
+                            coeff.index
                         );
                         prev_index = coeff.index;
                     }
@@ -289,7 +267,8 @@ impl<F: JoltField> SpartanInterleavedPolynomial<F> {
 
         // In the first round, we only need to compute the quadratic evaluation at infinity,
         // since the eval at zero is always zero.
-        let quadratic_eval_at_infty = self.unbound_coeffs_shards
+        let quadratic_eval_at_infty = self
+            .unbound_coeffs_shards
             .par_iter()
             .map(|shard_arc| {
                 let shard_coeffs = shard_arc.as_ref();
@@ -356,7 +335,8 @@ impl<F: JoltField> SpartanInterleavedPolynomial<F> {
 
         // Compute the number of non-zero bound coefficients that will be produced
         // per chunk.
-        let output_sizes: Vec<_> = self.unbound_coeffs_shards
+        let output_sizes: Vec<_> = self
+            .unbound_coeffs_shards
             .par_iter()
             .map(|shard_arc| Self::binding_output_length(shard_arc.as_ref()))
             .collect();
@@ -367,7 +347,8 @@ impl<F: JoltField> SpartanInterleavedPolynomial<F> {
         unsafe {
             self.bound_coeffs.set_len(total_output_len);
         }
-        let mut output_slices: Vec<&mut [SparseCoefficient<F>]> = Vec::with_capacity(self.unbound_coeffs_shards.len());
+        let mut output_slices: Vec<&mut [SparseCoefficient<F>]> =
+            Vec::with_capacity(self.unbound_coeffs_shards.len());
         let mut remainder = self.bound_coeffs.as_mut_slice();
         for slice_len in output_sizes {
             let (first, second) = remainder.split_at_mut(slice_len);
@@ -450,7 +431,11 @@ impl<F: JoltField> SpartanInterleavedPolynomial<F> {
                     }
                 }
             }
-            (DensePolynomial::new(az_vec), DensePolynomial::new(bz_vec), DensePolynomial::new(cz_vec))
+            (
+                DensePolynomial::new(az_vec),
+                DensePolynomial::new(bz_vec),
+                DensePolynomial::new(cz_vec),
+            )
         };
 
         // Drop the unbound coeffs shards now that we've bound them
@@ -467,19 +452,43 @@ impl<F: JoltField> SpartanInterleavedPolynomial<F> {
             bz_for_test.bound_poly_var_bot(&r_i);
             cz_for_test.bound_poly_var_bot(&r_i);
 
-            assert_eq!(az_bound.len(), az_for_test.len(), "Mismatch in length of Az polynomials after binding");
-            assert_eq!(bz_bound.len(), bz_for_test.len(), "Mismatch in length of Bz polynomials after binding");
-            assert_eq!(cz_bound.len(), cz_for_test.len(), "Mismatch in length of Cz polynomials after binding");
+            assert_eq!(
+                az_bound.len(),
+                az_for_test.len(),
+                "Mismatch in length of Az polynomials after binding"
+            );
+            assert_eq!(
+                bz_bound.len(),
+                bz_for_test.len(),
+                "Mismatch in length of Bz polynomials after binding"
+            );
+            assert_eq!(
+                cz_bound.len(),
+                cz_for_test.len(),
+                "Mismatch in length of Cz polynomials after binding"
+            );
 
             for i in 0..az_for_test.len() {
                 if az_bound[i] != az_for_test[i] {
-                    println!("az mismatch at index {}: bound = {}, test_bound = {}", i, az_bound[i], az_for_test[i]);
+                    println!(
+                        "az mismatch at index {}: bound = {}, test_bound = {}",
+                        i, az_bound[i], az_for_test[i]
+                    );
                 }
             }
             // Compare the underlying Z vectors directly after ensuring lengths match.
-            assert_eq!(az_bound.Z, az_for_test.Z, "Az polynomial data mismatch after binding");
-            assert_eq!(bz_bound.Z, bz_for_test.Z, "Bz polynomial data mismatch after binding");
-            assert_eq!(cz_bound.Z, cz_for_test.Z, "Cz polynomial data mismatch after binding");
+            assert_eq!(
+                az_bound.Z, az_for_test.Z,
+                "Az polynomial data mismatch after binding"
+            );
+            assert_eq!(
+                bz_bound.Z, bz_for_test.Z,
+                "Bz polynomial data mismatch after binding"
+            );
+            assert_eq!(
+                cz_bound.Z, cz_for_test.Z,
+                "Cz polynomial data mismatch after binding"
+            );
         }
     }
 

--- a/jolt-core/src/poly/spartan_interleaved_poly.rs
+++ b/jolt-core/src/poly/spartan_interleaved_poly.rs
@@ -478,15 +478,18 @@ impl<F: JoltField> SpartanInterleavedPolynomial<F> {
             }
             // Compare the underlying Z vectors directly after ensuring lengths match.
             assert_eq!(
-                &az_bound.Z[..az_for_test.len()], &az_for_test.Z[..az_for_test.len()],
+                &az_bound.Z[..az_for_test.len()],
+                &az_for_test.Z[..az_for_test.len()],
                 "Az polynomial data mismatch after binding"
             );
             assert_eq!(
-                &bz_bound.Z[..bz_for_test.len()], &bz_for_test.Z[..bz_for_test.len()],
+                &bz_bound.Z[..bz_for_test.len()],
+                &bz_for_test.Z[..bz_for_test.len()],
                 "Bz polynomial data mismatch after binding"
             );
             assert_eq!(
-                &cz_bound.Z[..cz_for_test.len()], &cz_for_test.Z[..cz_for_test.len()],
+                &cz_bound.Z[..cz_for_test.len()],
+                &cz_for_test.Z[..cz_for_test.len()],
                 "Cz polynomial data mismatch after binding"
             );
         }

--- a/jolt-core/src/poly/spartan_interleaved_poly.rs
+++ b/jolt-core/src/poly/spartan_interleaved_poly.rs
@@ -1,19 +1,17 @@
 use super::{
-    multilinear_polynomial::MultilinearPolynomial,
-    sparse_interleaved_poly::SparseCoefficient,
-    split_eq_poly::GruenSplitEqPolynomial,
-    unipoly::CompressedUniPoly,
+    multilinear_polynomial::MultilinearPolynomial, sparse_interleaved_poly::SparseCoefficient,
+    split_eq_poly::GruenSplitEqPolynomial, unipoly::CompressedUniPoly,
 };
 #[cfg(test)]
 use crate::poly::dense_mlpoly::DensePolynomial;
 #[cfg(test)]
 use crate::r1cs::inputs::JoltR1CSInputs;
+use crate::subprotocols::sumcheck::process_eq_sumcheck_round;
 use crate::{
     field::{JoltField, OptimizedMul},
     r1cs::builder::{eval_offset_lc, Constraint, OffsetEqConstraint},
     utils::{math::Math, transcript::Transcript},
 };
-use crate::subprotocols::sumcheck::process_eq_sumcheck_round;
 use ark_ff::Zero;
 use rayon::prelude::*;
 
@@ -227,10 +225,7 @@ impl<F: JoltField> SpartanInterleavedPolynomial<F> {
     ///
     /// Note that we implement the extra optimization of only computing the quadratic
     /// evaluation at infinity, since the eval at zero is always zero.
-    #[tracing::instrument(
-        skip_all,
-        name = "SpartanInterleavedPolynomial::first_sumcheck_round"
-    )]
+    #[tracing::instrument(skip_all, name = "SpartanInterleavedPolynomial::first_sumcheck_round")]
     pub fn first_sumcheck_round<ProofTranscript: Transcript>(
         &mut self,
         eq_poly: &mut GruenSplitEqPolynomial<F>,

--- a/jolt-core/src/poly/split_eq_poly.rs
+++ b/jolt-core/src/poly/split_eq_poly.rs
@@ -5,12 +5,148 @@ use super::dense_mlpoly::DensePolynomial;
 use crate::{field::JoltField, poly::eq_poly::EqPolynomial};
 
 #[derive(Debug, Clone, PartialEq)]
+/// A struct holding the equality polynomial evaluations for use in sum-check, when incorporating
+/// both the Gruen and Dao-Thaler optimizations.
+///
+/// For the `i = 0..n`-th round of sum-check, we want the following invariants:
+///
+/// - `current_index = n - i` (where `n = w.len()`)
+/// - `current_scalar = eq(w[(n - i)..],r[..i])`
+/// - `E_out_vec.last().unwrap() = [eq(w[..min(i, n/2)], x) for all x in {0, 1}^{n - min(i, n/2)}]`
+/// - If `i < n/2`, then `E_in_vec.last().unwrap() = [eq(w[n/2..(n/2 + i + 1)], x) for all x in {0,
+///   1}^{n/2 - i - 1}]`; else `E_in_vec` is empty
+///
+/// Note: all current applications of `SplitEqPolynomial` use the `LowToHigh` binding order. This
+/// means that we are iterating over `w` in the reverse order: `w.len()` down to `0`.
+pub struct GruenSplitEqPolynomial<F> {
+    pub(crate) current_index: usize,
+    pub(crate) current_scalar: F,
+    pub(crate) w: Vec<F>,
+    pub(crate) E_in_vec: Vec<Vec<F>>,
+    pub(crate) E_out_vec: Vec<Vec<F>>,
+}
+
+/// Old struct for split equality polynomial, without Gruen's optimization
+/// TODO: remove all usage of this struct with the new one
 pub struct SplitEqPolynomial<F> {
     num_vars: usize,
     pub(crate) E1: Vec<F>,
     pub(crate) E1_len: usize,
     pub(crate) E2: Vec<F>,
     pub(crate) E2_len: usize,
+}
+
+impl<F: JoltField> GruenSplitEqPolynomial<F> {
+    #[tracing::instrument(skip_all, name = "GruenSplitEqPolynomial::new")]
+    pub fn new(w: &[F]) -> Self {
+        let m = w.len() / 2;
+        //   w = [w2, w1, w_last]
+        //        ↑   ↑    ↑
+        //        |   |    |
+        //        |   |    last element
+        //        |   second half of remaining elements (for E1)
+        //        first half of remaining elements (for E2)
+        let (_, wprime) = w.split_last().unwrap();
+        let (w2, w1) = wprime.split_at(m);
+        let (E_out_vec, E_in_vec) = rayon::join(
+            || EqPolynomial::evals_cached(w2),
+            || EqPolynomial::evals_cached(w1),
+        );
+        Self {
+            current_index: w.len(),
+            current_scalar: F::one(),
+            w: w.to_vec(),
+            E_in_vec,
+            E_out_vec,
+        }
+    }
+
+    pub fn get_num_vars(&self) -> usize {
+        self.w.len()
+    }
+
+    pub fn len(&self) -> usize {
+        1 << self.current_index
+    }
+
+    pub fn E_in_current_len(&self) -> usize {
+        self.E_in_vec.last().unwrap().len()
+    }
+
+    pub fn E_out_current_len(&self) -> usize {
+        self.E_out_vec.last().unwrap().len()
+    }
+
+    /// Return the last vector from `E1` as a slice
+    pub fn E_in_current(&self) -> &[F] {
+        self.E_in_vec.last().unwrap()
+    }
+
+    pub fn to_E1_old(&self) -> Vec<F> {
+        if self.current_index > self.w.len() / 2 {
+            let wi = self.w[self.current_index - 1];
+            let E1_old_odd: Vec<F> = self
+                .E_in_vec
+                .last()
+                .unwrap()
+                .iter()
+                .map(|x| *x * (F::one() - wi))
+                .collect();
+            let E1_old_even: Vec<F> = self
+                .E_in_vec
+                .last()
+                .unwrap()
+                .iter()
+                .map(|x| *x * wi)
+                .collect();
+            // Interleave the two vectors
+            let mut E1_old = vec![];
+            for i in 0..E1_old_odd.len() {
+                E1_old.push(E1_old_odd[i]);
+                E1_old.push(E1_old_even[i]);
+            }
+            E1_old
+        } else {
+            // println!("Don't expect to call this");
+            vec![self.current_scalar; 1]
+        }
+    }
+
+    /// Return the last vector from `E2` as a slice
+    pub fn E_out_current(&self) -> &[F] {
+        self.E_out_vec.last().unwrap()
+    }
+
+    #[tracing::instrument(skip_all, name = "GruenSplitEqPolynomial::bind")]
+    pub fn bind(&mut self, r: F) {
+        // multiply `current_scalar` by `eq(w[i], r) = (1 - w[i]) * (1 - r) + w[i] * r`
+        self.current_scalar *= F::one() - self.w[self.current_index - 1] - r
+            + self.w[self.current_index - 1] * r
+            + self.w[self.current_index - 1] * r;
+        // decrement `current_index`
+        self.current_index -= 1;
+        // pop the last vector from `E_in_vec` or `E_out_vec` (since we don't need it anymore)
+        if self.w.len() / 2 < self.current_index {
+            self.E_in_vec.pop();
+        } else if 0 < self.current_index {
+            self.E_out_vec.pop();
+        }
+        // println!(
+        //     "current_index: {}, E1_len: {}, E2_len: {}",
+        //     self.current_index,
+        //     self.E_in_vec.len(),
+        //     self.E_out_vec.len()
+        // );
+    }
+
+    #[cfg(test)]
+    pub fn merge(&self) -> DensePolynomial<F> {
+        let evals = EqPolynomial::evals(&self.w[..self.current_index])
+            .iter()
+            .map(|x| *x * self.current_scalar)
+            .collect();
+        DensePolynomial::new(evals)
+    }
 }
 
 impl<F: JoltField> SplitEqPolynomial<F> {
@@ -93,14 +229,14 @@ mod tests {
 
     #[test]
     fn bind() {
-        const NUM_VARS: usize = 9;
+        const NUM_VARS: usize = 10;
         let mut rng = test_rng();
         let w: Vec<Fr> = std::iter::repeat_with(|| Fr::random(&mut rng))
             .take(NUM_VARS)
             .collect();
 
         let mut regular_eq = DensePolynomial::new(EqPolynomial::evals(&w));
-        let mut split_eq = SplitEqPolynomial::new(&w);
+        let mut split_eq = GruenSplitEqPolynomial::new(&w);
         assert_eq!(regular_eq, split_eq.merge());
 
         for _ in 0..NUM_VARS {
@@ -110,6 +246,65 @@ mod tests {
 
             let merged = split_eq.merge();
             assert_eq!(regular_eq.Z[..regular_eq.len()], merged.Z[..merged.len()]);
+        }
+    }
+
+    #[test]
+    fn equal_old_and_new_split_eq() {
+        const NUM_VARS: usize = 15;
+        let mut rng = test_rng();
+        let w: Vec<Fr> = std::iter::repeat_with(|| Fr::random(&mut rng))
+            .take(NUM_VARS)
+            .collect();
+
+        let mut old_split_eq = SplitEqPolynomial::new(&w);
+        let mut new_split_eq = GruenSplitEqPolynomial::new(&w);
+
+        assert_eq!(old_split_eq.get_num_vars(), new_split_eq.get_num_vars());
+        assert_eq!(old_split_eq.len(), new_split_eq.len());
+        assert_eq!(old_split_eq.E1, *new_split_eq.to_E1_old());
+        assert_eq!(old_split_eq.E2, *new_split_eq.E_out_current());
+        assert_eq!(old_split_eq.merge(), new_split_eq.merge());
+        // Show that they are the same after binding
+        for i in (0..NUM_VARS).rev() {
+            let r = Fr::random(&mut rng);
+            old_split_eq.bind(r);
+            new_split_eq.bind(r);
+            assert_eq!(old_split_eq.merge(), new_split_eq.merge());
+            if NUM_VARS / 2 < i {
+                assert_eq!(old_split_eq.E1_len, new_split_eq.E_in_current_len() * 2);
+                assert_eq!(old_split_eq.E2_len, new_split_eq.E_out_current_len());
+            } else if i > 0 {
+                assert_eq!(old_split_eq.E1_len, new_split_eq.E_in_current_len());
+                assert_eq!(old_split_eq.E2_len, new_split_eq.E_out_current_len() * 2);
+            }
+        }
+    }
+
+    #[test]
+    fn bench_old_and_new_split_eq() {
+        let mut rng = test_rng();
+        for num_vars in 5..30 {
+            let w: Vec<Fr> = std::iter::repeat_with(|| Fr::random(&mut rng))
+                .take(num_vars)
+                .collect();
+            println!("Testing for {} variables", num_vars);
+
+            let start_old_split_eq_time = std::time::Instant::now();
+            let _old_split_eq = SplitEqPolynomial::new(&w);
+            let end_old_split_eq_time = std::time::Instant::now();
+            println!(
+                "Time taken for creating old split eq: {:?}",
+                end_old_split_eq_time.duration_since(start_old_split_eq_time)
+            );
+
+            let start_new_split_eq_time = std::time::Instant::now();
+            let _new_split_eq = GruenSplitEqPolynomial::new(&w);
+            let end_new_split_eq_time = std::time::Instant::now();
+            println!(
+                "Time taken for creating new split eq: {:?}",
+                end_new_split_eq_time.duration_since(start_new_split_eq_time)
+            );
         }
     }
 }

--- a/jolt-core/src/poly/unipoly.rs
+++ b/jolt-core/src/poly/unipoly.rs
@@ -32,6 +32,7 @@ impl<F: JoltField> UniPoly<F> {
         UniPoly { coeffs }
     }
 
+    /// Interpolate a polynomial from its evaluations at the points 0, 1, 2, ..., n-1.
     pub fn from_evals(evals: &[F]) -> Self {
         UniPoly {
             coeffs: Self::vandermonde_interpolation(evals),
@@ -105,10 +106,6 @@ impl<F: JoltField> UniPoly<F> {
 
     pub fn degree(&self) -> usize {
         self.coeffs.len() - 1
-    }
-
-    pub fn len(&self) -> usize {
-        self.coeffs.len()
     }
 
     pub fn as_vec(&self) -> Vec<F> {
@@ -217,6 +214,41 @@ impl<F: JoltField> UniPoly<F> {
 
     pub fn shift_coefficients(&mut self, rhs: &F) {
         self.coeffs.par_iter_mut().for_each(|c| *c += *rhs);
+    }
+
+    /// This function computes a cubic polynomial s(X), given the following conditions:
+    /// - s(X) = l(X) * t(X), where l(X) is linear and t(X) is quadratic,
+    /// - l(X) = a + bX is given by l(0) = a and l(\infty) = b,
+    /// - t(X) = c + dX + eX^2 is given by t(0) = c and t(\infty) = e (but d is missing),
+    /// - s(0) + s(1) = hint,
+    ///
+    /// This is used in the optimized sum-check evaluation with split eq polynomial.
+    pub fn from_linear_times_quadratic_with_hint(
+        linear_coeffs: [F; 2],
+        quadratic_coeff_0: F,
+        quadratic_coeff_2: F,
+        hint: F,
+    ) -> Self {
+        let linear_eval_one = linear_coeffs[0] + linear_coeffs[1];
+
+        let cubic_coeff_0 = linear_coeffs[0] * quadratic_coeff_0;
+
+        // Compute the linear coefficient of the quadratic polynomial from the hint
+        // Given that s(0) + s(1) = hint, we can rewrite this as:
+        // a * c + (a + b) * (c + d + e) = hint, which means we can solve for d as:
+        // d = (hint - a * c) / (a + b) - c - e
+        let quadratic_coeff_1 =
+            (hint - cubic_coeff_0) / linear_eval_one - quadratic_coeff_0 - quadratic_coeff_2;
+
+        // Now derive the coefficients of the cubic polynomial from the evaluations
+        // We have s(X) = (a + bX) * (c + dX + eX^2) = ac + (ad + bc)X + (ae + bd)X^2 + beX^3
+        let coeffs = [
+            cubic_coeff_0,
+            linear_coeffs[0] * quadratic_coeff_1 + linear_coeffs[1] * quadratic_coeff_0,
+            linear_coeffs[0] * quadratic_coeff_2 + linear_coeffs[1] * quadratic_coeff_1,
+            linear_coeffs[1] * quadratic_coeff_2,
+        ];
+        Self::from_coeff(coeffs.to_vec())
     }
 }
 
@@ -440,5 +472,28 @@ mod tests {
                 }
             }
         }
+    }
+
+    #[test]
+    fn test_from_linear_times_quadratic_with_hint() {
+        // polynomial is s(x) = (x + 1) * (x^2 + 2x + 3) = x^3 + 3x^2 + 5x + 3
+        // hint = s(0) + s(1) = 3 + (1 + 3 + 5 + 3) = 15
+        let linear_coeffs = [Fr::from_u64(1u64), Fr::from_u64(1u64)];
+        let quadratic_coeff_0 = Fr::from_u64(3u64);
+        let quadratic_coeff_2 = Fr::from_u64(1u64);
+        let true_poly = UniPoly::from_coeff(vec![
+            Fr::from_u64(3u64),
+            Fr::from_u64(5u64),
+            Fr::from_u64(3u64),
+            Fr::from_u64(1u64),
+        ]);
+        let hint = Fr::from_u64(15u64);
+        let poly = UniPoly::from_linear_times_quadratic_with_hint(
+            linear_coeffs,
+            quadratic_coeff_0,
+            quadratic_coeff_2,
+            hint,
+        );
+        assert_eq!(poly.coeffs, true_poly.coeffs);
     }
 }

--- a/jolt-core/src/r1cs/spartan.rs
+++ b/jolt-core/src/r1cs/spartan.rs
@@ -9,7 +9,7 @@ use crate::poly::multilinear_polynomial::MultilinearPolynomial;
 use crate::poly::multilinear_polynomial::PolynomialEvaluation;
 use crate::poly::opening_proof::ProverOpeningAccumulator;
 use crate::poly::opening_proof::VerifierOpeningAccumulator;
-use crate::poly::split_eq_poly::SplitEqPolynomial;
+use crate::poly::split_eq_poly::GruenSplitEqPolynomial;
 use crate::r1cs::key::UniformSpartanKey;
 use crate::utils::math::Math;
 use crate::utils::thread::drop_in_background_thread;
@@ -130,7 +130,7 @@ where
         let tau = (0..num_rounds_x)
             .map(|_i| transcript.challenge_scalar())
             .collect::<Vec<F>>();
-        let mut eq_tau = SplitEqPolynomial::new(&tau);
+        let mut eq_tau = GruenSplitEqPolynomial::new(&tau);
 
         let mut az_bz_cz_poly = constraint_builder.compute_spartan_Az_Bz_Cz(&flattened_polys);
         let (outer_sumcheck_proof, outer_sumcheck_r, outer_sumcheck_claims) =


### PR DESCRIPTION
This PR implements multiple optimizations for Spartan's first sum-check:

1. We implement Gruen's optimization 
2. We also implement the optimization that in the first sum-check round, there is no need to compute the evaluation at zero, since it is zero due to R1CS relation being satisfied
3. Finally, we change the output type of `unbound_coeffs` to be a vector of chunks of sparse coefficients, instead of a unified vector of coefficients. This eliminates the coalescing at the end of `new()`, and chunking at the beginning of `first_sumcheck_round()`. Instead, we now just pass these parallel chunks from one function directly to the other. In theory, I could also keep the chunks separate for the next few rounds of `subsequent_sumcheck_round()`, but not sure if it's worth it. When we switch to streaming, this would need to be done anyway.

Altogether, we may see up to 2x speedup for Spartan's first sum-check (half coming from 1+2 and half coming from 3). And this is before the additional small value optimization, which I'm still working on.

Re point 1: this is similar to a prior PR I made about Gruen's optimization for dense interleaved poly. The difference is that, in order to integrate the optimization into that, we would need to change the sparse interleave poly + sparse grand product at the same time, which I didn't have time to do.

@jprider63 you may want to take a look. This one is more fleshed out & tested to work.

TODOs: implement Gruen's optimization for the rest of the sub-protocols. Then we can delete the old `SplitEqPolynomial` and replace it fully with what's called `GruenSplitEqPolynomial` here.