### PR TITLE
fix: make jolt pass riscv-arch-tests tests

### DIFF
--- a/tracer/src/emulator/memory.rs
+++ b/tracer/src/emulator/memory.rs
@@ -162,6 +162,7 @@ impl Memory {
     /// # Arguments
     /// * `address`
     pub fn validate_address(&self, address: u64) -> bool {
-        (address as usize) < self.data.len()
+        let word_index = (address >> 3) as usize;
+        word_index < self.data.len()
     }
 }

--- a/tracer/src/emulator/mod.rs
+++ b/tracer/src/emulator/mod.rs
@@ -1,5 +1,5 @@
 // @TODO: temporal
-const TEST_MEMORY_CAPACITY: u64 = 1024 * 512;
+const TEST_MEMORY_CAPACITY: u64 = 1024 * 1024 * 10; // big enough to run riscv-arch-test
 const PROGRAM_MEMORY_CAPACITY: u64 = 1024 * 1024 * 128; // big enough to run Linux and xv6
 
 extern crate fnv;


### PR DESCRIPTION
This PR fixes failures when performing riscv-arch-tests on the Jolt emulator.

- increase TEST_MEMORY_CAPACITY
- The issue occurred because memory is allocated as 64-bit words (8 bytes each), but the validation
was comparing byte addresses directly against the word count. Now properly converts byte addresses
to word indices using (`address >> 3`) before comparison.