### PR TITLE
fix: SH virtual instruction alignment check

### DIFF
--- a/common/src/attributes.rs
+++ b/common/src/attributes.rs
@@ -5,7 +5,8 @@ use syn::{Lit, Meta, MetaNameValue, NestedMeta};
 
 #[cfg(feature = "std")]
 use crate::constants::{
-    DEFAULT_MAX_INPUT_SIZE, DEFAULT_MAX_OUTPUT_SIZE, DEFAULT_MEMORY_SIZE, DEFAULT_STACK_SIZE,
+    DEFAULT_MAX_BYTECODE_SIZE, DEFAULT_MAX_INPUT_SIZE, DEFAULT_MAX_OUTPUT_SIZE,
+    DEFAULT_MAX_TRACE_LENGTH, DEFAULT_MEMORY_SIZE, DEFAULT_STACK_SIZE,
 };
 
 pub struct Attributes {
@@ -14,6 +15,8 @@ pub struct Attributes {
     pub stack_size: u64,
     pub max_input_size: u64,
     pub max_output_size: u64,
+    pub max_bytecode_size: u64,
+    pub max_trace_length: u64,
 }
 
 #[cfg(feature = "std")]
@@ -34,6 +37,8 @@ pub fn parse_attributes(attr: &Vec<NestedMeta>) -> Attributes {
                     "stack_size" => attributes.insert("stack_size", value),
                     "max_input_size" => attributes.insert("max_input_size", value),
                     "max_output_size" => attributes.insert("max_output_size", value),
+                    "max_bytecode_size" => attributes.insert("max_bytecode_size", value),
+                    "max_trace_length" => attributes.insert("max_trace_length", value),
                     _ => panic!("invalid attribute"),
                 };
             }
