### PR TITLE
feat: Add RV64IM instruction support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4014,6 +4014,7 @@ name = "tracer"
 version = "0.2.0"
 dependencies = [
  "ark-serialize 0.5.0",
+ "clap",
  "common",
  "derive_more 2.0.1",
  "fnv",
@@ -4026,6 +4027,7 @@ dependencies = [
  "strum",
  "strum_macros",
  "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/tracer/Cargo.toml
+++ b/tracer/Cargo.toml
@@ -15,6 +15,10 @@ homepage = "https://github.com/a16z/jolt/README.md"
 repository = "https://github.com/a16z/jolt"
 edition = "2021"
 
+[[bin]]
+name = "jolt-emu"
+path = "src/main.rs"
+
 [features]
 default = ["std"]
 std = ["common/std", "fnv/std", "object/std", "tracing/std"]
@@ -37,5 +41,6 @@ strum = "0.26.3"
 rand = "0.7.3"
 paste = "1.0.15"
 itertools = "0.10.0"
-
+tracing-subscriber = "0.3"
+clap = { version = "4.4", features = ["derive"] }
 common = { path = "../common", default-features = false }

--- a/tracer/src/emulator/cpu.rs
+++ b/tracer/src/emulator/cpu.rs
@@ -897,10 +897,10 @@ impl Cpu {
                     // addi rd+8, x2, nzuimm
                     let rd = (halfword >> 2) & 0x7; // [4:2]
                     let nzuimm = ((halfword >> 7) & 0x30) | // nzuimm[5:4] <= [12:11]
-						((halfword >> 1) & 0x3c0) | // nzuimm{9:6] <= [10:7]
-						((halfword >> 4) & 0x4) | // nzuimm[2] <= [6]
-						((halfword >> 2) & 0x8); // nzuimm[3] <= [5]
-                               // nzuimm == 0 is reserved instruction
+                        ((halfword >> 1) & 0x3c0) | // nzuimm{9:6] <= [10:7]
+                        ((halfword >> 4) & 0x4) | // nzuimm[2] <= [6]
+                        ((halfword >> 2) & 0x8); // nzuimm[3] <= [5]
+                                                 // nzuimm == 0 is reserved instruction
                     if nzuimm != 0 {
                         return (nzuimm << 20) | (2 << 15) | ((rd + 8) << 7) | 0x13;
                     }
@@ -912,7 +912,7 @@ impl Cpu {
                     let rd = (halfword >> 2) & 0x7; // [4:2]
                     let rs1 = (halfword >> 7) & 0x7; // [9:7]
                     let offset = ((halfword >> 7) & 0x38) | // offset[5:3] <= [12:10]
-						((halfword << 1) & 0xc0); // offset[7:6] <= [6:5]
+                        ((halfword << 1) & 0xc0); // offset[7:6] <= [6:5]
                     return (offset << 20) | ((rs1 + 8) << 15) | (3 << 12) | ((rd + 8) << 7) | 0x7;
                 }
                 2 => {
@@ -921,8 +921,8 @@ impl Cpu {
                     let rs1 = (halfword >> 7) & 0x7; // [9:7]
                     let rd = (halfword >> 2) & 0x7; // [4:2]
                     let offset = ((halfword >> 7) & 0x38) | // offset[5:3] <= [12:10]
-						((halfword >> 4) & 0x4) | // offset[2] <= [6]
-						((halfword << 1) & 0x40); // offset[6] <= [5]
+                        ((halfword >> 4) & 0x4) | // offset[2] <= [6]
+                        ((halfword << 1) & 0x40); // offset[6] <= [5]
                     return (offset << 20) | ((rs1 + 8) << 15) | (2 << 12) | ((rd + 8) << 7) | 0x3;
                 }
                 3 => {
@@ -932,7 +932,7 @@ impl Cpu {
                     let rs1 = (halfword >> 7) & 0x7; // [9:7]
                     let rd = (halfword >> 2) & 0x7; // [4:2]
                     let offset = ((halfword >> 7) & 0x38) | // offset[5:3] <= [12:10]
-						((halfword << 1) & 0xc0); // offset[7:6] <= [6:5]
+                        ((halfword << 1) & 0xc0); // offset[7:6] <= [6:5]
                     return (offset << 20) | ((rs1 + 8) << 15) | (3 << 12) | ((rd + 8) << 7) | 0x3;
                 }
                 4 => {
@@ -944,7 +944,7 @@ impl Cpu {
                     let rs1 = (halfword >> 7) & 0x7; // [9:7]
                     let rs2 = (halfword >> 2) & 0x7; // [4:2]
                     let offset = ((halfword >> 7) & 0x38) | // uimm[5:3] <= [12:10]
-						((halfword << 1) & 0xc0); // uimm[7:6] <= [6:5]
+                        ((halfword << 1) & 0xc0); // uimm[7:6] <= [6:5]
                     let imm11_5 = (offset >> 5) & 0x7f;
                     let imm4_0 = offset & 0x1f;
                     return (imm11_5 << 25)
@@ -960,8 +960,8 @@ impl Cpu {
                     let rs1 = (halfword >> 7) & 0x7; // [9:7]
                     let rs2 = (halfword >> 2) & 0x7; // [4:2]
                     let offset = ((halfword >> 7) & 0x38) | // offset[5:3] <= [12:10]
-						((halfword << 1) & 0x40) | // offset[6] <= [5]
-						((halfword >> 4) & 0x4); // offset[2] <= [6]
+                        ((halfword << 1) & 0x40) | // offset[6] <= [5]
+                        ((halfword >> 4) & 0x4); // offset[2] <= [6]
                     let imm11_5 = (offset >> 5) & 0x7f;
                     let imm4_0 = offset & 0x1f;
                     return (imm11_5 << 25)
@@ -978,7 +978,7 @@ impl Cpu {
                     let rs1 = (halfword >> 7) & 0x7; // [9:7]
                     let rs2 = (halfword >> 2) & 0x7; // [4:2]
                     let offset = ((halfword >> 7) & 0x38) | // uimm[5:3] <= [12:10]
-						((halfword << 1) & 0xc0); // uimm[7:6] <= [6:5]
+                        ((halfword << 1) & 0xc0); // uimm[7:6] <= [6:5]
                     let imm11_5 = (offset >> 5) & 0x7f;
                     let imm4_0 = offset & 0x1f;
                     return (imm11_5 << 25)
@@ -993,56 +993,93 @@ impl Cpu {
             1 => {
                 match funct3 {
                     0 => {
+                        // C.ADDI
                         let r = (halfword >> 7) & 0x1f; // [11:7]
                         let imm = match halfword & 0x1000 {
-							0x1000 => 0xffffffc0,
-							_ => 0
-						} | // imm[31:6] <= [12]
-						((halfword >> 7) & 0x20) | // imm[5] <= [12]
-						((halfword >> 2) & 0x1f); // imm[4:0] <= [6:2]
-                        if r == 0 && imm == 0 {
-                            // C.NOP
-                            // addi x0, x0, 0
-                            return 0x13;
-                        } else if r != 0 {
-                            // C.ADDI
-                            // addi r, r, imm
-                            return (imm << 20) | (r << 15) | (r << 7) | 0x13;
+                            0x1000 => 0xffffffc0,
+                            _ => 0
+                        } | // imm[31:6] <= [12]
+                        ((halfword >> 7) & 0x20) | // imm[5] <= [12]
+                        ((halfword >> 2) & 0x1f); // imm[4:0] <= [6:2]
+
+                        match (r, imm) {
+                            (0, 0) => {
+                                // NOP
+                                return 0x13;
+                            }
+                            (0, _) => {
+                                // HINT
+                                return 0x13;
+                            }
+                            (r, 0) => {
+                                // HINT
+                                return 0x13;
+                            }
+                            (r, imm) => {
+                                return (imm << 20) | (r << 15) | (r << 7) | 0x13;
+                            }
                         }
-                        // @TODO: Support HINTs
-                        // r == 0 and imm != 0 is HINTs
                     }
                     1 => {
-                        // @TODO: Support C.JAL in 32-bit mode
-                        // C.ADDIW
-                        // addiw r, r, imm
-                        let r = (halfword >> 7) & 0x1f;
-                        let imm = match halfword & 0x1000 {
-							0x1000 => 0xffffffc0,
-							_ => 0
-						} | // imm[31:6] <= [12]
-						((halfword >> 7) & 0x20) | // imm[5] <= [12]
-						((halfword >> 2) & 0x1f); // imm[4:0] <= [6:2]
-                        if r != 0 {
-                            return (imm << 20) | (r << 15) | (r << 7) | 0x1b;
+                        match self.xlen {
+                            Xlen::Bit32 => {
+                                // C.JAL (RV32C only)
+                                // jal x1, offset
+                                let offset = match halfword & 0x1000 {
+                                    0x1000 => 0xfffff000,
+                                    _ => 0
+                                } | // offset[31:12] <= [12]
+                                ((halfword >> 1) & 0x800) | // offset[11] <= [12]
+                                ((halfword >> 7) & 0x10) | // offset[4] <= [11]
+                                ((halfword >> 1) & 0x300) | // offset[9:8] <= [10:9]
+                                ((halfword << 2) & 0x400) | // offset[10] <= [8]
+                                ((halfword >> 1) & 0x40) | // offset[6] <= [7]
+                                ((halfword << 1) & 0x80) | // offset[7] <= [6]
+                                ((halfword >> 2) & 0xe) | // offset[3:1] <= [5:3]
+                                ((halfword << 3) & 0x20); // offset[5] <= [2]
+                                let imm = ((offset >> 1) & 0x80000) | // imm[19] <= offset[20]
+                                    ((offset << 8) & 0x7fe00) | // imm[18:9] <= offset[10:1]
+                                    ((offset >> 3) & 0x100) | // imm[8] <= offset[11]
+                                    ((offset >> 12) & 0xff); // imm[7:0] <= offset[19:12]
+                                return (imm << 12) | (1 << 7) | 0x6f;
+                            }
+                            Xlen::Bit64 => {
+                                // C.ADDIW (RV64C only)
+                                let r = (halfword >> 7) & 0x1f;
+                                let imm = match halfword & 0x1000 {
+                            0x1000 => 0xffffffc0,
+                            _ => 0
+                        } | // imm[31:6] <= [12]
+                        ((halfword >> 7) & 0x20) | // imm[5] <= [12]
+                        ((halfword >> 2) & 0x1f); // imm[4:0] <= [6:2]
+                                if r == 0 {
+                                    // Reserved
+                                } else if imm == 0 {
+                                    // sext.w rd
+                                    return (r << 15) | (r << 7) | 0x1b;
+                                } else {
+                                    // addiw r, r, imm
+                                    return (imm << 20) | (r << 15) | (r << 7) | 0x1b;
+                                }
+                            }
                         }
-                        // r == 0 is reserved instruction
                     }
                     2 => {
                         // C.LI
-                        // addi rd, x0, imm
                         let r = (halfword >> 7) & 0x1f;
                         let imm = match halfword & 0x1000 {
-							0x1000 => 0xffffffc0,
-							_ => 0
-						} | // imm[31:6] <= [12]
-						((halfword >> 7) & 0x20) | // imm[5] <= [12]
-						((halfword >> 2) & 0x1f); // imm[4:0] <= [6:2]
+                            0x1000 => 0xffffffc0,
+                            _ => 0
+                        } | // imm[31:6] <= [12]
+                        ((halfword >> 7) & 0x20) | // imm[5] <= [12]
+                        ((halfword >> 2) & 0x1f); // imm[4:0] <= [6:2]
                         if r != 0 {
+                            // addi rd, x0, imm
                             return (imm << 20) | (r << 7) | 0x13;
+                        } else {
+                            // HINT
+                            return 0x13;
                         }
-                        // @TODO: Support HINTs
-                        // r == 0 is for HINTs
                     }
                     3 => {
                         let r = (halfword >> 7) & 0x1f; // [11:7]
@@ -1050,14 +1087,14 @@ impl Cpu {
                             // C.ADDI16SP
                             // addi r, r, nzimm
                             let imm = match halfword & 0x1000 {
-								0x1000 => 0xfffffc00,
-								_ => 0
-							} | // imm[31:10] <= [12]
-							((halfword >> 3) & 0x200) | // imm[9] <= [12]
-							((halfword >> 2) & 0x10) | // imm[4] <= [6]
-							((halfword << 1) & 0x40) | // imm[6] <= [5]
-							((halfword << 4) & 0x180) | // imm[8:7] <= [4:3]
-							((halfword << 3) & 0x20); // imm[5] <= [2]
+                                0x1000 => 0xfffffc00,
+                                _ => 0
+                            } | // imm[31:10] <= [12]
+                            ((halfword >> 3) & 0x200) | // imm[9] <= [12]
+                            ((halfword >> 2) & 0x10) | // imm[4] <= [6]
+                            ((halfword << 1) & 0x40) | // imm[6] <= [5]
+                            ((halfword << 4) & 0x180) | // imm[8:7] <= [4:3]
+                            ((halfword << 3) & 0x20); // imm[5] <= [2]
                             if imm != 0 {
                                 return (imm << 20) | (r << 15) | (r << 7) | 0x13;
                             }
@@ -1067,15 +1104,19 @@ impl Cpu {
                             // C.LUI
                             // lui r, nzimm
                             let nzimm = match halfword & 0x1000 {
-								0x1000 => 0xfffc0000,
-								_ => 0
-							} | // nzimm[31:18] <= [12]
-							((halfword << 5) & 0x20000) | // nzimm[17] <= [12]
-							((halfword << 10) & 0x1f000); // nzimm[16:12] <= [6:2]
+                                0x1000 => 0xfffc0000,
+                                _ => 0
+                            } | // nzimm[31:18] <= [12]
+                            ((halfword << 5) & 0x20000) | // nzimm[17] <= [12]
+                            ((halfword << 10) & 0x1f000); // nzimm[16:12] <= [6:2]
                             if nzimm != 0 {
                                 return nzimm | (r << 7) | 0x37;
                             }
                             // nzimm == 0 is for reserved instruction
+                        }
+                        if r == 0 {
+                            // NOP
+                            return 0x13;
                         }
                     }
                     4 => {
@@ -1085,7 +1126,7 @@ impl Cpu {
                                 // C.SRLI
                                 // c.srli rs1+8, rs1+8, shamt
                                 let shamt = ((halfword >> 7) & 0x20) | // shamt[5] <= [12]
-									((halfword >> 2) & 0x1f); // shamt[4:0] <= [6:2]
+                                    ((halfword >> 2) & 0x1f); // shamt[4:0] <= [6:2]
                                 let rs1 = (halfword >> 7) & 0x7; // [9:7]
                                 return (shamt << 20)
                                     | ((rs1 + 8) << 15)
@@ -1097,7 +1138,7 @@ impl Cpu {
                                 // C.SRAI
                                 // srai rs1+8, rs1+8, shamt
                                 let shamt = ((halfword >> 7) & 0x20) | // shamt[5] <= [12]
-									((halfword >> 2) & 0x1f); // shamt[4:0] <= [6:2]
+                                    ((halfword >> 2) & 0x1f); // shamt[4:0] <= [6:2]
                                 let rs1 = (halfword >> 7) & 0x7; // [9:7]
                                 return (0x20 << 25)
                                     | (shamt << 20)
@@ -1111,11 +1152,11 @@ impl Cpu {
                                 // andi, r+8, r+8, imm
                                 let r = (halfword >> 7) & 0x7; // [9:7]
                                 let imm = match halfword & 0x1000 {
-									0x1000 => 0xffffffc0,
-									_ => 0
-								} | // imm[31:6] <= [12]
-								((halfword >> 7) & 0x20) | // imm[5] <= [12]
-								((halfword >> 2) & 0x1f); // imm[4:0] <= [6:2]
+                                    0x1000 => 0xffffffc0,
+                                    _ => 0
+                                } | // imm[31:6] <= [12]
+                                ((halfword >> 7) & 0x20) | // imm[5] <= [12]
+                                ((halfword >> 2) & 0x1f); // imm[4:0] <= [6:2]
                                 return (imm << 20)
                                     | ((r + 8) << 15)
                                     | (7 << 12)
@@ -1203,21 +1244,21 @@ impl Cpu {
                         // C.J
                         // jal x0, imm
                         let offset = match halfword & 0x1000 {
-								0x1000 => 0xfffff000,
-								_ => 0
-							} | // offset[31:12] <= [12]
-							((halfword >> 1) & 0x800) | // offset[11] <= [12]
-							((halfword >> 7) & 0x10) | // offset[4] <= [11]
-							((halfword >> 1) & 0x300) | // offset[9:8] <= [10:9]
-							((halfword << 2) & 0x400) | // offset[10] <= [8]
-							((halfword >> 1) & 0x40) | // offset[6] <= [7]
-							((halfword << 1) & 0x80) | // offset[7] <= [6]
-							((halfword >> 2) & 0xe) | // offset[3:1] <= [5:3]
-							((halfword << 3) & 0x20); // offset[5] <= [2]
+                                0x1000 => 0xfffff000,
+                                _ => 0
+                            } | // offset[31:12] <= [12]
+                            ((halfword >> 1) & 0x800) | // offset[11] <= [12]
+                            ((halfword >> 7) & 0x10) | // offset[4] <= [11]
+                            ((halfword >> 1) & 0x300) | // offset[9:8] <= [10:9]
+                            ((halfword << 2) & 0x400) | // offset[10] <= [8]
+                            ((halfword >> 1) & 0x40) | // offset[6] <= [7]
+                            ((halfword << 1) & 0x80) | // offset[7] <= [6]
+                            ((halfword >> 2) & 0xe) | // offset[3:1] <= [5:3]
+                            ((halfword << 3) & 0x20); // offset[5] <= [2]
                         let imm = ((offset >> 1) & 0x80000) | // imm[19] <= offset[20]
-							((offset << 8) & 0x7fe00) | // imm[18:9] <= offset[10:1]
-							((offset >> 3) & 0x100) | // imm[8] <= offset[11]
-							((offset >> 12) & 0xff); // imm[7:0] <= offset[19:12]
+                            ((offset << 8) & 0x7fe00) | // imm[18:9] <= offset[10:1]
+                            ((offset >> 3) & 0x100) | // imm[8] <= offset[11]
+                            ((offset >> 12) & 0xff); // imm[7:0] <= offset[19:12]
                         return (imm << 12) | 0x6f;
                     }
                     6 => {
@@ -1225,18 +1266,18 @@ impl Cpu {
                         // beq r+8, x0, offset
                         let r = (halfword >> 7) & 0x7;
                         let offset = match halfword & 0x1000 {
-								0x1000 => 0xfffffe00,
-								_ => 0
-							} | // offset[31:9] <= [12]
-							((halfword >> 4) & 0x100) | // offset[8] <= [12]
-							((halfword >> 7) & 0x18) | // offset[4:3] <= [11:10]
-							((halfword << 1) & 0xc0) | // offset[7:6] <= [6:5]
-							((halfword >> 2) & 0x6) | // offset[2:1] <= [4:3]
-							((halfword << 3) & 0x20); // offset[5] <= [2]
+                                0x1000 => 0xfffffe00,
+                                _ => 0
+                            } | // offset[31:9] <= [12]
+                            ((halfword >> 4) & 0x100) | // offset[8] <= [12]
+                            ((halfword >> 7) & 0x18) | // offset[4:3] <= [11:10]
+                            ((halfword << 1) & 0xc0) | // offset[7:6] <= [6:5]
+                            ((halfword >> 2) & 0x6) | // offset[2:1] <= [4:3]
+                            ((halfword << 3) & 0x20); // offset[5] <= [2]
                         let imm2 = ((offset >> 6) & 0x40) | // imm2[6] <= [12]
-							((offset >> 5) & 0x3f); // imm2[5:0] <= [10:5]
+                            ((offset >> 5) & 0x3f); // imm2[5:0] <= [10:5]
                         let imm1 = (offset & 0x1e) | // imm1[4:1] <= [4:1]
-							((offset >> 11) & 0x1); // imm1[0] <= [11]
+                            ((offset >> 11) & 0x1); // imm1[0] <= [11]
                         return (imm2 << 25) | ((r + 8) << 20) | (imm1 << 7) | 0x63;
                     }
                     7 => {
@@ -1244,18 +1285,18 @@ impl Cpu {
                         // bne r+8, x0, offset
                         let r = (halfword >> 7) & 0x7;
                         let offset = match halfword & 0x1000 {
-								0x1000 => 0xfffffe00,
-								_ => 0
-							} | // offset[31:9] <= [12]
-							((halfword >> 4) & 0x100) | // offset[8] <= [12]
-							((halfword >> 7) & 0x18) | // offset[4:3] <= [11:10]
-							((halfword << 1) & 0xc0) | // offset[7:6] <= [6:5]
-							((halfword >> 2) & 0x6) | // offset[2:1] <= [4:3]
-							((halfword << 3) & 0x20); // offset[5] <= [2]
+                                0x1000 => 0xfffffe00,
+                                _ => 0
+                            } | // offset[31:9] <= [12]
+                            ((halfword >> 4) & 0x100) | // offset[8] <= [12]
+                            ((halfword >> 7) & 0x18) | // offset[4:3] <= [11:10]
+                            ((halfword << 1) & 0xc0) | // offset[7:6] <= [6:5]
+                            ((halfword >> 2) & 0x6) | // offset[2:1] <= [4:3]
+                            ((halfword << 3) & 0x20); // offset[5] <= [2]
                         let imm2 = ((offset >> 6) & 0x40) | // imm2[6] <= [12]
-							((offset >> 5) & 0x3f); // imm2[5:0] <= [10:5]
+                            ((offset >> 5) & 0x3f); // imm2[5:0] <= [10:5]
                         let imm1 = (offset & 0x1e) | // imm1[4:1] <= [4:1]
-							((offset >> 11) & 0x1); // imm1[0] <= [11]
+                            ((offset >> 11) & 0x1); // imm1[0] <= [11]
                         return (imm2 << 25) | ((r + 8) << 20) | (1 << 12) | (imm1 << 7) | 0x63;
                     }
                     _ => {} // No happens
@@ -1268,7 +1309,7 @@ impl Cpu {
                         // slli r, r, shamt
                         let r = (halfword >> 7) & 0x1f;
                         let shamt = ((halfword >> 7) & 0x20) | // imm[5] <= [12]
-							((halfword >> 2) & 0x1f); // imm[4:0] <= [6:2]
+                            ((halfword >> 2) & 0x1f); // imm[4:0] <= [6:2]
                         if r != 0 {
                             return (shamt << 20) | (r << 15) | (1 << 12) | (r << 7) | 0x13;
                         }
@@ -1279,8 +1320,8 @@ impl Cpu {
                         // fld rd, offset(x2)
                         let rd = (halfword >> 7) & 0x1f;
                         let offset = ((halfword >> 7) & 0x20) | // offset[5] <= [12]
-							((halfword >> 2) & 0x18) | // offset[4:3] <= [6:5]
-							((halfword << 4) & 0x1c0); // offset[8:6] <= [4:2]
+                            ((halfword >> 2) & 0x18) | // offset[4:3] <= [6:5]
+                            ((halfword << 4) & 0x1c0); // offset[8:6] <= [4:2]
                         if rd != 0 {
                             return (offset << 20) | (2 << 15) | (3 << 12) | (rd << 7) | 0x7;
                         }
@@ -1291,8 +1332,8 @@ impl Cpu {
                         // lw r, offset(x2)
                         let r = (halfword >> 7) & 0x1f;
                         let offset = ((halfword >> 7) & 0x20) | // offset[5] <= [12]
-							((halfword >> 2) & 0x1c) | // offset[4:2] <= [6:4]
-							((halfword << 4) & 0xc0); // offset[7:6] <= [3:2]
+                            ((halfword >> 2) & 0x1c) | // offset[4:2] <= [6:4]
+                            ((halfword << 4) & 0xc0); // offset[7:6] <= [3:2]
                         if r != 0 {
                             return (offset << 20) | (2 << 15) | (2 << 12) | (r << 7) | 0x3;
                         }
@@ -1304,8 +1345,8 @@ impl Cpu {
                         // ld rd, offset(x2)
                         let rd = (halfword >> 7) & 0x1f;
                         let offset = ((halfword >> 7) & 0x20) | // offset[5] <= [12]
-							((halfword >> 2) & 0x18) | // offset[4:3] <= [6:5]
-							((halfword << 4) & 0x1c0); // offset[8:6] <= [4:2]
+                            ((halfword >> 2) & 0x18) | // offset[4:3] <= [6:5]
+                            ((halfword << 4) & 0x1c0); // offset[8:6] <= [4:2]
                         if rd != 0 {
                             return (offset << 20) | (2 << 15) | (3 << 12) | (rd << 7) | 0x3;
                         }
@@ -1317,39 +1358,48 @@ impl Cpu {
                         let rs2 = (halfword >> 2) & 0x1f; // [6:2]
                         match funct1 {
                             0 => {
-                                if rs1 != 0 && rs2 == 0 {
-                                    // C.JR
-                                    // jalr x0, 0(rs1)
-                                    return (rs1 << 15) | 0x67;
+                                // C.MV
+                                match (rs1, rs2) {
+                                    (0, 0) => {
+                                        // Reserved
+                                    }
+                                    (r, 0) if r != 0 => {
+                                        // C.JR: jalr x0, 0(rs1)
+                                        return (rs1 << 15) | 0x67;
+                                    }
+                                    (0, r2) if r2 != 0 => {
+                                        // HINT
+                                        return 0x13;
+                                    }
+                                    (rd, rs2) => {
+                                        // add rd, x0, rs2
+                                        return (rs2 << 20) | (rd << 7) | 0x33;
+                                    }
                                 }
-                                // rs1 == 0 is reserved instruction
-                                if rs1 != 0 && rs2 != 0 {
-                                    // C.MV
-                                    // add rs1, x0, rs2
-                                    // println!("C.MV RS1:{:x} RS2:{:x}", rs1, rs2);
-                                    return (rs2 << 20) | (rs1 << 7) | 0x33;
-                                }
-                                // rs1 == 0 && rs2 != 0 is Hints
-                                // @TODO: Support Hints
                             }
                             1 => {
-                                if rs1 == 0 && rs2 == 0 {
-                                    // C.EBREAK
-                                    // ebreak
-                                    return 0x00100073;
+                                // C.ADD
+                                match (rs1, rs2) {
+                                    (0, 0) => {
+                                        // C.EBREAK
+                                        // ebreak
+                                        return 0x00100073;
+                                    }
+                                    (r1, 0) if r1 != 0 => {
+                                        // C.JALR
+                                        // jalr x1, 0(rs1)
+                                        return (rs1 << 15) | (1 << 7) | 0x67;
+                                    }
+                                    (0, r2) if r2 != 0 => {
+                                        // HINT
+                                        return 0x13;
+                                    }
+                                    (rd, rs2) => {
+                                        // C.ADD
+                                        // add rs1, rs1, rs2
+                                        return (rs2 << 20) | (rs1 << 15) | (rs1 << 7) | 0x33;
+                                    }
                                 }
-                                if rs1 != 0 && rs2 == 0 {
-                                    // C.JALR
-                                    // jalr x1, 0(rs1)
-                                    return (rs1 << 15) | (1 << 7) | 0x67;
-                                }
-                                if rs1 != 0 && rs2 != 0 {
-                                    // C.ADD
-                                    // add rs1, rs1, rs2
-                                    return (rs2 << 20) | (rs1 << 15) | (rs1 << 7) | 0x33;
-                                }
-                                // rs1 == 0 && rs2 != 0 is Hists
-                                // @TODO: Supports Hinsts
                             }
                             _ => {} // Not happens
                         };
@@ -1360,7 +1410,7 @@ impl Cpu {
                         // fsd rs2, offset(x2)
                         let rs2 = (halfword >> 2) & 0x1f; // [6:2]
                         let offset = ((halfword >> 7) & 0x38) | // offset[5:3] <= [12:10]
-							((halfword >> 1) & 0x1c0); // offset[8:6] <= [9:7]
+                            ((halfword >> 1) & 0x1c0); // offset[8:6] <= [9:7]
                         let imm11_5 = (offset >> 5) & 0x3f;
                         let imm4_0 = offset & 0x1f;
                         return (imm11_5 << 25)
@@ -1375,7 +1425,7 @@ impl Cpu {
                         // sw rs2, offset(x2)
                         let rs2 = (halfword >> 2) & 0x1f; // [6:2]
                         let offset = ((halfword >> 7) & 0x3c) | // offset[5:2] <= [12:9]
-							((halfword >> 1) & 0xc0); // offset[7:6] <= [8:7]
+                            ((halfword >> 1) & 0xc0); // offset[7:6] <= [8:7]
                         let imm11_5 = (offset >> 5) & 0x3f;
                         let imm4_0 = offset & 0x1f;
                         return (imm11_5 << 25)
@@ -1391,7 +1441,7 @@ impl Cpu {
                         // sd rs, offset(x2)
                         let rs2 = (halfword >> 2) & 0x1f; // [6:2]
                         let offset = ((halfword >> 7) & 0x38) | // offset[5:3] <= [12:10]
-							((halfword >> 1) & 0x1c0); // offset[8:6] <= [9:7]
+                            ((halfword >> 1) & 0x1c0); // offset[8:6] <= [9:7]
                         let imm11_5 = (offset >> 5) & 0x3f;
                         let imm4_0 = offset & 0x1f;
                         return (imm11_5 << 25)

--- a/tracer/src/emulator/cpu.rs
+++ b/tracer/src/emulator/cpu.rs
@@ -880,8 +880,8 @@ impl Cpu {
     // @TODO: Rename to better name?
     pub(crate) fn most_negative(&self) -> i64 {
         match self.xlen {
-            Xlen::Bit32 => core::i32::MIN as i64,
-            Xlen::Bit64 => core::i64::MIN,
+            Xlen::Bit32 => i32::MIN as i64,
+            Xlen::Bit64 => i64::MIN,
         }
     }
 
@@ -1011,11 +1011,11 @@ impl Cpu {
                                 // HINT
                                 return 0x13;
                             }
-                            (r, 0) => {
+                            (_, 0) => {
                                 // HINT
                                 return 0x13;
                             }
-                            (r, imm) => {
+                            (_, _) => {
                                 return (imm << 20) | (r << 15) | (r << 7) | 0x13;
                             }
                         }
@@ -1385,16 +1385,16 @@ impl Cpu {
                                         // ebreak
                                         return 0x00100073;
                                     }
-                                    (r1, 0) if r1 != 0 => {
+                                    (rs1, 0) if rs1 != 0 => {
                                         // C.JALR
                                         // jalr x1, 0(rs1)
                                         return (rs1 << 15) | (1 << 7) | 0x67;
                                     }
-                                    (0, r2) if r2 != 0 => {
+                                    (0, rs2) if rs2 != 0 => {
                                         // HINT
                                         return 0x13;
                                     }
-                                    (rd, rs2) => {
+                                    (rs1, rs2) => {
                                         // C.ADD
                                         // add rs1, rs1, rs2
                                         return (rs2 << 20) | (rs1 << 15) | (rs1 << 7) | 0x33;
@@ -1493,7 +1493,7 @@ impl Cpu {
         let name: &'static str = inst.into();
         let mut s = format!("PC:{:016x} ", self.unsigned_data(self.pc as i64));
         s += &format!("{original_word:08x} ");
-        s += &format!("{}", name);
+        s += &format!("{name}");
         // s += &format!("{}", (inst.disassemble)(self, word, self.pc, true));
         s
     }

--- a/tracer/src/emulator/elf_analyzer.rs
+++ b/tracer/src/emulator/elf_analyzer.rs
@@ -652,45 +652,6 @@ impl ElfAnalyzer {
         map
     }
 
-    /// Finds a program data section whose name is .tohost. If found this method
-    /// returns an address of the section.
-    ///
-    /// # Arguments
-    /// * `program_data_section_headers`
-    /// * `string_table_section_headers`
-    pub fn find_tohost_addr(
-        &self,
-        program_data_section_headers: &Vec<&SectionHeader>,
-        string_table_section_headers: &Vec<&SectionHeader>,
-    ) -> Option<u64> {
-        let tohost_values = [0x2e, 0x74, 0x6f, 0x68, 0x6f, 0x73, 0x74, 0x00]; // ".tohost\null"
-        for program_data_header in program_data_section_headers {
-            let sh_addr = program_data_header.sh_addr;
-            let sh_name = program_data_header.sh_name as u64;
-            // Find all string sections so far.
-            // @TODO: Is there a way to know which string table section
-            //        sh_name of program data section points to?
-            for string_table_header in string_table_section_headers {
-                let sh_offset = string_table_header.sh_offset;
-                let sh_size = string_table_header.sh_size;
-                let mut found = true;
-                for k in 0..tohost_values.len() as u64 {
-                    let addr = sh_offset + sh_name + k;
-                    if addr >= sh_offset + sh_size
-                        || self.read_byte(addr as usize) != tohost_values[k as usize]
-                    {
-                        found = false;
-                        break;
-                    }
-                }
-                if found {
-                    return Some(sh_addr);
-                }
-            }
-        }
-        None
-    }
-
     /// Reads a byte from ELF file content
     ///
     /// # Arguments

--- a/tracer/src/emulator/mmu.rs
+++ b/tracer/src/emulator/mmu.rs
@@ -464,7 +464,7 @@ impl Mmu {
     ///
     /// # Arguments
     /// * `p_address` Physical address
-    fn load_raw(&mut self, p_address: u64) -> u8 {
+    pub fn load_raw(&mut self, p_address: u64) -> u8 {
         let effective_address = self.get_effective_address(p_address);
         self.assert_effective_load_address(effective_address);
         // @TODO: Mapping should be configurable with dtb
@@ -695,7 +695,7 @@ impl Mmu {
     ///
     /// # Arguments
     /// * `p_address` Physical address
-    fn load_doubleword_raw(&mut self, p_address: u64) -> u64 {
+    pub fn load_doubleword_raw(&mut self, p_address: u64) -> u64 {
         let effective_address = self.get_effective_address(p_address);
         match effective_address >= DRAM_BASE
             && effective_address.wrapping_add(7) > effective_address

--- a/tracer/src/emulator/mmu.rs
+++ b/tracer/src/emulator/mmu.rs
@@ -452,11 +452,12 @@ impl Mmu {
     /// # Arguments
     /// * `v_address` Virtual address
     /// * `value` data written
-    pub fn store_doubleword(&mut self, v_address: u64, value: u64) -> Result<(), Trap> {
+    pub fn store_doubleword(&mut self, v_address: u64, value: u64) -> Result<RAMWrite, Trap> {
         let effective_address = self.get_effective_address(v_address);
         assert_eq!(effective_address % 8, 0, "Unaligned store_doubleword");
-        self.trace_store(effective_address, value);
-        self.store_bytes(v_address, value, 8)
+        let memory_write = self.trace_store(effective_address, value);
+        self.store_bytes(v_address, value, 8)?;
+        Ok(memory_write)
     }
 
     /// Loads a byte from main memory or peripheral devices depending on

--- a/tracer/src/emulator/mmu.rs
+++ b/tracer/src/emulator/mmu.rs
@@ -344,12 +344,12 @@ impl Mmu {
     ///
     /// # Arguments
     /// * `v_address` Virtual address
-    pub fn load_doubleword(&mut self, v_address: u64) -> Result<u64, Trap> {
+    pub fn load_doubleword(&mut self, v_address: u64) -> Result<(u64, RAMRead), Trap> {
         let effective_address = self.get_effective_address(v_address);
         assert_eq!(effective_address % 8, 0, "Unaligned load_doubleword");
-        self.trace_load(effective_address);
+        let memory_read = self.trace_load(effective_address);
         match self.load_bytes(v_address, 8) {
-            Ok(data) => Ok(data),
+            Ok(data) => Ok((data, memory_read)),
             Err(e) => Err(e),
         }
     }

--- a/tracer/src/emulator/mod.rs
+++ b/tracer/src/emulator/mod.rs
@@ -263,7 +263,7 @@ impl Emulator {
     }
 
     /// Writes the signature region to a writer with specified granularity.
-    /// The signature is written in little-endian byte order.
+    /// Each word of the signature is written as a hexadecimal string representation.
     ///
     /// # Arguments
     /// * `writer` - Any type that implements Write trait

--- a/tracer/src/emulator/mod.rs
+++ b/tracer/src/emulator/mod.rs
@@ -1,5 +1,5 @@
 // @TODO: temporal
-const TEST_MEMORY_CAPACITY: u64 = 1024 * 512;
+const TEST_MEMORY_CAPACITY: u64 = 1024 * 512 * 100;
 const PROGRAM_MEMORY_CAPACITY: u64 = 1024 * 1024 * 128; // big enough to run Linux and xv6
 
 extern crate fnv;

--- a/tracer/src/emulator/mod.rs
+++ b/tracer/src/emulator/mod.rs
@@ -109,7 +109,7 @@ impl Emulator {
     /// * Disassembles every instruction and dumps to terminal
     /// * The emulator stops when the test finishes
     /// * Displays the result message (pass/fail) to terminal
-    pub fn run_test(&mut self) {
+    pub fn run_test(&mut self, trace: bool) {
         // @TODO: Send this message to terminal?
         #[cfg(feature = "std")]
         println!("This elf file seems like a riscv-tests elf file. Running in test mode.");
@@ -117,7 +117,8 @@ impl Emulator {
             let disas = self.cpu.disassemble_next_instruction();
             println!("{disas}");
 
-            self.tick(None);
+            let mut traces = if trace { Some(Vec::new()) } else { None };
+            self.tick(traces.as_mut());
 
             // Check if tohost has been written to
             let tohost_value = self.cpu.get_mut_mmu().load_doubleword_raw(self.tohost_addr);

--- a/tracer/src/instruction/addiw.rs
+++ b/tracer/src/instruction/addiw.rs
@@ -1,0 +1,25 @@
+use serde::{Deserialize, Serialize};
+
+use crate::{declare_riscv_instr, emulator::cpu::Cpu};
+
+use super::{
+    format::{format_i::FormatI, normalize_imm, InstructionFormat},
+    RISCVInstruction, RISCVTrace,
+};
+
+declare_riscv_instr!(
+    name   = ADDIW,
+    mask   = 0x0000707f,
+    match  = 0x0000001b,
+    format = FormatI,
+    ram    = ()
+);
+
+impl ADDIW {
+    fn exec(&self, cpu: &mut Cpu, _: &mut <ADDIW as RISCVInstruction>::RAMAccess) {
+        cpu.x[self.operands.rd] = cpu
+            .sign_extend(cpu.x[self.operands.rs1].wrapping_add(normalize_imm(self.operands.imm)));
+    }
+}
+
+impl RISCVTrace for ADDIW {}

--- a/tracer/src/instruction/addiw.rs
+++ b/tracer/src/instruction/addiw.rs
@@ -17,8 +17,8 @@ declare_riscv_instr!(
 
 impl ADDIW {
     fn exec(&self, cpu: &mut Cpu, _: &mut <ADDIW as RISCVInstruction>::RAMAccess) {
-        cpu.x[self.operands.rd] = cpu
-            .sign_extend(cpu.x[self.operands.rs1].wrapping_add(normalize_imm(self.operands.imm)));
+        cpu.x[self.operands.rd] =
+            cpu.x[self.operands.rs1].wrapping_add(normalize_imm(self.operands.imm)) as i32 as i64;
     }
 }
 

--- a/tracer/src/instruction/addiw.rs
+++ b/tracer/src/instruction/addiw.rs
@@ -17,6 +17,11 @@ declare_riscv_instr!(
 
 impl ADDIW {
     fn exec(&self, cpu: &mut Cpu, _: &mut <ADDIW as RISCVInstruction>::RAMAccess) {
+        // ADDIW is an RV64I instruction that adds the sign-extended 12-bit immediate to register
+        // rs1 and produces the proper sign extension of a 32-bit result in rd. Overflows are
+        // ignored and the result is the low 32 bits of the result sign-extended to 64 bits. Note,
+        // ADDIW rd, rs1, 0 writes the sign extension of the lower 32 bits of register rs1 into
+        // register rd (assembler pseudoinstruction SEXT.W).
         cpu.x[self.operands.rd] =
             cpu.x[self.operands.rs1].wrapping_add(normalize_imm(self.operands.imm)) as i32 as i64;
     }

--- a/tracer/src/instruction/addw.rs
+++ b/tracer/src/instruction/addw.rs
@@ -1,0 +1,26 @@
+use serde::{Deserialize, Serialize};
+
+use crate::{declare_riscv_instr, emulator::cpu::Cpu};
+
+use super::{
+    format::{format_r::FormatR, InstructionFormat},
+    RISCVInstruction, RISCVTrace,
+};
+
+declare_riscv_instr!(
+    name   = ADDW,
+    mask   = 0xfe00707f,
+    match  = 0x0000003b,
+    format = FormatR,
+    ram    = ()
+);
+
+impl ADDW {
+    fn exec(&self, cpu: &mut Cpu, _: &mut <ADDW as RISCVInstruction>::RAMAccess) {
+        cpu.x[self.operands.rd] = cpu.sign_extend(
+            (cpu.x[self.operands.rs1].wrapping_add(cpu.x[self.operands.rs2]) as i32) as i64,
+        );
+    }
+}
+
+impl RISCVTrace for ADDW {}

--- a/tracer/src/instruction/addw.rs
+++ b/tracer/src/instruction/addw.rs
@@ -17,9 +17,12 @@ declare_riscv_instr!(
 
 impl ADDW {
     fn exec(&self, cpu: &mut Cpu, _: &mut <ADDW as RISCVInstruction>::RAMAccess) {
-        cpu.x[self.operands.rd] = cpu.sign_extend(
-            (cpu.x[self.operands.rs1].wrapping_add(cpu.x[self.operands.rs2]) as i32) as i64,
-        );
+        // ADDW and SUBW are RV64I-only instructions that are defined analogously to ADD and SUB
+        // but operate on 32-bit values and produce signed 32-bit results. Overflows are ignored,
+        // and the low 32-bits of the result is sign-extended to 64-bits and written to the
+        // destination register.
+        cpu.x[self.operands.rd] =
+            cpu.x[self.operands.rs1].wrapping_add(cpu.x[self.operands.rs2]) as i32 as i64;
     }
 }
 

--- a/tracer/src/instruction/divuw.rs
+++ b/tracer/src/instruction/divuw.rs
@@ -15,6 +15,9 @@ declare_riscv_instr!(
 
 impl DIVUW {
     fn exec(&self, cpu: &mut Cpu, _: &mut <DIVUW as RISCVInstruction>::RAMAccess) {
+        // DIVW and DIVUW are RV64 instructions that divide the lower 32 bits of rs1 by the lower
+        // 32 bits of rs2, treating them as signed and unsigned integers, placing the 32-bit
+        // quotient in rd, sign-extended to 64 bits.
         let dividend = cpu.x[self.operands.rs1] as u32;
         let divisor = cpu.x[self.operands.rs2] as u32;
         cpu.x[self.operands.rd] = (if divisor == 0 {

--- a/tracer/src/instruction/divuw.rs
+++ b/tracer/src/instruction/divuw.rs
@@ -1,0 +1,27 @@
+use super::{
+    format::{format_r::FormatR, InstructionFormat},
+    RISCVInstruction, RISCVTrace,
+};
+use crate::{declare_riscv_instr, emulator::cpu::Cpu};
+use serde::{Deserialize, Serialize};
+
+declare_riscv_instr!(
+    name   = DIVUW,
+    mask   = 0xfe00707f,
+    match  = 0x1b00003b,
+    format = FormatR,
+    ram    = ()
+);
+
+impl DIVUW {
+    fn exec(&self, cpu: &mut Cpu, _: &mut <DIVUW as RISCVInstruction>::RAMAccess) {
+        let dividend = cpu.x[self.operands.rs1] as u32;
+        let divisor = cpu.x[self.operands.rs2] as u32;
+        cpu.x[self.operands.rd] = (if divisor == 0 {
+            u32::MAX
+        } else {
+            dividend.wrapping_div(divisor)
+        }) as i32 as i64;
+    }
+}
+impl RISCVTrace for DIVUW {}

--- a/tracer/src/instruction/divw.rs
+++ b/tracer/src/instruction/divw.rs
@@ -15,15 +15,18 @@ declare_riscv_instr!(
 
 impl DIVW {
     fn exec(&self, cpu: &mut Cpu, _: &mut <DIVW as RISCVInstruction>::RAMAccess) {
+        // DIVW and DIVUW are RV64 instructions that divide the lower 32 bits of rs1 by the lower
+        // 32 bits of rs2, treating them as signed and unsigned integers, placing the 32-bit
+        // quotient in rd, sign-extended to 64 bits.
         let dividend = cpu.x[self.operands.rs1] as i32;
         let divisor = cpu.x[self.operands.rs2] as i32;
-        cpu.x[self.operands.rd] = if divisor == 0 {
-            -1i32 as i64
+        cpu.x[self.operands.rd] = (if divisor == 0 {
+            -1i32
         } else if dividend == i32::MIN && divisor == -1 {
-            dividend as i64
+            dividend
         } else {
-            (dividend.wrapping_div(divisor)) as i64
-        };
+            dividend.wrapping_div(divisor)
+        }) as i64;
     }
 }
 impl RISCVTrace for DIVW {}

--- a/tracer/src/instruction/divw.rs
+++ b/tracer/src/instruction/divw.rs
@@ -1,0 +1,29 @@
+use super::{
+    format::{format_r::FormatR, InstructionFormat},
+    RISCVInstruction, RISCVTrace,
+};
+use crate::{declare_riscv_instr, emulator::cpu::Cpu};
+use serde::{Deserialize, Serialize};
+
+declare_riscv_instr!(
+    name   = DIVW,
+    mask   = 0xfe00707f,
+    match  = 0x1a00003b,
+    format = FormatR,
+    ram    = ()
+);
+
+impl DIVW {
+    fn exec(&self, cpu: &mut Cpu, _: &mut <DIVW as RISCVInstruction>::RAMAccess) {
+        let dividend = cpu.x[self.operands.rs1] as i32;
+        let divisor = cpu.x[self.operands.rs2] as i32;
+        cpu.x[self.operands.rd] = if divisor == 0 {
+            -1i32 as i64
+        } else if dividend == i32::MIN && divisor == -1 {
+            dividend as i64
+        } else {
+            (dividend.wrapping_div(divisor)) as i64
+        };
+    }
+}
+impl RISCVTrace for DIVW {}

--- a/tracer/src/instruction/format/format_u.rs
+++ b/tracer/src/instruction/format/format_u.rs
@@ -45,7 +45,7 @@ impl InstructionFormat for FormatU {
 			} | // imm[63:32] = [31]
 			((word as u64) & 0xfffff000)
                 // imm[31:12] = [31:12]
-            ) as u64,
+            ),
         }
     }
 

--- a/tracer/src/instruction/format/format_u.rs
+++ b/tracer/src/instruction/format/format_u.rs
@@ -45,7 +45,7 @@ impl InstructionFormat for FormatU {
 			} | // imm[63:32] = [31]
 			((word as u64) & 0xfffff000)
                 // imm[31:12] = [31:12]
-            ),
+            ) as i32 as u32 as u64,
         }
     }
 

--- a/tracer/src/instruction/format/format_u.rs
+++ b/tracer/src/instruction/format/format_u.rs
@@ -45,7 +45,7 @@ impl InstructionFormat for FormatU {
 			} | // imm[63:32] = [31]
 			((word as u64) & 0xfffff000)
                 // imm[31:12] = [31:12]
-            ) as i32 as u32 as u64,
+            ) as u64,
         }
     }
 

--- a/tracer/src/instruction/jalr.rs
+++ b/tracer/src/instruction/jalr.rs
@@ -18,7 +18,8 @@ declare_riscv_instr!(
 impl JALR {
     fn exec(&self, cpu: &mut Cpu, _: &mut <JALR as RISCVInstruction>::RAMAccess) {
         let tmp = cpu.sign_extend(cpu.pc as i64);
-        cpu.pc = (cpu.x[self.operands.rs1] as u64).wrapping_add(self.operands.imm);
+        cpu.pc =
+            ((cpu.x[self.operands.rs1] as u64).wrapping_add(self.operands.imm as i32 as u64)) & !1;
         if self.operands.rd != 0 {
             cpu.x[self.operands.rd] = tmp;
         }

--- a/tracer/src/instruction/ld.rs
+++ b/tracer/src/instruction/ld.rs
@@ -1,0 +1,25 @@
+use super::{
+    format::{format_i::FormatI, InstructionFormat},
+    RISCVInstruction, RISCVTrace,
+};
+use crate::{declare_riscv_instr, emulator::cpu::Cpu};
+use serde::{Deserialize, Serialize};
+
+declare_riscv_instr!(
+    name   = LD,
+    mask   = 0x0000707f,
+    match  = 0x00003003,
+    format = FormatI,
+    ram    = super::RAMRead
+);
+
+impl LD {
+    fn exec(&self, cpu: &mut Cpu, ram_access: &mut <LD as RISCVInstruction>::RAMAccess) {
+        let address =
+            (cpu.x[self.operands.rs1] as u64).wrapping_add(self.operands.imm as i32 as u64);
+        let value = cpu.get_mut_mmu().load_doubleword(address).unwrap();
+        cpu.x[self.operands.rd] = value as i64;
+        *ram_access = super::RAMRead { address, value };
+    }
+}
+impl RISCVTrace for LD {}

--- a/tracer/src/instruction/lui.rs
+++ b/tracer/src/instruction/lui.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 use crate::{declare_riscv_instr, emulator::cpu::Cpu};
 
 use super::{
-    format::{format_u::FormatU, InstructionFormat},
+    format::{format_u::FormatU, normalize_imm, InstructionFormat},
     RISCVInstruction, RISCVTrace,
 };
 
@@ -17,7 +17,7 @@ declare_riscv_instr!(
 
 impl LUI {
     fn exec(&self, cpu: &mut Cpu, _: &mut <LUI as RISCVInstruction>::RAMAccess) {
-        cpu.x[self.operands.rd] = self.operands.imm as i64;
+        cpu.x[self.operands.rd] = normalize_imm(self.operands.imm);
     }
 }
 

--- a/tracer/src/instruction/lwu.rs
+++ b/tracer/src/instruction/lwu.rs
@@ -1,0 +1,31 @@
+use super::{
+    format::{format_load::FormatLoad, InstructionFormat},
+    RISCVInstruction, RISCVTrace,
+};
+use crate::{declare_riscv_instr, emulator::cpu::Cpu};
+use serde::{Deserialize, Serialize};
+
+declare_riscv_instr!(
+    name   = LWU,
+    mask   = 0x0000707f,
+    match  = 0x00006003,
+    format = FormatLoad,
+    ram    = super::RAMRead
+);
+
+impl LWU {
+    fn exec(&self, cpu: &mut Cpu, ram_access: &mut <LWU as RISCVInstruction>::RAMAccess) {
+        cpu.x[self.operands.rd] = match cpu
+            .mmu
+            .load_word(cpu.x[self.operands.rs1].wrapping_add(self.operands.imm) as u64)
+        {
+            Ok((word, memory_read)) => {
+                *ram_access = memory_read;
+                // Zero extension for unsigned word load
+                word as i64
+            }
+            Err(_) => panic!("MMU load error"),
+        };
+    }
+}
+impl RISCVTrace for LWU {}

--- a/tracer/src/instruction/lwu.rs
+++ b/tracer/src/instruction/lwu.rs
@@ -15,10 +15,12 @@ declare_riscv_instr!(
 
 impl LWU {
     fn exec(&self, cpu: &mut Cpu, ram_access: &mut <LWU as RISCVInstruction>::RAMAccess) {
-        cpu.x[self.operands.rd] = match cpu
-            .mmu
-            .load_word(cpu.x[self.operands.rs1].wrapping_add(self.operands.imm) as u64)
-        {
+        // The LWU instruction, on the other hand, zero-extends the 32-bit value from memory for
+        // RV64I.
+        let address = cpu.x[self.operands.rs1].wrapping_add(self.operands.imm) as u64;
+        let value = cpu.mmu.load_word(address);
+
+        cpu.x[self.operands.rd] = match value {
             Ok((word, memory_read)) => {
                 *ram_access = memory_read;
                 // Zero extension for unsigned word load

--- a/tracer/src/instruction/mod.rs
+++ b/tracer/src/instruction/mod.rs
@@ -341,6 +341,23 @@ macro_rules! define_rv32im_enums {
                 }
             }
 
+            pub fn execute(&self, cpu: &mut Cpu) {
+                match self {
+                    RV32IMInstruction::NoOp(_) => panic!("Unsupported instruction: {:?}", self),
+                    RV32IMInstruction::UNIMPL => panic!("Unsupported instruction: {:?}", self),
+                    $(
+                        RV32IMInstruction::$instr(instr) => {
+                            let mut cycle: RISCVCycle<$instr> = RISCVCycle {
+                                instruction: *instr,
+                                register_state: Default::default(),
+                                ram_access: Default::default(),
+                            };
+                            instr.execute(cpu, &mut cycle.ram_access);
+                        }
+                    )*
+                }
+            }
+
             pub fn normalize(&self) -> NormalizedInstruction {
                 match self {
                     RV32IMInstruction::NoOp(address) => {

--- a/tracer/src/instruction/mod.rs
+++ b/tracer/src/instruction/mod.rs
@@ -567,18 +567,18 @@ impl RV32IMInstruction {
                 // I-type arithmetic instructions: ADDI, SLTI, SLTIU, XORI, ORI, ANDI,
                 // and also shift-immediate instructions SLLI, SRLI, SRAI.
                 let funct3 = (instr >> 12) & 0x7;
-                let funct7 = (instr >> 25) & 0x7f;
+                let funct6 = (instr >> 26) & 0x3f;
                 if funct3 == 0b001 {
-                    // SLLI uses shamt and expects funct7 == 0.
-                    if funct7 == 0 {
+                    // SLLI uses shamt and expects funct6 == 0.
+                    if funct6 == 0 {
                         Ok(SLLI::new(instr, address, true).into())
                     } else {
                         Err("Invalid funct7 for SLLI")
                     }
                 } else if funct3 == 0b101 {
-                    if funct7 == 0b0000000 {
+                    if funct6 == 0b000000 {
                         Ok(SRLI::new(instr, address, true).into())
-                    } else if funct7 == 0b0100000 {
+                    } else if funct6 == 0b010000 {
                         Ok(SRAI::new(instr, address, true).into())
                     } else {
                         Err("Invalid ALU shift funct7")

--- a/tracer/src/instruction/mod.rs
+++ b/tracer/src/instruction/mod.rs
@@ -1,5 +1,7 @@
 use add::ADD;
 use addi::ADDI;
+use addiw::ADDIW;
+use addw::ADDW;
 use and::AND;
 use andi::ANDI;
 use ark_serialize::{
@@ -14,40 +16,55 @@ use bltu::BLTU;
 use bne::BNE;
 use div::DIV;
 use divu::DIVU;
+use divuw::DIVUW;
+use divw::DIVW;
 use ecall::ECALL;
 use fence::FENCE;
 use jal::JAL;
 use jalr::JALR;
 use lb::LB;
 use lbu::LBU;
+use ld::LD;
 use lh::LH;
 use lhu::LHU;
 use lui::LUI;
 use lw::LW;
+use lwu::LWU;
 use mul::MUL;
 use mulh::MULH;
 use mulhsu::MULHSU;
 use mulhu::MULHU;
+use mulw::MULW;
 use or::OR;
 use ori::ORI;
 use rand::{rngs::StdRng, RngCore};
 use rem::REM;
 use remu::REMU;
+use remuw::REMUW;
+use remw::REMW;
 use sb::SB;
+use sd::SD;
 use serde::{Deserialize, Serialize};
 use sh::SH;
 use sll::SLL;
 use slli::SLLI;
+use slliw::SLLIW;
+use sllw::SLLW;
 use slt::SLT;
 use slti::SLTI;
 use sltiu::SLTIU;
 use sltu::SLTU;
 use sra::SRA;
 use srai::SRAI;
+use sraiw::SRAIW;
+use sraw::SRAW;
 use srl::SRL;
 use srli::SRLI;
+use srliw::SRLIW;
+use srlw::SRLW;
 use strum_macros::{EnumCount as EnumCountMacro, EnumIter, IntoStaticStr};
 use sub::SUB;
+use subw::SUBW;
 use sw::SW;
 use xor::XOR;
 use xori::XORI;
@@ -84,6 +101,8 @@ pub mod instruction_macros;
 
 pub mod add;
 pub mod addi;
+pub mod addiw;
+pub mod addw;
 pub mod and;
 pub mod andi;
 pub mod auipc;
@@ -102,10 +121,12 @@ pub mod jal;
 pub mod jalr;
 pub mod lb;
 pub mod lbu;
+pub mod ld;
 pub mod lh;
 pub mod lhu;
 pub mod lui;
 pub mod lw;
+pub mod lwu;
 pub mod mul;
 pub mod mulh;
 pub mod mulhsu;
@@ -115,18 +136,26 @@ pub mod ori;
 pub mod rem;
 pub mod remu;
 pub mod sb;
+pub mod sd;
 pub mod sh;
 pub mod sll;
 pub mod slli;
+pub mod slliw;
+pub mod sllw;
 pub mod slt;
 pub mod slti;
 pub mod sltiu;
 pub mod sltu;
 pub mod sra;
 pub mod srai;
+pub mod sraiw;
+pub mod sraw;
 pub mod srl;
 pub mod srli;
+pub mod srliw;
+pub mod srlw;
 pub mod sub;
+pub mod subw;
 pub mod sw;
 pub mod virtual_advice;
 pub mod virtual_assert_eq;
@@ -149,6 +178,12 @@ pub mod virtual_srl;
 pub mod virtual_srli;
 pub mod xor;
 pub mod xori;
+
+pub mod divuw;
+pub mod divw;
+pub mod mulw;
+pub mod remuw;
+pub mod remw;
 
 #[cfg(test)]
 pub mod test;
@@ -393,9 +428,13 @@ macro_rules! define_rv32im_enums {
 define_rv32im_enums! {
     instructions: [
         ADD, ADDI, AND, ANDI, AUIPC, BEQ, BGE, BGEU, BLT, BLTU, BNE, DIV, DIVU,
-        ECALL, FENCE, JAL, JALR, LB, LBU, LH, LHU, LUI, LW, MUL, MULH, MULHSU,
-        MULHU, OR, ORI, REM, REMU, SB, SH, SLL, SLLI, SLT, SLTI, SLTIU, SLTU,
+        ECALL, FENCE, JAL, JALR, LB, LBU, LD, LH, LHU, LUI, LW, MUL, MULH, MULHSU,
+        MULHU, OR, ORI, REM, REMU, SB, SD, SH, SLL, SLLI, SLT, SLTI, SLTIU, SLTU,
         SRA, SRAI, SRL, SRLI, SUB, SW, XOR, XORI,
+        // RV64I
+        ADDIW, SLLIW, SRLIW, SRAIW, ADDW, SUBW, SLLW, SRLW, SRAW, LWU,
+        // RV64M
+        DIVUW, DIVW, MULW, REMUW, REMW,
         // Virtual
         VirtualAdvice, VirtualAssertEQ, VirtualAssertHalfwordAlignment, VirtualAssertLTE,
         VirtualAssertValidDiv0, VirtualAssertValidSignedRemainder, VirtualAssertValidUnsignedRemainder,
@@ -461,7 +500,7 @@ impl RV32IMInstruction {
 
         match self.normalize().virtual_sequence_remaining {
             None => true,     // ordinary instruction
-            Some(0) => true,  // “anchor” of a virtual sequence
+            Some(0) => true,  // "anchor" of a virtual sequence
             Some(_) => false, // helper within the sequence
         }
     }
@@ -502,13 +541,15 @@ impl RV32IMInstruction {
                 }
             }
             0b0000011 => {
-                // Load instructions (I-type): LB, LH, LW, LBU, LHU.
+                // Load instructions (I-type): LB, LH, LW, LBU, LHU, LD, LWU.
                 match (instr >> 12) & 0x7 {
                     0b000 => Ok(LB::new(instr, address, true).into()),
                     0b001 => Ok(LH::new(instr, address, true).into()),
                     0b010 => Ok(LW::new(instr, address, true).into()),
+                    0b011 => Ok(LD::new(instr, address, true).into()),
                     0b100 => Ok(LBU::new(instr, address, true).into()),
                     0b101 => Ok(LHU::new(instr, address, true).into()),
+                    0b110 => Ok(LWU::new(instr, address, true).into()),
                     _ => Err("Invalid load funct3"),
                 }
             }
@@ -518,6 +559,7 @@ impl RV32IMInstruction {
                     0b000 => Ok(SB::new(instr, address, true).into()),
                     0b001 => Ok(SH::new(instr, address, true).into()),
                     0b010 => Ok(SW::new(instr, address, true).into()),
+                    0b011 => Ok(SD::new(instr, address, true).into()),
                     _ => Err("Invalid store funct3"),
                 }
             }
@@ -553,6 +595,18 @@ impl RV32IMInstruction {
                     }
                 }
             }
+            0b0011011 => {
+                // RV64I I-type arithmetic instructions.
+                let funct3 = (instr >> 12) & 0x7;
+                let funct7 = (instr >> 25) & 0x7f;
+                match (funct3, funct7) {
+                    (0b000, _) => Ok(ADDIW::new(instr, address, true).into()),
+                    (0b001, 0b0000000) => Ok(SLLIW::new(instr, address, true).into()),
+                    (0b101, 0b0000000) => Ok(SRLIW::new(instr, address, true).into()),
+                    (0b101, 0b0100000) => Ok(SRAIW::new(instr, address, true).into()),
+                    _ => Err("Invalid RV64I I-type arithmetic instruction"),
+                }
+            }
             0b0110011 => {
                 // R-type arithmetic instructions.
                 let funct3 = (instr >> 12) & 0x7;
@@ -578,6 +632,24 @@ impl RV32IMInstruction {
                     (0b110, 0b0000001) => Ok(REM::new(instr, address, true).into()),
                     (0b111, 0b0000001) => Ok(REMU::new(instr, address, true).into()),
                     _ => Err("Invalid R-type arithmetic instruction"),
+                }
+            }
+            0b0111011 => {
+                // RV64I R-type arithmetic instructions.
+                let funct3 = (instr >> 12) & 0x7;
+                let funct7 = (instr >> 25) & 0x7f;
+                match (funct3, funct7) {
+                    (0b000, 0b0000000) => Ok(ADDW::new(instr, address, true).into()),
+                    (0b000, 0b0100000) => Ok(SUBW::new(instr, address, true).into()),
+                    (0b001, 0b0000000) => Ok(SLLW::new(instr, address, true).into()),
+                    (0b100, 0b0000001) => Ok(DIVW::new(instr, address, true).into()),
+                    (0b101, 0b0000000) => Ok(SRLW::new(instr, address, true).into()),
+                    (0b101, 0b0100000) => Ok(SRAW::new(instr, address, true).into()),
+                    (0b000, 0b0000001) => Ok(MULW::new(instr, address, true).into()),
+                    (0b101, 0b0000001) => Ok(DIVUW::new(instr, address, true).into()),
+                    (0b110, 0b0000001) => Ok(REMW::new(instr, address, true).into()),
+                    (0b111, 0b0000001) => Ok(REMUW::new(instr, address, true).into()),
+                    _ => Err("Invalid RV64I R-type arithmetic instruction"),
                 }
             }
             0b0001111 => {

--- a/tracer/src/instruction/mod.rs
+++ b/tracer/src/instruction/mod.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::upper_case_acronyms)]
 use add::ADD;
 use addi::ADDI;
 use addiw::ADDIW;

--- a/tracer/src/instruction/mulw.rs
+++ b/tracer/src/instruction/mulw.rs
@@ -1,0 +1,23 @@
+use super::{
+    format::{format_r::FormatR, InstructionFormat},
+    RISCVInstruction, RISCVTrace,
+};
+use crate::{declare_riscv_instr, emulator::cpu::Cpu};
+use serde::{Deserialize, Serialize};
+
+declare_riscv_instr!(
+    name   = MULW,
+    mask   = 0xfe00707f,
+    match  = 0x0200003b,
+    format = FormatR,
+    ram    = ()
+);
+
+impl MULW {
+    fn exec(&self, cpu: &mut Cpu, _: &mut <MULW as RISCVInstruction>::RAMAccess) {
+        let a = cpu.x[self.operands.rs1] as i32 as i64;
+        let b = cpu.x[self.operands.rs2] as i32 as i64;
+        cpu.x[self.operands.rd] = a.wrapping_mul(b) as i32 as i64;
+    }
+}
+impl RISCVTrace for MULW {}

--- a/tracer/src/instruction/mulw.rs
+++ b/tracer/src/instruction/mulw.rs
@@ -15,9 +15,12 @@ declare_riscv_instr!(
 
 impl MULW {
     fn exec(&self, cpu: &mut Cpu, _: &mut <MULW as RISCVInstruction>::RAMAccess) {
-        let a = cpu.x[self.operands.rs1] as i32 as i64;
-        let b = cpu.x[self.operands.rs2] as i32 as i64;
-        cpu.x[self.operands.rd] = a.wrapping_mul(b) as i32 as i64;
+        // MULW is an RV64 instruction that multiplies the lower 32 bits of the source registers,
+        // placing the sign extension of the lower 32 bits of the result into the destination
+        // register.
+        let a = cpu.x[self.operands.rs1] as i32;
+        let b = cpu.x[self.operands.rs2] as i32;
+        cpu.x[self.operands.rd] = a.wrapping_mul(b) as i64;
     }
 }
 impl RISCVTrace for MULW {}

--- a/tracer/src/instruction/remuw.rs
+++ b/tracer/src/instruction/remuw.rs
@@ -15,6 +15,9 @@ declare_riscv_instr!(
 
 impl REMUW {
     fn exec(&self, cpu: &mut Cpu, _: &mut <REMUW as RISCVInstruction>::RAMAccess) {
+        // REMW and REMUW are RV64 instructions that provide the corresponding signed and unsigned
+        // remainder operations. Both REMW and REMUW always sign-extend the 32-bit result to 64 bits,
+        // including on a divide by zero.
         let dividend = cpu.x[self.operands.rs1] as u32;
         let divisor = cpu.x[self.operands.rs2] as u32;
         cpu.x[self.operands.rd] = (if divisor == 0 {

--- a/tracer/src/instruction/remuw.rs
+++ b/tracer/src/instruction/remuw.rs
@@ -1,0 +1,27 @@
+use super::{
+    format::{format_r::FormatR, InstructionFormat},
+    RISCVInstruction, RISCVTrace,
+};
+use crate::{declare_riscv_instr, emulator::cpu::Cpu};
+use serde::{Deserialize, Serialize};
+
+declare_riscv_instr!(
+    name   = REMUW,
+    mask   = 0xfe00707f,
+    match  = 0x1f00003b,
+    format = FormatR,
+    ram    = ()
+);
+
+impl REMUW {
+    fn exec(&self, cpu: &mut Cpu, _: &mut <REMUW as RISCVInstruction>::RAMAccess) {
+        let dividend = cpu.x[self.operands.rs1] as u32;
+        let divisor = cpu.x[self.operands.rs2] as u32;
+        cpu.x[self.operands.rd] = (if divisor == 0 {
+            dividend
+        } else {
+            dividend.wrapping_rem(divisor)
+        }) as i32 as i64;
+    }
+}
+impl RISCVTrace for REMUW {}

--- a/tracer/src/instruction/remw.rs
+++ b/tracer/src/instruction/remw.rs
@@ -15,15 +15,18 @@ declare_riscv_instr!(
 
 impl REMW {
     fn exec(&self, cpu: &mut Cpu, _: &mut <REMW as RISCVInstruction>::RAMAccess) {
+        // REMW and REMUW are RV64 instructions that provide the corresponding signed and unsigned
+        // remainder operations. Both REMW and REMUW always sign-extend the 32-bit result to 64 bits,
+        // including on a divide by zero.
         let dividend = cpu.x[self.operands.rs1] as i32;
         let divisor = cpu.x[self.operands.rs2] as i32;
-        cpu.x[self.operands.rd] = if divisor == 0 {
-            dividend as i64
+        cpu.x[self.operands.rd] = (if divisor == 0 {
+            dividend
         } else if dividend == i32::MIN && divisor == -1 {
             0
         } else {
-            (dividend.wrapping_rem(divisor)) as i64
-        };
+            dividend.wrapping_rem(divisor)
+        }) as i64;
     }
 }
 impl RISCVTrace for REMW {}

--- a/tracer/src/instruction/remw.rs
+++ b/tracer/src/instruction/remw.rs
@@ -1,0 +1,29 @@
+use super::{
+    format::{format_r::FormatR, InstructionFormat},
+    RISCVInstruction, RISCVTrace,
+};
+use crate::{declare_riscv_instr, emulator::cpu::Cpu};
+use serde::{Deserialize, Serialize};
+
+declare_riscv_instr!(
+    name   = REMW,
+    mask   = 0xfe00707f,
+    match  = 0x1e00003b,
+    format = FormatR,
+    ram    = ()
+);
+
+impl REMW {
+    fn exec(&self, cpu: &mut Cpu, _: &mut <REMW as RISCVInstruction>::RAMAccess) {
+        let dividend = cpu.x[self.operands.rs1] as i32;
+        let divisor = cpu.x[self.operands.rs2] as i32;
+        cpu.x[self.operands.rd] = if divisor == 0 {
+            dividend as i64
+        } else if dividend == i32::MIN && divisor == -1 {
+            0
+        } else {
+            (dividend.wrapping_rem(divisor)) as i64
+        };
+    }
+}
+impl RISCVTrace for REMW {}

--- a/tracer/src/instruction/sd.rs
+++ b/tracer/src/instruction/sd.rs
@@ -1,0 +1,33 @@
+use serde::{Deserialize, Serialize};
+
+use crate::{declare_riscv_instr, emulator::cpu::Cpu};
+
+use super::RAMWrite;
+
+use super::{
+    format::{format_s::FormatS, InstructionFormat},
+    RISCVInstruction, RISCVTrace,
+};
+
+declare_riscv_instr!(
+    name   = SD,
+    mask   = 0x0000707f,
+    match  = 0x00003023,
+    format = FormatS,
+    ram    = RAMWrite
+);
+
+impl SD {
+    fn exec(&self, cpu: &mut Cpu, ram_access: &mut <SD as RISCVInstruction>::RAMAccess) {
+        *ram_access = cpu
+            .mmu
+            .store_doubleword(
+                cpu.x[self.operands.rs1].wrapping_add(self.operands.imm) as u64,
+                cpu.x[self.operands.rs2] as u64,
+            )
+            .ok()
+            .unwrap();
+    }
+}
+
+impl RISCVTrace for SD {}

--- a/tracer/src/instruction/sd.rs
+++ b/tracer/src/instruction/sd.rs
@@ -19,6 +19,8 @@ declare_riscv_instr!(
 
 impl SD {
     fn exec(&self, cpu: &mut Cpu, ram_access: &mut <SD as RISCVInstruction>::RAMAccess) {
+        // The SD, SW, SH, and SB instructions store 64-bit, 32-bit, 16-bit, and 8-bit values from
+        // the low bits of register rs2 to memory respectively.
         *ram_access = cpu
             .mmu
             .store_doubleword(

--- a/tracer/src/instruction/slliw.rs
+++ b/tracer/src/instruction/slliw.rs
@@ -1,5 +1,5 @@
 use super::{
-    format::{format_r::FormatR, InstructionFormat},
+    format::{format_i::FormatI, InstructionFormat},
     RISCVInstruction, RISCVTrace,
 };
 use crate::{declare_riscv_instr, emulator::cpu::Cpu};
@@ -9,13 +9,14 @@ declare_riscv_instr!(
     name   = SLLIW,
     mask   = 0xfc00707f,
     match  = 0x0000101b,
-    format = FormatR,
+    format = FormatI,
     ram    = ()
 );
 
 impl SLLIW {
     fn exec(&self, cpu: &mut Cpu, _: &mut <SLLIW as RISCVInstruction>::RAMAccess) {
-        cpu.x[self.operands.rd] = (cpu.x[self.operands.rs1] << self.operands.rs2) as i32 as i64;
+        cpu.x[self.operands.rd] =
+            ((cpu.x[self.operands.rs1] as u32) << (self.operands.imm & 0x1f)) as i32 as i64;
     }
 }
 impl RISCVTrace for SLLIW {}

--- a/tracer/src/instruction/slliw.rs
+++ b/tracer/src/instruction/slliw.rs
@@ -15,8 +15,11 @@ declare_riscv_instr!(
 
 impl SLLIW {
     fn exec(&self, cpu: &mut Cpu, _: &mut <SLLIW as RISCVInstruction>::RAMAccess) {
-        cpu.x[self.operands.rd] =
-            ((cpu.x[self.operands.rs1] as u32) << (self.operands.imm & 0x1f)) as i32 as i64;
+        // SLLIW, SRLIW, and SRAIW are RV64I-only instructions that are analogously defined but
+        // operate on 32-bit values and sign-extend their 32-bit results to 64 bits. SLLIW, SRLIW,
+        // and SRAIW encodings with imm[5] ≠ 0 are reserved.
+        let shamt = (self.operands.imm & 0x1f) as u32;
+        cpu.x[self.operands.rd] = ((cpu.x[self.operands.rs1] as u32) << shamt) as i32 as i64;
     }
 }
 impl RISCVTrace for SLLIW {}

--- a/tracer/src/instruction/slliw.rs
+++ b/tracer/src/instruction/slliw.rs
@@ -1,0 +1,23 @@
+use super::{
+    format::{format_r::FormatR, InstructionFormat},
+    RISCVInstruction, RISCVTrace,
+};
+use crate::{declare_riscv_instr, emulator::cpu::Cpu};
+use serde::{Deserialize, Serialize};
+
+declare_riscv_instr!(
+    name   = SLLIW,
+    mask   = 0xfc00707f,
+    match  = 0x0000101b,
+    format = FormatR,
+    ram    = ()
+);
+
+impl SLLIW {
+    fn exec(&self, cpu: &mut Cpu, _: &mut <SLLIW as RISCVInstruction>::RAMAccess) {
+        let shamt = (cpu.x[self.operands.rs2] & 0x1f) as u32;
+        cpu.x[self.operands.rd] =
+            cpu.sign_extend(((cpu.x[self.operands.rs1] as u32) << shamt) as i32 as i64);
+    }
+}
+impl RISCVTrace for SLLIW {}

--- a/tracer/src/instruction/slliw.rs
+++ b/tracer/src/instruction/slliw.rs
@@ -15,9 +15,7 @@ declare_riscv_instr!(
 
 impl SLLIW {
     fn exec(&self, cpu: &mut Cpu, _: &mut <SLLIW as RISCVInstruction>::RAMAccess) {
-        let shamt = (cpu.x[self.operands.rs2] & 0x1f) as u32;
-        cpu.x[self.operands.rd] =
-            cpu.sign_extend(((cpu.x[self.operands.rs1] as u32) << shamt) as i32 as i64);
+        cpu.x[self.operands.rd] = (cpu.x[self.operands.rs1] << self.operands.rs2) as i32 as i64;
     }
 }
 impl RISCVTrace for SLLIW {}

--- a/tracer/src/instruction/sllw.rs
+++ b/tracer/src/instruction/sllw.rs
@@ -1,0 +1,23 @@
+use super::{
+    format::{format_r::FormatR, InstructionFormat},
+    RISCVInstruction, RISCVTrace,
+};
+use crate::{declare_riscv_instr, emulator::cpu::Cpu};
+use serde::{Deserialize, Serialize};
+
+declare_riscv_instr!(
+    name   = SLLW,
+    mask   = 0xfe00707f,
+    match  = 0x0000003b | (0b001 << 12),
+    format = FormatR,
+    ram    = ()
+);
+
+impl SLLW {
+    fn exec(&self, cpu: &mut Cpu, _: &mut <SLLW as RISCVInstruction>::RAMAccess) {
+        let shamt = (cpu.x[self.operands.rs2] & 0x1f) as u32;
+        cpu.x[self.operands.rd] =
+            cpu.sign_extend(((cpu.x[self.operands.rs1] as u32) << shamt) as i32 as i64);
+    }
+}
+impl RISCVTrace for SLLW {}

--- a/tracer/src/instruction/sllw.rs
+++ b/tracer/src/instruction/sllw.rs
@@ -15,9 +15,11 @@ declare_riscv_instr!(
 
 impl SLLW {
     fn exec(&self, cpu: &mut Cpu, _: &mut <SLLW as RISCVInstruction>::RAMAccess) {
+        // SLLW, SRLW, and SRAW are RV64I-only instructions that are analogously defined but operate
+        // on 32-bit values and sign-extend their 32-bit results to 64 bits. The shift amount is
+        // given by rs2[4:0].
         let shamt = (cpu.x[self.operands.rs2] & 0x1f) as u32;
-        cpu.x[self.operands.rd] =
-            cpu.sign_extend(((cpu.x[self.operands.rs1] as u32) << shamt) as i32 as i64);
+        cpu.x[self.operands.rd] = ((cpu.x[self.operands.rs1] as u32) << shamt) as i32 as i64;
     }
 }
 impl RISCVTrace for SLLW {}

--- a/tracer/src/instruction/sraiw.rs
+++ b/tracer/src/instruction/sraiw.rs
@@ -1,5 +1,5 @@
 use super::{
-    format::{format_r::FormatR, InstructionFormat},
+    format::{format_i::FormatI, InstructionFormat},
     RISCVInstruction, RISCVTrace,
 };
 use crate::{declare_riscv_instr, emulator::cpu::Cpu};
@@ -9,13 +9,14 @@ declare_riscv_instr!(
     name   = SRAIW,
     mask   = 0xfc00707f,
     match  = 0x4000501b,
-    format = FormatR,
+    format = FormatI,
     ram    = ()
 );
 
 impl SRAIW {
     fn exec(&self, cpu: &mut Cpu, _: &mut <SRAIW as RISCVInstruction>::RAMAccess) {
-        cpu.x[self.operands.rd] = ((cpu.x[self.operands.rs1] as i32) >> self.operands.rs2) as i64;
+        cpu.x[self.operands.rd] =
+            ((cpu.x[self.operands.rs1] as i32) >> (self.operands.imm & 0x1f)) as i64;
     }
 }
 impl RISCVTrace for SRAIW {}

--- a/tracer/src/instruction/sraiw.rs
+++ b/tracer/src/instruction/sraiw.rs
@@ -15,9 +15,7 @@ declare_riscv_instr!(
 
 impl SRAIW {
     fn exec(&self, cpu: &mut Cpu, _: &mut <SRAIW as RISCVInstruction>::RAMAccess) {
-        let shamt = (cpu.x[self.operands.rs2] & 0x1f) as u32;
-        cpu.x[self.operands.rd] =
-            cpu.sign_extend(((cpu.x[self.operands.rs1] as i32) >> shamt) as i64);
+        cpu.x[self.operands.rd] = ((cpu.x[self.operands.rs1] as i32) >> self.operands.rs2) as i64;
     }
 }
 impl RISCVTrace for SRAIW {}

--- a/tracer/src/instruction/sraiw.rs
+++ b/tracer/src/instruction/sraiw.rs
@@ -15,8 +15,11 @@ declare_riscv_instr!(
 
 impl SRAIW {
     fn exec(&self, cpu: &mut Cpu, _: &mut <SRAIW as RISCVInstruction>::RAMAccess) {
-        cpu.x[self.operands.rd] =
-            ((cpu.x[self.operands.rs1] as i32) >> (self.operands.imm & 0x1f)) as i64;
+        // SLLIW, SRLIW, and SRAIW are RV64I-only instructions that are analogously defined but
+        // operate on 32-bit values and sign-extend their 32-bit results to 64 bits. SLLIW, SRLIW,
+        // and SRAIW encodings with imm[5] ≠ 0 are reserved.
+        let shamt = (self.operands.imm & 0x1f) as u32;
+        cpu.x[self.operands.rd] = ((cpu.x[self.operands.rs1] as i32) >> shamt) as i64;
     }
 }
 impl RISCVTrace for SRAIW {}

--- a/tracer/src/instruction/sraiw.rs
+++ b/tracer/src/instruction/sraiw.rs
@@ -1,0 +1,23 @@
+use super::{
+    format::{format_r::FormatR, InstructionFormat},
+    RISCVInstruction, RISCVTrace,
+};
+use crate::{declare_riscv_instr, emulator::cpu::Cpu};
+use serde::{Deserialize, Serialize};
+
+declare_riscv_instr!(
+    name   = SRAIW,
+    mask   = 0xfc00707f,
+    match  = 0x4000501b,
+    format = FormatR,
+    ram    = ()
+);
+
+impl SRAIW {
+    fn exec(&self, cpu: &mut Cpu, _: &mut <SRAIW as RISCVInstruction>::RAMAccess) {
+        let shamt = (cpu.x[self.operands.rs2] & 0x1f) as u32;
+        cpu.x[self.operands.rd] =
+            cpu.sign_extend(((cpu.x[self.operands.rs1] as i32) >> shamt) as i64);
+    }
+}
+impl RISCVTrace for SRAIW {}

--- a/tracer/src/instruction/sraw.rs
+++ b/tracer/src/instruction/sraw.rs
@@ -1,0 +1,23 @@
+use super::{
+    format::{format_r::FormatR, InstructionFormat},
+    RISCVInstruction, RISCVTrace,
+};
+use crate::{declare_riscv_instr, emulator::cpu::Cpu};
+use serde::{Deserialize, Serialize};
+
+declare_riscv_instr!(
+    name   = SRAW,
+    mask   = 0xfe00707f,
+    match  = 0x4000003b | (0b101 << 12),
+    format = FormatR,
+    ram    = ()
+);
+
+impl SRAW {
+    fn exec(&self, cpu: &mut Cpu, _: &mut <SRAW as RISCVInstruction>::RAMAccess) {
+        let shamt = (cpu.x[self.operands.rs2] & 0x1f) as u32;
+        cpu.x[self.operands.rd] =
+            cpu.sign_extend(((cpu.x[self.operands.rs1] as i32) >> shamt) as i64);
+    }
+}
+impl RISCVTrace for SRAW {}

--- a/tracer/src/instruction/sraw.rs
+++ b/tracer/src/instruction/sraw.rs
@@ -15,9 +15,11 @@ declare_riscv_instr!(
 
 impl SRAW {
     fn exec(&self, cpu: &mut Cpu, _: &mut <SRAW as RISCVInstruction>::RAMAccess) {
+        // SLLW, SRLW, and SRAW are RV64I-only instructions that are analogously defined but operate
+        // on 32-bit values and sign-extend their 32-bit results to 64 bits. The shift amount is
+        // given by rs2[4:0].
         let shamt = (cpu.x[self.operands.rs2] & 0x1f) as u32;
-        cpu.x[self.operands.rd] =
-            cpu.sign_extend(((cpu.x[self.operands.rs1] as i32) >> shamt) as i64);
+        cpu.x[self.operands.rd] = ((cpu.x[self.operands.rs1] as i32) >> shamt) as i64;
     }
 }
 impl RISCVTrace for SRAW {}

--- a/tracer/src/instruction/srliw.rs
+++ b/tracer/src/instruction/srliw.rs
@@ -1,5 +1,5 @@
 use super::{
-    format::{format_r::FormatR, InstructionFormat},
+    format::{format_i::FormatI, InstructionFormat},
     RISCVInstruction, RISCVTrace,
 };
 use crate::{declare_riscv_instr, emulator::cpu::Cpu};
@@ -9,14 +9,14 @@ declare_riscv_instr!(
     name   = SRLIW,
     mask   = 0xfc00707f,
     match  = 0x0000501b,
-    format = FormatR,
+    format = FormatI,
     ram    = ()
 );
 
 impl SRLIW {
     fn exec(&self, cpu: &mut Cpu, _: &mut <SRLIW as RISCVInstruction>::RAMAccess) {
         cpu.x[self.operands.rd] =
-            ((cpu.x[self.operands.rs1] as u32) >> self.operands.rs2) as i32 as i64;
+            ((cpu.x[self.operands.rs1] as u32) >> (self.operands.imm & 0x1f)) as i32 as i64;
     }
 }
 impl RISCVTrace for SRLIW {}

--- a/tracer/src/instruction/srliw.rs
+++ b/tracer/src/instruction/srliw.rs
@@ -15,9 +15,8 @@ declare_riscv_instr!(
 
 impl SRLIW {
     fn exec(&self, cpu: &mut Cpu, _: &mut <SRLIW as RISCVInstruction>::RAMAccess) {
-        let shamt = (cpu.x[self.operands.rs2] & 0x1f) as u32;
         cpu.x[self.operands.rd] =
-            cpu.sign_extend(((cpu.x[self.operands.rs1] as u32) >> shamt) as i32 as i64);
+            ((cpu.x[self.operands.rs1] as u32) >> self.operands.rs2) as i32 as i64;
     }
 }
 impl RISCVTrace for SRLIW {}

--- a/tracer/src/instruction/srliw.rs
+++ b/tracer/src/instruction/srliw.rs
@@ -15,8 +15,11 @@ declare_riscv_instr!(
 
 impl SRLIW {
     fn exec(&self, cpu: &mut Cpu, _: &mut <SRLIW as RISCVInstruction>::RAMAccess) {
-        cpu.x[self.operands.rd] =
-            ((cpu.x[self.operands.rs1] as u32) >> (self.operands.imm & 0x1f)) as i32 as i64;
+        // SLLIW, SRLIW, and SRAIW are RV64I-only instructions that are analogously defined but
+        // operate on 32-bit values and sign-extend their 32-bit results to 64 bits. SLLIW, SRLIW,
+        // and SRAIW encodings with imm[5] ≠ 0 are reserved.
+        let shamt = (self.operands.imm & 0x1f) as u32;
+        cpu.x[self.operands.rd] = ((cpu.x[self.operands.rs1] as u32) >> shamt) as i32 as i64;
     }
 }
 impl RISCVTrace for SRLIW {}

--- a/tracer/src/instruction/srliw.rs
+++ b/tracer/src/instruction/srliw.rs
@@ -1,0 +1,23 @@
+use super::{
+    format::{format_r::FormatR, InstructionFormat},
+    RISCVInstruction, RISCVTrace,
+};
+use crate::{declare_riscv_instr, emulator::cpu::Cpu};
+use serde::{Deserialize, Serialize};
+
+declare_riscv_instr!(
+    name   = SRLIW,
+    mask   = 0xfc00707f,
+    match  = 0x0000501b,
+    format = FormatR,
+    ram    = ()
+);
+
+impl SRLIW {
+    fn exec(&self, cpu: &mut Cpu, _: &mut <SRLIW as RISCVInstruction>::RAMAccess) {
+        let shamt = (cpu.x[self.operands.rs2] & 0x1f) as u32;
+        cpu.x[self.operands.rd] =
+            cpu.sign_extend(((cpu.x[self.operands.rs1] as u32) >> shamt) as i32 as i64);
+    }
+}
+impl RISCVTrace for SRLIW {}

--- a/tracer/src/instruction/srlw.rs
+++ b/tracer/src/instruction/srlw.rs
@@ -1,0 +1,23 @@
+use super::{
+    format::{format_r::FormatR, InstructionFormat},
+    RISCVInstruction, RISCVTrace,
+};
+use crate::{declare_riscv_instr, emulator::cpu::Cpu};
+use serde::{Deserialize, Serialize};
+
+declare_riscv_instr!(
+    name   = SRLW,
+    mask   = 0xfe00707f,
+    match  = 0x0000003b | (0b101 << 12),
+    format = FormatR,
+    ram    = ()
+);
+
+impl SRLW {
+    fn exec(&self, cpu: &mut Cpu, _: &mut <SRLW as RISCVInstruction>::RAMAccess) {
+        let shamt = (cpu.x[self.operands.rs2] & 0x1f) as u32;
+        cpu.x[self.operands.rd] =
+            cpu.sign_extend(((cpu.x[self.operands.rs1] as u32) >> shamt) as i32 as i64);
+    }
+}
+impl RISCVTrace for SRLW {}

--- a/tracer/src/instruction/srlw.rs
+++ b/tracer/src/instruction/srlw.rs
@@ -15,9 +15,11 @@ declare_riscv_instr!(
 
 impl SRLW {
     fn exec(&self, cpu: &mut Cpu, _: &mut <SRLW as RISCVInstruction>::RAMAccess) {
+        // SLLW, SRLW, and SRAW are RV64I-only instructions that are analogously defined but operate
+        // on 32-bit values and sign-extend their 32-bit results to 64 bits. The shift amount is
+        // given by rs2[4:0].
         let shamt = (cpu.x[self.operands.rs2] & 0x1f) as u32;
-        cpu.x[self.operands.rd] =
-            cpu.sign_extend(((cpu.x[self.operands.rs1] as u32) >> shamt) as i32 as i64);
+        cpu.x[self.operands.rd] = ((cpu.x[self.operands.rs1] as u32) >> shamt) as i32 as i64;
     }
 }
 impl RISCVTrace for SRLW {}

--- a/tracer/src/instruction/subw.rs
+++ b/tracer/src/instruction/subw.rs
@@ -1,0 +1,23 @@
+use super::{
+    format::{format_r::FormatR, InstructionFormat},
+    RISCVInstruction, RISCVTrace,
+};
+use crate::{declare_riscv_instr, emulator::cpu::Cpu};
+use serde::{Deserialize, Serialize};
+
+declare_riscv_instr!(
+    name   = SUBW,
+    mask   = 0xfe00707f,
+    match  = 0x4000003b,
+    format = FormatR,
+    ram    = ()
+);
+
+impl SUBW {
+    fn exec(&self, cpu: &mut Cpu, _: &mut <SUBW as RISCVInstruction>::RAMAccess) {
+        cpu.x[self.operands.rd] = cpu.sign_extend(
+            (cpu.x[self.operands.rs1].wrapping_sub(cpu.x[self.operands.rs2]) as i32) as i64,
+        );
+    }
+}
+impl RISCVTrace for SUBW {}

--- a/tracer/src/instruction/subw.rs
+++ b/tracer/src/instruction/subw.rs
@@ -15,9 +15,12 @@ declare_riscv_instr!(
 
 impl SUBW {
     fn exec(&self, cpu: &mut Cpu, _: &mut <SUBW as RISCVInstruction>::RAMAccess) {
-        cpu.x[self.operands.rd] = cpu.sign_extend(
-            (cpu.x[self.operands.rs1].wrapping_sub(cpu.x[self.operands.rs2]) as i32) as i64,
-        );
+        // ADDW and SUBW are RV64I-only instructions that are defined analogously to ADD and SUB
+        // but operate on 32-bit values and produce signed 32-bit results. Overflows are ignored,
+        // and the low 32-bits of the result is sign-extended to 64-bits and written to the
+        // destination register.
+        cpu.x[self.operands.rd] =
+            (cpu.x[self.operands.rs1].wrapping_sub(cpu.x[self.operands.rs2]) as i32) as i64;
     }
 }
 impl RISCVTrace for SUBW {}

--- a/tracer/src/main.rs
+++ b/tracer/src/main.rs
@@ -1,0 +1,51 @@
+use std::fs::File;
+use std::path::Path;
+use std::process::exit;
+
+use clap::Parser;
+
+use emulator::{default_terminal::DefaultTerminal, Emulator};
+
+mod emulator;
+mod instruction;
+
+/// RISC-V emulator for Jolt
+#[derive(Parser, Debug)]
+#[command(author, version, about, long_about = None)]
+struct Args {
+    /// Path to the ELF file to execute
+    elf: String,
+
+    /// Path to write the signature file
+    #[arg(short, long)]
+    signature: Option<String>,
+
+    /// Signature granularity in bytes (must be a power of 2)
+    #[arg(long, default_value = "4")]
+    signature_granularity: usize,
+}
+
+fn main() {
+    let args = Args::parse();
+
+    // Initialize tracing
+    tracing_subscriber::fmt::init();
+
+    // Read the ELF file
+    let elf_path = Path::new(&args.elf);
+    let elf_content = std::fs::read(elf_path).expect("Failed to read ELF file");
+
+    // Create and run the emulator
+    let mut emulator = Emulator::new(Box::new(DefaultTerminal::new()));
+    emulator.setup_program(elf_content);
+    emulator.run();
+
+    // If signature file is specified, write the signature with specified granularity
+    if let Some(sig_path) = args.signature {
+        let mut file = File::create(sig_path).expect("Failed to create signature file");
+        if let Err(e) = emulator.write_signature(&mut file, args.signature_granularity) {
+            eprintln!("Failed to write signature file: {e}");
+            exit(1);
+        }
+    }
+}

--- a/tracer/src/main.rs
+++ b/tracer/src/main.rs
@@ -23,6 +23,10 @@ struct Args {
     /// Signature granularity in bytes (must be a power of 2)
     #[arg(long, default_value = "4")]
     signature_granularity: usize,
+
+    /// Execute the program in trace mode
+    #[arg(short, long, value_name = "true|false")]
+    trace: Option<bool>,
 }
 
 fn main() {
@@ -38,7 +42,7 @@ fn main() {
     // Create and run the emulator
     let mut emulator = Emulator::new(Box::new(DefaultTerminal::new()));
     emulator.setup_program(elf_content);
-    emulator.run();
+    emulator.run_test(args.trace.unwrap_or(false));
 
     // If signature file is specified, write the signature with specified granularity
     if let Some(sig_path) = args.signature {


### PR DESCRIPTION
This PR adds comprehensive RV64IM instruction support to the Jolt tracer. It passes riscv-arch-tests.

## Key Features Added:

### RV64I Instructions
- **Load/Store**: `LD`, `LDU`, `SD` for 64-bit memory operations
- **Arithmetic**: `ADDIW`, `SLLIW`, `SRLIW`, `SRAIW` for 32-bit operations with sign extension
- **Control Flow**: Enhanced `JALR` implementation with proper RISC-V compliance
- **Shift Operations**: `SLLW`, `SRLW`, `SRAW` with proper 32-bit operand handling


### RV64M Instructions  
- **Multiplication**: `MULW`, `DIVW`, `DIVUW` for 32-bit arithmetic
- **Division**: `REMW`, `REMUW` for remainder operations

### Emulator Infrastructure
- **Testing Framework**: Trace mode toggle for debugging and testing
- **Signature Generation**: Support for test result validation

### Bug Fixes & Improvements
- **Compressed Instructions**: Improved RISC-V C extension compliance
- **Format Parsing**: Fixed immediate value handling in U-format instructions
- **Memory Capacity**: Increased test memory for RV64I compatibility
- **Shift Decoding**: Corrected shift instruction handling for RV64I
