### PR TITLE
feat: small value optimization for Spartan

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Jolt uses [tracing_chrome](https://crates.io/crates/tracing-chrome) for performa
 
 To generate a trace, run:
 
-```cargo run --release -p jolt-core trace --name sha3 --format chrome --pcs hyper-kzg```
+```cargo run --release -p jolt-core profile --name sha3 --format chrome --pcs hyper-kzg```
 
 Where `--name` can be `sha2`, `sha3`, `sha2-chain`, or `fibonacci`. The corresponding guest programs can be found in the [`examples`](./examples/) directory. The benchmark inputs are provided in [`bench.rs`](./jolt-core/src/benches/bench.rs).
 

--- a/book/src/future/improvements-since-release.md
+++ b/book/src/future/improvements-since-release.md
@@ -4,13 +4,15 @@ There are many tasks described in the various files in the "roadmap/future" sect
 Let's use this file as the primary means of tracking what is done or in progress. Anything
 not mentioned in this file is presumably not yet started (or barely started). 
 
-## Functionality improvements
+## Functionality / overall improvements
 
 * Support for stdlib
 
-* Support for M-extension.
+* Support for M-extension
 
-* In progress: on-chain verifier (Solidity). 
+* On-chain verifier (Solidity)
+
+* Improved BN254-by-u64 (or i64/u128/i128) multiplication
 
 ## Verifier cost improvements
 
@@ -26,7 +28,7 @@ will reduce proof size by up to 200KB.
 
 * Reduce the number of polynomial evaluation proofs from 7-10 down to 1 (achieved in [this PR](https://github.com/a16z/jolt/pull/453)) 
 
-## Prover cost improvements (all in progress)
+## Prover cost improvements
 
 * Eliminate cost of pre-computed tables of eq evaluations for each sum-check,
 as per [Dao-Thaler](https://eprint.iacr.org/2024/1210).
@@ -34,6 +36,7 @@ as per [Dao-Thaler](https://eprint.iacr.org/2024/1210).
 * (Nearly) [eliminate](https://github.com/a16z/jolt/issues/347) second sum-check instance in Spartan.
 
 * Implement the sum-check prover optimization from Section 3 of Angus Gruen's [paper](https://eprint.iacr.org/2024/108).
+  (ONGOING, done for first sum-check in Spartan)
 
 * Implement the sum-check prover optimizations from [Bagad-Domb-Thaler](https://eprint.iacr.org/2024/1046), which actually apply whenever small values are being summed, even if those values reside in a big (e.g., 256-bit) field. This captures Spartan as applied in Jolt. Thanks to Lev Soukhanov for this observation.
 

--- a/book/src/opts.md
+++ b/book/src/opts.md
@@ -1,1 +1,7 @@
 # Optimizations
+
+## Split-Eq and Gruen's Optimization
+
+## Small-Value Optimization for (First) Sum-Check in Spartan
+
+For these, refer to the upcoming paper by Bagad-Dao-Domb-Thaler.

--- a/book/src/people.md
+++ b/book/src/people.md
@@ -9,3 +9,4 @@
 # Formal verification efforts
   - Carl Kwan
   - Quang Dao
+  - Galois Team

--- a/jolt-core/src/benches/bench.rs
+++ b/jolt-core/src/benches/bench.rs
@@ -294,8 +294,8 @@ where
     let inputs = postcard::to_stdvec(input).unwrap();
 
     let task = move || {
-        let (bytecode, memory_init) = program.decode();
         let (io_device, trace) = program.trace(&inputs);
+        let (bytecode, memory_init) = program.decode();
 
         let preprocessing: crate::jolt::vm::JoltProverPreprocessing<C, F, PCS, ProofTranscript> =
             RV32IJoltVM::prover_preprocess(
@@ -364,8 +364,8 @@ where
     inputs.append(&mut postcard::to_stdvec(&1000u32).unwrap());
 
     let task = move || {
-        let (bytecode, memory_init) = program.decode();
         let (io_device, trace) = program.trace(&inputs);
+        let (bytecode, memory_init) = program.decode();
 
         let preprocessing: crate::jolt::vm::JoltProverPreprocessing<C, F, PCS, ProofTranscript> =
             RV32IJoltVM::prover_preprocess(

--- a/jolt-core/src/field/mod.rs
+++ b/jolt-core/src/field/mod.rs
@@ -125,4 +125,43 @@ where
     }
 }
 
+pub trait OptimizedMulI128<Output>: Sized {
+    fn mul_i128_0_optimized(self, other: i128) -> Output;
+    fn mul_i128_1_optimized(self, other: i128) -> Output;
+    fn mul_i128_01_optimized(self, other: i128) -> Output;
+}
+
+/// Implement `OptimizedMul` for `JoltField` with `i128`
+impl<T> OptimizedMulI128<T> for T
+where
+    T: JoltField,
+{
+    #[inline(always)]
+    fn mul_i128_0_optimized(self, other: i128) -> T {
+        if other.is_zero() {
+            Self::zero()
+        } else {
+            self.mul_i128(other)
+        }
+    }
+
+    #[inline(always)]
+    fn mul_i128_1_optimized(self, other: i128) -> T {
+        if other.is_one() {
+            self
+        } else {
+            self.mul_i128(other)
+        }
+    }
+
+    #[inline(always)]
+    fn mul_i128_01_optimized(self, other: i128) -> T {
+        if other.is_zero() {
+            Self::zero()
+        } else {
+            self.mul_i128_1_optimized(other)
+        }
+    }
+}
+
 pub mod ark;

--- a/jolt-core/src/poly/dense_interleaved_poly.rs
+++ b/jolt-core/src/poly/dense_interleaved_poly.rs
@@ -196,7 +196,7 @@ impl<F: JoltField, ProofTranscript: Transcript> BatchedCubicSumcheck<F, ProofTra
 
     /// We want to compute the evaluations of the following univariate cubic polynomial at
     /// points {0, 1, 2, 3}:
-    ///     Σ eq(r, x) * left(x) * right(x)
+    ///     \sum_{x} eq(r, x) * left(x) * right(x)
     /// where the inner summation is over all but the "least significant bit" of the multilinear
     /// polynomials `eq`, `left`, and `right`. We denote this "least significant" variable x_b.
     ///

--- a/jolt-core/src/poly/dense_interleaved_poly.rs
+++ b/jolt-core/src/poly/dense_interleaved_poly.rs
@@ -16,9 +16,9 @@ use super::{split_eq_poly::SplitEqPolynomial, unipoly::UniPoly};
 ///
 /// A layer is assumed to be arranged in "interleaved" order, i.e. the natural
 /// order in the visual representation of the circuit:
-///      Λ        Λ        Λ        Λ
-///     / \      / \      / \      /  \
-///   L0   R0  L1   R1  L2   R2  L3   R3   <- This is layer would be represented as [L0, R0, L1, R1, L2, R2, L3, R3]
+///      /\        /\        /\        /\
+///     /  \      /  \      /  \      /  \
+///    L0  R0    L1  R1    L2  R2    L3  R3   <- This layer would be represented as [L0, R0, L1, R1, L2, R2, L3, R3]
 ///                                           (as opposed to e.g. [L0, L1, L2, L3, R0, R1, R2, R3])
 #[derive(Default, Debug, Clone)]
 pub struct DenseInterleavedPolynomial<F: JoltField> {

--- a/jolt-core/src/poly/sparse_interleaved_poly.rs
+++ b/jolt-core/src/poly/sparse_interleaved_poly.rs
@@ -428,7 +428,7 @@ impl<F: JoltField, ProofTranscript: Transcript> BatchedCubicSumcheck<F, ProofTra
 
     /// We want to compute the evaluations of the following univariate cubic polynomial at
     /// points {0, 1, 2, 3}:
-    ///     Σ eq(r, x) * left(x) * right(x)
+    ///     \sum_{x} eq(r, x) * left(x) * right(x)
     /// where the inner summation is over all but the "least significant bit" of the multilinear
     /// polynomials `eq`, `left`, and `right`. We denote this "least significant" variable x_b.
     ///
@@ -472,7 +472,7 @@ impl<F: JoltField, ProofTranscript: Transcript> BatchedCubicSumcheck<F, ProofTra
                     (eval_point_0, eval_point_2, eval_point_3)
                 })
                 .collect();
-            // This is what Σ eq(r, x) * left(x) * right(x) would be if
+            // This is what \sum_{x} eq(r, x) * left(x) * right(x) would be if
             // `left` and `right` were both all ones.
             let eq_eval_sums: (F, F, F) = eq_evals
                 .par_iter()
@@ -547,7 +547,7 @@ impl<F: JoltField, ProofTranscript: Transcript> BatchedCubicSumcheck<F, ProofTra
                     (eval_point_0, eval_point_2, eval_point_3)
                 })
                 .collect();
-            // Now compute \sum_x1 ((1 - j) * E1[0, x1] + j * E1[1, x1])
+            // Now compute \sum_{x1} ((1 - j) * E1[0, x1] + j * E1[1, x1])
             let E1_eval_sums: (F, F, F) = E1_evals
                 .par_iter()
                 .fold(
@@ -627,14 +627,14 @@ impl<F: JoltField, ProofTranscript: Transcript> BatchedCubicSumcheck<F, ProofTra
             //
             // As a refresher, the cubic evals we're computing are:
             //
-            // \sum_x2 E2[x2] * (\sum_x1 ((1 - j) * E1[0, x1] + j * E1[1, x1]) * \prod_k ((1 - j) * P_k(0 || x1 || x2) + j * P_k(1 || x1 || x2)))
+            // \sum_{x2} E2[x2] * (\sum_{x1} ((1 - j) * E1[0, x1] + j * E1[1, x1]) * \prod_k ((1 - j) * P_k(0 || x1 || x2) + j * P_k(1 || x1 || x2)))
             let evals_assuming_all_ones = if self.dense_len.is_power_of_two() {
                 // If `dense_len` is a power of 2, there is no 0-padding.
                 //
                 // So we have:
-                // \sum_x2 (E2[x2] * (\sum_x1 ((1 - j) * E1[0, x1] + j * E1[1, x1]) * 1))
-                //   = \sum_x2 (E2[x2] * \sum_x1 E1_evals[x1])
-                //   = (\sum_x2 E2[x2]) * (\sum_x1 E1_evals[x1])
+                // \sum_{x2} (E2[x2] * (\sum_{x1} ((1 - j) * E1[0, x1] + j * E1[1, x1]) * 1))
+                //   = \sum_{x2} (E2[x2] * \sum_{x1} E1_evals[x1])
+                //   = (\sum_{x2} E2[x2]) * (\sum_{x1} E1_evals[x1])
                 //   = 1 * E1_eval_sums
                 E1_eval_sums
             } else {

--- a/jolt-core/src/poly/sparse_interleaved_poly.rs
+++ b/jolt-core/src/poly/sparse_interleaved_poly.rs
@@ -31,17 +31,23 @@ impl<T> From<(usize, T)> for SparseCoefficient<T> {
 ///
 /// A layer is assumed to be arranged in "interleaved" order, i.e. the natural
 /// order in the visual representation of the circuit:
-///      Λ        Λ        Λ        Λ
-///     / \      / \      / \      /  \
-///   L0   R0  L1   R1  L2   R2  L3   R3   <- This is layer would be represented as [L0, R0, L1, R1, L2, R2, L3, R3]
+///      /\        /\        /\        /\
+///     /  \      /  \      /  \      /  \
+///    L0  R0    L1  R1    L2  R2    L3  R3   <- This layer would be represented as [L0, R0, L1, R1, L2, R2, L3, R3]
 ///                                           (as opposed to e.g. [L0, L1, L2, L3, R0, R1, R2, R3])
+///
+/// The "interleaved" order is the natural order in the visual representation of the circuit,
+/// where the left and right polynomials are interleaved.
+///
+/// The "interleaved" order is the natural order in the visual representation of the circuit,
+/// where the left and right polynomials are interleaved.
 ///
 /// Where SparseInterleavedPolynomial differs from DenseInterleavedPolynomial
 /// is that many of the coefficients are expected to be 1s, so the circuit may
 /// look something like this:
-///      Λ        Λ        Λ        Λ
-///     / \      / \      / \      /  \
-///    1   R0   1   1   L2   1    1    1
+///      /\        /\        /\        /\
+///     /  \      /  \      /  \      /  \
+///    1   R0    1   1     L2   1    1    1
 ///
 /// Instead of materializing all the 1s, we use a sparse vector to represent the layer,
 /// where each element of the vector contains the index and value of a non-one coefficient.
@@ -197,10 +203,10 @@ impl<F: JoltField> SparseInterleavedPolynomial<F> {
     }
 
     /// Computes the grand product layer output by this one.
-    ///     L0'      R0'      L1'      R1'     <- Output layer
-    ///      Λ        Λ        Λ        Λ
-    ///     / \      / \      / \      /  \
-    ///   L0   R0  L1   R1  L2   R2  L3   R3   <- This layer
+    ///      L0'       R0'       L1'       R1'     <- Output layer
+    ///      /\        /\        /\        /\
+    ///     /  \      /  \      /  \      /  \
+    ///    L0  R0    L1  R1    L2  R2    L3  R3   <- This layer
     #[tracing::instrument(skip_all, name = "SparseInterleavedPolynomial::layer_output")]
     pub fn layer_output(&self) -> Self {
         if let Some(coalesced) = &self.coalesced {

--- a/jolt-core/src/poly/spartan_interleaved_poly.rs
+++ b/jolt-core/src/poly/spartan_interleaved_poly.rs
@@ -517,8 +517,8 @@ impl<const NUM_SVO_ROUNDS: usize, F: JoltField> SpartanInterleavedPolynomial<NUM
                 // Quick math: the shard data has Az + Bz unbound coeffs. Worst case is that each such coeff
                 // is in its own `Y_SVO_SPACE_SIZE`-sized block, thus giving a 1-1 correspondence between
                 // unbound and bound coeffs for Az and Bz. We also need to acount for Cz.
-                // So the most conservative estimate is `3 * shard_data.len() / 2`, but in practice we see far fewer bound coeffs.
-                let estimated_num_bound_coeffs = shard_data.len() / 2;
+                // So the most conservative estimate is `3 * shard_data.len() / 2`, but in practice we see fewer bound coeffs.
+                let estimated_num_bound_coeffs = shard_data.len();
                 let mut task_bound_coeffs = Vec::with_capacity(estimated_num_bound_coeffs);
                 let mut task_sum_contrib_0 = F::zero();
                 let mut task_sum_contrib_infty = F::zero();

--- a/jolt-core/src/poly/spartan_interleaved_poly.rs
+++ b/jolt-core/src/poly/spartan_interleaved_poly.rs
@@ -516,7 +516,7 @@ impl<const NUM_SVO_ROUNDS: usize, F: JoltField> SpartanInterleavedPolynomial<NUM
                 // TODO: have a precise estimate. This is a (somewhat conservative) guess based on real workload (i.e. SHA-2 chain)
                 // Quick math: the shard data has Az + Bz unbound coeffs. Worst case is that each such coeff
                 // is in its own `Y_SVO_SPACE_SIZE`-sized block, thus giving a 1-1 correspondence between
-                // unbound and bound coeffs for Az and Bz. We also need to acount for Cz.
+                // unbound and bound coeffs for Az and Bz. We also need to account for the same number of Cz coeffs.
                 // So the most conservative estimate is `3 * shard_data.len() / 2`, but in practice we see fewer bound coeffs.
                 let estimated_num_bound_coeffs = shard_data.len();
                 let mut task_bound_coeffs = Vec::with_capacity(estimated_num_bound_coeffs);

--- a/jolt-core/src/poly/spartan_interleaved_poly.rs
+++ b/jolt-core/src/poly/spartan_interleaved_poly.rs
@@ -1,510 +1,922 @@
 use super::{
-    multilinear_polynomial::MultilinearPolynomial, sparse_interleaved_poly::SparseCoefficient,
-    split_eq_poly::GruenSplitEqPolynomial, unipoly::CompressedUniPoly,
+    eq_poly::EqPolynomial,
+    multilinear_polynomial::MultilinearPolynomial,
+    sparse_interleaved_poly::SparseCoefficient,
+    split_eq_poly::GruenSplitEqPolynomial,
+    unipoly::CompressedUniPoly,
 };
-#[cfg(test)]
-use crate::poly::dense_mlpoly::DensePolynomial;
-#[cfg(test)]
-use crate::r1cs::inputs::JoltR1CSInputs;
 use crate::subprotocols::sumcheck::process_eq_sumcheck_round;
 use crate::{
-    field::{JoltField, OptimizedMul},
+    field::{JoltField, OptimizedMul, OptimizedMulI128},
     r1cs::builder::{eval_offset_lc, Constraint, OffsetEqConstraint},
-    utils::{math::Math, transcript::Transcript},
+    utils::{
+        math::Math,
+        small_value::{NUM_SVO_ROUNDS, svo_helpers},
+        transcript::Transcript,
+    },
 };
 use ark_ff::Zero;
 use rayon::prelude::*;
 
-#[derive(Default, Debug, Clone)]
-pub struct SpartanInterleavedPolynomial<F: JoltField> {
-    /// Shards of sparse vectors representing the (interleaved) coefficients in the Az, Bz, Cz
-    /// polynomials used in the first Spartan sumcheck. Before the polynomial is bound
-    /// the first time, all the coefficients can be represented by `i128`s.
-    pub(crate) unbound_coeffs_shards: Vec<Vec<SparseCoefficient<i128>>>,
-    /// A sparse vector representing the (interleaved) coefficients in the Az, Bz, Cz
-    /// polynomials used in the first Spartan sumcheck. Once the polynomial has been
-    /// bound, we switch to using `bound_coeffs` instead of `unbound_coeffs`, because
-    /// coefficients will be full-width field elements rather than `i128`s.
+pub const TOTAL_NUM_ACCUMS: usize = svo_helpers::total_num_accums(NUM_SVO_ROUNDS);
+pub const NUM_NONTRIVIAL_TERNARY_POINTS: usize = svo_helpers::num_non_trivial_ternary_points(NUM_SVO_ROUNDS);
+pub const NUM_ACCUMS_EVAL_ZERO: usize = svo_helpers::num_accums_eval_zero(NUM_SVO_ROUNDS);
+pub const NUM_ACCUMS_EVAL_INFTY: usize = svo_helpers::num_accums_eval_infty(NUM_SVO_ROUNDS);
+
+pub const Y_SVO_SPACE_SIZE: usize = 1 << NUM_SVO_ROUNDS;
+pub const Y_SVO_RELATED_COEFF_BLOCK_SIZE: usize = 4 * Y_SVO_SPACE_SIZE; // Az/Bz * Xk=0/1 * Y_SVO_SPACE_SIZE
+
+// Modifications for streaming version:
+// 1. Do not have the `unbound_coeffs` in the struct
+// 2. Do streaming rounds until we get to a small enough cached size that we can store `bound_coeffs`
+
+#[derive(Clone, Debug)]
+pub struct SpartanInterleavedPolynomial<const NUM_SVO_ROUNDS: usize, F: JoltField> {
+    /// A list of sparse vectors representing the (interleaved) coefficients for the Az, Bz polynomials
+    /// Generated from binary evaluations. Each inner Vec is sorted by index.
+    ///
+    /// (note: **no** Cz coefficients are stored here, since they are not needed for small value
+    /// precomputation, and can be computed on the fly in streaming round)
+    pub(crate) ab_unbound_coeffs_shards: Vec<Vec<SparseCoefficient<i128>>>,
+
     pub(crate) bound_coeffs: Vec<SparseCoefficient<F>>,
-    /// A reused buffer where bound values are written to during `bind`.
-    /// With every bind, `coeffs` and `binding_scratch_space` are swapped.
+
     binding_scratch_space: Vec<SparseCoefficient<F>>,
-    /// The length of one of the Az, Bz, or Cz polynomials if it were represented by
-    /// a single dense vector.
-    dense_len: usize,
+
+    pub(crate) dense_len: usize,
 }
 
-impl<F: JoltField> SpartanInterleavedPolynomial<F> {
-    /// Computes the matrix-vector products Az, Bz, and Cz as a single interleaved sparse vector
-    #[tracing::instrument(skip_all, name = "SpartanInterleavedPolynomial::new")]
-    pub fn new(
+impl<const NUM_SVO_ROUNDS: usize, F: JoltField> SpartanInterleavedPolynomial<NUM_SVO_ROUNDS, F> {
+    /// Compute the unbound coefficients for the Az and Bz polynomials (no Cz coefficients are
+    /// needed), along with the accumulators for the small value optimization (SVO) rounds.
+    ///
+    /// Recall that the accumulators are of the form: accum_i[v_0, ..., v_{i-1}, u] = \sum_{y_rest}
+    /// \sum_{x_out} E_out(x_out || y_rest) * \sum_{x_in} E_in(x_in) * P(x_out, x_in, y_rest, u,
+    /// v_0, ..., v_{i-1}),
+    ///
+    /// for all i < NUM_SVO_ROUNDS, v_0,..., v_{i-1} \in {0,1,∞}, u \in {0,∞}, and P(X) = Az(X) *
+    /// Bz(X) - Cz(X).
+    ///
+    /// Note that we have reverse the order of variables from the paper, since in this codebase the
+    /// indexing is MSB to LSB (as we go from 0 to N-1, i.e. left to right).
+    ///
+    /// Note that only the accumulators with at least one infinity among v_j and u are non-zero, so
+    /// the fully binary ones do not need to be computed. Plus, the ones with at least one infinity
+    /// will NOT have any Cz contributions.
+    ///
+    /// This is why we do not need to compute the Cz terms in the unbound coefficients.
+    ///
+    /// The output of the accumulators is ([F; NUM_ACCUMS_EVAL_ZERO]; [F; NUM_ACCUMS_EVAL_INFTY]),
+    /// where the outer array is for evals at u = 0 and u = ∞. The inner array contains all non-zero
+    /// accumulators across all rounds, concatenated in order.
+    ///
+    /// For 1 round of small value optimization, this is:
+    /// - Eval at zero: empty
+    /// - Eval at infty: acc_1(infty)
+    ///
+    /// For 2 rounds of small value optimization, this is same as 1 round, with addition of:
+    /// (recall: we do MSB => LSB, so 0/infty refers to the leftmost variable)
+    /// - Eval at zero: acc_2(0, infty)
+    /// - Eval at infty: acc_2(infty,0), acc_2(infty,1), acc_2(infty, infty)
+    ///
+    /// Total = 5 accumulators
+    ///
+    /// For 3 rounds of small value optimization, this is same as 2 rounds, with addition of:
+    /// - Eval at zero: acc_3(0, 0, infty), acc_3(0, 1, infty),
+    ///   acc_3(0, infty, 0), acc_3(0, infty, 1), acc_3(0, infty, infty)
+    /// - Eval at infty: acc_3(infty, v_1, v_2), where v_1, v_2 \in {0, 1, infty}
+    ///
+    /// Total = 19 accumulators
+    #[tracing::instrument(
+        skip_all,
+        name = "NewSpartanInterleavedPolynomial::new_with_precompute"
+    )]
+    pub fn new_with_precompute(
+        padded_num_constraints: usize,
         uniform_constraints: &[Constraint],
         cross_step_constraints: &[OffsetEqConstraint],
-        flattened_polynomials: &[&MultilinearPolynomial<F>], // N variables of (S steps)
-        padded_num_constraints: usize,
-    ) -> Self {
+        flattened_polynomials: &[&MultilinearPolynomial<F>],
+        tau: &[F], // Challenges for ALL N_total R1CS variables
+    ) -> ([F; NUM_ACCUMS_EVAL_ZERO], [F; NUM_ACCUMS_EVAL_INFTY], Self) {
+        let func_span = tracing::info_span!("new_with_precompute_body");
+        let _func_guard = func_span.enter();
+
+        let var_setup_span = tracing::debug_span!("variable_setup_and_assertions");
+        let _var_setup_guard = var_setup_span.enter();
+
+        // The variable layout looks as follows:
+        // 0 ... (N/2 - l) ... (n_s) ... (N - l) ... (N - i - 1) ... (N - 1)
+        // where n_s = num_step_vars, n_c = num_constraint_vars, N = n_s + n_c, l = NUM_SVO_ROUNDS
+        // and i is an iterator over 0..l (for the SVO rounds)
+
+        // Within this layout, we have the partition:
+        // - 0 ... (N/2 - l) is x_out
+        // - (N/2 - l) ... (n_s) is x_in_step
+        // - (n_s) ... (N - l) is x_in_constraint (i.e. non_svo_constraint)
+        // - (N/2 - l) ... (N - l) in total is x_in
+        // - (N - l) ... (N - i - 1) is y_suffix_svo
+        // - (N - i - 1) ... (N - 1) is u || v_config
+
+        // --- Variable Definitions ---
         let num_steps = flattened_polynomials[0].len();
+        let num_step_vars = if num_steps > 0 { num_steps.log_2() } else { 0 };
+        let num_constraint_vars = if padded_num_constraints > 0 {
+            padded_num_constraints.log_2()
+        } else {
+            0
+        };
+        let total_num_vars = num_step_vars + num_constraint_vars;
 
-        let num_chunks = rayon::current_num_threads().next_power_of_two() * 16;
-        let chunk_size = num_steps.div_ceil(num_chunks);
+        assert_eq!(
+            tau.len(),
+            total_num_vars,
+            "tau length ({}) mismatch with R1CS variable count (step_vars {} + constraint_vars {})",
+            tau.len(),
+            num_step_vars,
+            num_constraint_vars
+        );
+        assert!(
+            NUM_SVO_ROUNDS <= num_constraint_vars,
+            "NUM_SVO_ROUNDS ({}) cannot exceed total constraint variables ({})",
+            NUM_SVO_ROUNDS,
+            num_constraint_vars
+        );
 
-        let unbound_coeffs_shards_iter = (0..num_chunks)
+        // Number of constraint variables that are NOT part of the SVO prefix Y.
+        let num_non_svo_constraint_vars = num_constraint_vars.saturating_sub(NUM_SVO_ROUNDS);
+        let num_non_svo_z_vars = num_step_vars + num_non_svo_constraint_vars;
+        assert_eq!(
+            num_non_svo_z_vars,
+            total_num_vars - NUM_SVO_ROUNDS,
+            "num_non_svo_z_vars ({}) + NUM_SVO_ROUNDS ({}) must be == total_num_vars ({})",
+            num_non_svo_z_vars,
+            NUM_SVO_ROUNDS,
+            total_num_vars
+        );
+
+        // --- Define Iteration Spaces for Non-SVO Z variables (x_out_val, x_in_val) ---
+        let potential_x_out_vars = total_num_vars / 2 - NUM_SVO_ROUNDS;
+        let iter_num_x_out_vars = std::cmp::min(potential_x_out_vars, num_step_vars);
+
+        let iter_num_x_in_vars = num_non_svo_z_vars - iter_num_x_out_vars;
+
+        let iter_num_x_in_step_vars = num_step_vars - iter_num_x_out_vars;
+        let iter_num_x_in_constraint_vars = num_non_svo_constraint_vars;
+        assert_eq!(
+            iter_num_x_in_vars,
+            iter_num_x_in_step_vars + iter_num_x_in_constraint_vars
+        );
+        assert_eq!(num_non_svo_z_vars, iter_num_x_out_vars + iter_num_x_in_vars);
+
+        // Assertions about the layout of uniform + offset constraints
+        let num_uniform_r1cs_constraints = uniform_constraints.len();
+        let rem_num_uniform_r1cs_constraints = num_uniform_r1cs_constraints % Y_SVO_SPACE_SIZE;
+        let num_cross_step_constraints = cross_step_constraints.len();
+        assert!(rem_num_uniform_r1cs_constraints + num_cross_step_constraints < Y_SVO_SPACE_SIZE,
+            "The last block of {} uniform constraints + {} cross step constraints must fit in a single block of size {}",
+            rem_num_uniform_r1cs_constraints,
+            num_cross_step_constraints,
+            Y_SVO_SPACE_SIZE
+        );
+
+        drop(_var_setup_guard);
+
+        let eq_setup_span = tracing::debug_span!("eq_poly_setup");
+        let _eq_setup_guard = eq_setup_span.enter();
+
+        // --- Setup: E_in and E_out tables ---
+        // Call GruenSplitEqPolynomial::new_for_small_value with the determined variable splits.
+        let eq_poly = GruenSplitEqPolynomial::new_for_small_value(
+            tau,
+            iter_num_x_out_vars,
+            iter_num_x_in_vars,
+            NUM_SVO_ROUNDS,
+        );
+        let E_in_evals = eq_poly.E_in_current();
+        let E_out_vec = &eq_poly.E_out_vec;
+
+        assert_eq!(E_out_vec.len(), NUM_SVO_ROUNDS);
+
+        let num_x_out_vals = 1usize << iter_num_x_out_vars;
+        let num_x_in_step_vals = 1usize << iter_num_x_in_step_vars;
+        let _num_x_in_non_svo_constraint_vals: usize = 1usize << iter_num_x_in_constraint_vars;
+
+        assert_eq!(
+            (1usize << iter_num_x_in_vars),
+            E_in_evals.len(),
+            "num_x_in_vals ({}) != E_in_evals.len ({})",
+            (1usize << iter_num_x_in_vars),
+            E_in_evals.len()
+        );
+
+        drop(_eq_setup_guard);
+
+        let main_fold_span = tracing::info_span!("parallel_fold_reduce_x_out");
+        let _main_fold_guard = main_fold_span.enter();
+
+        // Define the structure returned by each parallel map task
+        struct PrecomputeTaskOutput<F: JoltField> {
+            ab_coeffs_local: Vec<SparseCoefficient<i128>>,
+            svo_accums_zero_local: [F; NUM_ACCUMS_EVAL_ZERO],
+            svo_accums_infty_local: [F; NUM_ACCUMS_EVAL_INFTY],
+            // coeff_computation_time_local: std::time::Duration, // Commented out
+            // ta_update_time_local: std::time::Duration, // Commented out
+        }
+
+        let num_parallel_chunks = if num_x_out_vals > 0 {
+            std::cmp::min(
+                num_x_out_vals,
+                // Setting number of chunks for more even work distribution
+                rayon::current_num_threads().next_power_of_two() * 8,
+            )
+        } else {
+            1 // Avoid 0 chunks if num_x_out_vals is 0
+        };
+        assert!(
+            num_parallel_chunks > 0 || num_x_out_vals == 0,
+            "num_parallel_chunks must be positive if there are x_out_vals to process"
+        );
+
+        let x_out_chunk_size = if num_x_out_vals > 0 {
+            num_x_out_vals.div_ceil(num_parallel_chunks)
+        } else {
+            0 // No work per chunk if no x_out_vals
+        };
+
+        let collected_chunk_outputs: Vec<PrecomputeTaskOutput<F>> = (0..num_parallel_chunks)
             .into_par_iter()
-            .map(|chunk_index| {
-                let mut coeffs = Vec::with_capacity(chunk_size * padded_num_constraints * 3);
-                for step_index in chunk_size * chunk_index..chunk_size * (chunk_index + 1) {
-                    // Uniform constraints
-                    for (constraint_index, constraint) in uniform_constraints.iter().enumerate() {
-                        let global_index =
-                            3 * (step_index * padded_num_constraints + constraint_index);
+            .map(|chunk_idx| {
+                let x_out_task_span = tracing::debug_span!("chunk_task", chunk_idx);
+                let _x_out_task_guard = x_out_task_span.enter();
 
-                        // Az
-                        let mut az_coeff = 0;
-                        if !constraint.a.terms().is_empty() {
-                            az_coeff = constraint
-                                .a
-                                .evaluate_row(flattened_polynomials, step_index);
-                            if !az_coeff.is_zero() {
-                                coeffs.push((global_index, az_coeff).into());
-                            }
-                        }
-                        // Bz
-                        let mut bz_coeff = 0;
-                        if !constraint.b.terms().is_empty() {
-                            bz_coeff = constraint
-                                .b
-                                .evaluate_row(flattened_polynomials, step_index);
-                            if !bz_coeff.is_zero() {
-                                coeffs.push((global_index + 1, bz_coeff).into());
-                            }
-                        }
-                        // Cz = Az ⊙ Cz
-                        if !az_coeff.is_zero() && !bz_coeff.is_zero() {
-                            let cz_coeff = az_coeff * bz_coeff;
-                            #[cfg(test)]
-                            {
-                                if cz_coeff != constraint
-                                    .c
-                                    .evaluate_row(flattened_polynomials, step_index) {
-                                        let mut constraint_string = String::new();
-                                        let _ = constraint
-                                            .pretty_fmt::<4, JoltR1CSInputs, F>(
-                                                &mut constraint_string,
-                                                flattened_polynomials,
-                                                step_index,
-                                            );
-                                        println!("{constraint_string}");
-                                        panic!(
-                                            "Uniform constraint {constraint_index} violated at step {step_index}",
-                                        );
+                let mut chunk_ab_coeffs = Vec::new();
+                let mut chunk_svo_accums_zero = [F::zero(); NUM_ACCUMS_EVAL_ZERO];
+                let mut chunk_svo_accums_infty = [F::zero(); NUM_ACCUMS_EVAL_INFTY];
+                // let mut chunk_coeff_time = std::time::Duration::new(0, 0); // Commented out
+                // let mut chunk_ta_time = std::time::Duration::new(0, 0); // Commented out
+
+                let x_out_start = chunk_idx * x_out_chunk_size;
+                let x_out_end = std::cmp::min((chunk_idx + 1) * x_out_chunk_size, num_x_out_vals);
+
+                // Iterate over x_out_vals in this chunk
+                for x_out_val in x_out_start..x_out_end {
+                    // Accumulator for SUM_{x_in} E_in * P_ext for this specific x_out_val.
+                    let mut tA_sum_for_current_x_out = [F::zero(); NUM_NONTRIVIAL_TERNARY_POINTS];
+                    let mut current_x_out_svo_zero = [F::zero(); NUM_ACCUMS_EVAL_ZERO];
+                    let mut current_x_out_svo_infty = [F::zero(); NUM_ACCUMS_EVAL_INFTY];
+
+                    // Iterate over x_in_step_vals in this chunk
+                    for x_in_step_val in 0..num_x_in_step_vals {
+                        let current_step_idx = (x_out_val << iter_num_x_in_step_vars) | x_in_step_val;
+
+                        let mut current_x_in_constraint_val = 0;
+
+                        let mut binary_az_block = [0i128; Y_SVO_SPACE_SIZE];
+                        let mut binary_bz_block = [0i128; Y_SVO_SPACE_SIZE];
+
+                        // Phase 1: Process Uniform Constraints
+                        for (uniform_chunk_iter_idx, uniform_svo_chunk) in uniform_constraints.chunks(Y_SVO_SPACE_SIZE).enumerate() {
+                            // let coeff_start_time = std::time::Instant::now(); // Commented out
+                            for (idx_in_svo_block, constraint) in uniform_svo_chunk.iter().enumerate() {
+                                let original_uniform_idx_in_step = (uniform_chunk_iter_idx << NUM_SVO_ROUNDS) + idx_in_svo_block;
+
+                                let global_r1cs_idx = 2 * (current_step_idx * padded_num_constraints + original_uniform_idx_in_step);
+
+                                if !constraint.a.terms().is_empty() {
+                                    let az = constraint
+                                        .a
+                                        .evaluate_row(flattened_polynomials, current_step_idx);
+                                    if !az.is_zero() {
+                                        binary_az_block[idx_in_svo_block] = az;
+                                        chunk_ab_coeffs.push((global_r1cs_idx, az).into());
                                     }
+                                }
+
+                                if !constraint.b.terms().is_empty() {
+                                    let bz = constraint
+                                        .b
+                                        .evaluate_row(flattened_polynomials, current_step_idx);
+                                    if !bz.is_zero() {
+                                        binary_bz_block[idx_in_svo_block] = bz;
+                                        chunk_ab_coeffs.push((global_r1cs_idx + 1, bz).into());
+                                    }
+                                }
                             }
-                            coeffs.push((global_index + 2, cz_coeff).into());
+                            // chunk_coeff_time += coeff_start_time.elapsed(); // Commented out
+
+                            // If this is a full block, compute and update tA, then reset Az, Bz blocks
+                            // (the last block may not be full, in which case we need to delay
+                            // computation of tA until the offset constraints are processed)
+                            if uniform_svo_chunk.len() == Y_SVO_SPACE_SIZE {
+                                let x_in_val = (x_in_step_val << iter_num_x_in_constraint_vars) | current_x_in_constraint_val;
+                                let E_in_val = &E_in_evals[x_in_val];
+
+                                // let ta_start_time = std::time::Instant::now(); // Commented out
+                                svo_helpers::compute_and_update_tA_inplace_generic::<NUM_SVO_ROUNDS, F>(
+                                    &binary_az_block,
+                                    &binary_bz_block,
+                                    E_in_val,
+                                    &mut tA_sum_for_current_x_out,
+                                );
+                                // chunk_ta_time += ta_start_time.elapsed(); // Commented out
+
+                                current_x_in_constraint_val += 1;
+                                binary_az_block = [0i128; Y_SVO_SPACE_SIZE];
+                                binary_bz_block = [0i128; Y_SVO_SPACE_SIZE];
+                            }
                         }
-                    }
 
-                    // For the final step we will not compute the offset terms, and will assume the condition to be set to 0
-                    let next_step_index = if step_index + 1 < num_steps {
-                        Some(step_index + 1)
-                    } else {
-                        None
-                    };
+                        // Phase 2: Process Offset Constraints
+                        // (only 2 of them, in the same block as the last uniform constraints)
+                        // let coeff_start_time_phase2 = std::time::Instant::now(); // Commented out
 
-                    // Cross-step constraints
-                    for (constraint_index, constraint) in cross_step_constraints.iter().enumerate()
-                    {
-                        let global_index = 3
-                            * (step_index * padded_num_constraints
-                                + uniform_constraints.len()
-                                + constraint_index);
+                        for (idx, constraint) in cross_step_constraints.iter().enumerate() {
 
-                        // Az
-                        let eq_a_eval = eval_offset_lc(
-                            &constraint.a,
-                            flattened_polynomials,
-                            step_index,
-                            next_step_index,
-                        );
-                        let eq_b_eval = eval_offset_lc(
-                            &constraint.b,
-                            flattened_polynomials,
-                            step_index,
-                            next_step_index,
-                        );
-                        let az_coeff = eq_a_eval - eq_b_eval;
-                        if !az_coeff.is_zero() {
-                            coeffs.push((global_index, az_coeff).into());
-                            // If Az != 0, then the condition must be false (i.e. Bz = 0)
-                            #[cfg(test)]
-                            {
-                                let bz_coeff = eval_offset_lc(
+                            let actual_r1cs_constraint_idx = num_uniform_r1cs_constraints + idx;
+                            // Note: the indices 0...rem_num_uniform_r1cs_constraints are already processed in the uniform constraints loop
+                            let block_idx = rem_num_uniform_r1cs_constraints + idx;
+                            let global_r1cs_idx = 2 * (current_step_idx * padded_num_constraints + actual_r1cs_constraint_idx);
+                            let next_step_index_opt = if current_step_idx + 1 < num_steps { Some(current_step_idx + 1) } else { None };
+
+                            let eq_a_eval = eval_offset_lc(
+                                &constraint.a,
+                                flattened_polynomials,
+                                current_step_idx,
+                                next_step_index_opt,
+                            );
+                            let eq_b_eval = eval_offset_lc(
+                                &constraint.b,
+                                flattened_polynomials,
+                                current_step_idx,
+                                next_step_index_opt,
+                            );
+                            let az = eq_a_eval - eq_b_eval;
+                            if !az.is_zero() {
+                                binary_az_block[block_idx] = az;
+                                chunk_ab_coeffs.push((global_r1cs_idx, az).into());
+                            } else {
+                                let bz = eval_offset_lc(
                                     &constraint.cond,
                                     flattened_polynomials,
-                                    step_index,
-                                    next_step_index,
+                                    current_step_idx,
+                                    next_step_index_opt,
                                 );
-                                assert_eq!(bz_coeff, 0, "Cross-step constraint {constraint_index} violated at step {step_index}");
-                            }
-                        } else {
-                            // Bz
-                            let bz_coeff = eval_offset_lc(
-                                &constraint.cond,
-                                flattened_polynomials,
-                                step_index,
-                                next_step_index,
-                            );
-                            if !bz_coeff.is_zero() {
-                                coeffs.push((global_index + 1, bz_coeff).into());
+                                if !bz.is_zero() {
+                                    binary_bz_block[block_idx] = bz;
+                                    chunk_ab_coeffs.push((global_r1cs_idx + 1, bz).into());
+                                }
                             }
                         }
-                        // Cz is always 0 for cross-step constraints
+                        // chunk_coeff_time += coeff_start_time_phase2.elapsed(); // Commented out
+
+                        let x_in_val_phase2 = (x_in_step_val << iter_num_x_in_constraint_vars) | current_x_in_constraint_val;
+                        let E_in_val_phase2 = &E_in_evals[x_in_val_phase2];
+
+                        // No coeff computation time for padding as blocks are already zero
+                        // let ta_start_time = std::time::Instant::now(); // Commented out
+                        svo_helpers::compute_and_update_tA_inplace_generic::<NUM_SVO_ROUNDS, F>(
+                            &binary_az_block,
+                            &binary_bz_block,
+                            E_in_val_phase2, // Use E_in_val specific to this phase/block
+                            &mut tA_sum_for_current_x_out,
+                        );
+                        // chunk_ta_time += ta_start_time.elapsed(); // Commented out
+                    } // End x_in_step_val loop
+
+                    // Distribute the accumulated tA values to the SVO accumulators
+                    svo_helpers::distribute_tA_to_svo_accumulators_generic::<NUM_SVO_ROUNDS, F>(
+                        &tA_sum_for_current_x_out,
+                        x_out_val,
+                        E_out_vec,
+                        &mut current_x_out_svo_zero,
+                        &mut current_x_out_svo_infty,
+                    );
+
+                    // Accumulate SVO contributions for this x_out_val into chunk accumulators
+                    for i in 0..NUM_ACCUMS_EVAL_ZERO {
+                        chunk_svo_accums_zero[i] += current_x_out_svo_zero[i];
                     }
+                    for i in 0..NUM_ACCUMS_EVAL_INFTY {
+                        chunk_svo_accums_infty[i] += current_x_out_svo_infty[i];
+                    }
+
+                } // End loop over x_out_val in chunk
+
+                drop(_x_out_task_guard);
+                PrecomputeTaskOutput {
+                    ab_coeffs_local: chunk_ab_coeffs,
+                    svo_accums_zero_local: chunk_svo_accums_zero,
+                    svo_accums_infty_local: chunk_svo_accums_infty,
+                    // coeff_computation_time_local: chunk_coeff_time, // Commented out
+                    // ta_update_time_local: chunk_ta_time, // Commented out
                 }
+            }) // End .map() over chunks
+            .collect(); // Collect all chunk outputs
 
-                coeffs
-            });
-        let unbound_coeffs_shards: Vec<Vec<SparseCoefficient<i128>>> =
-            unbound_coeffs_shards_iter.collect();
+        drop(_main_fold_guard);
 
+        // --- Finalization ---
+        let finalization_span = tracing::info_span!("finalization");
+        let _finalization_guard = finalization_span.enter();
+
+        let mut final_svo_accums_zero = [F::zero(); NUM_ACCUMS_EVAL_ZERO];
+        let mut final_svo_accums_infty = [F::zero(); NUM_ACCUMS_EVAL_INFTY];
+        let mut final_ab_unbound_coeffs_shards: Vec<Vec<SparseCoefficient<i128>>> =
+            Vec::with_capacity(collected_chunk_outputs.len());
+        // let mut total_coeff_computation_time = std::time::Duration::new(0, 0); // Commented out
+        // let mut total_ta_update_time = std::time::Duration::new(0, 0); // Commented out
+
+        let aggregation_loop_span =
+            tracing::debug_span!("finalization_aggregate_chunk_outputs_loop");
+        let _aggregation_loop_guard = aggregation_loop_span.enter();
+
+        for task_output in collected_chunk_outputs {
+            final_ab_unbound_coeffs_shards.push(task_output.ab_coeffs_local); // Move Vec directly
+
+            if NUM_ACCUMS_EVAL_ZERO > 0 {
+                for idx in 0..NUM_ACCUMS_EVAL_ZERO {
+                    final_svo_accums_zero[idx] += task_output.svo_accums_zero_local[idx];
+                }
+            }
+
+            if NUM_ACCUMS_EVAL_INFTY > 0 {
+                for idx in 0..NUM_ACCUMS_EVAL_INFTY {
+                    final_svo_accums_infty[idx] += task_output.svo_accums_infty_local[idx];
+                }
+            }
+            // total_coeff_computation_time += task_output.coeff_computation_time_local; // Commented out
+            // total_ta_update_time += task_output.ta_update_time_local; // Commented out
+        }
+        drop(_aggregation_loop_guard);
+
+        // final_ab_unbound_coeffs_shards is now fully populated and SVO accumulators are summed.
+
+        // Debug check for sortedness
         #[cfg(test)]
         {
-            // Check that indices are monotonically increasing
-            for shard in &unbound_coeffs_shards {
-                if !shard.is_empty() {
-                    let mut prev_index = shard[0].index;
-                    for coeff in shard.iter().skip(1) {
-                        assert!(
-                            coeff.index > prev_index,
-                            "Indices not monotonically increasing in shard: prev {}, current {}",
-                            prev_index,
-                            coeff.index
-                        );
-                        prev_index = coeff.index;
-                    }
-                }
-            }
-        }
-
-        Self {
-            unbound_coeffs_shards,
-            bound_coeffs: vec![],
-            binding_scratch_space: vec![],
-            dense_len: num_steps * padded_num_constraints,
-        }
-    }
-
-    #[cfg(test)]
-    fn uninterleave(&self) -> (DensePolynomial<F>, DensePolynomial<F>, DensePolynomial<F>) {
-        let mut az = vec![F::zero(); self.dense_len];
-        let mut bz = vec![F::zero(); self.dense_len];
-        let mut cz = vec![F::zero(); self.dense_len];
-
-        if !self.is_bound() {
-            for shard_arc in &self.unbound_coeffs_shards {
-                for coeff in shard_arc {
-                    // Ensure that the index is within bounds for az, bz, cz vectors.
-                    // This check is mostly a safeguard; coeff.index / 3 should be < self.dense_len.
-                    if coeff.index / 3 < self.dense_len {
-                        match coeff.index % 3 {
-                            0 => az[coeff.index / 3] = F::from_i128(coeff.value),
-                            1 => bz[coeff.index / 3] = F::from_i128(coeff.value),
-                            2 => cz[coeff.index / 3] = F::from_i128(coeff.value),
-                            _ => unreachable!(),
+            if NUM_SVO_ROUNDS > 0 {
+                for shard in &final_ab_unbound_coeffs_shards { // Iterate over &Vec directly
+                    if !shard.is_empty() {
+                        let mut prev_index = shard[0].index;
+                        for coeff in shard.iter().skip(1) {
+                            assert!(
+                                coeff.index > prev_index,
+                                "Indices not monotonically increasing in shard: prev {}, current {}",
+                                prev_index, coeff.index
+                            );
+                            prev_index = coeff.index;
                         }
-                    } else {
-                        // This case should ideally not be reached if dense_len is calculated correctly.
-                        panic!("Coefficient index out of bounds during uninterleave (unbound)");
                     }
                 }
             }
-        } else {
-            for coeff in &self.bound_coeffs {
-                // Similar bounds check for the bound case.
-                if coeff.index / 3 < self.dense_len {
-                    match coeff.index % 3 {
-                        0 => az[coeff.index / 3] = coeff.value,
-                        1 => bz[coeff.index / 3] = coeff.value,
-                        2 => cz[coeff.index / 3] = coeff.value,
-                        _ => unreachable!(),
-                    }
-                } else {
-                    panic!("Coefficient index out of bounds during uninterleave (bound)");
-                }
-            }
+            println!("Per-shard sortedness check passed!");
         }
+
+        drop(_finalization_guard);
+        // let reporting_span = tracing::info_span!("timing_reporting"); // Commented out
+        // let _reporting_guard = reporting_span.enter(); // Commented out
+
+        // let total_instrumented_time = total_coeff_computation_time + total_ta_update_time; // Commented out
+        // if !total_instrumented_time.is_zero() { // Commented out
+        //     let coeff_time_percentage = (total_coeff_computation_time.as_secs_f64() // Commented out
+        //         / total_instrumented_time.as_secs_f64()) // Commented out
+        //         * 100.0; // Commented out
+        //     let ta_update_time_percentage = (total_ta_update_time.as_secs_f64() // Commented out
+        //         / total_instrumented_time.as_secs_f64()) // Commented out
+        //         * 100.0; // Commented out
+
+        //     println!( // Commented out
+        //         "Timing breakdown for new_with_precompute SVO part (instrumented sections):\n - Coefficient computation: {:.2}s ({:.2}%)\n - tA update (inplace extension & sum): {:.2}s ({:.2}%)\n Total instrumented: {:.2}s", // Commented out
+        //         total_coeff_computation_time.as_secs_f64(), // Commented out
+        //         coeff_time_percentage, // Commented out
+        //         total_ta_update_time.as_secs_f64(), // Commented out
+        //         ta_update_time_percentage, // Commented out
+        //         total_instrumented_time.as_secs_f64() // Commented out
+        //     ); // Commented out
+        // } else { // Commented out
+        //     // println!("Total instrumented time for SVO part was zero. No timing breakdown available."); // Commented out
+        // } // Commented out
+        // drop(_reporting_guard); // Commented out
+
+        // Return final SVO accumulators and Self struct.
         (
-            DensePolynomial::new(az),
-            DensePolynomial::new(bz),
-            DensePolynomial::new(cz),
+            final_svo_accums_zero,
+            final_svo_accums_infty,
+            Self {
+                ab_unbound_coeffs_shards: final_ab_unbound_coeffs_shards,
+                bound_coeffs: vec![],
+                binding_scratch_space: vec![],
+                dense_len: num_steps * padded_num_constraints,
+            },
         )
     }
 
-    pub fn is_bound(&self) -> bool {
-        !self.bound_coeffs.is_empty()
-    }
-
-    /// The first round of the first Spartan sumcheck. Since the polynomials
-    /// are still unbound at the beginning of this round, we can replace some
-    /// of the field arithmetic with `i128` arithmetic.
+    /// This function uses the streaming algorithm to compute the sum-check polynomial for the round
+    /// right after the small value precomputed rounds.
     ///
-    /// Note that we implement the extra optimization of only computing the quadratic
-    /// evaluation at infinity, since the eval at zero is always zero.
-    #[tracing::instrument(skip_all, name = "SpartanInterleavedPolynomial::first_sumcheck_round")]
-    pub fn first_sumcheck_round<ProofTranscript: Transcript>(
+    /// At this point, we have the `ab_unbound_coeffs` generated from `new_with_precompute`. We will
+    /// use these to compute the evals {Az/Bz/Cz}(r, u, x') needed for later linear-time sumcheck
+    /// rounds (storing them in `bound_coeffs`), and compute the polynomial for this
+    /// round at the same time.
+    ///
+    /// Recall that we need to compute
+    ///
+    /// `t_i(0) = \sum_{x_out} E_out[x_out] \sum_{x_in} E_in[x_in] * (unbound_coeffs_a(x_out, x_in,
+    /// 0, r) * unbound_coeffs_b(x_out, x_in, 0, r) - unbound_coeffs_c(x_out, x_in, 0, r))`
+    ///
+    /// and
+    ///
+    /// `t_i(∞) = \sum_{x_out} E_out[x_out] \sum_{x_in} E_in[x_in] * (unbound_coeffs_a(x_out,
+    /// x_in, ∞, r) * unbound_coeffs_b(x_out, x_in, ∞, r))`
+    ///
+    /// Here the "_a,b,c" subscript indicates the coefficients of `unbound_coeffs` corresponding to
+    /// Az, Bz, Cz respectively. Note that we index with x_out being the MSB here.
+    ///
+    /// Importantly, since the eval at `r` is not cached, we will need to recompute it via another
+    /// sum
+    ///
+    /// `unbound_coeffs_{a,b,c}(x_out, x_in, {0,∞}, r) = \sum_{binary y} eq(r, y) *
+    /// unbound_coeffs_{a,b,c}(x_out, x_in, {0,∞}, y)`
+    ///
+    /// (and the eval at ∞ is computed as (eval at 1) - (eval at 0))
+    ///
+    /// Since `unbound_coeffs` are in sparse format, we will need to be more careful with indexing;
+    /// see the old implementation for details.
+    ///
+    /// Finally, as we compute each `unbound_coeffs_{a,b,c}(x_out, x_in, {0,∞}, r)`, we will
+    /// store them in `bound_coeffs`. which is still in sparse format (the eval at 1 will be eval
+    /// at 0 + eval at ∞). We then derive the next challenge from the transcript, and bind these
+    /// bound coeffs for the next round.
+    #[tracing::instrument(
+        skip_all,
+        name = "NewSpartanInterleavedPolynomial::streaming_sumcheck_round"
+    )]
+    pub fn streaming_sumcheck_round<ProofTranscript: Transcript>(
         &mut self,
         eq_poly: &mut GruenSplitEqPolynomial<F>,
         transcript: &mut ProofTranscript,
-        r: &mut Vec<F>,
-        polys: &mut Vec<CompressedUniPoly<F>>,
+        r_challenges: &mut Vec<F>,
+        round_polys: &mut Vec<CompressedUniPoly<F>>,
         claim: &mut F,
     ) {
-        assert!(!self.is_bound());
+        let top_level_span = tracing::span!(tracing::Level::INFO, "streaming_sumcheck_round_body");
+        let _top_level_guard = top_level_span.enter();
 
-        let num_x_in_bits = eq_poly.E_in_current_len().log_2();
-        let x_in_bitmask = (1 << num_x_in_bits) - 1;
+        let setup_span = tracing::debug_span!("streaming_round_setup");
+        let _setup_guard = setup_span.enter();
 
-        // In the first round, we only need to compute the quadratic evaluation at infinity,
-        // since the eval at zero is always zero.
-        let quadratic_eval_at_infty = self
-            .unbound_coeffs_shards
-            .par_iter()
-            .map(|shard_coeffs| {
-                let mut shard_eval_point_infty = F::zero();
+        let num_y_svo_vars = r_challenges.len();
+        assert_eq!(
+            num_y_svo_vars, NUM_SVO_ROUNDS,
+            "r_challenges length mismatch with NUM_SVO_ROUNDS"
+        );
+        let mut r_rev = r_challenges.clone();
+        r_rev.reverse();
+        let eq_r_evals = EqPolynomial::evals(&r_rev);
 
-                let mut current_shard_inner_sums = F::zero();
-                let mut current_shard_prev_x_out = 0;
+        drop(_setup_guard);
 
-                for sparse_block in shard_coeffs.chunk_by(|x, y| x.index / 6 == y.index / 6) {
-                    let block_index = sparse_block[0].index / 6;
-                    let x_in = block_index & x_in_bitmask;
-                    let E_in_evals = eq_poly.E_in_current()[x_in];
-                    let x_out = block_index >> num_x_in_bits;
+        let main_processing_span = tracing::info_span!("streaming_round_main_processing");
+        let _main_processing_guard = main_processing_span.enter();
 
-                    if x_out != current_shard_prev_x_out {
-                        shard_eval_point_infty += eq_poly.E_out_current()[current_shard_prev_x_out]
-                            * current_shard_inner_sums;
-                        current_shard_inner_sums = F::zero();
-                        current_shard_prev_x_out = x_out;
+        struct StreamingTaskOutput<F: JoltField> {
+            bound_coeffs_local: Vec<SparseCoefficient<F>>,
+            sumcheck_eval_at_0_local: F,
+            sumcheck_eval_at_infty_local: F,
+        }
+
+        // These are needed to derive x_out_val_stream and x_in_val_stream from a block_id
+        let num_streaming_x_in_vars = eq_poly.E_in_current_len().log_2();
+
+        // Take ownership
+        let shards_to_process = std::mem::take(&mut self.ab_unbound_coeffs_shards);
+
+        let collected_chunk_outputs: Vec<StreamingTaskOutput<F>> = shards_to_process // Use the taken vec
+            .into_par_iter() // Consumes and gives ownership to closures
+            .map(|shard_data: Vec<SparseCoefficient<i128>>| { // shard_data is now owned Vec
+                let mut task_bound_coeffs = Vec::new();
+                let mut task_sum_contrib_0 = F::zero();
+                let mut task_sum_contrib_infty = F::zero();
+
+                for logical_block_coeffs in shard_data.chunk_by(|c1, c2| { // Use owned shard_data directly
+                    c1.index / Y_SVO_RELATED_COEFF_BLOCK_SIZE == c2.index / Y_SVO_RELATED_COEFF_BLOCK_SIZE
+                }) {
+                    if logical_block_coeffs.is_empty() {
+                        continue;
                     }
 
-                    // This holds the az0, az1, bz0, bz1 evals. No need for cz0, cz1 since we only need
-                    // the eval at infinity.
-                    let mut az0 = 0i128;
-                    let mut az1 = 0i128;
-                    let mut bz0 = 0i128;
-                    let mut bz1 = 0i128;
-                    for coeff in sparse_block {
-                        let local_idx = coeff.index % 6;
-                        if local_idx == 0 {
-                            az0 = coeff.value;
-                        } else if local_idx == 1 {
-                            bz0 = coeff.value;
-                        } else if local_idx == 3 {
-                            az1 = coeff.value;
-                        } else if local_idx == 4 {
-                            bz1 = coeff.value;
+                    let current_block_id = logical_block_coeffs[0].index / Y_SVO_RELATED_COEFF_BLOCK_SIZE;
+
+                    let x_out_val_stream = current_block_id >> num_streaming_x_in_vars;
+                    let x_in_val_stream = current_block_id & ((1 << num_streaming_x_in_vars) - 1);
+
+                    let e_out_val = eq_poly.E_out_current()[x_out_val_stream];
+                    let e_in_val = if eq_poly.E_in_current_len() > 1 {
+                        eq_poly.E_in_current()[x_in_val_stream]
+                    } else if eq_poly.E_in_current_len() == 1 {
+                        eq_poly.E_in_current()[0]
+                    } else { // E_in_current_len() == 0, meaning no x_in variables for eq_poly
+                        F::one() // Effective contribution of E_in is 1
+                    };
+
+                    let mut az0_at_r = F::zero();
+                    let mut az1_at_r = F::zero();
+                    let mut bz0_at_r = F::zero();
+                    let mut bz1_at_r = F::zero();
+                    let mut cz0_at_r = F::zero();
+                    let mut cz1_at_r = F::zero();
+
+                    let mut coeff_idx_in_block = 0;
+                    while coeff_idx_in_block < logical_block_coeffs.len() {
+                        let current_coeff = &logical_block_coeffs[coeff_idx_in_block];
+                        let local_offset =
+                            current_coeff.index % Y_SVO_RELATED_COEFF_BLOCK_SIZE;
+                        let current_is_B = (local_offset % 2) == 1;
+                        let y_val_idx = (local_offset / 2) % Y_SVO_SPACE_SIZE;
+                        let x_next_val = (local_offset / 2) / Y_SVO_SPACE_SIZE; // 0 or 1
+                        let eq_r_y = eq_r_evals[y_val_idx];
+
+                        if current_is_B { // Current coefficient is Bz
+                            let bz_orig_val = current_coeff.value;
+                            match x_next_val {
+                                0 => bz0_at_r += eq_r_y.mul_i128_1_optimized(bz_orig_val),
+                                1 => bz1_at_r += eq_r_y.mul_i128_1_optimized(bz_orig_val),
+                                _ => unreachable!(),
+                            }
+                            coeff_idx_in_block += 1;
+                        } else { // Current coefficient is Az
+                            let az_orig_val = current_coeff.value;
+                            let mut bz_orig_for_this_az = 0i128;
+
+                            match x_next_val {
+                                0 => az0_at_r += eq_r_y.mul_i128_1_optimized(az_orig_val),
+                                1 => az1_at_r += eq_r_y.mul_i128_1_optimized(az_orig_val),
+                                _ => unreachable!(),
+                            }
+
+                            if coeff_idx_in_block + 1 < logical_block_coeffs.len() {
+                                let next_coeff = &logical_block_coeffs[coeff_idx_in_block + 1];
+                                if next_coeff.index == current_coeff.index + 1 {
+                                    bz_orig_for_this_az = next_coeff.value;
+                                    let next_local_offset = next_coeff.index % Y_SVO_RELATED_COEFF_BLOCK_SIZE;
+                                    let next_x_next_val = (next_local_offset / 2) / Y_SVO_SPACE_SIZE;
+                                    debug_assert_eq!(x_next_val, next_x_next_val, "Paired Az/Bz should share x_next_val. Current idx {}, next idx {}, current x_next {}, next x_next {}", current_coeff.index, next_coeff.index, x_next_val, next_x_next_val);
+
+                                    match x_next_val { // x_next_val of the current Az
+                                        0 => bz0_at_r += eq_r_y.mul_i128_1_optimized(bz_orig_for_this_az),
+                                        1 => bz1_at_r += eq_r_y.mul_i128_1_optimized(bz_orig_for_this_az),
+                                        _ => unreachable!(),
+                                    }
+                                    coeff_idx_in_block += 1; // Consumed the Bz coefficient as well
+                                }
+                            }
+                            coeff_idx_in_block += 1; // Consumed the Az coefficient
+
+                            if !az_orig_val.is_zero() && !bz_orig_for_this_az.is_zero() {
+                                let cz_orig_val =
+                                    az_orig_val.wrapping_mul(bz_orig_for_this_az);
+                                match x_next_val { // x_next_val of the current Az
+                                    0 => cz0_at_r += eq_r_y.mul_i128(cz_orig_val),
+                                    1 => cz1_at_r += eq_r_y.mul_i128(cz_orig_val),
+                                    _ => unreachable!(),
+                                }
+                            }
                         }
                     }
-                    let az_infty = az1 - az0;
-                    let bz_infty = bz1 - bz0;
-                    if az_infty != 0 && bz_infty != 0 {
-                        current_shard_inner_sums += E_in_evals.mul_i128(
-                            az_infty.checked_mul(bz_infty).unwrap_or_else(|| {
-                                panic!("az_infty * bz_infty overflow");
-                            }),
-                        );
-                    }
-                }
-                shard_eval_point_infty +=
-                    eq_poly.E_out_current()[current_shard_prev_x_out] * current_shard_inner_sums;
-                shard_eval_point_infty
-            })
-            .sum();
 
+                    if !az0_at_r.is_zero() {
+                        task_bound_coeffs.push((6 * current_block_id, az0_at_r).into());
+                    }
+                    if !bz0_at_r.is_zero() {
+                        task_bound_coeffs.push((6 * current_block_id + 1, bz0_at_r).into());
+                    }
+                    if !cz0_at_r.is_zero() {
+                        task_bound_coeffs.push((6 * current_block_id + 2, cz0_at_r).into());
+                    }
+                    if !az1_at_r.is_zero() {
+                        task_bound_coeffs.push((6 * current_block_id + 3, az1_at_r).into());
+                    }
+                    if !bz1_at_r.is_zero() {
+                        task_bound_coeffs.push((6 * current_block_id + 4, bz1_at_r).into());
+                    }
+                    if !cz1_at_r.is_zero() {
+                        task_bound_coeffs.push((6 * current_block_id + 5, cz1_at_r).into());
+                    }
+
+                    let p_at_xk0 = az0_at_r * bz0_at_r - cz0_at_r;
+                    let az_eval_infty = az1_at_r - az0_at_r;
+                    let bz_eval_infty = bz1_at_r - bz0_at_r;
+                    let p_slope_term = az_eval_infty * bz_eval_infty;
+
+                    task_sum_contrib_0 += e_out_val * e_in_val * p_at_xk0;
+                    task_sum_contrib_infty += e_out_val * e_in_val * p_slope_term;
+                }
+
+                StreamingTaskOutput {
+                    bound_coeffs_local: task_bound_coeffs,
+                    sumcheck_eval_at_0_local: task_sum_contrib_0,
+                    sumcheck_eval_at_infty_local: task_sum_contrib_infty,
+                }
+            })
+            .collect();
+
+        drop(_main_processing_guard);
+
+        // Aggregate sumcheck contributions directly from collected_chunk_outputs
+        let sum_aggregation_span = tracing::info_span!("streaming_round_aggregate_sums");
+        let _sum_aggregation_guard = sum_aggregation_span.enter();
+        let mut total_sumcheck_eval_at_0 = F::zero();
+        let mut total_sumcheck_eval_at_infty = F::zero();
+        for task_output in &collected_chunk_outputs {
+            // Iterate by reference before consuming collected_chunk_outputs
+            total_sumcheck_eval_at_0 += task_output.sumcheck_eval_at_0_local;
+            total_sumcheck_eval_at_infty += task_output.sumcheck_eval_at_infty_local;
+        }
+        drop(_sum_aggregation_guard);
+
+        // Compute r_i challenge using aggregated sumcheck values
         let r_i = process_eq_sumcheck_round(
-            (F::zero(), quadratic_eval_at_infty),
+            (total_sumcheck_eval_at_0, total_sumcheck_eval_at_infty),
             eq_poly,
-            polys,
-            r,
+            round_polys,
+            r_challenges,
             claim,
             transcript,
         );
 
-        // Compute the number of non-zero bound coefficients that will be produced
-        // per chunk.
-        let output_sizes: Vec<_> = self
-            .unbound_coeffs_shards
-            .par_iter()
-            .map(|shard| Self::binding_output_length(shard))
+        // Bind coefficients directly from task outputs into scratch space
+        let bind_coeffs_span = tracing::span!(tracing::Level::INFO, "streaming_round_bind_coeffs");
+        let _bind_coeffs_guard = bind_coeffs_span.enter();
+
+        // Calculate the output size for binding for each task's local coefficients
+        let calc_output_sizes_span =
+            tracing::debug_span!("streaming_bind_calc_per_task_output_sizes");
+        let _calc_output_sizes_guard = calc_output_sizes_span.enter();
+        let per_task_output_sizes: Vec<usize> = collected_chunk_outputs
+            .par_iter() // Iterate over collected_chunk_outputs by reference for calculating sizes
+            .map(|task_output| {
+                let coeffs_from_task = &task_output.bound_coeffs_local;
+                let mut current_task_total_output_size = 0;
+                for sub_block_of_6 in
+                    coeffs_from_task.chunk_by(|sc1, sc2| sc1.index / 6 == sc2.index / 6)
+                {
+                    // Self::binding_output_length expects a slice representing one such sub_block_of_6
+                    current_task_total_output_size += Self::binding_output_length(sub_block_of_6);
+                }
+                current_task_total_output_size
+            })
             .collect();
+        drop(_calc_output_sizes_guard);
 
-        let total_output_len = output_sizes.iter().sum();
-        self.bound_coeffs = Vec::with_capacity(total_output_len);
-        #[allow(clippy::uninit_vec)]
+        let total_binding_output_len: usize = per_task_output_sizes.iter().sum();
+
+        // Prepare binding_scratch_space
+        if self.binding_scratch_space.capacity() < total_binding_output_len {
+            self.binding_scratch_space
+                .reserve_exact(total_binding_output_len - self.binding_scratch_space.capacity());
+        }
         unsafe {
-            self.bound_coeffs.set_len(total_output_len);
+            self.binding_scratch_space.set_len(total_binding_output_len);
         }
-        let mut output_slices: Vec<&mut [SparseCoefficient<F>]> =
-            Vec::with_capacity(self.unbound_coeffs_shards.len());
-        let mut remainder = self.bound_coeffs.as_mut_slice();
-        for slice_len in output_sizes {
-            let (first, second) = remainder.split_at_mut(slice_len);
-            output_slices.push(first);
-            remainder = second;
+
+        // Create mutable slices into binding_scratch_space, one for each task's output
+        let create_output_slices_span =
+            tracing::debug_span!("streaming_bind_create_output_slices_for_tasks");
+        let _create_output_slices_guard = create_output_slices_span.enter();
+        let mut output_slices_for_tasks: Vec<&mut [SparseCoefficient<F>]> =
+            Vec::with_capacity(collected_chunk_outputs.len());
+        let mut scratch_remainder = self.binding_scratch_space.as_mut_slice();
+        for slice_len in per_task_output_sizes {
+            let (first, second) = scratch_remainder.split_at_mut(slice_len);
+            output_slices_for_tasks.push(first);
+            scratch_remainder = second;
         }
-        debug_assert_eq!(remainder.len(), 0);
+        debug_assert_eq!(scratch_remainder.len(), 0);
+        drop(_create_output_slices_guard);
 
-        self.unbound_coeffs_shards
-            .par_iter()
-            .zip_eq(output_slices.into_par_iter())
-            .for_each(|(unbound_coeffs_in_shard, output_slice_for_shard)| {
-                let mut output_index = 0;
-                for block in unbound_coeffs_in_shard.chunk_by(|x, y| x.index / 6 == y.index / 6) {
-                    let block_index = block[0].index / 6;
+        // Parallel binding loop: iterate over tasks and their designated output slices
+        let parallel_bind_loop_span =
+            tracing::info_span!("streaming_bind_parallel_task_coeff_binding_loop");
+        let _parallel_bind_loop_guard = parallel_bind_loop_span.enter();
 
-                    let mut az_coeff: (Option<i128>, Option<i128>) = (None, None);
-                    let mut bz_coeff: (Option<i128>, Option<i128>) = (None, None);
-                    let mut cz_coeff: (Option<i128>, Option<i128>) = (None, None);
+        collected_chunk_outputs // Now consume collected_chunk_outputs
+            .into_par_iter()
+            .zip_eq(output_slices_for_tasks.into_par_iter())
+            .for_each(|(task_output, output_slice_for_task)| {
+                let bind_task_span = tracing::debug_span!("streaming_bind_process_task_coeffs");
+                let _bind_task_guard = bind_task_span.enter();
 
-                    for coeff in block {
+                let coeffs_from_task = &task_output.bound_coeffs_local; // These are the Vec<SparseCoefficient<F>> from a StreamingTaskOutput
+
+                let mut current_output_idx_in_slice = 0;
+                // Iterate through sub-blocks of 6 within this task's coeffs_from_task
+                for sub_block_of_6 in
+                    coeffs_from_task.chunk_by(|sc1, sc2| sc1.index / 6 == sc2.index / 6)
+                {
+                    if sub_block_of_6.is_empty() {
+                        continue;
+                    }
+                    let block_idx_for_6_coeffs = sub_block_of_6[0].index / 6;
+
+                    let mut az0 = F::zero();
+                    let mut bz0 = F::zero();
+                    let mut cz0 = F::zero();
+                    let mut az1 = F::zero();
+                    let mut bz1 = F::zero();
+                    let mut cz1 = F::zero();
+
+                    for coeff in sub_block_of_6 {
                         match coeff.index % 6 {
-                            0 => az_coeff.0 = Some(coeff.value),
-                            1 => bz_coeff.0 = Some(coeff.value),
-                            2 => cz_coeff.0 = Some(coeff.value),
-                            3 => az_coeff.1 = Some(coeff.value),
-                            4 => bz_coeff.1 = Some(coeff.value),
-                            5 => cz_coeff.1 = Some(coeff.value),
+                            0 => az0 = coeff.value,
+                            1 => bz0 = coeff.value,
+                            2 => cz0 = coeff.value,
+                            3 => az1 = coeff.value,
+                            4 => bz1 = coeff.value,
+                            5 => cz1 = coeff.value,
                             _ => unreachable!(),
                         }
                     }
-                    if az_coeff != (None, None) {
-                        let (low, high) = (az_coeff.0.unwrap_or(0), az_coeff.1.unwrap_or(0));
-                        output_slice_for_shard[output_index] = (
-                            3 * block_index,
-                            F::from_i128(low) + r_i.mul_i128(high - low),
-                        )
-                            .into();
-                        output_index += 1;
+
+                    let new_block_idx = block_idx_for_6_coeffs;
+
+                    let bound_az = az0 + r_i * (az1 - az0);
+                    if !bound_az.is_zero() {
+                        if current_output_idx_in_slice < output_slice_for_task.len() {
+                            output_slice_for_task[current_output_idx_in_slice] =
+                                (3 * new_block_idx, bound_az).into();
+                        }
+                        current_output_idx_in_slice += 1;
                     }
-                    if bz_coeff != (None, None) {
-                        let (low, high) = (bz_coeff.0.unwrap_or(0), bz_coeff.1.unwrap_or(0));
-                        output_slice_for_shard[output_index] = (
-                            3 * block_index + 1,
-                            F::from_i128(low) + r_i.mul_i128(high - low),
-                        )
-                            .into();
-                        output_index += 1;
+                    let bound_bz = bz0 + r_i * (bz1 - bz0);
+                    if !bound_bz.is_zero() {
+                        if current_output_idx_in_slice < output_slice_for_task.len() {
+                            output_slice_for_task[current_output_idx_in_slice] =
+                                (3 * new_block_idx + 1, bound_bz).into();
+                        }
+                        current_output_idx_in_slice += 1;
                     }
-                    if cz_coeff != (None, None) {
-                        let (low, high) = (cz_coeff.0.unwrap_or(0), cz_coeff.1.unwrap_or(0));
-                        output_slice_for_shard[output_index] = (
-                            3 * block_index + 2,
-                            F::from_i128(low) + r_i.mul_i128(high - low),
-                        )
-                            .into();
-                        output_index += 1;
+                    let bound_cz = cz0 + r_i * (cz1 - cz0);
+                    if !bound_cz.is_zero() {
+                        if current_output_idx_in_slice < output_slice_for_task.len() {
+                            output_slice_for_task[current_output_idx_in_slice] =
+                                (3 * new_block_idx + 2, bound_cz).into();
+                        }
+                        current_output_idx_in_slice += 1;
                     }
                 }
-                debug_assert_eq!(output_index, output_slice_for_shard.len())
+                debug_assert_eq!(
+                    current_output_idx_in_slice,
+                    output_slice_for_task.len(),
+                    "Mismatch in written elements vs pre-calculated slice length for task output"
+                );
             });
+        drop(_parallel_bind_loop_guard);
 
-        #[cfg(test)]
-        let (mut az_for_test, mut bz_for_test, mut cz_for_test) = {
-            let original_dense_len = self.dense_len; // dense_len before it's halved for self
-            let mut az_vec = vec![F::zero(); original_dense_len];
-            let mut bz_vec = vec![F::zero(); original_dense_len];
-            let mut cz_vec = vec![F::zero(); original_dense_len];
+        let swap_span = tracing::debug_span!("streaming_bind_swap_coeff_buffers");
+        let _swap_guard = swap_span.enter();
+        std::mem::swap(&mut self.bound_coeffs, &mut self.binding_scratch_space);
+        drop(_swap_guard);
 
-            for shard_arc in &self.unbound_coeffs_shards {
-                for coeff in shard_arc {
-                    if coeff.index / 3 < original_dense_len {
-                        match coeff.index % 3 {
-                            0 => az_vec[coeff.index / 3] = F::from_i128(coeff.value),
-                            1 => bz_vec[coeff.index / 3] = F::from_i128(coeff.value),
-                            2 => cz_vec[coeff.index / 3] = F::from_i128(coeff.value),
-                            _ => unreachable!(),
-                        }
-                    }
-                }
-            }
-            (
-                DensePolynomial::new(az_vec),
-                DensePolynomial::new(bz_vec),
-                DensePolynomial::new(cz_vec),
-            )
-        };
+        self.dense_len = eq_poly.len();
 
-        // Drop the unbound coeffs shards now that we've bound them
-        self.unbound_coeffs_shards.clear();
-        self.unbound_coeffs_shards.shrink_to_fit();
-
-        self.dense_len /= 2;
-
-        #[cfg(test)]
-        {
-            // Check that the binding is consistent with binding Az, Bz, Cz individually
-            let (az_bound, bz_bound, cz_bound) = self.uninterleave();
-            az_for_test.bound_poly_var_bot(&r_i);
-            bz_for_test.bound_poly_var_bot(&r_i);
-            cz_for_test.bound_poly_var_bot(&r_i);
-
-            assert_eq!(
-                az_bound.len(),
-                az_for_test.len(),
-                "Mismatch in length of Az polynomials after binding"
-            );
-            assert_eq!(
-                bz_bound.len(),
-                bz_for_test.len(),
-                "Mismatch in length of Bz polynomials after binding"
-            );
-            assert_eq!(
-                cz_bound.len(),
-                cz_for_test.len(),
-                "Mismatch in length of Cz polynomials after binding"
-            );
-
-            for i in 0..az_for_test.len() {
-                if az_bound[i] != az_for_test[i] {
-                    println!(
-                        "az mismatch at index {}: bound = {}, test_bound = {}",
-                        i, az_bound[i], az_for_test[i]
-                    );
-                }
-            }
-            // Compare the underlying Z vectors directly after ensuring lengths match.
-            assert_eq!(
-                &az_bound.Z[..az_for_test.len()],
-                &az_for_test.Z[..az_for_test.len()],
-                "Az polynomial data mismatch after binding"
-            );
-            assert_eq!(
-                &bz_bound.Z[..bz_for_test.len()],
-                &bz_for_test.Z[..bz_for_test.len()],
-                "Bz polynomial data mismatch after binding"
-            );
-            assert_eq!(
-                &cz_bound.Z[..cz_for_test.len()],
-                &cz_for_test.Z[..cz_for_test.len()],
-                "Cz polynomial data mismatch after binding"
-            );
-        }
+        drop(_bind_coeffs_guard);
+        drop(_top_level_guard);
     }
 
-    /// All subsequent rounds of the first Spartan sumcheck.
+    /// This function computes the polynomial for each of the remaining rounds, using the
+    /// linear-time algorithm with split-eq optimizations
+    ///
+    /// At this point, we have computed the `bound_coeffs` for the current round.
+    /// We need to compute:
+    ///
+    /// `t_i(0) = \sum_{x_out} E_out[x_out] \sum_{x_in} E_in[x_in] *
+    /// (az_bound[x_out, x_in, 0] * bz_bound[x_out, x_in, 0] - cz_bound[x_out, x_in, 0])`
+    ///
+    /// and
+    ///
+    /// `t_i(∞) = \sum_{x_out} E_out[x_out] \sum_{x_in} E_in[x_in] *
+    /// az_bound[x_out, x_in, ∞] * bz_bound[x_out, x_in, ∞]`
+    ///
+    /// (ordering of indices is MSB to LSB, so x_out is the MSB and x_in is the LSB)
+    ///
+    /// We then process this to form `s_i(X) = l_i(X) * t_i(X)`, append `s_i.compress()` to the transcript,
+    /// derive next challenge `r_i`, then bind both `eq_poly` and `bound_coeffs` with `r_i`.
+    ///
+    /// NOTE: this is now basically identical to `subsequent_sumcheck_round`, modulo extra Gruen's optimization, and modulo tests (we can add tests back later)
     #[tracing::instrument(
         skip_all,
-        name = "SpartanInterleavedPolynomial::subsequent_sumcheck_round"
+        name = "NewSpartanInterleavedPolynomial::remaining_sumcheck_round"
     )]
-    pub fn subsequent_sumcheck_round<ProofTranscript: Transcript>(
+    pub fn remaining_sumcheck_round<ProofTranscript: Transcript>(
         &mut self,
         eq_poly: &mut GruenSplitEqPolynomial<F>,
         transcript: &mut ProofTranscript,
-        r: &mut Vec<F>,
-        polys: &mut Vec<CompressedUniPoly<F>>,
-        claim: &mut F,
+        r_challenges: &mut Vec<F>,
+        round_polys: &mut Vec<CompressedUniPoly<F>>,
+        current_claim: &mut F,
     ) {
-        assert!(self.is_bound());
+        let top_level_span = tracing::span!(tracing::Level::INFO, "remaining_sumcheck_round_body");
+        let _top_level_guard = top_level_span.enter();
 
         // In order to parallelize, we do a first pass over the coefficients to
         // determine how to divide it into chunks that can be processed independently.
@@ -520,8 +932,12 @@ impl<F: JoltField> SpartanInterleavedPolynomial<F> {
             .par_chunk_by(|x, y| x.index / block_size == y.index / block_size)
             .collect();
 
+        let compute_evals_span = tracing::info_span!("remaining_round_compute_evals");
+        let _compute_evals_guard = compute_evals_span.enter();
+
+        // If `E_in` is fully bound, then we simply sum over `E_out`
         let quadratic_evals = if eq_poly.E_in_current_len() == 1 {
-            let evals = chunks
+            let evals: (F, F) = chunks
                 .par_iter()
                 .flat_map_iter(|chunk| {
                     chunk
@@ -555,31 +971,31 @@ impl<F: JoltField> SpartanInterleavedPolynomial<F> {
                 );
             evals
         } else {
-            let num_x_in_bits = eq_poly.E_in_current_len().log_2();
-            let x_bitmask = (1 << num_x_in_bits) - 1;
+            // If `E_in` is not fully bound, then we have to collect the sum over `E_out` as well
+            let num_x1_bits = eq_poly.E_in_current_len().log_2();
+            let x1_bitmask = (1 << num_x1_bits) - 1;
 
-            let evals = chunks
+            let evals: (F, F) = chunks
                 .par_iter()
                 .map(|chunk| {
                     let mut eval_point_0 = F::zero();
                     let mut eval_point_infty = F::zero();
 
                     let mut inner_sums = (F::zero(), F::zero());
-                    let mut prev_x_out = 0;
+                    let mut prev_x2 = 0;
 
                     for sparse_block in chunk.chunk_by(|x, y| x.index / 6 == y.index / 6) {
                         let block_index = sparse_block[0].index / 6;
-                        let x_in = block_index & x_bitmask;
-                        let E_in_eval = eq_poly.E_in_current()[x_in];
-                        let x_out = block_index >> num_x_in_bits;
+                        let x1 = block_index & x1_bitmask;
+                        let E_in_evals = eq_poly.E_in_current()[x1];
+                        let x2 = block_index >> num_x1_bits;
 
-                        if x_out != prev_x_out {
-                            let E_out_eval = eq_poly.E_out_current()[prev_x_out];
-                            eval_point_0 += E_out_eval * inner_sums.0;
-                            eval_point_infty += E_out_eval * inner_sums.1;
+                        if x2 != prev_x2 {
+                            eval_point_0 += eq_poly.E_out_current()[prev_x2] * inner_sums.0;
+                            eval_point_infty += eq_poly.E_out_current()[prev_x2] * inner_sums.1;
 
                             inner_sums = (F::zero(), F::zero());
-                            prev_x_out = x_out;
+                            prev_x2 = x2;
                         }
 
                         let mut block = [F::zero(); 6];
@@ -594,13 +1010,14 @@ impl<F: JoltField> SpartanInterleavedPolynomial<F> {
                         let az_eval_infty = az.1 - az.0;
                         let bz_eval_infty = bz.1 - bz.0;
 
-                        inner_sums.0 += E_in_eval.mul_0_optimized(az.0.mul_0_optimized(bz.0) - cz0);
-                        inner_sums.1 +=
-                            E_in_eval.mul_0_optimized(az_eval_infty.mul_0_optimized(bz_eval_infty));
+                        inner_sums.0 +=
+                            E_in_evals.mul_0_optimized(az.0.mul_0_optimized(bz.0) - cz0);
+                        inner_sums.1 += E_in_evals
+                            .mul_0_optimized(az_eval_infty.mul_0_optimized(bz_eval_infty));
                     }
 
-                    eval_point_0 += eq_poly.E_out_current()[prev_x_out] * inner_sums.0;
-                    eval_point_infty += eq_poly.E_out_current()[prev_x_out] * inner_sums.1;
+                    eval_point_0 += eq_poly.E_out_current()[prev_x2] * inner_sums.0;
+                    eval_point_infty += eq_poly.E_out_current()[prev_x2] * inner_sums.1;
 
                     (eval_point_0, eval_point_infty)
                 })
@@ -610,11 +1027,23 @@ impl<F: JoltField> SpartanInterleavedPolynomial<F> {
                 );
             evals
         };
+        drop(_compute_evals_guard);
 
-        let r_i = process_eq_sumcheck_round(quadratic_evals, eq_poly, polys, r, claim, transcript);
+        let process_sumcheck_span = tracing::info_span!("remaining_round_process_eq_sumcheck");
+        let _process_sumcheck_guard = process_sumcheck_span.enter();
+        // Use the helper function to process the rest of the sumcheck round
+        let r_i = process_eq_sumcheck_round(
+            quadratic_evals, // (t_i(0), t_i(infty))
+            eq_poly,         // Helper will bind this
+            round_polys,
+            r_challenges,
+            current_claim,
+            transcript,
+        );
+        drop(_process_sumcheck_guard);
 
-        #[cfg(test)]
-        let (mut az, mut bz, mut cz) = self.uninterleave();
+        let bind_coeffs_span = tracing::info_span!("remaining_round_bind_coeffs");
+        let _bind_coeffs_guard = bind_coeffs_span.enter();
 
         let output_sizes: Vec<_> = chunks
             .par_iter()
@@ -694,22 +1123,13 @@ impl<F: JoltField> SpartanInterleavedPolynomial<F> {
 
         std::mem::swap(&mut self.bound_coeffs, &mut self.binding_scratch_space);
         self.dense_len /= 2;
-
-        #[cfg(test)]
-        {
-            // Check that the binding is consistent with binding Az, Bz, Cz individually
-            let (az_bound, bz_bound, cz_bound) = self.uninterleave();
-            az.bound_poly_var_bot(&r_i);
-            bz.bound_poly_var_bot(&r_i);
-            cz.bound_poly_var_bot(&r_i);
-            assert!(az_bound.Z[..az_bound.len()] == az.Z[..az.len()]);
-            assert!(bz_bound.Z[..bz_bound.len()] == bz.Z[..bz.len()]);
-            assert!(cz_bound.Z[..cz_bound.len()] == cz.Z[..cz.len()]);
-        }
+        drop(_bind_coeffs_guard);
+        drop(_top_level_guard);
     }
 
     /// Computes the number of non-zero coefficients that would result from
-    /// binding the given slice of coefficients.
+    /// binding the given slice of coefficients. Only invoked on `bound_coeffs` which holds
+    /// Az/Bz/Cz bound evaluations.
     fn binding_output_length<T>(coeffs: &[SparseCoefficient<T>]) -> usize {
         let mut output_size = 0;
         for block in coeffs.chunk_by(|x, y| x.index / 6 == y.index / 6) {
@@ -740,7 +1160,6 @@ impl<F: JoltField> SpartanInterleavedPolynomial<F> {
                 }
             }
         }
-
         output_size
     }
 
@@ -758,7 +1177,6 @@ impl<F: JoltField> SpartanInterleavedPolynomial<F> {
                 }
             }
         }
-
         [final_az_eval, final_bz_eval, final_cz_eval]
     }
 }

--- a/jolt-core/src/poly/spartan_interleaved_poly.rs
+++ b/jolt-core/src/poly/spartan_interleaved_poly.rs
@@ -580,7 +580,13 @@ impl<const NUM_SVO_ROUNDS: usize, F: JoltField> SpartanInterleavedPolynomial<NUM
                                     bz_orig_for_this_az = next_coeff.value;
                                     let next_local_offset = next_coeff.index % Y_SVO_RELATED_COEFF_BLOCK_SIZE;
                                     let next_x_next_val = (next_local_offset / 2) / Y_SVO_SPACE_SIZE;
-                                    debug_assert_eq!(x_next_val, next_x_next_val, "Paired Az/Bz should share x_next_val. Current idx {}, next idx {}, current x_next {}, next x_next {}", current_coeff.index, next_coeff.index, x_next_val, next_x_next_val);
+                                    debug_assert_eq!(x_next_val, next_x_next_val,
+                                        "Paired Az/Bz should share x_next_val. Current idx {}, next idx {}, current x_next {}, next x_next {}",
+                                        current_coeff.index,
+                                        next_coeff.index,
+                                        x_next_val,
+                                        next_x_next_val,
+                                    );
 
                                     match x_next_val { // x_next_val of the current Az
                                         0 => bz0_at_r += eq_r_y.mul_i128_1_optimized(bz_orig_for_this_az),
@@ -701,7 +707,7 @@ impl<const NUM_SVO_ROUNDS: usize, F: JoltField> SpartanInterleavedPolynomial<NUM
             .into_par_iter()
             .zip_eq(output_slices_for_tasks.into_par_iter())
             .for_each(|(task_output, output_slice_for_task)| {
-                let coeffs_from_task = &task_output.bound_coeffs_local; // These are the Vec<SparseCoefficient<F>> from a StreamingTaskOutput
+                let coeffs_from_task = &task_output.bound_coeffs_local;
 
                 let mut current_output_idx_in_slice = 0;
                 // Iterate through sub-blocks of 6 within this task's coeffs_from_task

--- a/jolt-core/src/poly/spartan_interleaved_poly.rs
+++ b/jolt-core/src/poly/spartan_interleaved_poly.rs
@@ -223,7 +223,7 @@ impl<const NUM_SVO_ROUNDS: usize, F: JoltField> SpartanInterleavedPolynomial<NUM
         );
 
         let x_out_chunk_size = if num_x_out_vals > 0 {
-            num_x_out_vals.div_ceil(num_parallel_chunks)
+            std::cmp::max(1, num_x_out_vals.div_ceil(num_parallel_chunks))
         } else {
             0 // No work per chunk if no x_out_vals
         };

--- a/jolt-core/src/poly/spartan_interleaved_poly.rs
+++ b/jolt-core/src/poly/spartan_interleaved_poly.rs
@@ -1,8 +1,6 @@
 use super::{
-    eq_poly::EqPolynomial,
-    multilinear_polynomial::MultilinearPolynomial,
-    sparse_interleaved_poly::SparseCoefficient,
-    split_eq_poly::GruenSplitEqPolynomial,
+    eq_poly::EqPolynomial, multilinear_polynomial::MultilinearPolynomial,
+    sparse_interleaved_poly::SparseCoefficient, split_eq_poly::GruenSplitEqPolynomial,
     unipoly::CompressedUniPoly,
 };
 use crate::subprotocols::sumcheck::process_eq_sumcheck_round;
@@ -11,7 +9,7 @@ use crate::{
     r1cs::builder::{eval_offset_lc, Constraint, OffsetEqConstraint},
     utils::{
         math::Math,
-        small_value::{NUM_SVO_ROUNDS, svo_helpers},
+        small_value::{svo_helpers, NUM_SVO_ROUNDS},
         transcript::Transcript,
     },
 };
@@ -19,7 +17,8 @@ use ark_ff::Zero;
 use rayon::prelude::*;
 
 pub const TOTAL_NUM_ACCUMS: usize = svo_helpers::total_num_accums(NUM_SVO_ROUNDS);
-pub const NUM_NONTRIVIAL_TERNARY_POINTS: usize = svo_helpers::num_non_trivial_ternary_points(NUM_SVO_ROUNDS);
+pub const NUM_NONTRIVIAL_TERNARY_POINTS: usize =
+    svo_helpers::num_non_trivial_ternary_points(NUM_SVO_ROUNDS);
 pub const NUM_ACCUMS_EVAL_ZERO: usize = svo_helpers::num_accums_eval_zero(NUM_SVO_ROUNDS);
 pub const NUM_ACCUMS_EVAL_INFTY: usize = svo_helpers::num_accums_eval_infty(NUM_SVO_ROUNDS);
 
@@ -455,7 +454,8 @@ impl<const NUM_SVO_ROUNDS: usize, F: JoltField> SpartanInterleavedPolynomial<NUM
         #[cfg(test)]
         {
             if NUM_SVO_ROUNDS > 0 {
-                for shard in &final_ab_unbound_coeffs_shards { // Iterate over &Vec directly
+                for shard in &final_ab_unbound_coeffs_shards {
+                    // Iterate over &Vec directly
                     if !shard.is_empty() {
                         let mut prev_index = shard[0].index;
                         for coeff in shard.iter().skip(1) {

--- a/jolt-core/src/poly/split_eq_poly.rs
+++ b/jolt-core/src/poly/split_eq_poly.rs
@@ -113,11 +113,7 @@ impl<F: JoltField> GruenSplitEqPolynomial<F> {
             n - 1 // Use up to n-1, excluding the last variable of w (tau)
         };
 
-        let num_actual_suffix_vars = if split_point_x_in < suffix_slice_end {
-            suffix_slice_end - split_point_x_in
-        } else {
-            0
-        };
+        let num_actual_suffix_vars = suffix_slice_end.saturating_sub(split_point_x_in);
 
         let mut w_E_out_vars: Vec<F> = Vec::with_capacity(num_x_out_vars + num_actual_suffix_vars);
         w_E_out_vars.extend_from_slice(&w[0..split_point_x_out]);

--- a/jolt-core/src/poly/split_eq_poly.rs
+++ b/jolt-core/src/poly/split_eq_poly.rs
@@ -480,5 +480,5 @@ mod tests {
             );
         });
         assert!(result3.is_err());
-    }    
+    }
 }

--- a/jolt-core/src/r1cs/builder.rs
+++ b/jolt-core/src/r1cs/builder.rs
@@ -7,7 +7,6 @@ use crate::poly::multilinear_polynomial::MultilinearPolynomial;
 use crate::{
     field::JoltField,
     jolt::vm::JoltPolynomials,
-    poly::spartan_interleaved_poly::SpartanInterleavedPolynomial,
     r1cs::key::{SparseConstraints, UniformR1CS},
 };
 use ark_ff::One;
@@ -183,7 +182,7 @@ impl<F: JoltField> AuxComputation<F> {
 
 pub struct R1CSBuilder<const C: usize, F: JoltField, I: ConstraintInput> {
     _inputs: PhantomData<I>,
-    constraints: Vec<Constraint>,
+    pub(crate) constraints: Vec<Constraint>,
     aux_computations: BTreeMap<usize, AuxComputation<F>>,
 }
 
@@ -506,12 +505,12 @@ pub(crate) fn eval_offset_lc<F: JoltField>(
 
 // TODO(sragss): Detailed documentation with wiki.
 pub struct CombinedUniformBuilder<const C: usize, F: JoltField, I: ConstraintInput> {
-    uniform_builder: R1CSBuilder<C, F, I>,
+    pub(crate) uniform_builder: R1CSBuilder<C, F, I>,
 
     /// Padded to the nearest power of 2
-    uniform_repeat: usize, // TODO(JP): Remove padding of steps
+    pub(crate) uniform_repeat: usize, // TODO(JP): Remove padding of steps
 
-    offset_equality_constraints: Vec<OffsetEqConstraint>,
+    pub(crate) offset_equality_constraints: Vec<OffsetEqConstraint>,
 }
 
 impl<const C: usize, F: JoltField, I: ConstraintInput> CombinedUniformBuilder<C, F, I> {
@@ -619,18 +618,5 @@ impl<const C: usize, F: JoltField, I: ConstraintInput> CombinedUniformBuilder<C,
         }
 
         CrossStepR1CS { constraints }
-    }
-
-    #[tracing::instrument(skip_all)]
-    pub fn compute_spartan_Az_Bz_Cz(
-        &self,
-        flattened_polynomials: &[&MultilinearPolynomial<F>], // N variables of (S steps)
-    ) -> SpartanInterleavedPolynomial<F> {
-        SpartanInterleavedPolynomial::new(
-            &self.uniform_builder.constraints,
-            &self.offset_equality_constraints,
-            flattened_polynomials,
-            self.padded_rows_per_step(),
-        )
     }
 }

--- a/jolt-core/src/r1cs/builder.rs
+++ b/jolt-core/src/r1cs/builder.rs
@@ -27,7 +27,7 @@ pub struct Constraint {
 
 impl Constraint {
     #[cfg(test)]
-    pub(crate) fn pretty_fmt<const C: usize, I: ConstraintInput, F: JoltField>(
+    pub(crate) fn _pretty_fmt<const C: usize, I: ConstraintInput, F: JoltField>(
         &self,
         f: &mut String,
         flattened_polynomials: &[&MultilinearPolynomial<F>],

--- a/jolt-core/src/subprotocols/sumcheck.rs
+++ b/jolt-core/src/subprotocols/sumcheck.rs
@@ -208,7 +208,7 @@ impl<F: JoltField, ProofTranscript: Transcript> SumcheckInstanceProof<F, ProofTr
                 padded_num_constraints,
                 uniform_constraints,
                 cross_step_constraints,
-                &flattened_polys,
+                flattened_polys,
                 tau,
             );
 

--- a/jolt-core/src/utils/mod.rs
+++ b/jolt-core/src/utils/mod.rs
@@ -9,6 +9,7 @@ pub mod gaussian_elimination;
 pub mod instruction_utils;
 pub mod math;
 pub mod profiling;
+pub mod small_value;
 pub mod sol_types;
 pub mod thread;
 pub mod transcript;

--- a/jolt-core/src/utils/small_value.rs
+++ b/jolt-core/src/utils/small_value.rs
@@ -327,7 +327,7 @@ pub mod svo_helpers {
         let az11 = binary_az_evals[3];
         let bz11 = binary_bz_evals[3]; // Y0=1, Y1=1
 
-        // Extended evaluations (points with at least one \'I\')
+        // Extended evaluations (points with at least one I)
         // temp_tA indices follow the order: (0,I), (1,I), (I,0), (I,1), (I,I)
 
         // 1. Point (0,I) -> temp_tA[0]
@@ -1008,9 +1008,8 @@ pub mod svo_helpers {
 
         for i in 0..19 {
             let current_tA = tA_accums[i];
-            // No !current_tA.is_zero() check, as requested
 
-            let (y0_c, y1_c, y2_c) = Y_EXT_CODE_MAP[i]; // (MSB, Mid, LSB) from code\'s perspective
+            let (y0_c, y1_c, y2_c) = Y_EXT_CODE_MAP[i]; // (MSB, Mid, LSB) from code's perspective
 
             // --- Contributions to Paper Round s_p=0 Accumulators (u = Y2_c) ---
             // E-factor uses E_out_vec[0] (where Y2_c is u_eff), E_suffix is (Y0_c, Y1_c)
@@ -1122,6 +1121,8 @@ pub mod svo_helpers {
 
     // Distributes the accumulated tA values (sum over x_in) for a single x_out_val
     // to the appropriate SVO round accumulators.
+    // This is the generic version that works for any number of SVO rounds.
+    // We keep around the hard-coded versions for intuition
     #[inline]
     pub fn distribute_tA_to_svo_accumulators<
         const NUM_SVO_ROUNDS: usize,

--- a/jolt-core/src/utils/small_value.rs
+++ b/jolt-core/src/utils/small_value.rs
@@ -910,7 +910,7 @@ pub mod svo_helpers {
 
         // Y_ext = (1,I) -> tA_accums[1]
         // Contributes to A_0(empty,I) (i.e. accums_infty[0]) via E_out_0[x_out_val | 1]
-        // (no term A_1(1,I) as it is not needed i.e. it\'s an eval at 1)
+        // (no term A_1(1,I) as it is not needed i.e. it's an eval at 1)
         accums_infty[0] += E0_y1 * tA_accums[1];
 
         // Y_ext = (I,0) -> tA_accums[2]

--- a/jolt-core/src/utils/small_value.rs
+++ b/jolt-core/src/utils/small_value.rs
@@ -1,0 +1,1802 @@
+// Small Value Optimization (SVO) helpers for Spartan first sum-check
+
+use crate::field::{JoltField, OptimizedMulI128};
+
+/// Number of rounds to use for small value optimization.
+/// Testing & estimation shows that 3 rounds is the best tradeoff
+/// It may be 4 rounds when we switch to streaming
+pub const NUM_SVO_ROUNDS: usize = 3;
+
+pub mod svo_helpers {
+    use super::*;
+    use crate::poly::split_eq_poly::GruenSplitEqPolynomial;
+    use crate::poly::unipoly::CompressedUniPoly;
+    use crate::subprotocols::sumcheck::process_eq_sumcheck_round;
+    use crate::utils::transcript::Transcript;
+
+    // SVOEvalPoint enum definition
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+    pub enum SVOEvalPoint {
+        Zero,
+        One,
+        Infinity,
+    }
+
+    #[inline]
+    pub const fn pow(base: usize, exp: usize) -> usize {
+        let mut res = 1;
+        let mut i = 0;
+        while i < exp {
+            res = res * base;
+            i += 1;
+        }
+        res
+    }
+
+    pub const fn num_non_trivial_ternary_points(num_svo_rounds: usize) -> usize {
+        // Returns 3^num_svo_rounds - 2^num_svo_rounds
+        // This is equivalent to num_non_binary_points
+        num_non_binary_points(num_svo_rounds)
+    }
+    
+    pub const fn total_num_accums(num_svo_rounds: usize) -> usize {
+        // Compute the sum \sum_{i=1}^{num_svo_rounds} (3^i - 2^i)
+        // Note: original loop was 1 to num_svo_rounds inclusive.
+        // num_non_binary_points(i) is 3^i - 2^i
+        let mut sum = 0;
+        let mut i = 1;
+        while i <= num_svo_rounds { // Original was i <= num_svo_rounds
+            sum += num_non_binary_points(i);
+            i += 1;
+        }
+        sum
+    }
+    
+    pub const fn num_accums_eval_zero(num_svo_rounds: usize) -> usize {
+        // Returns \sum_{i=0}^{num_svo_rounds - 1} (3^i - 2^i)
+        let mut sum = 0;
+        let mut i = 0;
+        while i < num_svo_rounds {
+            sum += num_non_binary_points(i);
+            i += 1;
+        }
+        sum
+    }
+    
+    pub const fn num_accums_eval_infty(num_svo_rounds: usize) -> usize {
+        // Returns \sum_{i=0}^{num_svo_rounds - 1} 3^i
+        let mut sum = 0;
+        let mut i = 0;
+        while i < num_svo_rounds {
+            sum += pow(3, i);
+            i += 1;
+        }
+        sum
+    }
+
+    pub const fn num_non_binary_points(n: usize) -> usize {
+        if n == 0 {
+            return 0;
+        }
+        pow(3, n) - pow(2, n)
+    }
+
+    pub const fn k_to_y_ext_msb<const N: usize>(
+        k_ternary: usize,
+    ) -> ([SVOEvalPoint; N], bool /*is_binary*/) {
+        let mut coords = [SVOEvalPoint::Zero; N];
+        let mut temp_k = k_ternary;
+        let mut is_binary_flag = true;
+
+        if N == 0 {
+            return (coords, is_binary_flag);
+        }
+
+        let mut i_rev = 0;
+        while i_rev < N {
+            let i_dim_msb = N - 1 - i_rev;
+            let digit = temp_k % 3;
+            coords[i_dim_msb] = if digit == 0 {
+                SVOEvalPoint::Zero
+            } else if digit == 1 {
+                SVOEvalPoint::One
+            } else {
+                is_binary_flag = false;
+                SVOEvalPoint::Infinity
+            };
+            temp_k /= 3;
+            i_rev += 1;
+        }
+        (coords, is_binary_flag)
+    }
+
+    pub const fn build_y_ext_code_map<const N: usize, const M: usize>() -> [[SVOEvalPoint; N]; M] {
+        let mut map = [[SVOEvalPoint::Zero; N]; M];
+        let mut current_map_idx = 0;
+
+        if N == 0 {
+            return map;
+        }
+
+        let num_total_ternary_points = pow(3, N);
+        let mut k_ternary_idx = 0;
+        while k_ternary_idx < num_total_ternary_points {
+            let (coords_msb, is_binary) = k_to_y_ext_msb::<N>(k_ternary_idx);
+            if !is_binary {
+                if current_map_idx < M {
+                    map[current_map_idx] = coords_msb;
+                    current_map_idx += 1;
+                }
+            }
+            k_ternary_idx += 1;
+        }
+        map
+    }
+
+    pub const fn v_coords_to_base3_idx(v_coords_lsb_y_ext_order: &[SVOEvalPoint]) -> usize {
+        let mut idx = 0;
+        let mut current_power_of_3 = 1;
+        let mut i = 0;
+        while i < v_coords_lsb_y_ext_order.len() {
+            let point_val = match v_coords_lsb_y_ext_order[i] {
+                SVOEvalPoint::Zero => 0,
+                SVOEvalPoint::One => 1,
+                SVOEvalPoint::Infinity => 2,
+            };
+            idx += point_val * current_power_of_3;
+            if i < v_coords_lsb_y_ext_order.len() - 1 {
+                    current_power_of_3 = current_power_of_3 * 3;
+            }
+            i += 1;
+        }
+        idx
+    }
+
+    pub const fn v_coords_has_infinity(v_coords_lsb_y_ext_order: &[SVOEvalPoint]) -> bool {
+        let mut i = 0;
+        while i < v_coords_lsb_y_ext_order.len() {
+            if matches!(v_coords_lsb_y_ext_order[i], SVOEvalPoint::Infinity) {
+                return true;
+            }
+            i += 1;
+        }
+        false
+    }
+
+    pub const fn v_coords_to_non_binary_base3_idx(v_coords_lsb_y_ext_order: &[SVOEvalPoint]) -> usize {
+        let num_v_vars = v_coords_lsb_y_ext_order.len();
+        if num_v_vars == 0 {
+            return 0; 
+        }
+
+        let mut index_count = 0;
+        let target_v_config_ternary_value = v_coords_to_base3_idx(v_coords_lsb_y_ext_order);
+
+        let max_k_v = pow(3, num_v_vars);
+        let mut k_v_ternary = 0;
+        while k_v_ternary < max_k_v {
+            if k_v_ternary == target_v_config_ternary_value {
+                break;
+            }
+
+            let mut current_k_v_has_inf = false;
+            let mut temp_k = k_v_ternary;
+            let mut var_idx = 0;
+            while var_idx < num_v_vars {
+                if temp_k % 3 == 2 {
+                    current_k_v_has_inf = true;
+                    break;
+                }
+                temp_k /= 3;
+                var_idx += 1;
+            }
+
+            if current_k_v_has_inf {
+                index_count += 1;
+            }
+            k_v_ternary += 1;
+        }
+        index_count
+    }
+
+    pub const fn precompute_accumulator_offsets<const N: usize>() -> ([usize; N], [usize; N]) {
+        let mut offsets_infty = [0; N];
+        let mut offsets_zero = [0; N];
+        if N == 0 {
+            return (offsets_infty, offsets_zero);
+        }
+
+        let mut current_sum_infty = 0;
+        let mut current_sum_zero = 0;
+        let mut s_p = 0;
+        while s_p < N {
+            offsets_infty[s_p] = current_sum_infty;
+            offsets_zero[s_p] = current_sum_zero;
+
+            current_sum_infty += pow(3, s_p);
+            current_sum_zero += pow(3, s_p) - pow(2, s_p);
+            s_p += 1;
+        }
+        (offsets_infty, offsets_zero)
+    }
+
+    #[inline]
+    fn get_v_config_digits(mut k_global: usize, num_vars: usize) -> Vec<usize> {
+        if num_vars == 0 {
+            return vec![];
+        }
+        let mut digits = vec![0; num_vars];
+        let mut i = num_vars;
+        while i > 0 {
+            // Fill from LSB of digits vec, which corresponds to LSB of k_global
+            digits[i - 1] = k_global % 3;
+            k_global /= 3;
+            i -= 1;
+        }
+        digits
+    }
+
+    #[inline]
+    fn is_v_config_non_binary(v_config: &[usize]) -> bool {
+        v_config.iter().any(|&digit| digit == 2)
+    }
+
+    pub fn compute_and_update_tA_inplace_generic<const NUM_SVO_ROUNDS: usize, F: JoltField>(
+        binary_az_evals: &[i128],
+        binary_bz_evals: &[i128],
+        e_in_val: &F,
+        temp_tA: &mut [F],
+    ) {
+        match NUM_SVO_ROUNDS {
+            1 => {
+                compute_and_update_tA_inplace_1(binary_az_evals, binary_bz_evals, e_in_val, temp_tA)
+            }
+            2 => {
+                compute_and_update_tA_inplace_2(binary_az_evals, binary_bz_evals, e_in_val, temp_tA)
+            }
+            3 => {
+                compute_and_update_tA_inplace_3(binary_az_evals, binary_bz_evals, e_in_val, temp_tA)
+            }
+            // 81 - 16 = 65 non-binary points
+            4 => compute_and_update_tA_inplace::<
+                    4, 
+                    65, 
+                    81,
+                    F, 
+                >(
+                binary_az_evals,
+                binary_bz_evals,
+                e_in_val,
+                temp_tA,
+            ),
+            _ => {
+                panic!("Unsupported number of SVO rounds: {}", NUM_SVO_ROUNDS);
+            }
+        }
+    }
+
+    /// Special case when `num_svo_rounds == 1`
+    /// In this case, we know that there is 3 - 2 = 1 temp_tA accumulator,
+    /// corresponding to temp_tA(infty), which should be updated via
+    /// temp_tA[infty] += e_in_val * (az[1] - az[0]) * (bz[1] - bz[0])
+    #[inline]
+    pub fn compute_and_update_tA_inplace_1<F: JoltField>(
+        binary_az_evals: &[i128],
+        binary_bz_evals: &[i128],
+        e_in_val: &F,
+        temp_tA: &mut [F],
+    ) {
+        debug_assert!(binary_az_evals.len() == 2);
+        debug_assert!(binary_bz_evals.len() == 2);
+        debug_assert!(temp_tA.len() == 1);
+        let az_I = binary_az_evals[1] - binary_az_evals[0];
+        if az_I != 0 {
+            let bz_I = binary_bz_evals[1] - binary_bz_evals[0];
+            if bz_I != 0 {
+                let product_i128 = az_I
+                    .checked_mul(bz_I)
+                    .expect("Az_I*Bz_I product overflow i128");
+                temp_tA[0] += e_in_val.mul_i128(product_i128);
+            }
+        }
+    }
+
+    /// Special case when `num_svo_rounds == 2`
+    /// In this case, we know that there are 4 binary evals of Az and Bz,
+    /// corresponding to (0,0) => 0, (0,1) => 1, (1,0) => 2, (1,1) => 3. (i.e. big endian, TODO: double-check this)
+    ///
+    /// There are 9 - 4 = 5 temp_tA accumulators, with the following logic (in this order 0 => 4 indexing):
+    /// temp_tA[0,∞] += e_in_val * (az[0,1] - az[0,0]) * (bz[0,1] - bz[0,0])
+    /// temp_tA[1,∞] += e_in_val * (az[1,1] - az[1,0]) * (bz[1,1] - bz[1,0])
+    /// temp_tA[∞,0] += e_in_val * (az[1,0] - az[0,0]) * (bz[1,0] - bz[0,0])
+    /// temp_tA[∞,1] += e_in_val * (az[1,1] - az[0,1]) * (bz[1,1] - bz[0,1])
+    /// temp_tA[∞,∞] += e_in_val * (az[1,∞] - az[0,∞]) * (bz[1,∞] - bz[0,∞])
+    #[inline]
+    pub fn compute_and_update_tA_inplace_2<F: JoltField>(
+        binary_az_evals: &[i128],
+        binary_bz_evals: &[i128],
+        e_in_val: &F,
+        temp_tA: &mut [F],
+    ) {
+        debug_assert!(binary_az_evals.len() == 4);
+        debug_assert!(binary_bz_evals.len() == 4);
+        debug_assert!(temp_tA.len() == 5);
+        // Binary evaluations: (Y0,Y1) -> index Y0*2 + Y1
+        let az00 = binary_az_evals[0];
+        let bz00 = binary_bz_evals[0]; // Y0=0, Y1=0
+        let az01 = binary_az_evals[1];
+        let bz01 = binary_bz_evals[1]; // Y0=0, Y1=1
+        let az10 = binary_az_evals[2];
+        let bz10 = binary_bz_evals[2]; // Y0=1, Y1=0
+        let az11 = binary_az_evals[3];
+        let bz11 = binary_bz_evals[3]; // Y0=1, Y1=1
+
+        // Extended evaluations (points with at least one \'I\')
+        // temp_tA indices follow the order: (0,I), (1,I), (I,0), (I,1), (I,I)
+
+        // 1. Point (0,I) -> temp_tA[0]
+        let az_0I = az01 - az00;
+        let bz_0I = bz01 - bz00;
+        if az_0I != 0 && bz_0I != 0 {
+            let prod_0I = az_0I
+                .checked_mul(bz_0I)
+                .expect("Product overflow for (0,I)");
+            temp_tA[0] += e_in_val.mul_i128(prod_0I);
+        }
+
+        // 2. Point (1,I) -> temp_tA[1]
+        let az_1I = az11 - az10;
+        let bz_1I = bz11 - bz10;
+        if az_1I != 0 && bz_1I != 0 {
+            let prod_1I = az_1I
+                .checked_mul(bz_1I)
+                .expect("Product overflow for (1,I)");
+            temp_tA[1] += e_in_val.mul_i128(prod_1I);
+        }
+
+        // 3. Point (I,0) -> temp_tA[2]
+        let az_I0 = az10 - az00;
+        if az_I0 != 0 {
+            let bz_I0 = bz10 - bz00;
+            if bz_I0 != 0 {
+                let prod_I0 = az_I0
+                    .checked_mul(bz_I0)
+                    .expect("Product overflow for (I,0)");
+                temp_tA[2] += e_in_val.mul_i128(prod_I0);
+            }
+        }
+
+        // 4. Point (I,1) -> temp_tA[3]
+        let az_I1 = az11 - az01;
+        if az_I1 != 0 {
+            let bz_I1 = bz11 - bz01;
+            if bz_I1 != 0 {
+                let prod_I1 = az_I1
+                    .checked_mul(bz_I1)
+                    .expect("Product overflow for (I,1)");
+                temp_tA[3] += e_in_val.mul_i128(prod_I1);
+            }
+        }
+
+        // 5. Point (I,I) -> temp_tA[4]
+        let az_II = az_1I - az_0I;
+        if az_II != 0 {
+            let bz_II = bz_1I - bz_0I;
+            if bz_II != 0 {
+                let prod_II = az_II
+                    .checked_mul(bz_II)
+                    .expect("Product overflow for (I,I)");
+                // At this point, pretty unlikely for prod_II to be 1
+                temp_tA[4] += e_in_val.mul_i128(prod_II);
+            }
+        }
+    }
+
+    /// Special case when `num_svo_rounds == 3`
+    /// In this case, we know that there are 8 binary evals of Az and Bz,
+    /// corresponding to (0,0,0) => 0, (0,0,1) => 1, (0,1,0) => 2, (0,1,1) => 3, (1,0,0) => 4,
+    /// (1,0,1) => 5, (1,1,0) => 6, (1,1,1) => 7.
+    ///
+    /// There are 27 - 8 = 19 temp_tA accumulators, with the following logic:
+    /// (listed in increasing order, when considering ∞ as 2 and going from MSB to LSB)
+    ///
+    /// temp_tA[0,0,∞] += e_in_val * (az[0,0,1] - az[0,0,0]) * (bz[0,0,1] - bz[0,0,0])
+    /// temp_tA[0,1,∞] += e_in_val * (az[0,1,1] - az[0,1,0]) * (bz[0,1,1] - bz[0,1,0])
+    /// temp_tA[0,∞,0] += e_in_val * (az[0,1,0] - az[0,0,0]) * (bz[0,1,0] - bz[0,0,0])
+    /// temp_tA[0,∞,1] += e_in_val * (az[0,1,1] - az[0,0,1]) * (bz[0,1,1] - bz[0,0,1])
+    /// temp_tA[0,∞,∞] += e_in_val * (az[0,1,∞] - az[0,0,∞]) * (bz[0,1,∞] - bz[0,0,∞])
+    ///
+    /// temp_tA[1,0,∞] += e_in_val * (az[1,0,1] - az[1,0,0]) * (bz[1,0,1] - bz[1,0,0])
+    /// temp_tA[1,1,∞] += e_in_val * (az[1,1,1] - az[1,1,0]) * (bz[1,1,1] - bz[1,1,0])
+    /// temp_tA[1,∞,0] += e_in_val * (az[1,1,0] - az[1,0,0]) * (bz[1,1,0] - bz[1,0,0])
+    /// temp_tA[1,∞,1] += e_in_val * (az[1,1,0] - az[1,0,0]) * (bz[1,1,0] - bz[1,0,0])
+    /// temp_tA[1,∞,∞] += e_in_val * (az[1,1,∞] - az[1,0,∞]) * (bz[1,1,∞] - bz[1,0,∞])
+    ///
+    /// temp_tA[∞,0,0] += e_in_val * (az[1,0,0] - az[0,0,0]) * (bz[1,0,0] - bz[0,0,0])
+    /// temp_tA[∞,0,1] += e_in_val * (az[1,0,1] - az[0,0,1]) * (bz[1,0,1] - bz[0,0,1])
+    /// temp_tA[∞,0,∞] += e_in_val * (az[1,0,∞] - az[0,0,∞]) * (bz[1,0,∞] - bz[0,0,∞])
+    /// temp_tA[∞,1,0] += e_in_val * (az[1,1,0] - az[0,1,0]) * (bz[1,1,0] - bz[0,1,0])
+    /// temp_tA[∞,1,1] += e_in_val * (az[1,1,1] - az[0,1,1]) * (bz[1,1,1] - bz[0,1,1])
+    /// temp_tA[∞,1,∞] += e_in_val * (az[1,1,∞] - az[0,1,∞]) * (bz[1,1,∞] - bz[0,1,∞])
+    /// temp_tA[∞,∞,0] += e_in_val * (az[1,∞,0] - az[0,∞,0]) * (bz[1,∞,0] - bz[0,∞,0])
+    /// temp_tA[∞,∞,1] += e_in_val * (az[1,∞,1] - az[0,∞,1]) * (bz[1,∞,1] - bz[0,∞,1])
+    /// temp_tA[∞,∞,∞] += e_in_val * (az[1,∞,∞] - az[0,∞,∞]) * (bz[1,∞,∞] - bz[0,∞,∞])
+    ///
+    #[inline]
+    pub fn compute_and_update_tA_inplace_3<F: JoltField>(
+        binary_az_evals: &[i128],
+        binary_bz_evals: &[i128],
+        e_in_val: &F,
+        temp_tA: &mut [F],
+    ) {
+        debug_assert!(binary_az_evals.len() == 8);
+        debug_assert!(binary_bz_evals.len() == 8);
+        debug_assert!(temp_tA.len() == 19);
+
+        // Binary evaluations (Y0,Y1,Y2) -> index Y0*4 + Y1*2 + Y2
+        let az000 = binary_az_evals[0];
+        let bz000 = binary_bz_evals[0];
+        let az001 = binary_az_evals[1];
+        let bz001 = binary_bz_evals[1];
+        let az010 = binary_az_evals[2];
+        let bz010 = binary_bz_evals[2];
+        let az011 = binary_az_evals[3];
+        let bz011 = binary_bz_evals[3];
+        let az100 = binary_az_evals[4];
+        let bz100 = binary_bz_evals[4];
+        let az101 = binary_az_evals[5];
+        let bz101 = binary_bz_evals[5];
+        let az110 = binary_az_evals[6];
+        let bz110 = binary_bz_evals[6];
+        let az111 = binary_az_evals[7];
+        let bz111 = binary_bz_evals[7];
+
+        // Populate temp_tA in lexicographical MSB-first order
+        // Z=0, O=1, I=2 for Y_i
+
+        // Point (0,0,I) -> temp_tA[0]
+        let az_00I = az001 - az000;
+        let bz_00I = bz001 - bz000;
+        if az_00I != 0 && bz_00I != 0 {
+            let prod = az_00I.checked_mul(bz_00I).expect("Prod overflow");
+            // Test `mul_i128_1_optimized`
+            temp_tA[0] += e_in_val.mul_i128_1_optimized(prod);
+        }
+
+        // Point (0,1,I) -> temp_tA[1]
+        let az_01I = az011 - az010;
+        let bz_01I = bz011 - bz010;
+        if az_01I != 0 && bz_01I != 0 {
+            let prod = az_01I.checked_mul(bz_01I).expect("Prod overflow");
+            temp_tA[1] += e_in_val.mul_i128(prod);
+        }
+
+        // Point (0,I,0) -> temp_tA[2]
+        let az_0I0 = az010 - az000;
+        let bz_0I0 = bz010 - bz000;
+        if az_0I0 != 0 && bz_0I0 != 0 {
+            let prod = az_0I0.checked_mul(bz_0I0).expect("Prod overflow");
+            temp_tA[2] += e_in_val.mul_i128(prod);
+        }
+
+        // Point (0,I,1) -> temp_tA[3]
+        let az_0I1 = az011 - az001;
+        let bz_0I1 = bz011 - bz001;
+        if az_0I1 != 0 && bz_0I1 != 0 {
+            let prod = az_0I1.checked_mul(bz_0I1).expect("Prod overflow");
+            temp_tA[3] += e_in_val.mul_i128(prod);
+        }
+
+        // Point (0,I,I) -> temp_tA[4]
+        let az_0II = az_01I - az_00I;
+        let bz_0II = bz_01I - bz_00I; // Need to compute this outside for III term
+        if az_0II != 0 && bz_0II != 0 {
+            let prod = az_0II.checked_mul(bz_0II).expect("Prod overflow");
+            temp_tA[4] += e_in_val.mul_i128(prod);
+        }
+
+        // Point (1,0,I) -> temp_tA[5]
+        let az_10I = az101 - az100;
+        let bz_10I = bz101 - bz100;
+        if az_10I != 0 && bz_10I != 0 {
+            let prod = az_10I.checked_mul(bz_10I).expect("Prod overflow");
+            temp_tA[5] += e_in_val.mul_i128(prod);
+        }
+
+        // Point (1,1,I) -> temp_tA[6]
+        let az_11I = az111 - az110;
+        let bz_11I = bz111 - bz110;
+        if az_11I != 0 && bz_11I != 0 {
+            let prod = az_11I.checked_mul(bz_11I).expect("Prod overflow");
+            temp_tA[6] += e_in_val.mul_i128(prod);
+        }
+
+        // Point (1,I,0) -> temp_tA[7]
+        let az_1I0 = az110 - az100;
+        let bz_1I0 = bz110 - bz100;
+        if az_1I0 != 0 && bz_1I0 != 0 {
+            let prod = az_1I0.checked_mul(bz_1I0).expect("Prod overflow");
+            temp_tA[7] += e_in_val.mul_i128(prod);
+        }
+
+        // Point (1,I,1) -> temp_tA[8]
+        let az_1I1 = az111 - az101;
+        let bz_1I1 = bz111 - bz101;
+        if az_1I1 != 0 && bz_1I1 != 0 {
+            let prod = az_1I1.checked_mul(bz_1I1).expect("Prod overflow");
+            temp_tA[8] += e_in_val.mul_i128(prod);
+        }
+
+        // Point (1,I,I) -> temp_tA[9]
+        let az_1II = az_11I - az_10I;
+        let bz_1II = bz_11I - bz_10I; // Need to compute this outside for III term
+        if az_1II != 0 && bz_1II != 0 {
+            let prod = az_1II.checked_mul(bz_1II).expect("Prod overflow");
+            temp_tA[9] += e_in_val.mul_i128(prod);
+        }
+
+        // Point (I,0,0) -> temp_tA[10]
+        let az_I00 = az100 - az000;
+        let bz_I00 = bz100 - bz000;
+        if az_I00 != 0 && bz_I00 != 0 {
+            let prod = az_I00.checked_mul(bz_I00).expect("Prod overflow");
+            temp_tA[10] += e_in_val.mul_i128(prod);
+        }
+
+        // Point (I,0,1) -> temp_tA[11]
+        let az_I01 = az101 - az001;
+        let bz_I01 = bz101 - bz001;
+        if az_I01 != 0 && bz_I01 != 0 {
+            let prod = az_I01.checked_mul(bz_I01).expect("Prod overflow");
+            temp_tA[11] += e_in_val.mul_i128(prod);
+        }
+
+        // Point (I,0,I) -> temp_tA[12]
+        let az_I0I = az_I01 - az_I00; // Uses precomputed az_I01, az_I00
+        if az_I0I != 0 {
+            let bz_I0I = bz_I01 - bz_I00; // Uses precomputed bz_I01, bz_I00
+            if bz_I0I != 0 {
+                let prod = az_I0I.checked_mul(bz_I0I).expect("Prod overflow");
+                temp_tA[12] += e_in_val.mul_i128(prod);
+            }
+        }
+
+        // Point (I,1,0) -> temp_tA[13]
+        let az_I10 = az110 - az010;
+        let bz_I10 = bz110 - bz010;
+        if az_I10 != 0 && bz_I10 != 0 {
+            let prod = az_I10.checked_mul(bz_I10).expect("Prod overflow");
+            temp_tA[13] += e_in_val.mul_i128(prod);
+        }
+
+        // Point (I,1,1) -> temp_tA[14]
+        let az_I11 = az111 - az011;
+        let bz_I11 = bz111 - bz011;
+        if az_I11 != 0 && bz_I11 != 0 {
+            let prod = az_I11.checked_mul(bz_I11).expect("Prod overflow");
+            temp_tA[14] += e_in_val.mul_i128(prod);
+        }
+
+        // Point (I,1,I) -> temp_tA[15]
+        let az_I1I = az_I11 - az_I10; // Uses precomputed az_I11, az_I10
+        if az_I1I != 0 {
+            let bz_I1I = bz_I11 - bz_I10; // Uses precomputed bz_I11, bz_I10
+            if bz_I1I != 0 {
+                let prod = az_I1I.checked_mul(bz_I1I).expect("Prod overflow");
+                temp_tA[15] += e_in_val.mul_i128(prod);
+            }
+        }
+
+        // Point (I,I,0) -> temp_tA[16]
+        let az_II0 = az_1I0 - az_0I0; // Uses precomputed az_1I0, az_0I0
+        if az_II0 != 0 {
+            let bz_II0 = bz_1I0 - bz_0I0; // Uses precomputed bz_1I0, bz_0I0
+            if bz_II0 != 0 {
+                let prod = az_II0.checked_mul(bz_II0).expect("Prod overflow");
+                temp_tA[16] += e_in_val.mul_i128(prod);
+            }
+        }
+
+        // Point (I,I,1) -> temp_tA[17]
+        let az_II1 = az_1I1 - az_0I1; // Uses precomputed az_1I1, az_0I1
+        if az_II1 != 0 {
+            let bz_II1 = bz_1I1 - bz_0I1; // Uses precomputed bz_1I1, bz_0I1
+            if bz_II1 != 0 {
+                let prod = az_II1.checked_mul(bz_II1).expect("Prod overflow");
+                temp_tA[17] += e_in_val.mul_i128(prod);
+            }
+        }
+
+        // Point (I,I,I) -> temp_tA[18]
+        // az_III depends on az_1II and az_0II.
+        // az_1II was computed for temp_tA[9]
+        // az_0II was computed for temp_tA[4]
+        let az_III = az_1II - az_0II;
+        if az_III != 0 {
+            // bz_III depends on bz_1II and bz_0II.
+            // bz_1II was computed for temp_tA[9]
+            // bz_0II was computed for temp_tA[4]
+            let bz_III = bz_1II - bz_0II;
+            if bz_III != 0 {
+                let prod = az_III.checked_mul(bz_III).expect("Prod overflow");
+                temp_tA[18] += e_in_val.mul_i128(prod);
+            }
+        }
+    }
+
+    /// Converts MSB-first SVOEvalPoint coordinates to their global ternary index k.
+    /// k = sum_{i=0}^{N-1} val(coords_msb[i]) * 3^(N-1-i)
+    pub const fn svo_coords_msb_to_k_ternary_idx<const N: usize>(coords_msb: &[SVOEvalPoint; N]) -> usize {
+        if N == 0 {
+            return 0; 
+        }
+        let mut k_val = 0;
+        let mut i_msb_dim = 0; // iterates from 0 (MSB) to N-1 (LSB)
+        while i_msb_dim < N {
+            let digit_val = match coords_msb[i_msb_dim] {
+                SVOEvalPoint::Zero => 0,
+                SVOEvalPoint::One => 1,
+                SVOEvalPoint::Infinity => 2,
+            };
+            let power_of_3_for_dim = pow(3, N - 1 - i_msb_dim);
+            k_val += digit_val * power_of_3_for_dim;
+            i_msb_dim += 1;
+        }
+        k_val
+    }
+
+    /// Recursive helper to compute extended polynomial evaluations.
+    /// Uses memoization to store intermediate results.
+    fn get_extended_eval<const N: usize, const NUM_TERN_PTS: usize>(
+        k_target: usize,
+        binary_evals_input: &[i128],
+        memoized_evals: &mut [Option<i128>; NUM_TERN_PTS], // Using array for memoization table
+        ternary_point_info_table: &[TernaryPointInfo<N>; NUM_TERN_PTS],
+    ) -> i128 {
+        if let Some(val) = memoized_evals[k_target] {
+            return val;
+        }
+
+        let point_info = ternary_point_info_table[k_target]; // This is a copy, which is fine for this small struct
+        let result = if point_info.is_binary {
+            binary_evals_input[point_info.binary_eval_idx]
+        } else {
+            // These recursive calls must use the same memoization table and info table
+            let eval_at_1 = get_extended_eval(
+                point_info.k_val_at_one,
+                binary_evals_input,
+                memoized_evals,
+                ternary_point_info_table,
+            );
+            let eval_at_0 = get_extended_eval(
+                point_info.k_val_at_zero,
+                binary_evals_input,
+                memoized_evals,
+                ternary_point_info_table,
+            );
+            eval_at_1 - eval_at_0
+        };
+
+        memoized_evals[k_target] = Some(result);
+        result
+    }
+
+    /// Performs in-place multilinear extension on ternary evaluation vectors
+    /// and updates the temporary accumulator `temp_tA` with the product contribution.
+    /// This is the generic version with no bound on num_svo_rounds.
+    /// TODO: optimize this further
+    #[inline]
+    pub fn compute_and_update_tA_inplace<
+        const NUM_SVO_ROUNDS: usize, 
+        const M_NON_BINARY_POINTS_CONST: usize, // num_non_binary_points(NUM_SVO_ROUNDS)
+        const NUM_TERNARY_POINTS_CONST: usize, // pow(3, NUM_SVO_ROUNDS)
+        F: JoltField,
+    >(
+        binary_az_evals_input: &[i128], // Source of 2^N binary evals for Az
+        binary_bz_evals_input: &[i128], // Source of 2^N binary evals for Bz
+        e_in_val: &F,
+        temp_tA: &mut [F], // Target for M_NON_BINARY_POINTS_CONST non-binary extended products
+    ) {
+        if NUM_SVO_ROUNDS == 0 {
+            debug_assert!(
+                temp_tA.is_empty(),
+                "temp_tA should be empty for 0 SVO rounds"
+            );
+            // M_NON_BINARY_POINTS_CONST would be 0, NUM_TERNARY_POINTS_CONST would be 1.
+            // The loops below would not run.
+            return;
+        }
+        
+        // Verify consistency of const generic arguments with NUM_SVO_ROUNDS
+        debug_assert_eq!(M_NON_BINARY_POINTS_CONST, num_non_binary_points(NUM_SVO_ROUNDS), "M_NON_BINARY_POINTS_CONST mismatch");
+        debug_assert_eq!(NUM_TERNARY_POINTS_CONST, pow(3, NUM_SVO_ROUNDS), "NUM_TERNARY_POINTS_CONST mismatch");
+
+
+        let num_binary_points = 1 << NUM_SVO_ROUNDS;
+        // temp_tA length is M_NON_BINARY_POINTS_CONST
+
+        debug_assert_eq!(
+            binary_az_evals_input.len(),
+            num_binary_points,
+            "binary_az_evals_input length mismatch"
+        );
+        debug_assert_eq!(
+            binary_bz_evals_input.len(),
+            num_binary_points,
+            "binary_bz_evals_input length mismatch"
+        );
+        debug_assert_eq!(
+            temp_tA.len(),
+            M_NON_BINARY_POINTS_CONST, // temp_tA stores only non-binary point contributions
+            "temp_tA length mismatch with M_NON_BINARY_POINTS_CONST"
+        );
+
+        // This table contains info for ALL 3^N points, used by the recursive helper.
+        let ternary_point_info_table: [TernaryPointInfo<NUM_SVO_ROUNDS>; NUM_TERNARY_POINTS_CONST] =
+            precompute_ternary_point_infos::<NUM_SVO_ROUNDS, NUM_TERNARY_POINTS_CONST>();
+
+        // Memoization tables for all 3^N points.
+        // Initialize with a value that signifies "not computed yet".
+        // Using array for memoization tables.
+        let mut memoized_az_evals: [Option<i128>; NUM_TERNARY_POINTS_CONST] = [None; NUM_TERNARY_POINTS_CONST];
+        let mut memoized_bz_evals: [Option<i128>; NUM_TERNARY_POINTS_CONST] = [None; NUM_TERNARY_POINTS_CONST];
+        
+        // Get the map of non-binary points. The order here dictates temp_tA indexing.
+        let y_ext_code_map_non_binary: [[SVOEvalPoint; NUM_SVO_ROUNDS]; M_NON_BINARY_POINTS_CONST] =
+            build_y_ext_code_map::<NUM_SVO_ROUNDS, M_NON_BINARY_POINTS_CONST>();
+        
+        for i_temp_tA in 0..M_NON_BINARY_POINTS_CONST {
+            let current_y_ext_coords_msb: &[SVOEvalPoint; NUM_SVO_ROUNDS] = &y_ext_code_map_non_binary[i_temp_tA];
+            
+            // Convert the MSB coordinates of the current non-binary point to its global k_ternary_idx
+            let k_target_idx = svo_coords_msb_to_k_ternary_idx::<NUM_SVO_ROUNDS>(current_y_ext_coords_msb);
+
+            // Sanity check: the k_target_idx must be non-binary.
+            // The ternary_point_info_table can be indexed by k_target_idx.
+            debug_assert!(k_target_idx < NUM_TERNARY_POINTS_CONST, "k_target_idx out of bounds for ternary_point_info_table");
+            debug_assert!(!ternary_point_info_table[k_target_idx].is_binary, "Target for temp_tA[{}] (k={}) is unexpectedly binary.", i_temp_tA, k_target_idx);
+
+            let az_val = get_extended_eval::<NUM_SVO_ROUNDS, NUM_TERNARY_POINTS_CONST>(
+                k_target_idx,
+                binary_az_evals_input,
+                &mut memoized_az_evals,
+                &ternary_point_info_table,
+            );
+
+            if az_val != 0 {
+                let bz_val = get_extended_eval::<NUM_SVO_ROUNDS, NUM_TERNARY_POINTS_CONST>(
+                    k_target_idx,
+                    binary_bz_evals_input,
+                    &mut memoized_bz_evals,
+                    &ternary_point_info_table,
+                );
+
+                if bz_val != 0 {
+                    let product = az_val
+                        .checked_mul(bz_val)
+                        .expect("Extended Az*Bz product overflow i128");
+                    // Note: temp_tA is indexed by `i_temp_tA` which is the iteration order
+                    // of non-binary points from build_y_ext_code_map.
+                    temp_tA[i_temp_tA] += e_in_val.mul_i128(product);
+                }
+            }
+        }
+    }
+
+    /// Generic version for distributing tA to svo accumulators
+    pub fn distribute_tA_to_svo_accumulators_generic<const NUM_SVO_ROUNDS: usize, F: JoltField>(
+        tA_accums: &[F],
+        x_out_val: usize,
+        E_out_vec: &[Vec<F>],
+        accums_zero: &mut [F],
+        accums_infty: &mut [F],
+    ) {
+        match NUM_SVO_ROUNDS {
+            1 => distribute_tA_to_svo_accumulators_1(
+                tA_accums,
+                x_out_val,
+                E_out_vec,
+                accums_zero,
+                accums_infty,
+            ),
+            2 => distribute_tA_to_svo_accumulators_2(
+                tA_accums,
+                x_out_val,
+                E_out_vec,
+                accums_zero,
+                accums_infty,
+            ),
+            3 => distribute_tA_to_svo_accumulators_3(
+                tA_accums,
+                x_out_val,
+                E_out_vec,
+                accums_zero,
+                accums_infty,
+            ),
+            4 => {
+                // 81 - 16 = 65 non-binary points
+                distribute_tA_to_svo_accumulators::<4, 65, F>(
+                tA_accums,
+                x_out_val,
+                E_out_vec,
+                accums_zero,
+                accums_infty,)
+            },
+            5 => {
+                // 243 - 32 = 211 non-binary points
+                distribute_tA_to_svo_accumulators::<5, 211, F>(
+                tA_accums,
+                x_out_val,
+                E_out_vec,
+                accums_zero,
+                accums_infty,)
+            },
+            _ => unreachable!("You should not try this many rounds of SVO"),
+        }
+    }
+
+    /// Hardcoded version for `num_svo_rounds == 1`
+    /// We have only one non-binary point (Y0=I), mapping to accum_1(I)
+    #[inline]
+    pub fn distribute_tA_to_svo_accumulators_1<F: JoltField>(
+        tA_accums: &[F],
+        x_out_val: usize,
+        E_out_vec: &[Vec<F>],
+        _accums_zero: &mut [F],
+        accums_infty: &mut [F],
+    ) {
+        debug_assert!(_accums_zero.len() == 0);
+        debug_assert!(accums_infty.len() == 1);
+        debug_assert!(tA_accums.len() == 1);
+
+        accums_infty[0] += E_out_vec[0][x_out_val] * tA_accums[0];
+    }
+
+    /// Hardcoded version for `num_svo_rounds == 2`
+    /// We have 5 non-binary points with their corresponding mappings: (recall, LSB is rightmost)
+    /// tA_accums indices:
+    ///   [0]: Y_ext = (0,I)
+    ///   [1]: Y_ext = (1,I)
+    ///   [2]: Y_ext = (I,0)
+    ///   [3]: Y_ext = (I,1)
+    ///   [4]: Y_ext = (I,I)
+    ///
+    /// Target flat accumulators (NUM_SVO_ROUNDS = 2):
+    ///   accums_zero (len 1): [ A_1(0,I) ]
+    ///   accums_infty (len 4): [ A_0(empty,I), A_1(I,0), A_1(I,1), A_1(I,I) ]
+    /// Note that A_0(empty,I) should receive contributions from (0,I) and (1,I).
+    #[inline]
+    pub fn distribute_tA_to_svo_accumulators_2<F: JoltField>(
+        tA_accums: &[F],
+        x_out_val: usize,
+        E_out_vec: &[Vec<F>],
+        accums_zero: &mut [F],
+        accums_infty: &mut [F],
+    ) {
+        debug_assert!(tA_accums.len() == 5);
+        debug_assert!(accums_zero.len() == 1);
+        debug_assert!(accums_infty.len() == 4);
+        debug_assert!(E_out_vec.len() >= 2);
+
+        let E0_y0 = E_out_vec[0][(x_out_val << 1) | 0];
+        let E0_y1 = E_out_vec[0][(x_out_val << 1) | 1];
+        let E1_yempty = E_out_vec[1][x_out_val];
+
+        // Y_ext = (0,I) -> tA_accums[0]
+        // Contributes to A_0(empty,I) (i.e. accums_infty[0]) via E_out_0[x_out_val | 0] and
+        // A_1(0,I) (i.e. accums_zero[0]) via E_out_1[x_out_val]
+
+        accums_infty[0] += E0_y0 * tA_accums[0];
+
+        accums_zero[0] += E1_yempty * tA_accums[0];
+
+        // Y_ext = (1,I) -> tA_accums[1]
+        // Contributes to A_0(empty,I) (i.e. accums_infty[0]) via E_out_0[x_out_val | 1]
+        // (no term A_1(1,I) as it is not needed i.e. it\'s an eval at 1)
+        accums_infty[0] += E0_y1 * tA_accums[1];
+
+        // Y_ext = (I,0) -> tA_accums[2]
+        // Contributes to A_1(I,0) (i.e. accums_infty[1]) via E_out_1[x_out_val]
+        accums_infty[1] += E1_yempty * tA_accums[2];
+
+        // Y_ext = (I,1) -> tA_accums[3]
+        // Contributes to A_1(I,1) (i.e. accums_infty[2]) via E_out_1[x_out_val]
+        accums_infty[2] += E1_yempty * tA_accums[3];
+
+        // Y_ext = (I,I) -> tA_accums[4]
+        // Contributes to A_1(I,I) (i.e. accums_infty[3]) via E_out_1[x_out_val]
+        accums_infty[3] += E1_yempty * tA_accums[4];
+    }
+
+    /// Hardcoded version for `num_svo_rounds == 3`
+    ///
+    #[inline]
+    pub fn distribute_tA_to_svo_accumulators_3<F: JoltField>(
+        tA_accums: &[F],
+        x_out_val: usize,
+        E_out_vec: &[Vec<F>],
+        accums_zero: &mut [F],
+        accums_infty: &mut [F],
+    ) {
+        debug_assert!(tA_accums.len() == 19);
+        debug_assert!(accums_zero.len() == 6);
+        debug_assert!(accums_infty.len() == 13);
+        debug_assert!(E_out_vec.len() >= 3);
+
+        use SVOEvalPoint::{Infinity, One, Zero};
+
+        // Accumulator slots (conceptual LSB-first paper round s_p)
+        // Nomenclature: A_{s_p}(v_{s_p-1},...,v_0, u_s_p)
+        // accums_infty slots
+        const ACCUM_IDX_A0_I: usize = 0; // A_0(I)
+        const ACCUM_IDX_A1_0_I: usize = 1; // A_1(v0=0, I)
+        const ACCUM_IDX_A1_1_I: usize = 2; // A_1(v0=1, I)
+        const ACCUM_IDX_A1_I_I: usize = 3; // A_1(v0=I, I)
+        const ACCUM_IDX_A2_00_I: usize = 4; // A_2(v1=0,v0=0,I)
+        const ACCUM_IDX_A2_01_I: usize = 5; // A_2(v1=0,v0=1,I)
+        const ACCUM_IDX_A2_0I_I: usize = 6; // A_2(v1=0,v0=I,I)
+        const ACCUM_IDX_A2_10_I: usize = 7; // A_2(v1=1,v0=0,I)
+        const ACCUM_IDX_A2_11_I: usize = 8; // A_2(v1=1,v0=1,I)
+        const ACCUM_IDX_A2_1I_I: usize = 9; // A_2(v1=1,v0=I,I)
+        const ACCUM_IDX_A2_I0_I: usize = 10; // A_2(v1=I,v0=0,I)
+        const ACCUM_IDX_A2_I1_I: usize = 11; // A_2(v1=I,v0=1,I)
+        const ACCUM_IDX_A2_II_I: usize = 12; // A_2(v1=I,v0=I,I)
+
+        // accums_zero slots
+        const ACCUM_IDX_A1_I_0: usize = 0; // A_1(v0=I, 0)
+        const ACCUM_IDX_A2_0I_0: usize = 1; // A_2(v1=0,v0=I,0)
+        const ACCUM_IDX_A2_1I_0: usize = 2; // A_2(v1=1,v0=I,0)
+        const ACCUM_IDX_A2_I0_0: usize = 3; // A_2(v1=I,v0=0,0)
+        const ACCUM_IDX_A2_I1_0: usize = 4; // A_2(v1=I,v0=1,0)
+        const ACCUM_IDX_A2_II_0: usize = 5; // A_2(v1=I,v0=I,0)
+
+        // E_out_vec[s_code] interpretation (s_code is MSB-first index for Y_c variables):
+        // E_out_vec[0] (s_code=0 in E_out_vec): Y2_c is u_eff for E. y_suffix_eff=(Y0_c, Y1_c). Index (x_out << 2) | (Y0_c_bit << 1) | Y1_c_bit
+        let e0_suf00 = E_out_vec[0][(x_out_val << 2) | 0b00]; // y_suffix_eff=(Y0_c=0, Y1_c=0)
+        let e0_suf01 = E_out_vec[0][(x_out_val << 2) | 0b01]; // y_suffix_eff=(Y0_c=0, Y1_c=1)
+        let e0_suf10 = E_out_vec[0][(x_out_val << 2) | 0b10]; // y_suffix_eff=(Y0_c=1, Y1_c=0)
+        let e0_suf11 = E_out_vec[0][(x_out_val << 2) | 0b11]; // y_suffix_eff=(Y0_c=1, Y1_c=1)
+
+        // E_out_vec[1] (s_code=1 in E_out_vec): Y1_c is u_eff for E. y_suffix_eff=(Y0_c). Index (x_out << 1) | Y0_c_bit
+        let e1_suf0 = E_out_vec[1][(x_out_val << 1) | 0]; // y_suffix_eff=(Y0_c=0)
+        let e1_suf1 = E_out_vec[1][(x_out_val << 1) | 1]; // y_suffix_eff=(Y0_c=1)
+
+        // E_out_vec[2] (s_code=2 in E_out_vec): Y0_c is u_eff for E. y_suffix_eff=(). Index x_out_val
+        let e2_sufempty = E_out_vec[2][x_out_val];
+
+        // Y_EXT_CODE_MAP[tA_idx] gives (Y0_c, Y1_c, Y2_c) for tA_accums[tA_idx]
+        // Y0_c is MSB, Y2_c is LSB for code variables. This order matches compute_and_update_tA_inplace_3.
+        const Y_EXT_CODE_MAP: [(SVOEvalPoint, SVOEvalPoint, SVOEvalPoint); 19] = [
+            (Zero, Zero, Infinity),
+            (Zero, One, Infinity),
+            (Zero, Infinity, Zero),
+            (Zero, Infinity, One),
+            (Zero, Infinity, Infinity),
+            (One, Zero, Infinity),
+            (One, One, Infinity),
+            (One, Infinity, Zero),
+            (One, Infinity, One),
+            (One, Infinity, Infinity),
+            (Infinity, Zero, Zero),
+            (Infinity, Zero, One),
+            (Infinity, Zero, Infinity),
+            (Infinity, One, Zero),
+            (Infinity, One, One),
+            (Infinity, One, Infinity),
+            (Infinity, Infinity, Zero),
+            (Infinity, Infinity, One),
+            (Infinity, Infinity, Infinity),
+        ];
+
+        for i in 0..19 {
+            let current_tA = tA_accums[i];
+            // No !current_tA.is_zero() check, as requested
+
+            let (y0_c, y1_c, y2_c) = Y_EXT_CODE_MAP[i]; // (MSB, Mid, LSB) from code\'s perspective
+
+            // --- Contributions to Paper Round s_p=0 Accumulators (u = Y2_c) ---
+            // E-factor uses E_out_vec[0] (where Y2_c is u_eff), E_suffix is (Y0_c, Y1_c)
+            if y2_c == Infinity {
+                // u = I
+                if y0_c != Infinity && y1_c != Infinity {
+                    // Suffix (Y0_c,Y1_c) for E_out_vec[0] must be binary
+                    let e_val = match (y0_c, y1_c) {
+                        (Zero, Zero) => e0_suf00,
+                        (Zero, One) => e0_suf01,
+                        (One, Zero) => e0_suf10,
+                        (One, One) => e0_suf11,
+                        _ => unreachable!(), // Should be covered by binary check above
+                    };
+                    accums_infty[ACCUM_IDX_A0_I] += current_tA * e_val;
+                }
+            }
+            // No A_0(0) slots defined in the provided consts for accums_zero.
+
+            // --- Contributions to Paper Round s_p=1 Accumulators (u = Y1_c, v0 = Y2_c) ---
+            // E-factor uses E_out_vec[1] (where Y1_c is u_eff), E_suffix is (Y0_c)
+            if y0_c != Infinity {
+                // Suffix Y0_c for E_out_vec[1] must be binary
+                let e1_val = if y0_c == Zero { e1_suf0 } else { e1_suf1 }; // y0_c is One or Zero here
+
+                if y1_c == Infinity {
+                    // u = I
+                    match y2_c {
+                        // v0 = Y2_c
+                        Zero => {
+                            accums_infty[ACCUM_IDX_A1_0_I] += current_tA * e1_val;
+                        }
+                        One => {
+                            accums_infty[ACCUM_IDX_A1_1_I] += current_tA * e1_val;
+                        }
+                        Infinity => {
+                            accums_infty[ACCUM_IDX_A1_I_I] += current_tA * e1_val;
+                        }
+                    }
+                } else if y1_c == Zero {
+                    // u = 0
+                    if y2_c == Infinity {
+                        // v0 = I, for A_1(I,0)
+                        accums_zero[ACCUM_IDX_A1_I_0] += current_tA * e1_val;
+                    }
+                }
+            }
+
+            // --- Contributions to Paper Round s_p=2 Accumulators (u = Y0_c, v = (Y1_c,Y2_c)) ---
+            // E-factor uses E_out_vec[2] (where Y0_c is u_eff), E_suffix is empty
+            let e2_val = e2_sufempty;
+            if y0_c == Infinity {
+                // u = I
+                match (y1_c, y2_c) {
+                    // v = (Y1_c, Y2_c)
+                    (Zero, Zero) => {
+                        accums_infty[ACCUM_IDX_A2_00_I] += current_tA * e2_val;
+                    }
+                    (Zero, One) => {
+                        accums_infty[ACCUM_IDX_A2_01_I] += current_tA * e2_val;
+                    }
+                    (Zero, Infinity) => {
+                        accums_infty[ACCUM_IDX_A2_0I_I] += current_tA * e2_val;
+                    }
+                    (One, Zero) => {
+                        accums_infty[ACCUM_IDX_A2_10_I] += current_tA * e2_val;
+                    }
+                    (One, One) => {
+                        accums_infty[ACCUM_IDX_A2_11_I] += current_tA * e2_val;
+                    }
+                    (One, Infinity) => {
+                        accums_infty[ACCUM_IDX_A2_1I_I] += current_tA * e2_val;
+                    }
+                    (Infinity, Zero) => {
+                        accums_infty[ACCUM_IDX_A2_I0_I] += current_tA * e2_val;
+                    }
+                    (Infinity, One) => {
+                        accums_infty[ACCUM_IDX_A2_I1_I] += current_tA * e2_val;
+                    }
+                    (Infinity, Infinity) => {
+                        accums_infty[ACCUM_IDX_A2_II_I] += current_tA * e2_val;
+                    }
+                }
+            } else if y0_c == Zero {
+                // u = 0
+                match (y1_c, y2_c) {
+                    // v = (Y1_c, Y2_c)
+                    // Only specific v configs for A_2(v,0) are stored, based on ACCUM_IDX constants
+                    (Zero, Infinity) => {
+                        accums_zero[ACCUM_IDX_A2_0I_0] += current_tA * e2_val;
+                    }
+                    (One, Infinity) => {
+                        accums_zero[ACCUM_IDX_A2_1I_0] += current_tA * e2_val;
+                    }
+                    (Infinity, Zero) => {
+                        accums_zero[ACCUM_IDX_A2_I0_0] += current_tA * e2_val;
+                    }
+                    (Infinity, One) => {
+                        accums_zero[ACCUM_IDX_A2_I1_0] += current_tA * e2_val;
+                    }
+                    (Infinity, Infinity) => {
+                        accums_zero[ACCUM_IDX_A2_II_0] += current_tA * e2_val;
+                    }
+                    _ => {} // Other v configs (e.g. fully binary, or other Infinity patterns) for u=0 are not stored.
+                }
+            }
+        }
+    }
+
+    // Distributes the accumulated tA values (sum over x_in) for a single x_out_val
+    // to the appropriate SVO round accumulators.
+    #[inline]
+    pub fn distribute_tA_to_svo_accumulators<const NUM_SVO_ROUNDS: usize, const M_NON_BINARY_POINTS: usize, F: JoltField>(
+        tA_accums: &[F],
+        x_out_val: usize,
+        E_out_vec: &[Vec<F>],
+        accums_zero: &mut [F],
+        accums_infty: &mut [F],
+    ) {
+        if NUM_SVO_ROUNDS == 0 {
+            debug_assert!(tA_accums.is_empty(), "tA_accums should be empty for N=0");
+            debug_assert!(accums_zero.is_empty(), "accums_zero should be empty for N=0");
+            debug_assert!(accums_infty.is_empty(), "accums_infty should be empty for N=0");
+            return;
+        }
+
+        // Assert that the provided M_NON_BINARY_POINTS is correct.
+        debug_assert_eq!(
+            M_NON_BINARY_POINTS,
+            num_non_binary_points(NUM_SVO_ROUNDS),
+            "M_NON_BINARY_POINTS mismatch with calculated value"
+        );
+        
+        let y_ext_code_map: [[SVOEvalPoint; NUM_SVO_ROUNDS]; M_NON_BINARY_POINTS] =
+            build_y_ext_code_map::<NUM_SVO_ROUNDS, M_NON_BINARY_POINTS>();
+        
+        let round_offsets_tuple = precompute_accumulator_offsets::<NUM_SVO_ROUNDS>();
+        let round_offsets_infty: [usize; NUM_SVO_ROUNDS] = round_offsets_tuple.0;
+        let round_offsets_zero: [usize; NUM_SVO_ROUNDS] = round_offsets_tuple.1;
+
+        debug_assert_eq!(tA_accums.len(), M_NON_BINARY_POINTS, "tA_accums length mismatch with expected non-binary points");
+
+        for tA_idx in 0..M_NON_BINARY_POINTS {
+            let current_tA_val = tA_accums[tA_idx];
+            if current_tA_val.is_zero() {
+                continue;
+            }
+
+            let y_ext_coords_msb: &[SVOEvalPoint; NUM_SVO_ROUNDS] = &y_ext_code_map[tA_idx];
+
+            for s_p in 0..NUM_SVO_ROUNDS {
+                let num_suffix_vars_for_E = if NUM_SVO_ROUNDS > s_p + 1 {
+                    NUM_SVO_ROUNDS - 1 - s_p
+                } else {
+                    0
+                };
+
+                let mut e_suffix_bin_idx = 0;
+                let mut e_suffix_is_binary = true;
+                if num_suffix_vars_for_E > 0 {
+                    for i_suffix_msb in 0..num_suffix_vars_for_E {
+                        let coord_val_for_suffix = y_ext_coords_msb[i_suffix_msb];
+                        e_suffix_bin_idx <<= 1;
+                        match coord_val_for_suffix {
+                            SVOEvalPoint::Zero => { }
+                            SVOEvalPoint::One  => { e_suffix_bin_idx |= 1; }
+                            SVOEvalPoint::Infinity => {
+                                e_suffix_is_binary = false;
+                                break;
+                            }
+                        }
+                    }
+                }
+                
+                let e_factor: F;
+                if e_suffix_is_binary && E_out_vec.len() > s_p && !E_out_vec[s_p].is_empty() {
+                    let e_vec_target_idx = (x_out_val << num_suffix_vars_for_E) | e_suffix_bin_idx;
+                    if e_vec_target_idx < E_out_vec[s_p].len() {
+                        e_factor = E_out_vec[s_p][e_vec_target_idx];
+                    } else {
+                        e_factor = F::zero();
+                    }
+                } else {
+                    e_factor = F::zero();
+                }
+
+                if e_factor.is_zero() {
+                    continue;
+                }
+
+                let u_A = y_ext_coords_msb[NUM_SVO_ROUNDS - 1 - s_p];
+
+                let mut v_A_coords_lsb_buffer = [SVOEvalPoint::Zero; NUM_SVO_ROUNDS];
+                if s_p > 0 {
+                    for i_v_lsb in 0..s_p {
+                        v_A_coords_lsb_buffer[i_v_lsb] = y_ext_coords_msb[NUM_SVO_ROUNDS - 1 - i_v_lsb];
+                    }
+                }
+                let v_A_slice_lsb_order = &v_A_coords_lsb_buffer[0..s_p];
+
+                match u_A {
+                    SVOEvalPoint::Infinity => {
+                        let base_offset = round_offsets_infty[s_p];
+                        let idx_within_block = v_coords_to_base3_idx(v_A_slice_lsb_order);
+                        let final_idx = base_offset + idx_within_block;
+                        if final_idx < accums_infty.len() {
+                             accums_infty[final_idx] += current_tA_val * e_factor;
+                        }
+                    }
+                    SVOEvalPoint::Zero => {
+                        if s_p == 0 { 
+                            continue; 
+                        }
+                        
+                        if v_coords_has_infinity(v_A_slice_lsb_order) {
+                            let base_offset = round_offsets_zero[s_p];
+                            let num_slots_in_block_A_sp_zero = 
+                                pow(3, s_p) - pow(2, s_p);
+
+                            if num_slots_in_block_A_sp_zero > 0 { 
+                                 let idx_within_block = v_coords_to_non_binary_base3_idx(v_A_slice_lsb_order);
+                                 let final_idx = base_offset + idx_within_block;
+                                 if final_idx < accums_zero.len() && idx_within_block < num_slots_in_block_A_sp_zero {
+                                     accums_zero[final_idx] += current_tA_val * e_factor;
+                                 }
+                            }
+                        }
+                    }
+                    SVOEvalPoint::One => { }
+                }
+            }
+        }
+    }
+
+    /// Process the first few sum-check rounds using small value optimization (SVO)
+    /// We take in the pre-computed accumulator values, and use them to compute the quadratic
+    /// evaluations (and thus cubic polynomials) for the first few sum-check rounds.
+    pub fn process_svo_sumcheck_rounds<
+        const NUM_SVO_ROUNDS: usize,
+        F: JoltField,
+        ProofTranscript: Transcript,
+    >(
+        accums_zero: &[F],
+        accums_infty: &[F],
+        r_challenges: &mut Vec<F>,
+        round_polys: &mut Vec<CompressedUniPoly<F>>,
+        claim: &mut F,
+        transcript: &mut ProofTranscript,
+        eq_poly: &mut GruenSplitEqPolynomial<F>,
+    ) {
+        // Assert lengths of accumulator slices based on NUM_SVO_ROUNDS
+        let expected_accums_zero_len = num_accums_eval_zero(NUM_SVO_ROUNDS);
+        let expected_accums_infty_len = num_accums_eval_infty(NUM_SVO_ROUNDS);
+        assert_eq!(
+            accums_zero.len(),
+            expected_accums_zero_len,
+            "accums_zero length mismatch"
+        );
+        assert_eq!(
+            accums_infty.len(),
+            expected_accums_infty_len,
+            "accums_infty length mismatch"
+        );
+
+        let mut lagrange_coeffs: Vec<F> = vec![F::one()];
+        let mut current_acc_zero_offset = 0;
+        let mut current_acc_infty_offset = 0;
+
+        for i in 0..NUM_SVO_ROUNDS {
+            let mut quadratic_eval_0 = F::zero();
+            let mut quadratic_eval_infty = F::zero();
+
+            let num_vars_in_v_config = i; // v_config is (v_0, ..., v_{i-1})
+            let num_lagrange_coeffs_for_round = pow(3, num_vars_in_v_config);
+
+            // Compute quadratic_eval_infty
+            let num_accs_infty_curr_round = pow(3, num_vars_in_v_config);
+            if num_accs_infty_curr_round > 0
+                && current_acc_infty_offset + num_accs_infty_curr_round <= accums_infty.len()
+            {
+                let accums_infty_slice = &accums_infty[current_acc_infty_offset
+                    ..current_acc_infty_offset + num_accs_infty_curr_round];
+                for k in 0..num_lagrange_coeffs_for_round {
+                    if k < accums_infty_slice.len() && k < lagrange_coeffs.len() {
+                        quadratic_eval_infty += accums_infty_slice[k] * lagrange_coeffs[k];
+                    }
+                }
+            }
+            current_acc_infty_offset += num_accs_infty_curr_round;
+
+            // Compute quadratic_eval_0
+            let num_accs_zero_curr_round = if num_vars_in_v_config == 0 {
+                0 // 3^0 - 2^0 = 0
+            } else {
+                pow(3, num_vars_in_v_config) - pow(2, num_vars_in_v_config)
+            };
+
+            if num_accs_zero_curr_round > 0
+                && current_acc_zero_offset + num_accs_zero_curr_round <= accums_zero.len()
+            {
+                let accums_zero_slice = &accums_zero[current_acc_zero_offset
+                    ..current_acc_zero_offset + num_accs_zero_curr_round];
+                let mut non_binary_v_config_counter = 0;
+                for k_global in 0..num_lagrange_coeffs_for_round {
+                    let v_config = get_v_config_digits(k_global, num_vars_in_v_config);
+                    if is_v_config_non_binary(&v_config) {
+                        if non_binary_v_config_counter < accums_zero_slice.len()
+                            && k_global < lagrange_coeffs.len()
+                        {
+                            quadratic_eval_0 += accums_zero_slice[non_binary_v_config_counter]
+                                * lagrange_coeffs[k_global];
+                            non_binary_v_config_counter += 1;
+                        }
+                    }
+                }
+                current_acc_zero_offset += num_accs_zero_curr_round;
+            }
+
+            let r_i = process_eq_sumcheck_round(
+                (quadratic_eval_0, quadratic_eval_infty),
+                eq_poly,
+                round_polys,
+                r_challenges,
+                claim,
+                transcript,
+            );
+
+            let lagrange_coeffs_r_i = [F::one() - r_i, r_i, r_i * (r_i - F::one())];
+
+            if i < NUM_SVO_ROUNDS.saturating_sub(1) {
+                lagrange_coeffs = lagrange_coeffs_r_i
+                    .iter()
+                    .flat_map(|lagrange_coeff| {
+                        lagrange_coeffs
+                            .iter()
+                            .map(move |coeff| *lagrange_coeff * *coeff)
+                    })
+                    .collect();
+            }
+        }
+    }
+
+    #[derive(Debug, Clone, Copy)]
+    pub struct TernaryPointInfo<const N: usize> {
+        /// True if this point (y_0, ..., y_{N-1}) has all y_i in {0, 1}.
+        pub is_binary: bool,
+        /// If is_binary is true, this is the index into the binary_az_evals_input.
+        /// If is_binary is false, this field is unused (can be 0).
+        pub binary_eval_idx: usize,
+        /// If is_binary is false, this is the k_ternary_idx corresponding to
+        /// replacing the *most significant* Infinity with a 1.
+        /// If is_binary is true, this field is unused (can be 0).
+        pub k_val_at_one: usize,
+        /// If is_binary is false, this is the k_ternary_idx corresponding to
+        /// replacing the *most significant* Infinity with a 0.
+        /// If is_binary is true, this field is unused (can be 0).
+        pub k_val_at_zero: usize,
+    }
+
+    impl<const N: usize> TernaryPointInfo<N> {
+        pub const fn default_val() -> Self {
+            Self {
+                is_binary: false,
+                binary_eval_idx: 0,
+                k_val_at_one: 0,
+                k_val_at_zero: 0,
+            }
+        }
+    }
+
+    /// Converts a k_ternary_idx (0 to 3^N - 1) to its base-3 digits, MSB-first.
+    /// Example: N=3, k=5 (012_base3). Returns [0,1,2].
+    /// k=26 (222_base3). Returns [2,2,2].
+    pub const fn get_msb_ternary_digits<const N: usize>(k: usize) -> [u8; N] {
+        if N == 0 {
+            return [0u8; N];
+        }
+        let mut digits = [0u8; N];
+        let mut temp_k = k;
+        let mut i_rev = 0;
+        while i_rev < N {
+            let i_dim_msb = N - 1 - i_rev; // Current dimension index (MSB is 0, LSB is N-1)
+            digits[i_dim_msb] = (temp_k % 3) as u8;
+            temp_k /= 3;
+            i_rev += 1;
+        }
+        digits
+    }
+
+    pub const fn precompute_ternary_point_infos<const N: usize, const NUM_TERNARY_POINTS_VAL: usize>() -> [TernaryPointInfo<N>; NUM_TERNARY_POINTS_VAL] {
+        if N == 0 {
+            // NUM_TERNARY_POINTS_VAL should be 1 in this case (pow(3,0)=1)
+            // An empty array cannot be returned if NUM_TERNARY_POINTS_VAL is > 0.
+            // The caller should handle N=0 as a special case if an empty array is truly desired.
+            // For now, if N=0 but NUM_TERNARY_POINTS_VAL = 1, we provide one default entry.
+             if NUM_TERNARY_POINTS_VAL == 1 {
+                let mut infos = [TernaryPointInfo::<N>::default_val(); NUM_TERNARY_POINTS_VAL];
+                // For N=0, point k=0 is binary, index 0.
+                // infos[0] = TernaryPointInfo { is_binary: true, binary_eval_idx: 0, k_val_at_one: 0, k_val_at_zero: 0 };
+                // However, the existing code for N=0 for compute_and_update_tA_inplace simply returns.
+                // Let's keep it simple and consistent with that.
+                // If N=0, NUM_TERNARY_POINTS_VAL will be 1.
+                // The point k=0 is binary, with binary_eval_idx = 0.
+                // The actual logic in compute_and_update_tA_inplace will handle N=0 separately.
+                // So this precomputation for N=0 might not even be used directly if compute_and_update_tA_inplace returns early.
+                // For safety, and if it were used, the single point k=0 is binary.
+                 let mut point_info = TernaryPointInfo::<N>::default_val();
+                 point_info.is_binary = true;
+                 point_info.binary_eval_idx = 0;
+                 infos[0] = point_info;
+                 return infos;
+             } else {
+                // This state implies an inconsistency (e.g. N=0 but NUM_TERNARY_POINTS_VAL != 1)
+                // Const panics are not stable yet, so we return a default array.
+                // This should be caught by debug_asserts in the calling function.
+                 return [TernaryPointInfo::<N>::default_val(); NUM_TERNARY_POINTS_VAL];
+             }
+        }
+
+        let mut infos = [TernaryPointInfo::<N>::default_val(); NUM_TERNARY_POINTS_VAL];
+        let mut k_ternary_idx = 0;
+        while k_ternary_idx < NUM_TERNARY_POINTS_VAL {
+            let current_coords_base3_msb = get_msb_ternary_digits::<N>(k_ternary_idx);
+            let mut is_binary_point_flag = true;
+            let mut first_inf_dim_msb_idx: Option<usize> = None; // Dimension index (0 to N-1, MSB-first)
+
+            let mut i_dim_msb = 0;
+            while i_dim_msb < N {
+                if current_coords_base3_msb[i_dim_msb] == 2 { // 2 represents Infinity
+                    is_binary_point_flag = false;
+                    if first_inf_dim_msb_idx.is_none() {
+                        first_inf_dim_msb_idx = Some(i_dim_msb);
+                    }
+                    // We only care about the *most significant* (smallest index) infinity for the reduction rule.
+                    // So we can break once the first one is found.
+                    break;
+                }
+                i_dim_msb += 1;
+            }
+
+            if is_binary_point_flag {
+                let mut binary_idx = 0;
+                let mut dim_idx_msb = 0;
+                while dim_idx_msb < N {
+                    binary_idx <<= 1;
+                    if current_coords_base3_msb[dim_idx_msb] == 1 {
+                        binary_idx |= 1;
+                    }
+                    dim_idx_msb += 1;
+                }
+                infos[k_ternary_idx] = TernaryPointInfo {
+                    is_binary: true,
+                    binary_eval_idx: binary_idx,
+                    k_val_at_one: 0, // Unused
+                    k_val_at_zero: 0, // Unused
+                };
+            } else {
+                // This is a non-binary point.
+                // j_inf_dim is the index of the *most significant* dimension that is Infinity.
+                // Example: N=3, point (Inf, 0, Inf) = (2,0,2)_base3. k_ternary_idx = 2*9 + 0*3 + 2*1 = 20.
+                // current_coords_base3_msb = [2,0,2].
+                // first_inf_dim_msb_idx will be Some(0).
+                let j_inf_dim = first_inf_dim_msb_idx.unwrap(); // Safe due to !is_binary_point_flag
+
+                // Power of 3 for the dimension j_inf_dim (0-indexed from MSB)
+                // N=3, j_inf_dim=0 (MSB y_0), power = 3^(3-1-0) = 3^2 = 9
+                // N=3, j_inf_dim=1 (Mid y_1), power = 3^(3-1-1) = 3^1 = 3
+                // N=3, j_inf_dim=2 (LSB y_2), power = 3^(3-1-2) = 3^0 = 1
+                let inf_dim_power_of_3 = pow(3, N - 1 - j_inf_dim);
+
+                // k_ternary_idx has a '2' at dimension j_inf_dim (MSB-numbering).
+                // k_at_1_idx corresponds to changing this '2' to a '1'.
+                // k_at_0_idx corresponds to changing this '2' to a '0'.
+                let k_at_1_val = k_ternary_idx - inf_dim_power_of_3;
+                let k_at_0_val = k_ternary_idx - 2 * inf_dim_power_of_3;
+
+                infos[k_ternary_idx] = TernaryPointInfo {
+                    is_binary: false,
+                    binary_eval_idx: 0, // Unused
+                    k_val_at_one: k_at_1_val,
+                    k_val_at_zero: k_at_0_val,
+                };
+            }
+            k_ternary_idx += 1;
+        }
+        infos
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::svo_helpers::*;
+    use ark_bn254::Fr as TestField;
+    use ark_ff::Zero;
+
+    fn test_consistency_for_num_rounds(num_svo_rounds: usize) {
+        let num_binary_points = 1 << num_svo_rounds;
+        let num_temp_tA = num_non_trivial_ternary_points(num_svo_rounds);
+
+        // Test with non-zero patterned data
+        let binary_az_evals: Vec<i128> = (0..num_binary_points)
+            .map(|i| (i + 1) as i128 * 2)
+            .collect();
+        let binary_bz_evals: Vec<i128> = (0..num_binary_points)
+            .map(|i| (i + 2) as i128 * 3)
+            .collect();
+        let e_in_val = TestField::from(10u64);
+
+        let mut temp_tA_new = vec![TestField::zero(); num_temp_tA];
+        let mut temp_tA_old = vec![TestField::zero(); num_temp_tA];
+
+        // Call the new general function (the one being tested)
+        match num_svo_rounds {
+            1 => compute_and_update_tA_inplace::<1,  1, 3, TestField>(
+                &binary_az_evals,
+                &binary_bz_evals,
+                &e_in_val,
+                &mut temp_tA_new,
+            ),
+            2 => compute_and_update_tA_inplace::<2, 5, 9, TestField>(
+                &binary_az_evals,
+                &binary_bz_evals,
+                &e_in_val,
+                &mut temp_tA_new,
+            ),
+            3 => compute_and_update_tA_inplace::<3, 19, 27, TestField>(
+                &binary_az_evals,
+                &binary_bz_evals,
+                &e_in_val,
+                &mut temp_tA_new,
+            ),
+            _ => panic!("Unsupported NUM_SVO_ROUNDS for this consistency test structure"),
+        }
+
+        // Call the old hardcoded function
+        match num_svo_rounds {
+            1 => compute_and_update_tA_inplace_1(
+                &binary_az_evals,
+                &binary_bz_evals,
+                &e_in_val,
+                &mut temp_tA_old,
+            ),
+            2 => compute_and_update_tA_inplace_2(
+                &binary_az_evals,
+                &binary_bz_evals,
+                &e_in_val,
+                &mut temp_tA_old,
+            ),
+            3 => compute_and_update_tA_inplace_3(
+                &binary_az_evals,
+                &binary_bz_evals,
+                &e_in_val,
+                &mut temp_tA_old,
+            ),
+            _ => panic!("Unsupported NUM_SVO_ROUNDS for this consistency test structure"),
+        }
+        assert_eq!(
+            temp_tA_new, temp_tA_old,
+            "Mismatch for NUM_SVO_ROUNDS = {} with patterned data",
+            num_svo_rounds
+        );
+
+        // Test with all zeros for binary evals
+        let binary_az_evals_zeros: Vec<i128> = vec![0; num_binary_points];
+        let binary_bz_evals_zeros: Vec<i128> = vec![0; num_binary_points];
+        let mut temp_tA_new_zeros = vec![TestField::zero(); num_temp_tA];
+        let mut temp_tA_old_zeros = vec![TestField::zero(); num_temp_tA];
+
+        match num_svo_rounds {
+            1 => compute_and_update_tA_inplace::<1,  1, 3, TestField>(
+                &binary_az_evals_zeros,
+                &binary_bz_evals_zeros,
+                &e_in_val,
+                &mut temp_tA_new_zeros,
+            ),
+            2 => compute_and_update_tA_inplace::<2, 5, 9, TestField>(
+                &binary_az_evals_zeros,
+                &binary_bz_evals_zeros,
+                &e_in_val,
+                &mut temp_tA_new_zeros,
+            ),
+            3 => compute_and_update_tA_inplace::<3, 19, 27, TestField>(
+                &binary_az_evals_zeros,
+                &binary_bz_evals_zeros,
+                &e_in_val,
+                &mut temp_tA_new_zeros,
+            ),
+            _ => panic!("Unsupported NUM_SVO_ROUNDS for this consistency test structure"),
+        }
+
+        match num_svo_rounds {
+            1 => compute_and_update_tA_inplace_1(
+                &binary_az_evals_zeros,
+                &binary_bz_evals_zeros,
+                &e_in_val,
+                &mut temp_tA_old_zeros,
+            ),
+            2 => compute_and_update_tA_inplace_2(
+                &binary_az_evals_zeros,
+                &binary_bz_evals_zeros,
+                &e_in_val,
+                &mut temp_tA_old_zeros,
+            ),
+            3 => compute_and_update_tA_inplace_3(
+                &binary_az_evals_zeros,
+                &binary_bz_evals_zeros,
+                &e_in_val,
+                &mut temp_tA_old_zeros,
+            ),
+            _ => panic!("Unsupported NUM_SVO_ROUNDS for this consistency test structure"),
+        }
+        assert_eq!(
+            temp_tA_new_zeros, temp_tA_old_zeros,
+            "Mismatch for NUM_SVO_ROUNDS = {} with zero data",
+            num_svo_rounds
+        );
+
+        // Test with e_in_val = 0
+        let e_in_val_zero = TestField::zero();
+        let mut temp_tA_new_zero_e = vec![TestField::zero(); num_temp_tA];
+        let mut temp_tA_old_zero_e = vec![TestField::zero(); num_temp_tA];
+
+        match num_svo_rounds {
+            1 => compute_and_update_tA_inplace::<1,  1, 3, TestField>(
+                &binary_az_evals,
+                &binary_bz_evals,
+                &e_in_val_zero,
+                &mut temp_tA_new_zero_e,
+            ),
+            2 => compute_and_update_tA_inplace::<2, 5, 9, TestField>(
+                &binary_az_evals,
+                &binary_bz_evals,
+                &e_in_val_zero,
+                &mut temp_tA_new_zero_e,
+            ),
+            3 => compute_and_update_tA_inplace::<3, 19, 27, TestField>(
+                &binary_az_evals,
+                &binary_bz_evals,
+                &e_in_val_zero,
+                &mut temp_tA_new_zero_e,
+            ),
+            _ => panic!("Unsupported NUM_SVO_ROUNDS for this consistency test structure"),
+        }
+
+        match num_svo_rounds {
+            1 => compute_and_update_tA_inplace_1(
+                &binary_az_evals,
+                &binary_bz_evals,
+                &e_in_val_zero,
+                &mut temp_tA_old_zero_e,
+            ),
+            2 => compute_and_update_tA_inplace_2(
+                &binary_az_evals,
+                &binary_bz_evals,
+                &e_in_val_zero,
+                &mut temp_tA_old_zero_e,
+            ),
+            3 => compute_and_update_tA_inplace_3(
+                &binary_az_evals,
+                &binary_bz_evals,
+                &e_in_val_zero,
+                &mut temp_tA_old_zero_e,
+            ),
+            _ => panic!("Unsupported NUM_SVO_ROUNDS for this consistency test structure"),
+        }
+        assert_eq!(
+            temp_tA_new_zero_e, temp_tA_old_zero_e,
+            "Mismatch for NUM_SVO_ROUNDS = {} with zero e_in_val",
+            num_svo_rounds
+        );
+        for val in temp_tA_new_zero_e {
+            // Confirm they are all zero
+            assert!(
+                val.is_zero(),
+                "temp_tA should be all zeros if e_in_val is zero"
+            );
+        }
+    }
+
+    #[test]
+    fn test_compute_and_update_tA_inplace_vs_hardcoded_1() {
+        test_consistency_for_num_rounds(1);
+    }
+
+    #[test]
+    fn test_compute_and_update_tA_inplace_vs_hardcoded_2() {
+        test_consistency_for_num_rounds(2);
+    }
+
+    #[test]
+    fn test_compute_and_update_tA_inplace_vs_hardcoded_3() {
+        test_consistency_for_num_rounds(3);
+    }
+
+    // --- Tests for distribute_tA_to_svo_accumulators ---
+
+    fn test_distribute_consistency(num_svo_rounds: usize) {
+        let num_tA = num_non_trivial_ternary_points(num_svo_rounds);
+        let tA_accums: Vec<TestField> = (0..num_tA)
+            .map(|i| TestField::from((i + 1) as u64 * 100))
+            .collect();
+
+        let x_out_val = 1; // Arbitrary x_out_val for testing E_out_vec indexing
+
+        let mut E_out_vec: Vec<Vec<TestField>> = Vec::with_capacity(num_svo_rounds);
+        for s_e in 0..num_svo_rounds {
+            let num_suffix_vars = if num_svo_rounds > s_e + 1 {
+                num_svo_rounds - (s_e + 1)
+            } else {
+                0
+            };
+            let num_e_entries_for_x_out = 1 << num_suffix_vars;
+            let total_e_entries = (x_out_val + 10) * num_e_entries_for_x_out; 
+            let mut e_s: Vec<TestField> = Vec::with_capacity(total_e_entries);
+            for i in 0..total_e_entries {
+                e_s.push(TestField::from((s_e + 1) as u64 * 10 + (i + 1) as u64));
+            }
+            E_out_vec.push(e_s);
+        }
+
+        let num_zero = num_accums_eval_zero(num_svo_rounds);
+        let num_infty = num_accums_eval_infty(num_svo_rounds);
+
+        let mut accums_zero_new = vec![TestField::zero(); num_zero];
+        let mut accums_infty_new = vec![TestField::zero(); num_infty];
+        let mut accums_zero_old = vec![TestField::zero(); num_zero];
+        let mut accums_infty_old = vec![TestField::zero(); num_infty];
+
+        match num_svo_rounds {
+            1 => {
+                distribute_tA_to_svo_accumulators::<1, 1, TestField>(
+                    &tA_accums,
+                    x_out_val,
+                    &E_out_vec,
+                    &mut accums_zero_new,
+                    &mut accums_infty_new,
+                );
+                distribute_tA_to_svo_accumulators_1(
+                    &tA_accums,
+                    x_out_val,
+                    &E_out_vec,
+                    &mut accums_zero_old,
+                    &mut accums_infty_old,
+                );
+            }
+            2 => {
+                distribute_tA_to_svo_accumulators::<2, 5, TestField>(
+                    &tA_accums,
+                    x_out_val,
+                    &E_out_vec,
+                    &mut accums_zero_new,
+                    &mut accums_infty_new,
+                );
+                distribute_tA_to_svo_accumulators_2(
+                    &tA_accums,
+                    x_out_val,
+                    &E_out_vec,
+                    &mut accums_zero_old,
+                    &mut accums_infty_old,
+                );
+            }
+            3 => {
+                distribute_tA_to_svo_accumulators::<3, 19, TestField>(
+                    &tA_accums,
+                    x_out_val,
+                    &E_out_vec,
+                    &mut accums_zero_new,
+                    &mut accums_infty_new,
+                );
+                distribute_tA_to_svo_accumulators_3(
+                    &tA_accums,
+                    x_out_val,
+                    &E_out_vec,
+                    &mut accums_zero_old,
+                    &mut accums_infty_old,
+                );
+            }
+            _ => panic!("Unsupported NUM_SVO_ROUNDS for distribute consistency test"),
+        }
+
+        assert_eq!(
+            accums_zero_new, accums_zero_old,
+            "accums_zero mismatch for N={}",
+            num_svo_rounds
+        );
+        assert_eq!(
+            accums_infty_new, accums_infty_old,
+            "accums_infty mismatch for N={}",
+            num_svo_rounds
+        );
+    }
+
+    #[test]
+    fn test_distribute_tA_vs_hardcoded_1() {
+        test_distribute_consistency(1);
+    }
+
+    #[test]
+    fn test_distribute_tA_vs_hardcoded_2() {
+        test_distribute_consistency(2);
+    }
+
+    #[test]
+    fn test_distribute_tA_vs_hardcoded_3() {
+        test_distribute_consistency(3);
+    }
+}


### PR DESCRIPTION
This PR overhauls the Spartan first sum-check to use small-value optimization (SVO). This will be described in detail in an upcoming paper by Bagad-Dao-Domb-Thaler, itself a merge of two prior works [BDT24] and [DT24].

We currently settle on 3 rounds of SVO as that leads to the most performance improvement (both estimated and demonstrated in benchmarks). When we do streaming, we may want to do 4 rounds of SVO instead, as the extra SVO round is slightly less expensive than one streaming round.

Some miscellaneous changes include:
- Update parts of the book to reflect the changes
- Update `bench.rs` which currently gives an error (`decode()` needs to be _after_ `trace()`, not before)
- Update README to have the correct command for profiling (`profile` instead of `trace`)

There was a prior performance degradation due to no pre-allocation of the `ab_unbound_coeffs` chunks. This has been fixed now (thanks @moodlezoup). We consistently see around a 1.3x speedup for Spartan first sum-check, with more when proving gets memory-bound (i.e. the new method uses 50% or fewer memory)