### PR TITLE
feat(clint): implement mtime synchronization with CSR TIME register

### DIFF
--- a/tracer/src/emulator/device/clint.rs
+++ b/tracer/src/emulator/device/clint.rs
@@ -16,8 +16,18 @@ impl Clint {
             clock: 0,
             msip: 0,
             mtimecmp: 0,
-            mtime: 0, // @TODO: Should be bound to csr time register
+            mtime: 0, // Will be synchronized with CSR time register via sync_with_cpu_clock()
         }
+    }
+
+    /// Synchronizes mtime with CPU clock. This should be called after CPU initialization
+    /// to ensure mtime is properly bound to CSR time register as per RISC-V specification.
+    /// 
+    /// # Arguments
+    /// * `cpu_clock` Current CPU clock value to synchronize with
+    pub fn sync_with_cpu_clock(&mut self, cpu_clock: u64) {
+        // cpu core clock : mtime clock in clint = 8 : 1 is the same ratio used in CPU tick()
+        self.mtime = cpu_clock * 8;
     }
 
     /// Runs one cycle. `Clint` can raise interrupt. If it does it rises a certain bit


### PR DESCRIPTION
## Summary
Implements proper synchronization between CLINT's `mtime` register and CPU clock to resolve TODO comment about binding mtime to CSR TIME register.

## Changes
- **Added** `sync_with_cpu_clock()` method to CLINT for proper initialization
- **Updated** CPU constructor to synchronize CLINT with CPU clock during initialization  
- **Maintained** existing CSR TIME register routing to CLINT's `read_mtime()`/`write_mtime()`
- **Fixed** test memory allocation issues (increased from 32 to 64 bytes for 64-bit trace operations)

## Implementation Details
- Uses 8:1 ratio between CPU clock and mtime clock (consistent with existing tick logic)
- CSR TIME register reads/writes already properly routed to CLINT
- Synchronization called once during CPU initialization

## Testing
- ✅ All 21 tests pass
- ✅ No clippy warnings
- ✅ Maintains backward compatibility

Resolves the TODO: `mtime: 0, // @TODO: Should be bound to csr time register`