### PR TITLE
chore: update devcontainer to use base:noble

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,9 @@
+FROM mcr.microsoft.com/devcontainers/base:noble
+
+RUN <<-'EOF' bash
+	set -eu -o pipefail
+	apt-get update
+	apt-get install -y --no-install-recommends ca-certificates pkg-config libssl-dev
+	curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sed 's#/proc/self/exe#\/bin\/sh#g' | sh -s -- -y --no-update-default-toolchain 1>/dev/null
+	rm -rf /var/lib/apt/lists/*
+EOF

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,7 +3,9 @@
 {
 	"name": "Rust",
 	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-	"image": "mcr.microsoft.com/devcontainers/rust:1-1-bookworm",
+	"build": {
+		"dockerfile": "Dockerfile"
+	},
 	"features": {
 		"ghcr.io/devcontainers/features/common-utils:2": {
 			"installZsh": true,


### PR DESCRIPTION
This PR will use base:noble whose GLIBC meet the requirements of the jolt toolchain.