### PR TITLE
Draft: Use Gruen's optimization when computing univariate polynomials

### DIFF
--- a/jolt-core/benches/compute_cubic.rs
+++ b/jolt-core/benches/compute_cubic.rs
@@ -4,7 +4,7 @@ use criterion::Criterion;
 use jolt_core::field::JoltField;
 use jolt_core::poly::dense_interleaved_poly::DenseInterleavedPolynomial;
 use jolt_core::poly::sparse_interleaved_poly::{SparseCoefficient, SparseInterleavedPolynomial};
-use jolt_core::poly::split_eq_poly::SplitEqPolynomial;
+use jolt_core::poly::split_eq_poly::GruenSplitEqPolynomial;
 use jolt_core::subprotocols::sumcheck::BatchedCubicSumcheck;
 use jolt_core::utils::math::Math;
 use jolt_core::utils::transcript::KeccakTranscript;
@@ -46,7 +46,7 @@ fn benchmark_dense_interleaved<F: JoltField>(c: &mut Criterion, num_vars: usize)
                     let r_eq: Vec<F> = std::iter::repeat_with(|| F::random(&mut rng))
                         .take(num_vars)
                         .collect();
-                    let eq_poly = SplitEqPolynomial::new(&r_eq);
+                    let eq_poly = GruenSplitEqPolynomial::new(&r_eq);
                     let claim = F::random(&mut rng);
                     (poly, eq_poly, claim)
                 },
@@ -84,7 +84,7 @@ fn benchmark_sparse_interleaved<F: JoltField>(
                     let r_eq: Vec<F> = std::iter::repeat_with(|| F::random(&mut rng))
                         .take((batch_size << num_vars).next_power_of_two().log_2())
                         .collect();
-                    let eq_poly = SplitEqPolynomial::new(&r_eq);
+                    let eq_poly = GruenSplitEqPolynomial::new(&r_eq);
                     let claim = F::random(&mut rng);
                     (poly, eq_poly, claim)
                 },

--- a/jolt-core/src/poly/dense_interleaved_poly.rs
+++ b/jolt-core/src/poly/dense_interleaved_poly.rs
@@ -217,7 +217,7 @@ impl<F: JoltField, ProofTranscript: Transcript> BatchedCubicSumcheck<F, ProofTra
         // We use the Dao-Thaler and Gruen optimizations for the EQ polynomial, so there are two
         // cases we must handle. For details, refer to Section 3 of
         // https://eprint.iacr.org/2024/1210.pdf
