### PR TITLE
Update extractor to use new memory config struct

### DIFF
--- a/zklean-extractor/src/constants.rs
+++ b/zklean-extractor/src/constants.rs
@@ -1,4 +1,4 @@
-use common::constants;
+use common::{constants, rv_trace::MemoryConfig};
 use jolt_core::jolt::vm::rv32i_vm;
 
 /// Groups the constants used for a specific instruction set / decomposition strategy / memory
@@ -15,10 +15,8 @@ pub trait JoltParameterSet {
     /// from `C` and `LOG_M`, since those constants need to be able to decompose a pair of
     /// `WORD_SIZE` registers
     const WORD_SIZE: usize = (Self::LOG_M * Self::C) / 2;
-    /// The maximum number of input wires in the memory layout
-    const MAX_INPUT_SIZE: u64;
-    /// The maximum number of output wires in the memory layout
-    const MAX_OUTPUT_SIZE: u64;
+    /// The memory config to use
+    const MEMORY_CONFIG: MemoryConfig;
 }
 
 /// The parameters used by Jolt for 32-bit risc-v
@@ -28,6 +26,10 @@ pub struct RV32IParameterSet;
 impl JoltParameterSet for RV32IParameterSet {
     const C: usize = rv32i_vm::C;
     const M: usize = rv32i_vm::M;
-    const MAX_INPUT_SIZE: u64 = constants::DEFAULT_MAX_INPUT_SIZE;
-    const MAX_OUTPUT_SIZE: u64 = constants::DEFAULT_MAX_OUTPUT_SIZE;
+    const MEMORY_CONFIG: MemoryConfig = MemoryConfig {
+        max_input_size: constants::DEFAULT_MAX_INPUT_SIZE,
+        max_output_size: constants::DEFAULT_MAX_OUTPUT_SIZE,
+        stack_size: constants::DEFAULT_STACK_SIZE,
+        memory_size: constants::DEFAULT_MEMORY_SIZE,
+    };
 }

--- a/zklean-extractor/src/r1cs.rs
+++ b/zklean-extractor/src/r1cs.rs
@@ -32,7 +32,7 @@ where
 
         // XXX Make max input/output sizes configurable?
         let uniform_constraints = {
-            let memory_layout = MemoryLayout::new(J::MAX_INPUT_SIZE, J::MAX_OUTPUT_SIZE);
+            let memory_layout = MemoryLayout::new(&J::MEMORY_CONFIG);
 
             let mut r1cs_builder = R1CSBuilder::<{ J::C }, F, JoltR1CSInputs>::new();
             CS::uniform_constraints(&mut r1cs_builder, memory_layout.input_start);


### PR DESCRIPTION
A recent PR made the ZkLean extractor fail to compile. This fixes it.