### PR TITLE
Ref/spartan sumcheck

### DIFF
--- a/jolt-core/src/jolt/instruction/mod.rs
+++ b/jolt-core/src/jolt/instruction/mod.rs
@@ -86,7 +86,7 @@ macro_rules! define_rv32im_trait_impls {
         impl InstructionLookup<32> for RV32IMInstruction {
             fn lookup_table(&self) -> Option<LookupTables<32>> {
                 match self {
-                    RV32IMInstruction::NoOp => None,
+                    RV32IMInstruction::NoOp(_) => None,
                     $(
                         RV32IMInstruction::$instr(instr) => instr.lookup_table(),
                     )*
@@ -99,7 +99,7 @@ macro_rules! define_rv32im_trait_impls {
         impl InstructionFlags for RV32IMInstruction {
             fn circuit_flags(&self) -> [bool; NUM_CIRCUIT_FLAGS] {
                 match self {
-                    RV32IMInstruction::NoOp => [false; NUM_CIRCUIT_FLAGS],
+                    RV32IMInstruction::NoOp(_) => [false; NUM_CIRCUIT_FLAGS],
                     $(
                         RV32IMInstruction::$instr(instr) => instr.circuit_flags(),
                     )*
@@ -112,7 +112,7 @@ macro_rules! define_rv32im_trait_impls {
         impl<const WORD_SIZE: usize> InstructionLookup<WORD_SIZE> for RV32IMCycle {
             fn lookup_table(&self) -> Option<LookupTables<WORD_SIZE>> {
                 match self {
-                    RV32IMCycle::NoOp => None,
+                    RV32IMCycle::NoOp(_) => None,
                     $(
                         RV32IMCycle::$instr(cycle) => cycle.instruction.lookup_table(),
                     )*
@@ -124,7 +124,7 @@ macro_rules! define_rv32im_trait_impls {
         impl<const WORD_SIZE: usize> LookupQuery<WORD_SIZE> for RV32IMCycle {
             fn to_instruction_inputs(&self) -> (u64, i64) {
                 match self {
-                    RV32IMCycle::NoOp => (0, 0),
+                    RV32IMCycle::NoOp(_) => (0, 0),
                     $(
                         RV32IMCycle::$instr(cycle) => LookupQuery::<WORD_SIZE>::to_instruction_inputs(cycle),
                     )*
@@ -134,7 +134,7 @@ macro_rules! define_rv32im_trait_impls {
 
             fn to_lookup_operands(&self) -> (u64, u64) {
                 match self {
-                    RV32IMCycle::NoOp => (0, 0),
+                    RV32IMCycle::NoOp(_) => (0, 0),
                     $(
                         RV32IMCycle::$instr(cycle) => LookupQuery::<WORD_SIZE>::to_lookup_operands(cycle),
                     )*
@@ -144,7 +144,7 @@ macro_rules! define_rv32im_trait_impls {
 
             fn to_lookup_output(&self) -> u64 {
                 match self {
-                    RV32IMCycle::NoOp => 0,
+                    RV32IMCycle::NoOp(_) => 0,
                     $(
                         RV32IMCycle::$instr(cycle) => LookupQuery::<WORD_SIZE>::to_lookup_output(cycle),
                     )*

--- a/jolt-core/src/jolt/vm/bytecode.rs
+++ b/jolt-core/src/jolt/vm/bytecode.rs
@@ -143,7 +143,7 @@ impl<F: JoltField, ProofTranscript: Transcript> BytecodeShoutProof<F, ProofTrans
                     let k = preprocessing
                         .virtual_address_map
                         .get(&(instr.address, instr.virtual_sequence_remaining.unwrap_or(0)))
-                        .unwrap();
+                        .unwrap_or(&0);
                     result[*k] += E[j];
                     j += 1;
                 }
@@ -466,7 +466,7 @@ pub fn prove_booleanity<F: JoltField, ProofTranscript: Transcript>(
             let k = preprocessing
                 .virtual_address_map
                 .get(&(instr.address, instr.virtual_sequence_remaining.unwrap_or(0)))
-                .unwrap();
+                .unwrap_or(&0);
             F[*k]
         })
         .collect();

--- a/jolt-core/src/jolt/vm/bytecode.rs
+++ b/jolt-core/src/jolt/vm/bytecode.rs
@@ -53,12 +53,15 @@ impl BytecodePreprocessing {
         }
 
         // Bytecode: Prepend a single no-op instruction
-        bytecode.insert(0, RV32IMInstruction::NoOp);
+        bytecode.insert(0, RV32IMInstruction::NoOp(0));
         assert_eq!(virtual_address_map.insert((0, 0), 0), None);
 
         // Bytecode: Pad to nearest power of 2
+        // Get last address
+        let last_address = bytecode.last().unwrap().normalize().address;
         let code_size = bytecode.len().next_power_of_two();
-        bytecode.resize(code_size, RV32IMInstruction::NoOp);
+        let padding = code_size - bytecode.len();
+        bytecode.extend((0..padding).map(|i| RV32IMInstruction::NoOp(last_address + 4 * (i + 1))));
 
         Self {
             bytecode,

--- a/jolt-core/src/jolt/vm/mod.rs
+++ b/jolt-core/src/jolt/vm/mod.rs
@@ -241,7 +241,9 @@ where
 
         // TODO(JP): Drop padding on number of steps
         let padded_trace_length = trace_length.next_power_of_two();
-        trace.resize(padded_trace_length, RV32IMCycle::NoOp);
+        let padding = padded_trace_length - trace_length;
+        let last_address = trace.last().unwrap().instruction().normalize().address;
+        trace.extend((0..padding).map(|i| RV32IMCycle::NoOp(last_address + 4 * (i + 1))));
 
         let mut transcript = ProofTranscript::new(b"Jolt transcript");
         let mut opening_accumulator: ProverOpeningAccumulator<F, ProofTranscript> =

--- a/jolt-core/src/jolt/vm/mod.rs
+++ b/jolt-core/src/jolt/vm/mod.rs
@@ -244,12 +244,12 @@ where
         let padding = padded_trace_length - trace_length;
         let last_address = trace.last().unwrap().instruction().normalize().address;
         if padding != 0 {
-            // Pad the trace with NoOp instructions followed by a final JALR
+            // Pad with NoOps (with sequential addresses) followed by a final JALR
             trace.extend((0..padding - 1).map(|i| RV32IMCycle::NoOp(last_address + 4 * i)));
+            // Final JALR sets NextPC = 0
             trace.push(RV32IMCycle::last_jalr(last_address + 4 * (padding - 1)));
         } else {
-            // In case we have a perfect power of two instructions, just replace last JAL one with JALR
-            // to set the last PC to 0.
+            // Replace last JAL with JALR to set NextPC = 0
             assert!(matches!(trace.last().unwrap(), RV32IMCycle::JAL(_)));
             *trace.last_mut().unwrap() = RV32IMCycle::last_jalr(last_address);
         }

--- a/jolt-core/src/poly/spartan_interleaved_poly.rs
+++ b/jolt-core/src/poly/spartan_interleaved_poly.rs
@@ -241,12 +241,12 @@ impl<const NUM_SVO_ROUNDS: usize, F: JoltField> SpartanInterleavedPolynomial<NUM
                         let mut binary_az_block = [0i128; Y_SVO_SPACE_SIZE];
                         let mut binary_bz_block = [0i128; Y_SVO_SPACE_SIZE];
 
-                        // Phase 1: Process Uniform Constraints
+                        // Process Uniform Constraints
                         for (uniform_chunk_iter_idx, uniform_svo_chunk) in uniform_constraints.chunks(Y_SVO_SPACE_SIZE).enumerate() {
                             for (idx_in_svo_block, constraint) in uniform_svo_chunk.iter().enumerate() {
-                                let original_uniform_idx_in_step = (uniform_chunk_iter_idx << NUM_SVO_ROUNDS) + idx_in_svo_block;
+                                let constraint_idx_in_step = (uniform_chunk_iter_idx << NUM_SVO_ROUNDS) + idx_in_svo_block;
 
-                                let global_r1cs_idx = 2 * (current_step_idx * padded_num_constraints + original_uniform_idx_in_step);
+                                let global_r1cs_idx = 2 * (current_step_idx * padded_num_constraints + constraint_idx_in_step);
 
                                 if !constraint.a.terms().is_empty() {
                                     let az = constraint
@@ -271,7 +271,7 @@ impl<const NUM_SVO_ROUNDS: usize, F: JoltField> SpartanInterleavedPolynomial<NUM
 
                             // If this is a full block, compute and update tA, then reset Az, Bz blocks
                             // (the last block may not be full, in which case we need to delay
-                            // computation of tA until the offset constraints are processed)
+                            // computation of tA until after processing all constraints in the block)
                             if uniform_svo_chunk.len() == Y_SVO_SPACE_SIZE {
                                 let x_in_val = (x_in_step_val << iter_num_x_in_constraint_vars) | current_x_in_constraint_val;
                                 let E_in_val = &E_in_evals[x_in_val];

--- a/jolt-core/src/poly/spartan_interleaved_poly.rs
+++ b/jolt-core/src/poly/spartan_interleaved_poly.rs
@@ -6,7 +6,7 @@ use super::{
 use crate::subprotocols::sumcheck::process_eq_sumcheck_round;
 use crate::{
     field::{JoltField, OptimizedMul, OptimizedMulI128},
-    r1cs::builder::{eval_offset_lc, Constraint, OffsetEqConstraint},
+    r1cs::builder::Constraint,
     utils::{
         math::Math,
         small_value::{svo_helpers, NUM_SVO_ROUNDS},
@@ -92,7 +92,6 @@ impl<const NUM_SVO_ROUNDS: usize, F: JoltField> SpartanInterleavedPolynomial<NUM
     pub fn new_with_precompute(
         padded_num_constraints: usize,
         uniform_constraints: &[Constraint],
-        cross_step_constraints: &[OffsetEqConstraint],
         flattened_polynomials: &[MultilinearPolynomial<F>],
         tau: &[F],
     ) -> ([F; NUM_ACCUMS_EVAL_ZERO], [F; NUM_ACCUMS_EVAL_INFTY], Self) {
@@ -155,17 +154,9 @@ impl<const NUM_SVO_ROUNDS: usize, F: JoltField> SpartanInterleavedPolynomial<NUM
         );
         assert_eq!(num_non_svo_z_vars, iter_num_x_out_vars + iter_num_x_in_vars);
 
-        // Assertions about the layout of uniform + offset constraints
-        let num_cross_step_constraints = cross_step_constraints.len();
+        // Assertions about the layout of uniform constraints
         let num_uniform_r1cs_constraints = uniform_constraints.len();
-        let constraints_per_cycle = num_uniform_r1cs_constraints + num_cross_step_constraints;
         let rem_num_uniform_r1cs_constraints = num_uniform_r1cs_constraints % Y_SVO_SPACE_SIZE;
-
-        // TODO: remove this assertion by handling the switchover point more generally
-        // Currently, it should not fail with 3 or 4 SVO rounds
-        assert!(rem_num_uniform_r1cs_constraints + num_cross_step_constraints < Y_SVO_SPACE_SIZE,
-            "The last block of {rem_num_uniform_r1cs_constraints} uniform constraints + {num_cross_step_constraints} cross step constraints must fit in a single block of size {Y_SVO_SPACE_SIZE}"
-        );
 
         // --- Setup: E_in and E_out tables ---
         // Call GruenSplitEqPolynomial::new_for_small_value with the determined variable splits.
@@ -228,7 +219,7 @@ impl<const NUM_SVO_ROUNDS: usize, F: JoltField> SpartanInterleavedPolynomial<NUM
 
                 // We will be pushing at most 2 values (corresponding to Az and Bz) to `chunk_ab_coeffs`
                 // for each constraint in the chunk.
-                let max_ab_coeffs_capacity = 2 * cycles_per_chunk * constraints_per_cycle;
+                let max_ab_coeffs_capacity = 2 * cycles_per_chunk * num_uniform_r1cs_constraints;
                 let mut chunk_ab_coeffs = Vec::with_capacity(max_ab_coeffs_capacity);
 
                 let mut chunk_svo_accums_zero = [F::zero(); NUM_ACCUMS_EVAL_ZERO];
@@ -298,57 +289,18 @@ impl<const NUM_SVO_ROUNDS: usize, F: JoltField> SpartanInterleavedPolynomial<NUM
                             }
                         }
 
-                        // Phase 2: Process Offset Constraints
-                        // (only 2 of them, in the same block as the last uniform constraints)
-                        for (idx, constraint) in cross_step_constraints.iter().enumerate() {
+                        // Process the last block if it wasn't full
+                        if rem_num_uniform_r1cs_constraints > 0 {
+                            let x_in_val_last = (x_in_step_val << iter_num_x_in_constraint_vars) | current_x_in_constraint_val;
+                            let E_in_val_last = &E_in_evals[x_in_val_last];
 
-                            let actual_r1cs_constraint_idx = num_uniform_r1cs_constraints + idx;
-                            // Note: the indices 0...rem_num_uniform_r1cs_constraints are already processed in the uniform constraints loop
-                            let block_idx = rem_num_uniform_r1cs_constraints + idx;
-                            let global_r1cs_idx = 2 * (current_step_idx * padded_num_constraints + actual_r1cs_constraint_idx);
-                            let next_step_index_opt = if current_step_idx + 1 < num_steps { Some(current_step_idx + 1) } else { None };
-
-                            let eq_a_eval = eval_offset_lc(
-                                &constraint.a,
-                                flattened_polynomials,
-                                current_step_idx,
-                                next_step_index_opt,
+                            svo_helpers::compute_and_update_tA_inplace_generic::<NUM_SVO_ROUNDS, F>(
+                                &binary_az_block,
+                                &binary_bz_block,
+                                E_in_val_last,
+                                &mut tA_sum_for_current_x_out,
                             );
-                            let eq_b_eval = eval_offset_lc(
-                                &constraint.b,
-                                flattened_polynomials,
-                                current_step_idx,
-                                next_step_index_opt,
-                            );
-                            let az = eq_a_eval - eq_b_eval;
-                            if !az.is_zero() {
-                                binary_az_block[block_idx] = az;
-                                chunk_ab_coeffs.push((global_r1cs_idx, az).into());
-                            } else {
-                                // TODO(moodlezoup): bz should always be zero here I think
-                                let bz = eval_offset_lc(
-                                    &constraint.cond,
-                                    flattened_polynomials,
-                                    current_step_idx,
-                                    next_step_index_opt,
-                                );
-                                if !bz.is_zero() {
-                                    binary_bz_block[block_idx] = bz;
-                                    chunk_ab_coeffs.push((global_r1cs_idx + 1, bz).into());
-                                }
-                            }
                         }
-
-                        let x_in_val_phase2 = (x_in_step_val << iter_num_x_in_constraint_vars) | current_x_in_constraint_val;
-                        let E_in_val_phase2 = &E_in_evals[x_in_val_phase2];
-
-                        // No coeff computation time for padding as blocks are already zero
-                        svo_helpers::compute_and_update_tA_inplace_generic::<NUM_SVO_ROUNDS, F>(
-                            &binary_az_block,
-                            &binary_bz_block,
-                            E_in_val_phase2, // Use E_in_val specific to this phase/block
-                            &mut tA_sum_for_current_x_out,
-                        );
                     } // End x_in_step_val loop
 
                     // Distribute the accumulated tA values to the SVO accumulators

--- a/jolt-core/src/r1cs/builder.rs
+++ b/jolt-core/src/r1cs/builder.rs
@@ -1,9 +1,9 @@
 use super::ops::{Term, Variable, LC};
+use crate::r1cs::inputs::JoltR1CSInputs;
 use crate::{
     field::JoltField,
     r1cs::key::{SparseConstraints, UniformR1CS},
 };
-use crate::{poly::multilinear_polynomial::MultilinearPolynomial, r1cs::inputs::JoltR1CSInputs};
 use std::marker::PhantomData;
 
 /// Constraints over a single row. Each variable points to a single item in Z and the corresponding coefficient.
@@ -19,7 +19,7 @@ impl Constraint {
     pub(crate) fn _pretty_fmt<F: JoltField>(
         &self,
         f: &mut String,
-        flattened_polynomials: &[MultilinearPolynomial<F>],
+        flattened_polynomials: &[crate::poly::multilinear_polynomial::MultilinearPolynomial<F>],
         step_index: usize,
     ) -> std::fmt::Result {
         use std::fmt::Write as _;

--- a/jolt-core/src/r1cs/builder.rs
+++ b/jolt-core/src/r1cs/builder.rs
@@ -252,42 +252,6 @@ impl R1CSBuilder {
     }
 }
 
-/// An Offset Linear Combination. If OffsetLC.0 is true, then the OffsetLC.1 refers to the next step in a uniform
-/// constraint system.
-pub type OffsetLC = (bool, LC);
-
-/// A conditional constraint that Linear Combinations a, b are equal where a and b need not be in the same step an a
-/// uniform constraint system.
-#[derive(Debug)]
-pub struct OffsetEqConstraint {
-    pub cond: OffsetLC,
-    pub a: OffsetLC,
-    pub b: OffsetLC,
-}
-
-impl OffsetEqConstraint {
-    pub fn new(
-        condition: (impl Into<LC>, bool),
-        a: (impl Into<LC>, bool),
-        b: (impl Into<LC>, bool),
-    ) -> Self {
-        Self {
-            cond: (condition.1, condition.0.into()),
-            a: (a.1, a.0.into()),
-            b: (b.1, b.0.into()),
-        }
-    }
-
-    #[cfg(test)]
-    pub fn empty() -> Self {
-        Self::new(
-            (LC::new(vec![]), false),
-            (LC::new(vec![]), false),
-            (LC::new(vec![]), false),
-        )
-    }
-}
-
 // TODO(sragss): Detailed documentation with wiki.
 pub struct CombinedUniformBuilder<F: JoltField> {
     _field: PhantomData<F>,

--- a/jolt-core/src/r1cs/builder.rs
+++ b/jolt-core/src/r1cs/builder.rs
@@ -1,7 +1,4 @@
-use super::{
-    key::{CrossStepR1CS, CrossStepR1CSConstraint, SparseEqualityItem},
-    ops::{Term, Variable, LC},
-};
+use super::ops::{Term, Variable, LC};
 use crate::{
     field::JoltField,
     r1cs::key::{SparseConstraints, UniformR1CS},
@@ -291,21 +288,6 @@ impl OffsetEqConstraint {
     }
 }
 
-pub(crate) fn eval_offset_lc<F: JoltField>(
-    offset: &OffsetLC,
-    flattened_polynomials: &[MultilinearPolynomial<F>],
-    step: usize,
-    next_step_m: Option<usize>,
-) -> i128 {
-    if !offset.0 {
-        offset.1.evaluate_row(flattened_polynomials, step)
-    } else if let Some(next_step) = next_step_m {
-        offset.1.evaluate_row(flattened_polynomials, next_step)
-    } else {
-        offset.1.constant_term_field()
-    }
-}
-
 // TODO(sragss): Detailed documentation with wiki.
 pub struct CombinedUniformBuilder<F: JoltField> {
     _field: PhantomData<F>,
@@ -313,30 +295,21 @@ pub struct CombinedUniformBuilder<F: JoltField> {
 
     /// Padded to the nearest power of 2
     pub(crate) uniform_repeat: usize, // TODO(JP): Remove padding of steps
-
-    pub(crate) offset_equality_constraints: Vec<OffsetEqConstraint>,
 }
 
 impl<F: JoltField> CombinedUniformBuilder<F> {
-    pub fn construct(
-        uniform_builder: R1CSBuilder,
-        uniform_repeat: usize,
-        offset_equality_constraints: Vec<OffsetEqConstraint>,
-    ) -> Self {
+    pub fn construct(uniform_builder: R1CSBuilder, uniform_repeat: usize) -> Self {
         assert!(uniform_repeat.is_power_of_two());
         Self {
             _field: PhantomData,
             uniform_builder,
             uniform_repeat,
-            offset_equality_constraints,
         }
     }
 
     /// Number of constraint rows per step, padded to the next power of two.
     pub(super) fn padded_rows_per_step(&self) -> usize {
-        let num_constraints =
-            self.uniform_builder.constraints.len() + self.offset_equality_constraints.len();
-        num_constraints.next_power_of_two()
+        self.uniform_builder.constraints.len().next_power_of_two()
     }
 
     /// Total number of rows used across all repeated constraints. Not padded to nearest power of two.
@@ -351,70 +324,5 @@ impl<F: JoltField> CombinedUniformBuilder<F> {
     /// Materializes the uniform constraints into sparse (value != 0) A, B, C matrices represented in (row, col, value) format.
     pub fn materialize_uniform(&self) -> UniformR1CS<F> {
         self.uniform_builder.materialize()
-    }
-
-    /// Converts builder::OffsetEqConstraints into key::CrossStepR1CSConstraint
-    pub fn materialize_offset_eq(&self) -> CrossStepR1CS<F> {
-        // (a - b) * condition == 0
-        // A: a - b
-        // B: condition
-        // C: 0
-
-        let mut constraints = Vec::with_capacity(self.offset_equality_constraints.len());
-        for constraint in &self.offset_equality_constraints {
-            let mut eq = SparseEqualityItem::<F>::empty();
-            let mut condition = SparseEqualityItem::<F>::empty();
-
-            constraint
-                .cond
-                .1
-                .terms()
-                .iter()
-                .for_each(|term| match term.0 {
-                    Variable::Input(inner) => {
-                        condition
-                            .offset_vars
-                            .push((inner, constraint.cond.0, F::from_i64(term.1)))
-                    }
-                    Variable::Constant => {}
-                });
-            if let Some(term) = constraint.cond.1.constant_term() {
-                condition.constant = F::from_i64(term.1);
-            }
-
-            // Can't simply combine like terms because of the offset
-            let lhs = constraint.a.1.clone();
-            let rhs = -constraint.b.1.clone();
-
-            lhs.terms().iter().for_each(|term| match term.0 {
-                Variable::Input(inner) => {
-                    eq.offset_vars
-                        .push((inner, constraint.a.0, F::from_i64(term.1)))
-                }
-                Variable::Constant => {}
-            });
-            rhs.terms().iter().for_each(|term| match term.0 {
-                Variable::Input(inner) => {
-                    eq.offset_vars
-                        .push((inner, constraint.b.0, F::from_i64(term.1)))
-                }
-                Variable::Constant => {}
-            });
-
-            // Handle constants
-            lhs.terms().iter().for_each(|term| {
-                assert!(
-                    !matches!(term.0, Variable::Constant),
-                    "Constants only supported in RHS"
-                )
-            });
-            if let Some(term) = rhs.constant_term() {
-                eq.constant = F::from_i64(term.1);
-            }
-
-            constraints.push(CrossStepR1CSConstraint::new(eq, condition));
-        }
-
-        CrossStepR1CS { constraints }
     }
 }

--- a/jolt-core/src/r1cs/constraints.rs
+++ b/jolt-core/src/r1cs/constraints.rs
@@ -1,7 +1,7 @@
 use crate::{field::JoltField, jolt::instruction::CircuitFlags};
 
 use super::{
-    builder::{CombinedUniformBuilder, OffsetEqConstraint, R1CSBuilder},
+    builder::{CombinedUniformBuilder, R1CSBuilder},
     inputs::JoltR1CSInputs,
 };
 
@@ -11,25 +11,16 @@ pub trait R1CSConstraints<F: JoltField> {
     fn construct_constraints(padded_trace_length: usize) -> CombinedUniformBuilder<F> {
         let mut uniform_builder = R1CSBuilder::new();
         Self::uniform_constraints(&mut uniform_builder);
-        let cross_step_constraints = Self::cross_step_constraints();
 
         CombinedUniformBuilder::construct(
             uniform_builder,
             padded_trace_length,
-            cross_step_constraints,
         )
     }
     /// Constructs Jolt's uniform constraints.
     /// Uniform constraints are constraints that hold for each step of
     /// the execution trace.
     fn uniform_constraints(builder: &mut R1CSBuilder);
-    /// Construct's Jolt's cross-step constraints.
-    /// Cross-step constraints are constraints whose inputs involve witness
-    /// values from multiple steps of the execution trace.
-    /// Currently, all of Jolt's cross-step constraints are of the form
-    ///     if condition { some constraint on steps i and i+1 }
-    /// This structure is captured in `OffsetEqConstraint`.
-    fn cross_step_constraints() -> Vec<OffsetEqConstraint>;
 }
 
 pub struct JoltRV32IMConstraints;
@@ -262,30 +253,5 @@ impl<F: JoltField> R1CSConstraints<F> for JoltRV32IMConstraints {
             JoltR1CSInputs::RealInstructionAddress + 4
                 - 4 * JoltR1CSInputs::OpFlags(CircuitFlags::DoNotUpdatePC),
         );
-    }
-
-    fn cross_step_constraints() -> Vec<OffsetEqConstraint> {
-        // If the next instruction's address is not zero (i.e. it's
-        // not padding), then check the PC update.
-        let pc_constraint = OffsetEqConstraint::new(
-            (JoltR1CSInputs::RealInstructionAddress, true),
-            (JoltR1CSInputs::NextPC, false),
-            (JoltR1CSInputs::RealInstructionAddress, true),
-        );
-
-        // If the current instruction is virtual, check that the next instruction
-        // in the trace is the next instruction in bytecode. Virtual sequences
-        // do not involve jumps or branches, so this should always hold,
-        // EXCEPT if we encounter a virtual instruction followed by a padding
-        // instruction. But that should never happen because the execution
-        // trace should always end with some return handling, which shouldn't involve
-        // any virtual sequences.
-        let virtual_sequence_constraint = OffsetEqConstraint::new(
-            (JoltR1CSInputs::OpFlags(CircuitFlags::Virtual), false),
-            (JoltR1CSInputs::VirtualInstructionAddress, true),
-            (JoltR1CSInputs::VirtualInstructionAddress + 1, false),
-        );
-
-        vec![pc_constraint, virtual_sequence_constraint]
     }
 }

--- a/jolt-core/src/r1cs/constraints.rs
+++ b/jolt-core/src/r1cs/constraints.rs
@@ -12,10 +12,7 @@ pub trait R1CSConstraints<F: JoltField> {
         let mut uniform_builder = R1CSBuilder::new();
         Self::uniform_constraints(&mut uniform_builder);
 
-        CombinedUniformBuilder::construct(
-            uniform_builder,
-            padded_trace_length,
-        )
+        CombinedUniformBuilder::construct(uniform_builder, padded_trace_length)
     }
     /// Constructs Jolt's uniform constraints.
     /// Uniform constraints are constraints that hold for each step of

--- a/jolt-core/src/r1cs/inputs.rs
+++ b/jolt-core/src/r1cs/inputs.rs
@@ -272,7 +272,8 @@ impl JoltR1CSInputs {
             JoltR1CSInputs::NextPC => {
                 let coeffs: Vec<u64> = trace
                     .par_iter()
-                    .map(|cycle| {
+                    .enumerate()
+                    .map(|(i, cycle)| {
                         let is_branch =
                             cycle.instruction().circuit_flags()[CircuitFlags::Branch as usize];
                         let should_branch =

--- a/jolt-core/src/r1cs/key.rs
+++ b/jolt-core/src/r1cs/key.rs
@@ -204,8 +204,7 @@ impl<F: JoltField> UniformSpartanKey<F> {
         let const_eval = if self.uniform_r1cs.num_vars < num_vars && with_const {
             let const_position_bits =
                 index_to_field_bitvector(self.uniform_r1cs.num_vars as u64, var_bits);
-            let eq_const = EqPolynomial::new(r.to_vec()).evaluate(&const_position_bits);
-            eq_const
+            EqPolynomial::new(r.to_vec()).evaluate(&const_position_bits)
         } else {
             F::zero()
         };

--- a/jolt-core/src/r1cs/spartan.rs
+++ b/jolt-core/src/r1cs/spartan.rs
@@ -380,9 +380,9 @@ where
             .verify(claim_inner_joint, num_rounds_inner_sumcheck, 2, transcript)
             .map_err(|_| SpartanError::InvalidInnerSumcheckProof)?;
 
-        let num_steps_bits = key.num_steps.log_2();
+        let num_cycles_bits = key.num_steps.log_2();
 
-        let (rx_step, rx_constr) = outer_sumcheck_r.split_at(num_steps_bits);
+        let (rx_step, rx_constr) = outer_sumcheck_r.split_at(num_cycles_bits);
 
         let ry_var = inner_sumcheck_r.to_vec();
         let eval_z =
@@ -407,7 +407,7 @@ where
             where r_t = shift_sumcheck_r
         */
 
-        let num_rounds_shift_sumcheck = num_steps_bits;
+        let num_rounds_shift_sumcheck = num_cycles_bits;
         let (claim_shift_sumcheck, shift_sumcheck_r) = self
             .shift_sumcheck_proof
             .verify(

--- a/jolt-core/src/r1cs/spartan.rs
+++ b/jolt-core/src/r1cs/spartan.rs
@@ -160,7 +160,7 @@ where
 
         let num_cycles = key.num_steps;
         let num_cycles_bits = num_cycles.ilog2() as usize;
-        let num_vars_uniform = key.num_vars_uniform_padded().next_power_of_two();
+        let num_vars_uniform = key.num_vars_uniform_padded();
 
         let inner_sumcheck_RLC: F = transcript.challenge_scalar();
         let claim_inner_joint =

--- a/jolt-core/src/r1cs/spartan.rs
+++ b/jolt-core/src/r1cs/spartan.rs
@@ -210,7 +210,7 @@ where
             poly_evals[0] * poly_evals[1]
         };
 
-        let (inner_sumcheck_proof, inner_sumcheck_r, _claims_inner) =
+        let (inner_sumcheck_proof, _inner_sumcheck_r, _claims_inner) =
             SumcheckInstanceProof::prove_arbitrary(
                 &claim_inner_joint,
                 num_rounds_inner_sumcheck,
@@ -225,7 +225,7 @@ where
         // Evaluate all witness polynomials P_i at r_cycle for the verifier
         // Verifier computes: z(r_inner, r_cycle) = Σ_i eq(r_inner, i) * P_i(r_cycle)
         let flattened_polys_ref: Vec<_> = input_polys.iter().collect();
-        let (claimed_witness_evals, chis) =
+        let (claimed_witness_evals, _chis) =
             MultilinearPolynomial::batch_evaluate(&flattened_polys_ref, r_cycle);
 
         /*  Sumcheck 3: Shift sumcheck for NextPC verification
@@ -271,7 +271,7 @@ where
         // );
 
         // For shift sumcheck, we need PC evaluation at shift_r
-        let (shift_sumcheck_witness_evals_partial, chis2) =
+        let (shift_sumcheck_witness_evals_partial, _chis2) =
             MultilinearPolynomial::batch_evaluate(&[&input_polys[pc_index]], &shift_sumcheck_r);
         let shift_sumcheck_witness_eval = shift_sumcheck_witness_evals_partial[0];
 

--- a/jolt-core/src/r1cs/spartan.rs
+++ b/jolt-core/src/r1cs/spartan.rs
@@ -122,12 +122,14 @@ where
         /* Sumcheck 1: Outer sumcheck */
 
         let tau: Vec<F> = transcript.challenge_vector(num_rounds_x);
+        // For the first sumcheck, we only use uniform constraints (no cross-step constraints)
+        // This makes A block-diagonal with blocks being A_small
+        let uniform_constraints_only_padded = constraint_builder.uniform_builder.constraints.len().next_power_of_two();
         let (outer_sumcheck_proof, outer_sumcheck_r, outer_sumcheck_claims) =
             SumcheckInstanceProof::prove_spartan_small_value::<NUM_SVO_ROUNDS>(
                 num_rounds_x,
-                constraint_builder.padded_rows_per_step(),
+                uniform_constraints_only_padded,
                 &constraint_builder.uniform_builder.constraints,
-                &constraint_builder.offset_equality_constraints,
                 &input_polys,
                 &tau,
                 transcript,

--- a/jolt-core/src/r1cs/spartan.rs
+++ b/jolt-core/src/r1cs/spartan.rs
@@ -170,7 +170,7 @@ where
 
         let (eq_r_cycle, eq_plus_one_r_cycle) = EqPlusOnePolynomial::evals(r_cycle, None);
 
-        // Evaluate A_small, B_small, C_small combined with RLC at point r_var
+        // Evaluate A_small, B_small, C_small combined with RLC at point rx_var
         let poly_abc_small =
             DensePolynomial::new(key.evaluate_small_matrix_rlc(rx_var, inner_sumcheck_RLC));
 

--- a/jolt-core/src/subprotocols/sparse_dense_shout.rs
+++ b/jolt-core/src/subprotocols/sparse_dense_shout.rs
@@ -772,7 +772,7 @@ mod tests {
             RV32IMCycle::VirtualSRAI(cycle) => cycle.random(rng).into(),
             RV32IMCycle::VirtualSRL(cycle) => cycle.random(rng).into(),
             RV32IMCycle::VirtualSRLI(cycle) => cycle.random(rng).into(),
-            _ => RV32IMCycle::NoOp,
+            _ => RV32IMCycle::NoOp(0),
         }
     }
 

--- a/jolt-core/src/subprotocols/sumcheck.rs
+++ b/jolt-core/src/subprotocols/sumcheck.rs
@@ -431,7 +431,6 @@ impl<F: JoltField, ProofTranscript: Transcript> SumcheckInstanceProof<F, ProofTr
         num_rounds: usize,
         padded_num_constraints: usize,
         uniform_constraints: &[Constraint],
-        cross_step_constraints: &[OffsetEqConstraint],
         flattened_polys: &[MultilinearPolynomial<F>],
         tau: &[F],
         transcript: &mut ProofTranscript,
@@ -445,7 +444,6 @@ impl<F: JoltField, ProofTranscript: Transcript> SumcheckInstanceProof<F, ProofTr
             SpartanInterleavedPolynomial::<NUM_SVO_ROUNDS, F>::new_with_precompute(
                 padded_num_constraints,
                 uniform_constraints,
-                cross_step_constraints,
                 flattened_polys,
                 tau,
             );

--- a/jolt-core/src/subprotocols/sumcheck.rs
+++ b/jolt-core/src/subprotocols/sumcheck.rs
@@ -9,7 +9,7 @@ use crate::poly::multilinear_polynomial::{
 use crate::poly::spartan_interleaved_poly::SpartanInterleavedPolynomial;
 use crate::poly::split_eq_poly::{GruenSplitEqPolynomial, SplitEqPolynomial};
 use crate::poly::unipoly::{CompressedUniPoly, UniPoly};
-use crate::r1cs::builder::{Constraint, OffsetEqConstraint};
+use crate::r1cs::builder::Constraint;
 use crate::utils::errors::ProofVerifyError;
 use crate::utils::mul_0_optimized;
 use crate::utils::small_value::svo_helpers::process_svo_sumcheck_rounds;

--- a/tracer/src/instruction/mod.rs
+++ b/tracer/src/instruction/mod.rs
@@ -252,7 +252,7 @@ macro_rules! define_rv32im_enums {
     ) => {
         #[derive(Debug, IntoStaticStr, From, Clone, Serialize, Deserialize)]
         pub enum RV32IMInstruction {
-            NoOp,
+            NoOp(usize),
             UNIMPL,
             $(
                 $instr($instr),
@@ -263,7 +263,7 @@ macro_rules! define_rv32im_enums {
             From, Debug, Copy, Clone, Serialize, Deserialize, IntoStaticStr, EnumIter, EnumCountMacro,
         )]
         pub enum RV32IMCycle {
-            NoOp,
+            NoOp(usize),
             $(
                 $instr(RISCVCycle<$instr>),
             )*
@@ -272,7 +272,7 @@ macro_rules! define_rv32im_enums {
         impl RV32IMCycle {
             pub fn ram_access(&self) -> RAMAccess {
                 match self {
-                    RV32IMCycle::NoOp => RAMAccess::NoOp,
+                    RV32IMCycle::NoOp(_) => RAMAccess::NoOp,
                     $(
                         RV32IMCycle::$instr(cycle) => cycle.ram_access.into(),
                     )*
@@ -281,7 +281,7 @@ macro_rules! define_rv32im_enums {
 
             pub fn rs1_read(&self) -> (usize, u64) {
                 match self {
-                    RV32IMCycle::NoOp => (0, 0),
+                    RV32IMCycle::NoOp(_) => (0, 0),
                     $(
                         RV32IMCycle::$instr(cycle) => (
                             cycle.instruction.operands.normalize().rs1,
@@ -293,7 +293,7 @@ macro_rules! define_rv32im_enums {
 
             pub fn rs2_read(&self) -> (usize, u64) {
                 match self {
-                    RV32IMCycle::NoOp => (0, 0),
+                    RV32IMCycle::NoOp(_) => (0, 0),
                     $(
                         RV32IMCycle::$instr(cycle) => (
                             cycle.instruction.operands.normalize().rs2,
@@ -305,7 +305,7 @@ macro_rules! define_rv32im_enums {
 
             pub fn rd_write(&self) -> (usize, u64, u64) {
                 match self {
-                    RV32IMCycle::NoOp => (0, 0, 0),
+                    RV32IMCycle::NoOp(_) => (0, 0, 0),
                     $(
                         RV32IMCycle::$instr(cycle) => (
                             cycle.instruction.operands.normalize().rd,
@@ -318,7 +318,7 @@ macro_rules! define_rv32im_enums {
 
             pub fn instruction(&self) -> RV32IMInstruction {
                 match self {
-                    RV32IMCycle::NoOp => RV32IMInstruction::NoOp,
+                    RV32IMCycle::NoOp(address) => RV32IMInstruction::NoOp(*address),
                     $(
                         RV32IMCycle::$instr(cycle) => cycle.instruction.into(),
                     )*
@@ -329,7 +329,7 @@ macro_rules! define_rv32im_enums {
         impl RV32IMInstruction {
             pub fn trace(&self, cpu: &mut Cpu) {
                 match self {
-                    RV32IMInstruction::NoOp => panic!("Unsupported instruction: {:?}", self),
+                    RV32IMInstruction::NoOp(_) => panic!("Unsupported instruction: {:?}", self),
                     RV32IMInstruction::UNIMPL => panic!("Unsupported instruction: {:?}", self),
                     $(
                         RV32IMInstruction::$instr(instr) => instr.trace(cpu),
@@ -339,7 +339,12 @@ macro_rules! define_rv32im_enums {
 
             pub fn normalize(&self) -> NormalizedInstruction {
                 match self {
-                    RV32IMInstruction::NoOp => Default::default(),
+                    RV32IMInstruction::NoOp(address) => {
+                        NormalizedInstruction {
+                            address: *address,
+                            ..Default::default()
+                        }
+                    },
                     RV32IMInstruction::UNIMPL => panic!("Unsupported instruction: {:?}", self),
                     $(
                         RV32IMInstruction::$instr(instr) => NormalizedInstruction {
@@ -353,7 +358,7 @@ macro_rules! define_rv32im_enums {
 
             pub fn set_virtual_sequence_remaining(&mut self, remaining: Option<usize>) {
                 match self {
-                    RV32IMInstruction::NoOp => (),
+                    RV32IMInstruction::NoOp(_) => (),
                     RV32IMInstruction::UNIMPL => (),
                     $(
                         RV32IMInstruction::$instr(instr) => {instr.virtual_sequence_remaining = remaining;}
@@ -429,7 +434,7 @@ impl Valid for RV32IMInstruction {
 impl RV32IMInstruction {
     pub fn is_real(&self) -> bool {
         // ignore no-op
-        if matches!(self, RV32IMInstruction::NoOp) {
+        if matches!(self, RV32IMInstruction::NoOp(_)) {
             return false;
         }
 

--- a/tracer/src/instruction/mod.rs
+++ b/tracer/src/instruction/mod.rs
@@ -618,15 +618,14 @@ impl<T: RISCVInstruction> RISCVCycle<T> {
     }
 }
 
-impl RISCVCycle<JALR> {
-    pub fn last_jalr(address: u64) -> Self {
-        Self {
+impl RV32IMCycle {
+    pub fn last_jalr(address: usize) -> Self {
+        Self::JALR(RISCVCycle {
             instruction: JALR {
-                address,
+                address: address as u64,
                 ..Default::default()
             },
-            ram_access: Default::default(),
-            register_state: Default::default(),
-        }
+            ..Default::default()
+        })
     }
 }

--- a/tracer/src/instruction/mod.rs
+++ b/tracer/src/instruction/mod.rs
@@ -252,6 +252,7 @@ macro_rules! define_rv32im_enums {
     ) => {
         #[derive(Debug, IntoStaticStr, From, Clone, Serialize, Deserialize)]
         pub enum RV32IMInstruction {
+            /// No-operation instruction (address)
             NoOp(usize),
             UNIMPL,
             $(
@@ -263,6 +264,7 @@ macro_rules! define_rv32im_enums {
             From, Debug, Copy, Clone, Serialize, Deserialize, IntoStaticStr, EnumIter, EnumCountMacro,
         )]
         pub enum RV32IMCycle {
+            /// No-operation cycle (address)
             NoOp(usize),
             $(
                 $instr(RISCVCycle<$instr>),

--- a/tracer/src/instruction/mod.rs
+++ b/tracer/src/instruction/mod.rs
@@ -617,3 +617,16 @@ impl<T: RISCVInstruction> RISCVCycle<T> {
         }
     }
 }
+
+impl RISCVCycle<JALR> {
+    pub fn last_jalr(address: u64) -> Self {
+        Self {
+            instruction: JALR {
+                address,
+                ..Default::default()
+            },
+            ram_access: Default::default(),
+            register_state: Default::default(),
+        }
+    }
+}


### PR DESCRIPTION
Refactors first and second spartan sumcheck to be over uniform constraints
Refactors third sumcheck to be like a pcnext sumcheck batched with a virutalinstructionaddress sumcheck
So, third sumcheck ensures cross-step constraints.

Cross step constraints were remove.
NoOp padding instructions now have address in them to ensure third sumcheck passing.