-        let quadratic_evals = if eq_poly.E_in_vec.is_empty() {
+        let quadratic_evals = if eq_poly.E_in_current_len() == 1 {
             // If `eq_poly.E_in` has been fully bound, we compute the cubic polynomial as we would
             // without the Dao-Thaler optimization, using the standard linear-time sumcheck
             // algorithm.

--- a/jolt-core/src/poly/dense_interleaved_poly.rs
+++ b/jolt-core/src/poly/dense_interleaved_poly.rs
@@ -263,7 +263,7 @@ impl<F: JoltField, ProofTranscript: Transcript> BatchedCubicSumcheck<F, ProofTra
                 .map(|(E_out_eval, P_x_out)| {
                     // The for-loop below corresponds to the inner sum:
                     // \sum_x1 ((1 - j) * E1[0, x1] + j * E1[1, x1]) * \prod_k ((1 - j) * P_k(0 || x1 || x2) + j * P_k(1 || x1 || x2))
-                    let mut inner_sum = (F::zero(), F::zero(), F::zero());
+                    let mut inner_sum = (F::zero(), F::zero());
                     for (E_in_eval, P_chunk) in eq_poly.E_in_current().iter().zip(P_x_out.chunks(4)) {
                         let left = (
                             *P_chunk.first().unwrap_or(&F::zero()),

--- a/jolt-core/src/poly/sparse_interleaved_poly.rs
+++ b/jolt-core/src/poly/sparse_interleaved_poly.rs
@@ -450,7 +450,11 @@ impl<F: JoltField, ProofTranscript: Transcript> BatchedCubicSumcheck<F, ProofTra
     /// If `self` is not coalesced, we basically do the same thing but with with the
     /// sparse vectors in `self.coeffs`, some fancy optimizations, and many more cases to check 😬
     #[tracing::instrument(skip_all, name = "SparseInterleavedPolynomial::compute_cubic")]
-    fn compute_cubic(&self, eq_poly: &GruenSplitEqPolynomial<F>, previous_round_claim: F) -> UniPoly<F> {
+    fn compute_cubic(
+        &self,
+        eq_poly: &GruenSplitEqPolynomial<F>,
+        previous_round_claim: F,
+    ) -> UniPoly<F> {
         if let Some(coalesced) = &self.coalesced {
             return BatchedCubicSumcheck::<F, ProofTranscript>::compute_cubic(
                 coalesced,
@@ -495,7 +499,8 @@ impl<F: JoltField, ProofTranscript: Transcript> BatchedCubicSumcheck<F, ProofTra
 
                             let E_out_eval = eq_poly.E_out_current()[block_index];
                             (
-                                E_out_eval.mul_0_optimized(left.0.mul_1_optimized(right.0) - F::one()),
+                                E_out_eval
+                                    .mul_0_optimized(left.0.mul_1_optimized(right.0) - F::one()),
                                 E_out_eval * (left_eval_at_infty * right_eval_at_infty - F::one()),
                             )
                         })
@@ -505,10 +510,7 @@ impl<F: JoltField, ProofTranscript: Transcript> BatchedCubicSumcheck<F, ProofTra
                     |sum, evals| (sum.0 + evals.0, sum.1 + evals.1),
                 );
 
-            (
-                E_out_eval_sum + deltas.0,
-                E_out_eval_sum + deltas.1,
-            )
+            (E_out_eval_sum + deltas.0, E_out_eval_sum + deltas.1)
         } else {
             // This is a more complicated version of the `else` case in
             // `DenseInterleavedPolynomial::compute_cubic`. Read that one first.
@@ -552,9 +554,8 @@ impl<F: JoltField, ProofTranscript: Transcript> BatchedCubicSumcheck<F, ProofTra
                                     eq_poly.E_in_current()[x_in].mul_0_optimized(
                                         left.0.mul_1_optimized(right.0) - F::one(),
                                     ),
-                                    eq_poly.E_in_current()[x_in] * (
-                                        left_eval_at_infty * right_eval_at_infty - F::one()
-                                    ),
+                                    eq_poly.E_in_current()[x_in]
+                                        * (left_eval_at_infty * right_eval_at_infty - F::one()),
                                 );
                                 inner_sum.0 += delta.0;
                                 inner_sum.1 += delta.1;
@@ -608,7 +609,10 @@ impl<F: JoltField, ProofTranscript: Transcript> BatchedCubicSumcheck<F, ProofTra
                     // e.g. 1 1 1 1 1 1 1 1 0 0 0 0
                     //
                     // This handles this last chunk:
-                    let last_chunk_eval: F = eq_poly.E_in_current()[..(self.dense_len % chunk_size) / 4].into_iter().sum();
+                    let last_chunk_eval: F = eq_poly.E_in_current()
+                        [..(self.dense_len % chunk_size) / 4]
+                        .into_iter()
+                        .sum();
                     E_out_sum * E_in_eval_sum
                         + eq_poly.E_out_current()[num_all_one_chunks] * last_chunk_eval
                 }

--- a/jolt-core/src/subprotocols/grand_product.rs
+++ b/jolt-core/src/subprotocols/grand_product.rs
@@ -5,7 +5,7 @@ use crate::poly::commitment::commitment_scheme::CommitmentScheme;
 use crate::poly::dense_interleaved_poly::DenseInterleavedPolynomial;
 use crate::poly::dense_mlpoly::DensePolynomial;
 use crate::poly::opening_proof::{ProverOpeningAccumulator, VerifierOpeningAccumulator};
-use crate::poly::split_eq_poly::SplitEqPolynomial;
+use crate::poly::split_eq_poly::GruenSplitEqPolynomial;
 use crate::utils::math::Math;
 use crate::utils::thread::drop_in_background_thread;
 use crate::utils::transcript::Transcript;
@@ -205,7 +205,7 @@ where
         r_grand_product: &mut Vec<F>,
         transcript: &mut ProofTranscript,
     ) -> BatchedGrandProductLayerProof<F, ProofTranscript> {
-        let mut eq_poly = SplitEqPolynomial::new(r_grand_product);
+        let mut eq_poly = GruenSplitEqPolynomial::new(r_grand_product);
 
         let (sumcheck_proof, r_sumcheck, sumcheck_claims) =
             self.prove_sumcheck(claim, &mut eq_poly, transcript);

--- a/jolt-core/src/subprotocols/sumcheck.rs
+++ b/jolt-core/src/subprotocols/sumcheck.rs
@@ -7,7 +7,7 @@ use crate::poly::multilinear_polynomial::{
     BindingOrder, MultilinearPolynomial, PolynomialBinding, PolynomialEvaluation,
 };
 use crate::poly::spartan_interleaved_poly::SpartanInterleavedPolynomial;
-use crate::poly::split_eq_poly::{GruenSplitEqPolynomial, SplitEqPolynomial};
+use crate::poly::split_eq_poly::GruenSplitEqPolynomial;
 use crate::poly::unipoly::{CompressedUniPoly, UniPoly};
 use crate::r1cs::builder::Constraint;
 use crate::utils::errors::ProofVerifyError;
@@ -29,17 +29,17 @@ where
     F: JoltField,
     ProofTranscript: Transcript,
 {
-    fn compute_cubic(&self, eq_poly: &SplitEqPolynomial<F>, previous_round_claim: F) -> UniPoly<F>;
+    fn compute_cubic(&self, eq_poly: &GruenSplitEqPolynomial<F>, previous_round_claim: F) -> UniPoly<F>;
     fn final_claims(&self) -> (F, F);
 
     #[cfg(test)]
-    fn sumcheck_sanity_check(&self, eq_poly: &SplitEqPolynomial<F>, round_claim: F);
+    fn sumcheck_sanity_check(&self, eq_poly: &GruenSplitEqPolynomial<F>, round_claim: F);
 
     #[tracing::instrument(skip_all, name = "BatchedCubicSumcheck::prove_sumcheck")]
     fn prove_sumcheck(
         &mut self,
         claim: &F,
-        eq_poly: &mut SplitEqPolynomial<F>,
+        eq_poly: &mut GruenSplitEqPolynomial<F>,
         transcript: &mut ProofTranscript,
     ) -> (SumcheckInstanceProof<F, ProofTranscript>, Vec<F>, (F, F)) {
         let num_rounds = eq_poly.get_num_vars();

--- a/jolt-core/src/subprotocols/sumcheck.rs
+++ b/jolt-core/src/subprotocols/sumcheck.rs
@@ -29,7 +29,11 @@ where
     F: JoltField,
     ProofTranscript: Transcript,
 {
-    fn compute_cubic(&self, eq_poly: &GruenSplitEqPolynomial<F>, previous_round_claim: F) -> UniPoly<F>;
+    fn compute_cubic(
+        &self,
+        eq_poly: &GruenSplitEqPolynomial<F>,
+        previous_round_claim: F,
+    ) -> UniPoly<F>;
     fn final_claims(&self) -> (F, F);
 
     #[cfg(test)]


### PR DESCRIPTION
This PR changes the computation of the univariate polynomials in each sumcheck round to use both the Dao-Thaler and Gruen optimizations (see Sec. 3 of https://eprint.iacr.org/2024/1210.pdf). To do so, we use the `GruenSplitEqPolynomial` data structure, which allows us to avoid computing the cubic evaluations at `{0, 1, 2, 3}` directly, and instead compute evaluations of quadratic polynomials at 0 and infinity.

Changes:
* Change `BatchedGrandProductProof::compute_cubic` to use `GruenSplitEqPolynomial`.

Planned changes:
* Use `GruenSplitEqPolynomial` in the following places in T&S:
  * [The RAM-check polynomials](https://github.com/a16z/jolt/blob/feat/twist-shout-integration/jolt-core/src/jolt/vm/ram.rs#L635)
  * [The register polynomials](https://github.com/a16z/jolt/blob/feat/twist-shout-integration/jolt-core/src/jolt/vm/registers.rs#L469)
  * [The bytecode polynomials](https://github.com/a16z/jolt/blob/feat/twist-shout-integration/jolt-core/src/jolt/vm/bytecode.rs#L366)