@@ -54,6 +59,12 @@ pub fn parse_attributes(attr: &Vec<NestedMeta>) -> Attributes {
     let max_output_size = *attributes
         .get("max_output_size")
         .unwrap_or(&DEFAULT_MAX_OUTPUT_SIZE);
+    let max_bytecode_size = *attributes
+        .get("max_bytecode_size")
+        .unwrap_or(&DEFAULT_MAX_BYTECODE_SIZE);
+    let max_trace_length = *attributes
+        .get("max_trace_length")
+        .unwrap_or(&DEFAULT_MAX_TRACE_LENGTH);
 
     Attributes {
         wasm,
@@ -61,5 +72,7 @@ pub fn parse_attributes(attr: &Vec<NestedMeta>) -> Attributes {
         stack_size,
         max_input_size,
         max_output_size,
+        max_bytecode_size,
+        max_trace_length,
     }
 }

--- a/common/src/constants.rs
+++ b/common/src/constants.rs
@@ -11,6 +11,8 @@ pub const DEFAULT_MEMORY_SIZE: u64 = 10 * 1024 * 1024;
 pub const DEFAULT_STACK_SIZE: u64 = 4096;
 pub const DEFAULT_MAX_INPUT_SIZE: u64 = 4096;
 pub const DEFAULT_MAX_OUTPUT_SIZE: u64 = 4096;
+pub const DEFAULT_MAX_BYTECODE_SIZE: u64 = 1 << 20;
+pub const DEFAULT_MAX_TRACE_LENGTH: u64 = 1 << 24;
 
 pub const fn virtual_register_index(index: u64) -> u64 {
     index + VIRTUAL_REGISTER_COUNT

--- a/common/src/rv_trace.rs
+++ b/common/src/rv_trace.rs
@@ -202,7 +202,7 @@ impl From<&RVTraceRow> for [MemoryOp; MEMORY_OPS_PER_INSTRUCTION] {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, PartialEq, Serialize, Deserialize)]
 pub struct ELFInstruction {
     pub address: u64,
     pub opcode: RV32IM,
@@ -216,6 +216,16 @@ pub struct ELFInstruction {
     /// `virtual_sequence_remaining` will be Some(0); if this is the penultimate instruction
     /// in the sequence, `virtual_sequence_remaining` will be Some(1); etc.
     pub virtual_sequence_remaining: Option<usize>,
+}
+
+impl core::fmt::Debug for ELFInstruction {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(
+            f,
+            "ELFInstruction {{ address: {:X}, opcode: {:?}, rs1: {:?}, rs2: {:?}, rd: {:?}, imm: {:?}, virtual_sequence_remaining: {:?} }}",
+            self.address, self.opcode, self.rs1, self.rs2, self.rd, self.imm, self.virtual_sequence_remaining
+        )
+    }
 }
 
 /// Boolean flags used in Jolt's R1CS constraints (`opflags` in the Jolt paper).

--- a/jolt-core/src/jolt/instruction/sh.rs
+++ b/jolt-core/src/jolt/instruction/sh.rs
@@ -40,7 +40,11 @@ impl<const WORD_SIZE: usize> VirtualInstructionSequence for SHInstruction<WORD_S
 
         let is_aligned =
             AssertHalfwordAlignmentInstruction::<WORD_SIZE>(dest, offset_unsigned).lookup_entry();
-        debug_assert_eq!(is_aligned, 1);
+        debug_assert_eq!(
+            is_aligned, 1,
+            "Unaligned halfword store at addr = {} + offset = {}",
+            dest, offset_unsigned
+        );
         virtual_trace.push(RVTraceRow {
             instruction: ELFInstruction {
                 address: trace_row.instruction.address,
@@ -63,7 +67,11 @@ impl<const WORD_SIZE: usize> VirtualInstructionSequence for SHInstruction<WORD_S
         });
 
         let ram_address = ADDInstruction::<WORD_SIZE>(dest, offset_unsigned).lookup_entry();
-        assert!(ram_address % 2 == 0);
+        assert_eq!(
+            ram_address % 2,
+            0,
+            "SH instruction must write to an even address"
+        );
         virtual_trace.push(RVTraceRow {
             instruction: ELFInstruction {
                 address: trace_row.instruction.address,
@@ -348,10 +356,15 @@ impl<const WORD_SIZE: usize> VirtualInstructionSequence for SHInstruction<WORD_S
     }
 
     fn virtual_sequence(instruction: ELFInstruction) -> Vec<ELFInstruction> {
+        // make sure rs1_val dest value is aligned with the instruction's imm
+        let imm = instruction.imm.unwrap();
+        // Select a valid aligned rs1_val such that (rs1_val + imm) is always even
+        let rs1_val = if imm % 2 == 0 { Some(0) } else { Some(1) };
+
         let dummy_trace_row = RVTraceRow {
             instruction,
             register_state: RegisterState {
-                rs1_val: Some(0),
+                rs1_val,
                 rs2_val: Some(0),
                 rd_post_val: Some(0),
             },

--- a/jolt-core/src/jolt/instruction/sh.rs
+++ b/jolt-core/src/jolt/instruction/sh.rs
@@ -42,8 +42,7 @@ impl<const WORD_SIZE: usize> VirtualInstructionSequence for SHInstruction<WORD_S
             AssertHalfwordAlignmentInstruction::<WORD_SIZE>(dest, offset_unsigned).lookup_entry();
         debug_assert_eq!(
             is_aligned, 1,
-            "Unaligned halfword store at addr = {} + offset = {}",
-            dest, offset_unsigned
+            "Unaligned halfword store at addr = {dest} + offset = {offset_unsigned}"
         );
         virtual_trace.push(RVTraceRow {
             instruction: ELFInstruction {

--- a/jolt-core/src/poly/commitment/bmmtv/hyperbmmtv.rs
+++ b/jolt-core/src/poly/commitment/bmmtv/hyperbmmtv.rs
@@ -114,6 +114,10 @@ where
         SRS::trim(Arc::new(srs), powers_len - 1)
     }
 
+    fn srs_size(setup: &Self::Setup) -> usize {
+        setup.0.g1_powers().len()
+    }
+
     #[tracing::instrument(skip_all, name = "HyperBmmtv::commit")]
     fn commit(
         poly: &MultilinearPolynomial<Self::Field>,

--- a/jolt-core/src/poly/commitment/commitment_scheme.rs
+++ b/jolt-core/src/poly/commitment/commitment_scheme.rs
@@ -24,6 +24,7 @@ pub trait CommitmentScheme<ProofTranscript: Transcript>: Clone + Sync + Send + '
     type BatchedProof: Sync + Send + CanonicalSerialize + CanonicalDeserialize;
 
     fn setup(max_len: usize) -> Self::Setup;
+    fn srs_size(setup: &Self::Setup) -> usize;
     fn commit(poly: &MultilinearPolynomial<Self::Field>, setup: &Self::Setup) -> Self::Commitment;
     fn batch_commit<U>(polys: &[U], gens: &Self::Setup) -> Vec<Self::Commitment>
     where

--- a/jolt-core/src/poly/commitment/hyperkzg.rs
+++ b/jolt-core/src/poly/commitment/hyperkzg.rs
@@ -427,6 +427,10 @@ where
         .trim(max_poly_len)
     }
 
+    fn srs_size(setup: &Self::Setup) -> usize {
+        setup.0.kzg_pk.g1_powers().len()
+    }
+
     #[tracing::instrument(skip_all, name = "HyperKZG::commit")]
     fn commit(poly: &MultilinearPolynomial<Self::Field>, setup: &Self::Setup) -> Self::Commitment {
         assert!(

--- a/jolt-core/src/poly/commitment/kzg.rs
+++ b/jolt-core/src/poly/commitment/kzg.rs
@@ -233,7 +233,6 @@ where
         assert!(polys
             .par_iter()
             .all(|s| s.borrow().len() == polys[0].borrow().len()));
-        assert!(polys[0].borrow().len() <= g1_powers.len());
 
         if let Some(invalid) = polys
             .iter()

--- a/jolt-core/src/poly/commitment/mock.rs
+++ b/jolt-core/src/poly/commitment/mock.rs
@@ -47,6 +47,11 @@ where
     type BatchedProof = MockProof<F>;
 
     fn setup(_max_poly_len: usize) -> Self::Setup {}
+
+    fn srs_size(_setup: &Self::Setup) -> usize {
+        1 << 10
+    }
+
     fn commit(poly: &MultilinearPolynomial<Self::Field>, _setup: &Self::Setup) -> Self::Commitment {
         MockCommitment { poly: poly.clone() }
     }

--- a/jolt-core/src/poly/commitment/zeromorph.rs
+++ b/jolt-core/src/poly/commitment/zeromorph.rs
@@ -440,6 +440,10 @@ where
         .trim(max_poly_len)
     }
 
+    fn srs_size(setup: &Self::Setup) -> usize {
+        setup.0.commit_pp.g1_powers().len()
+    }
+
     fn commit(poly: &MultilinearPolynomial<Self::Field>, setup: &Self::Setup) -> Self::Commitment {
         assert!(
             setup.0.commit_pp.g1_powers().len() > poly.len(),

--- a/jolt-sdk/macros/src/lib.rs
+++ b/jolt-sdk/macros/src/lib.rs
@@ -252,6 +252,10 @@ impl MacroBuilder {
         let max_output_size = proc_macro2::Literal::u64_unsuffixed(attributes.max_output_size);
         let stack_size = proc_macro2::Literal::u64_unsuffixed(attributes.stack_size);
         let memory_size = proc_macro2::Literal::u64_unsuffixed(attributes.memory_size);
+        let max_bytecode_size = proc_macro2::Literal::u64_unsuffixed(attributes.max_bytecode_size);
+        let max_trace_length = proc_macro2::Literal::u64_unsuffixed(attributes.max_trace_length);
+        let max_memory_size =
+            proc_macro2::Literal::u64_unsuffixed(attributes.memory_size.next_power_of_two());
         let imports = self.make_imports();
 
         let fn_name = self.get_func_name();
@@ -273,15 +277,14 @@ impl MacroBuilder {
                 };
                 let memory_layout = MemoryLayout::new(&memory_config);
 
-                // TODO(moodlezoup): Feed in size parameters via macro
                 let preprocessing: JoltProverPreprocessing<4, jolt::F, jolt::PCS, jolt::ProofTranscript> =
                     RV32IJoltVM::prover_preprocess(
                         bytecode,
                         memory_layout,
                         memory_init,
-                        1 << 20,
-                        1 << 20,
-                        1 << 24
+                        #max_bytecode_size,
+                        #max_memory_size,
+                        #max_trace_length
                     );
 
                 preprocessing
@@ -295,6 +298,11 @@ impl MacroBuilder {
         let max_output_size = proc_macro2::Literal::u64_unsuffixed(attributes.max_output_size);
         let stack_size = proc_macro2::Literal::u64_unsuffixed(attributes.stack_size);
         let memory_size = proc_macro2::Literal::u64_unsuffixed(attributes.memory_size);
+        let max_bytecode_size = proc_macro2::Literal::u64_unsuffixed(attributes.max_bytecode_size);
+        let max_trace_length = proc_macro2::Literal::u64_unsuffixed(attributes.max_trace_length);
+        let max_memory_size =
+            proc_macro2::Literal::u64_unsuffixed(attributes.memory_size.next_power_of_two());
+
         let imports = self.make_imports();
 
         let fn_name = self.get_func_name();
@@ -316,15 +324,14 @@ impl MacroBuilder {
                 };
                 let memory_layout = MemoryLayout::new(&memory_config);
 
-                // TODO(moodlezoup): Feed in size parameters via macro
                 let preprocessing: JoltVerifierPreprocessing<4, jolt::F, jolt::PCS, jolt::ProofTranscript> =
                     RV32IJoltVM::verifier_preprocess(
                         bytecode,
                         memory_layout,
                         memory_init,
-                        1 << 20,
-                        1 << 20,
-                        1 << 24
+                        #max_bytecode_size,
+                        #max_memory_size,
+                        #max_trace_length
                     );
 
                 preprocessing
@@ -366,7 +373,6 @@ impl MacroBuilder {
 
                 let mut input_bytes = vec![];
                 #(#set_program_args;)*
-
                 let (io_device, trace) = program.trace(&input_bytes);
 
                 let (jolt_proof, jolt_commitments, output_io_device, _) = RV32IJoltVM::prove(
@@ -658,6 +664,11 @@ impl MacroBuilder {
     fn make_wasm_function(&self) -> TokenStream2 {
         let fn_name = self.get_func_name();
         let verify_wasm_fn_name = Ident::new(&format!("verify_{fn_name}"), fn_name.span());
+        let attributes = parse_attributes(&self.attr);
+        let max_bytecode_size = proc_macro2::Literal::u64_unsuffixed(attributes.max_bytecode_size);
+        let max_trace_length = proc_macro2::Literal::u64_unsuffixed(attributes.max_trace_length);
+        let max_memory_size =
+            proc_macro2::Literal::u64_unsuffixed(attributes.memory_size.next_power_of_two());
 
         quote! {
             #[wasm_bindgen]
@@ -671,9 +682,9 @@ impl MacroBuilder {
                 let preprocessing = RV32IJoltVM::preprocess(
                     decoded_preprocessing_data.bytecode,
                     decoded_preprocessing_data.memory_init,
-                    1 << 20,
-                    1 << 20,
-                    1 << 24,
+                    #max_bytecode_size,
+                    #max_memory_size,
+                    #max_trace_length,
                 );
 
                 let result = RV32IJoltVM::verify(preprocessing, proof.proof, proof.commitments);


### PR DESCRIPTION
- Fixed a bug where virtual sequences generated for SH were failing alignment checks.
- Add max_trace_length and max_bytecode_size to `provable` attribtues
- Improved error reporting 