### PR TITLE
Add Dao-Thaler and Gruen's optimizations to Twist and Shout sumchecks

### DIFF
--- a/jolt-core/src/jolt/vm/bytecode.rs
+++ b/jolt-core/src/jolt/vm/bytecode.rs
@@ -382,7 +382,7 @@ impl<F: JoltField, ProofTranscript: Transcript> BatchableSumcheckInstance<F, Pro
         self.input_claim
     }
 
-    fn compute_prover_message(&mut self, _round: usize) -> Vec<F> {
+    fn compute_prover_message(&mut self, _round: usize, _previous_claim: F) -> Vec<F> {
         let prover_state = self
             .prover_state
             .as_ref()
@@ -669,7 +669,7 @@ impl<F: JoltField, ProofTranscript: Transcript> BatchableSumcheckInstance<F, Pro
         self.input_claim
     }
 
-    fn compute_prover_message(&mut self, round: usize) -> Vec<F> {
+    fn compute_prover_message(&mut self, round: usize, _previous_claim: F) -> Vec<F> {
         let K_log = self.K.log_2();
 
         if round < K_log {
@@ -996,7 +996,7 @@ impl<F: JoltField, ProofTranscript: Transcript> BatchableSumcheckInstance<F, Pro
         self.input_claim
     }
 
-    fn compute_prover_message(&mut self, _round: usize) -> Vec<F> {
+    fn compute_prover_message(&mut self, _round: usize, _previous_claim: F) -> Vec<F> {
         let prover_state = self
             .prover_state
             .as_ref()

--- a/jolt-core/src/jolt/vm/output_check.rs
+++ b/jolt-core/src/jolt/vm/output_check.rs
@@ -249,7 +249,7 @@ impl<F: JoltField, ProofTranscript: Transcript> BatchableSumcheckInstance<F, Pro
     }
 
     #[tracing::instrument(skip_all, name = "OutputSumcheck::compute_prover_message")]
-    fn compute_prover_message(&mut self, _: usize) -> Vec<F> {
+    fn compute_prover_message(&mut self, _: usize, _previous_claim: F) -> Vec<F> {
         const DEGREE: usize = 3;
         let OutputSumcheckProverState {
             eq_poly,
@@ -439,7 +439,7 @@ impl<F: JoltField, ProofTranscript: Transcript> BatchableSumcheckInstance<F, Pro
     }
 
     #[tracing::instrument(skip_all, name = "ValFinalSumcheck::compute_prover_message")]
-    fn compute_prover_message(&mut self, _: usize) -> Vec<F> {
+    fn compute_prover_message(&mut self, _: usize, _previous_claim: F) -> Vec<F> {
         const DEGREE: usize = 2;
 
         let ValFinalSumcheckProverState { inc, wa, .. } = self.prover_state.as_ref().unwrap();

--- a/jolt-core/src/jolt/vm/ram.rs
+++ b/jolt-core/src/jolt/vm/ram.rs
@@ -174,7 +174,7 @@ impl<F: JoltField, ProofTranscript: Transcript> BatchableSumcheckInstance<F, Pro
         self.claimed_evaluation - self.init_eval
     }
 
-    fn compute_prover_message(&mut self, _round: usize) -> Vec<F> {
+    fn compute_prover_message(&mut self, _round: usize, _previous_claim: F) -> Vec<F> {
         let prover_state = self
             .prover_state
             .as_ref()
@@ -326,7 +326,7 @@ impl<F: JoltField, ProofTranscript: Transcript> BatchableSumcheckInstance<F, Pro
         F::zero() // Always zero for booleanity
     }
 
-    fn compute_prover_message(&mut self, round: usize) -> Vec<F> {
+    fn compute_prover_message(&mut self, round: usize, _previous_claim: F) -> Vec<F> {
         let K_log = self.K.log_2();
 
         if round < K_log {
@@ -611,7 +611,7 @@ impl<F: JoltField, ProofTranscript: Transcript> BatchableSumcheckInstance<F, Pro
         self.input_claim
     }
 
-    fn compute_prover_message(&mut self, _round: usize) -> Vec<F> {
+    fn compute_prover_message(&mut self, _round: usize, _previous_claim: F) -> Vec<F> {
         let prover_state = self
             .prover_state
             .as_ref()
@@ -721,7 +721,7 @@ impl<F: JoltField, ProofTranscript: Transcript> BatchableSumcheckInstance<F, Pro
         self.input_claim
     }
 
-    fn compute_prover_message(&mut self, _round: usize) -> Vec<F> {
+    fn compute_prover_message(&mut self, _round: usize, _previous_claim: F) -> Vec<F> {
         let prover_state = self
             .prover_state
             .as_ref()

--- a/jolt-core/src/jolt/vm/ram_read_write_checking.rs
+++ b/jolt-core/src/jolt/vm/ram_read_write_checking.rs
@@ -452,7 +452,7 @@ impl<F: JoltField> RamReadWriteChecking<F> {
         }
     }
 
-    fn phase1_compute_prover_message(&mut self, round: usize) -> Vec<F> {
+    fn phase1_compute_prover_message(&mut self, round: usize, previous_claim: F) -> Vec<F> {
         const DEGREE: usize = 3;
         let ReadWriteCheckingProverState {
             trace,
@@ -467,11 +467,11 @@ impl<F: JoltField> RamReadWriteChecking<F> {
         } = self.prover_state.as_mut().unwrap();
 
         let univariate_poly_evals: [F; DEGREE] = if gruens_eq_r_prime.E_in_current_len() == 1 {
-            I.par_iter()
+            let quadratic_coeffs = I.par_iter()
                 .zip(data_buffers.par_iter_mut())
                 .zip(val_checkpoints.par_chunks(self.K))
                 .map(|((I_chunk, buffers), checkpoint)| {
-                    let mut evals = [F::zero(), F::zero(), F::zero()];
+                    let mut evals = [F::zero(), F::zero()];
 
                     let DataBuffers {
                         val_j_0,
@@ -538,30 +538,32 @@ impl<F: JoltField> RamReadWriteChecking<F> {
                                 val_j_0[col] += inc;
                             }
 
-                            let eq_r_prime_evals =
-                                eq_r_prime.sumcheck_evals(j_prime / 2, DEGREE, BindingOrder::LowToHigh);
-                            let inc_cycle_evals =
-                                inc_cycle.sumcheck_evals(j_prime / 2, DEGREE, BindingOrder::LowToHigh);
+                            let eq_r_prime_eval = gruens_eq_r_prime.E_out_current()[j_prime / 2];
+                            let inc_cycle_evals = {
+                                let inc_cycle_0 = inc_cycle.get_bound_coeff(j_prime);
+                                let inc_cycle_1 = inc_cycle.get_bound_coeff(j_prime + 1);
+                                let inc_cycle_infty = inc_cycle_1 - inc_cycle_0;
+                                [inc_cycle_0, inc_cycle_infty]
+                            };
 
-                            let mut inner_sum_evals = [F::zero(); DEGREE];
+                            let mut inner_sum_evals = [F::zero(); DEGREE - 1];
                             for k in dirty_indices.drain(..) {
                                 if !ra[0][k].is_zero() || !ra[1][k].is_zero() {
                                     // let kj = k * (T >> (round - 1)) + j_prime / 2;
-                                    let m_ra = ra[1][k] - ra[0][k];
-                                    let ra_eval_2 = ra[1][k] + m_ra;
-                                    let ra_eval_3 = ra_eval_2 + m_ra;
+                                    let ra_evals = [
+                                        ra[0][k],
+                                        ra[1][k] - ra[0][k],
+                                    ];
 
-                                    let m_val = val_j_r[1][k] - val_j_r[0][k];
-                                    let val_eval_2 = val_j_r[1][k] + m_val;
-                                    let val_eval_3 = val_eval_2 + m_val;
+                                    let val_evals = [
+                                        val_j_r[0][k],
+                                        val_j_r[1][k] - val_j_r[0][k],
+                                    ];
 
-                                    inner_sum_evals[0] += ra[0][k].mul_0_optimized(
-                                        val_j_r[0][k] + self.z * (inc_cycle_evals[0] + val_j_r[0][k]),
-                                    );
-                                    inner_sum_evals[1] += ra_eval_2
-                                        * (val_eval_2 + self.z * (inc_cycle_evals[1] + val_eval_2));
-                                    inner_sum_evals[2] += ra_eval_3
-                                        * (val_eval_3 + self.z * (inc_cycle_evals[2] + val_eval_3));
+                                    inner_sum_evals[0] += ra_evals[0]
+                                        .mul_0_optimized(val_evals[0] + self.z * (inc_cycle_evals[0] + val_evals[0]));
+                                    inner_sum_evals[1] += ra_evals[1]
+                                        * (val_evals[1] + self.z * (inc_cycle_evals[1] + val_evals[1]));
 
                                     ra[0][k] = F::zero();
                                     ra[1][k] = F::zero();
@@ -571,23 +573,62 @@ impl<F: JoltField> RamReadWriteChecking<F> {
                                 val_j_r[1][k] = F::zero();
                             }
 
-                            evals[0] += eq_r_prime_evals[0] * inner_sum_evals[0];
-                            evals[1] += eq_r_prime_evals[1] * inner_sum_evals[1];
-                            evals[2] += eq_r_prime_evals[2] * inner_sum_evals[2];
+                            evals[0] += eq_r_prime_eval * inner_sum_evals[0];
+                            evals[1] += eq_r_prime_eval * inner_sum_evals[1];
                         });
 
                     evals
                 })
                 .reduce(
-                    || [F::zero(); DEGREE],
+                    || [F::zero(); DEGREE - 1],
                     |running, new| {
                         [
                             running[0] + new[0],
                             running[1] + new[1],
-                            running[2] + new[2],
                         ]
                     },
-                )
+                );
+
+            // We want to compute the evaluations of the cubic polynomial s(X) = l(X) * q(X), where
+            // l is linear, and q is quadratic, at the points {0, 2, 3}.
+            //
+            // At this point, we have
+            // - the linear polynomial, l(X) = a + bX
+            // - the quadratic polynomial, q(X) = c + dX + eX^2
+            // - the previous round's claim s(0) + s(1) = a * c + (a + b) * (c + d + e)
+            //
+            // Both l and q are represented by their evaluations at 0 and infinity. I.e., we have a, b, c,
+            // and e, but not d. We compute s by first computing l and t at points 2 and 3.
+
+            // Evaluations of the linear polynomial linear polynomial
+            let eq_eval_1 = gruens_eq_r_prime.current_scalar
+                * gruens_eq_r_prime.w[gruens_eq_r_prime.current_index - 1];
+            let eq_eval_0 = gruens_eq_r_prime.current_scalar - eq_eval_1;
+            let eq_m = eq_eval_1 - eq_eval_0;
+            let eq_eval_2 = eq_eval_1 + eq_m;
+            let eq_eval_3 = eq_eval_2 + eq_m;
+
+            // Evaluations of the quadratic polynomial
+            let quadratic_eval_0 = quadratic_coeffs[0];
+            let cubic_eval_0 = eq_eval_0 * quadratic_eval_0;
+            let cubic_eval_1 = previous_claim - cubic_eval_0;
+            // q(1) = c + d + e
+            let quadratic_eval_1 = cubic_eval_1 / eq_eval_1;
+            // q(2) = c + 2d + 4e = q(1) + q(1) - q(0) + 2e
+            let e_times_2 = quadratic_coeffs[1] + quadratic_coeffs[1];
+            let quadratic_eval_2 = quadratic_eval_1
+                + quadratic_eval_1 - quadratic_eval_0
+                + e_times_2;
+            // q(3) = c + 3d + 9e = q(2) + q(1) - q(0) + 4e
+            let quadratic_eval_3 = quadratic_eval_2
+                + quadratic_eval_1 - quadratic_eval_0
+                + e_times_2 + e_times_2;
+
+            [
+                cubic_eval_0,
+                eq_eval_2 * quadratic_eval_2,
+                eq_eval_3 * quadratic_eval_3,
+            ]
         } else {
             I.par_iter()
                 .zip(data_buffers.par_iter_mut())
@@ -1129,10 +1170,10 @@ impl<F: JoltField, ProofTranscript: Transcript> BatchableSumcheckInstance<F, Pro
         self.rv_claim + self.z * self.wv_claim
     }
 
-    fn compute_prover_message(&mut self, round: usize) -> Vec<F> {
+    fn compute_prover_message(&mut self, round: usize, previous_claim: F) -> Vec<F> {
         let prover_state = self.prover_state.as_ref().unwrap();
         if round < prover_state.chunk_size.log_2() {
-            self.phase1_compute_prover_message(round)
+            self.phase1_compute_prover_message(round, previous_claim)
         } else if round < self.T.log_2() {
             self.phase2_compute_prover_message()
         } else {

--- a/jolt-core/src/jolt/vm/ram_read_write_checking.rs
+++ b/jolt-core/src/jolt/vm/ram_read_write_checking.rs
@@ -896,9 +896,9 @@ impl<F: JoltField> RamReadWriteChecking<F> {
         // - the previous round's claim s(0) + s(1) = a * c + (a + b) * (c + d + e)
         //
         // Both l and q are represented by their evaluations at 0 and infinity. I.e., we have a, b, c,
-        // and e, but not d. We compute s by first computing l and t at points 2 and 3.
+        // and e, but not d. We compute s by first computing l and q at points 2 and 3.
 
-        // Evaluations of the linear polynomial linear polynomial
+        // Evaluations of the linear polynomial
         let eq_eval_1 = gruens_eq_r_prime.current_scalar
             * gruens_eq_r_prime.w[gruens_eq_r_prime.current_index - 1];
         let eq_eval_0 = gruens_eq_r_prime.current_scalar - eq_eval_1;
@@ -1106,7 +1106,7 @@ impl<F: JoltField> RamReadWriteChecking<F> {
         drop(_inner_guard);
         drop(inner_span);
 
-        gruens_eq_r_prime.bind(r_j); // TODO(hamlinb) Could this be parallelized?
+        gruens_eq_r_prime.bind(r_j);
         eq_r_prime.bind_parallel(r_j, BindingOrder::LowToHigh);
         inc_cycle.bind_parallel(r_j, BindingOrder::LowToHigh);
 

--- a/jolt-core/src/jolt/vm/ram_read_write_checking.rs
+++ b/jolt-core/src/jolt/vm/ram_read_write_checking.rs
@@ -461,132 +461,384 @@ impl<F: JoltField> RamReadWriteChecking<F> {
             A,
             val_checkpoints,
             inc_cycle,
+            gruens_eq_r_prime,
             eq_r_prime,
             ..
         } = self.prover_state.as_mut().unwrap();
 
-        let univariate_poly_evals: [F; DEGREE] = I
-            .par_iter()
-            .zip(data_buffers.par_iter_mut())
-            .zip(val_checkpoints.par_chunks(self.K))
-            .map(|((I_chunk, buffers), checkpoint)| {
-                let mut evals = [F::zero(), F::zero(), F::zero()];
+        let univariate_poly_evals: [F; DEGREE] = if gruens_eq_r_prime.E_in_current_len() == 1 {
+            I.par_iter()
+                .zip(data_buffers.par_iter_mut())
+                .zip(val_checkpoints.par_chunks(self.K))
+                .map(|((I_chunk, buffers), checkpoint)| {
+                    let mut evals = [F::zero(), F::zero(), F::zero()];
 
-                let DataBuffers {
-                    val_j_0,
-                    val_j_r,
-                    ra,
-                    dirty_indices,
-                } = buffers;
-                *val_j_0 = checkpoint.to_vec();
+                    let DataBuffers {
+                        val_j_0,
+                        val_j_r,
+                        ra,
+                        dirty_indices,
+                    } = buffers;
+                    *val_j_0 = checkpoint.to_vec();
 
-                // Iterate over I_chunk, two rows at a time.
-                I_chunk
-                    .chunk_by(|a, b| a.0 / 2 == b.0 / 2)
-                    .for_each(|inc_chunk| {
-                        let j_prime = inc_chunk[0].0; // row index
+                    // Iterate over I_chunk, two rows at a time.
+                    I_chunk
+                        .chunk_by(|a, b| a.0 / 2 == b.0 / 2)
+                        .for_each(|inc_chunk| {
+                            let j_prime = inc_chunk[0].0; // row index
 
-                        for j in j_prime << round..(j_prime + 1) << round {
-                            let j_bound = j % (1 << round);
-                            let k = remap_address(
-                                trace[j].ram_access().address() as u64,
-                                &self.memory_layout,
-                            ) as usize;
-                            if ra[0][k].is_zero() {
-                                dirty_indices.push(k);
-                            }
-                            ra[0][k] += A[j_bound];
-                        }
-
-                        for j in (j_prime + 1) << round..(j_prime + 2) << round {
-                            let j_bound = j % (1 << round);
-                            let k = remap_address(
-                                trace[j].ram_access().address() as u64,
-                                &self.memory_layout,
-                            ) as usize;
-                            if ra[0][k].is_zero() && ra[1][k].is_zero() {
-                                dirty_indices.push(k);
-                            }
-                            ra[1][k] += A[j_bound];
-                        }
-
-                        for &k in dirty_indices.iter() {
-                            val_j_r[0][k] = val_j_0[k];
-                        }
-                        let mut inc_iter = inc_chunk.iter().peekable();
-
-                        // First of the two rows
-                        loop {
-                            let (row, col, inc_lt, inc) = inc_iter.next().unwrap();
-                            debug_assert_eq!(*row, j_prime);
-                            val_j_r[0][*col] += *inc_lt;
-                            val_j_0[*col] += *inc;
-                            if inc_iter.peek().unwrap().0 != j_prime {
-                                break;
-                            }
-                        }
-                        for &k in dirty_indices.iter() {
-                            val_j_r[1][k] = val_j_0[k];
-                        }
-
-                        // Second of the two rows
-                        for inc in inc_iter {
-                            let (row, col, inc_lt, inc) = *inc;
-                            debug_assert_eq!(row, j_prime + 1);
-                            val_j_r[1][col] += inc_lt;
-                            val_j_0[col] += inc;
-                        }
-
-                        let eq_r_prime_evals =
-                            eq_r_prime.sumcheck_evals(j_prime / 2, DEGREE, BindingOrder::LowToHigh);
-                        let inc_cycle_evals =
-                            inc_cycle.sumcheck_evals(j_prime / 2, DEGREE, BindingOrder::LowToHigh);
-
-                        let mut inner_sum_evals = [F::zero(); DEGREE];
-                        for k in dirty_indices.drain(..) {
-                            if !ra[0][k].is_zero() || !ra[1][k].is_zero() {
-                                // let kj = k * (T >> (round - 1)) + j_prime / 2;
-                                let m_ra = ra[1][k] - ra[0][k];
-                                let ra_eval_2 = ra[1][k] + m_ra;
-                                let ra_eval_3 = ra_eval_2 + m_ra;
-
-                                let m_val = val_j_r[1][k] - val_j_r[0][k];
-                                let val_eval_2 = val_j_r[1][k] + m_val;
-                                let val_eval_3 = val_eval_2 + m_val;
-
-                                inner_sum_evals[0] += ra[0][k].mul_0_optimized(
-                                    val_j_r[0][k] + self.z * (inc_cycle_evals[0] + val_j_r[0][k]),
-                                );
-                                inner_sum_evals[1] += ra_eval_2
-                                    * (val_eval_2 + self.z * (inc_cycle_evals[1] + val_eval_2));
-                                inner_sum_evals[2] += ra_eval_3
-                                    * (val_eval_3 + self.z * (inc_cycle_evals[2] + val_eval_3));
-
-                                ra[0][k] = F::zero();
-                                ra[1][k] = F::zero();
+                            for j in j_prime << round..(j_prime + 1) << round {
+                                let j_bound = j % (1 << round);
+                                let k = remap_address(
+                                    trace[j].ram_access().address() as u64,
+                                    &self.memory_layout,
+                                ) as usize;
+                                if ra[0][k].is_zero() {
+                                    dirty_indices.push(k);
+                                }
+                                ra[0][k] += A[j_bound];
                             }
 
-                            val_j_r[0][k] = F::zero();
-                            val_j_r[1][k] = F::zero();
-                        }
+                            for j in (j_prime + 1) << round..(j_prime + 2) << round {
+                                let j_bound = j % (1 << round);
+                                let k = remap_address(
+                                    trace[j].ram_access().address() as u64,
+                                    &self.memory_layout,
+                                ) as usize;
+                                if ra[0][k].is_zero() && ra[1][k].is_zero() {
+                                    dirty_indices.push(k);
+                                }
+                                ra[1][k] += A[j_bound];
+                            }
 
-                        evals[0] += eq_r_prime_evals[0] * inner_sum_evals[0];
-                        evals[1] += eq_r_prime_evals[1] * inner_sum_evals[1];
-                        evals[2] += eq_r_prime_evals[2] * inner_sum_evals[2];
-                    });
+                            for &k in dirty_indices.iter() {
+                                val_j_r[0][k] = val_j_0[k];
+                            }
+                            let mut inc_iter = inc_chunk.iter().peekable();
 
-                evals
-            })
-            .reduce(
-                || [F::zero(); DEGREE],
-                |running, new| {
-                    [
-                        running[0] + new[0],
-                        running[1] + new[1],
-                        running[2] + new[2],
-                    ]
-                },
-            );
+                            // First of the two rows
+                            loop {
+                                let (row, col, inc_lt, inc) = inc_iter.next().unwrap();
+                                debug_assert_eq!(*row, j_prime);
+                                val_j_r[0][*col] += *inc_lt;
+                                val_j_0[*col] += *inc;
+                                if inc_iter.peek().unwrap().0 != j_prime {
+                                    break;
+                                }
+                            }
+                            for &k in dirty_indices.iter() {
+                                val_j_r[1][k] = val_j_0[k];
+                            }
+
+                            // Second of the two rows
+                            for inc in inc_iter {
+                                let (row, col, inc_lt, inc) = *inc;
+                                debug_assert_eq!(row, j_prime + 1);
+                                val_j_r[1][col] += inc_lt;
+                                val_j_0[col] += inc;
+                            }
+
+                            let eq_r_prime_evals =
+                                eq_r_prime.sumcheck_evals(j_prime / 2, DEGREE, BindingOrder::LowToHigh);
+                            let inc_cycle_evals =
+                                inc_cycle.sumcheck_evals(j_prime / 2, DEGREE, BindingOrder::LowToHigh);
+
+                            let mut inner_sum_evals = [F::zero(); DEGREE];
+                            for k in dirty_indices.drain(..) {
+                                if !ra[0][k].is_zero() || !ra[1][k].is_zero() {
+                                    // let kj = k * (T >> (round - 1)) + j_prime / 2;
+                                    let m_ra = ra[1][k] - ra[0][k];
+                                    let ra_eval_2 = ra[1][k] + m_ra;
+                                    let ra_eval_3 = ra_eval_2 + m_ra;
+
+                                    let m_val = val_j_r[1][k] - val_j_r[0][k];
+                                    let val_eval_2 = val_j_r[1][k] + m_val;
+                                    let val_eval_3 = val_eval_2 + m_val;
+
+                                    inner_sum_evals[0] += ra[0][k].mul_0_optimized(
+                                        val_j_r[0][k] + self.z * (inc_cycle_evals[0] + val_j_r[0][k]),
+                                    );
+                                    inner_sum_evals[1] += ra_eval_2
+                                        * (val_eval_2 + self.z * (inc_cycle_evals[1] + val_eval_2));
+                                    inner_sum_evals[2] += ra_eval_3
+                                        * (val_eval_3 + self.z * (inc_cycle_evals[2] + val_eval_3));
+
+                                    ra[0][k] = F::zero();
+                                    ra[1][k] = F::zero();
+                                }
+
+                                val_j_r[0][k] = F::zero();
+                                val_j_r[1][k] = F::zero();
+                            }
+
+                            evals[0] += eq_r_prime_evals[0] * inner_sum_evals[0];
+                            evals[1] += eq_r_prime_evals[1] * inner_sum_evals[1];
+                            evals[2] += eq_r_prime_evals[2] * inner_sum_evals[2];
+                        });
+
+                    evals
+                })
+                .reduce(
+                    || [F::zero(); DEGREE],
+                    |running, new| {
+                        [
+                            running[0] + new[0],
+                            running[1] + new[1],
+                            running[2] + new[2],
+                        ]
+                    },
+                )
+        } else {
+            I.par_iter()
+                .zip(data_buffers.par_iter_mut())
+                .zip(val_checkpoints.par_chunks(self.K))
+                .map(|((I_chunk, buffers), checkpoint)| {
+                    let mut evals = [F::zero(), F::zero(), F::zero()];
+
+                    let DataBuffers {
+                        val_j_0,
+                        val_j_r,
+                        ra,
+                        dirty_indices,
+                    } = buffers;
+                    *val_j_0 = checkpoint.to_vec();
+
+                    // Iterate over I_chunk, two rows at a time.
+                    I_chunk
+                        .chunk_by(|a, b| a.0 / 2 == b.0 / 2)
+                        .for_each(|inc_chunk| {
+                            let j_prime = inc_chunk[0].0; // row index
+
+                            for j in j_prime << round..(j_prime + 1) << round {
+                                let j_bound = j % (1 << round);
+                                let k = remap_address(
+                                    trace[j].ram_access().address() as u64,
+                                    &self.memory_layout,
+                                ) as usize;
+                                if ra[0][k].is_zero() {
+                                    dirty_indices.push(k);
+                                }
+                                ra[0][k] += A[j_bound];
+                            }
+
+                            for j in (j_prime + 1) << round..(j_prime + 2) << round {
+                                let j_bound = j % (1 << round);
+                                let k = remap_address(
+                                    trace[j].ram_access().address() as u64,
+                                    &self.memory_layout,
+                                ) as usize;
+                                if ra[0][k].is_zero() && ra[1][k].is_zero() {
+                                    dirty_indices.push(k);
+                                }
+                                ra[1][k] += A[j_bound];
+                            }
+
+                            for &k in dirty_indices.iter() {
+                                val_j_r[0][k] = val_j_0[k];
+                            }
+                            let mut inc_iter = inc_chunk.iter().peekable();
+
+                            // First of the two rows
+                            loop {
+                                let (row, col, inc_lt, inc) = inc_iter.next().unwrap();
+                                debug_assert_eq!(*row, j_prime);
+                                val_j_r[0][*col] += *inc_lt;
+                                val_j_0[*col] += *inc;
+                                if inc_iter.peek().unwrap().0 != j_prime {
+                                    break;
+                                }
+                            }
+                            for &k in dirty_indices.iter() {
+                                val_j_r[1][k] = val_j_0[k];
+                            }
+
+                            // Second of the two rows
+                            for inc in inc_iter {
+                                let (row, col, inc_lt, inc) = *inc;
+                                debug_assert_eq!(row, j_prime + 1);
+                                val_j_r[1][col] += inc_lt;
+                                val_j_0[col] += inc;
+                            }
+
+                            let eq_r_prime_evals =
+                                eq_r_prime.sumcheck_evals(j_prime / 2, DEGREE, BindingOrder::LowToHigh);
+                            let inc_cycle_evals =
+                                inc_cycle.sumcheck_evals(j_prime / 2, DEGREE, BindingOrder::LowToHigh);
+
+                            let mut inner_sum_evals = [F::zero(); DEGREE];
+                            for k in dirty_indices.drain(..) {
+                                if !ra[0][k].is_zero() || !ra[1][k].is_zero() {
+                                    // let kj = k * (T >> (round - 1)) + j_prime / 2;
+                                    let m_ra = ra[1][k] - ra[0][k];
+                                    let ra_eval_2 = ra[1][k] + m_ra;
+                                    let ra_eval_3 = ra_eval_2 + m_ra;
+
+                                    let m_val = val_j_r[1][k] - val_j_r[0][k];
+                                    let val_eval_2 = val_j_r[1][k] + m_val;
+                                    let val_eval_3 = val_eval_2 + m_val;
+
+                                    inner_sum_evals[0] += ra[0][k].mul_0_optimized(
+                                        val_j_r[0][k] + self.z * (inc_cycle_evals[0] + val_j_r[0][k]),
+                                    );
+                                    inner_sum_evals[1] += ra_eval_2
+                                        * (val_eval_2 + self.z * (inc_cycle_evals[1] + val_eval_2));
+                                    inner_sum_evals[2] += ra_eval_3
+                                        * (val_eval_3 + self.z * (inc_cycle_evals[2] + val_eval_3));
+
+                                    ra[0][k] = F::zero();
+                                    ra[1][k] = F::zero();
+                                }
+
+                                val_j_r[0][k] = F::zero();
+                                val_j_r[1][k] = F::zero();
+                            }
+
+                            evals[0] += eq_r_prime_evals[0] * inner_sum_evals[0];
+                            evals[1] += eq_r_prime_evals[1] * inner_sum_evals[1];
+                            evals[2] += eq_r_prime_evals[2] * inner_sum_evals[2];
+                        });
+
+                    evals
+                })
+                .reduce(
+                    || [F::zero(); DEGREE],
+                    |running, new| {
+                        [
+                            running[0] + new[0],
+                            running[1] + new[1],
+                            running[2] + new[2],
+                        ]
+                    },
+                )
+        };
+
+        #[cfg(test)]
+        {
+            let test_univariate_poly_evals: [F; DEGREE] = I
+                .par_iter()
+                .zip(data_buffers.par_iter_mut())
+                .zip(val_checkpoints.par_chunks(self.K))
+                .map(|((I_chunk, buffers), checkpoint)| {
+                    let mut evals = [F::zero(), F::zero(), F::zero()];
+
+                    let DataBuffers {
+                        val_j_0,
+                        val_j_r,
+                        ra,
+                        dirty_indices,
+                    } = buffers;
+                    *val_j_0 = checkpoint.to_vec();
+
+                    // Iterate over I_chunk, two rows at a time.
+                    I_chunk
+                        .chunk_by(|a, b| a.0 / 2 == b.0 / 2)
+                        .for_each(|inc_chunk| {
+                            let j_prime = inc_chunk[0].0; // row index
+
+                            for j in j_prime << round..(j_prime + 1) << round {
+                                let j_bound = j % (1 << round);
+                                let k = remap_address(
+                                    trace[j].ram_access().address() as u64,
+                                    &self.memory_layout,
+                                ) as usize;
+                                if ra[0][k].is_zero() {
+                                    dirty_indices.push(k);
+                                }
+                                ra[0][k] += A[j_bound];
+                            }
+
+                            for j in (j_prime + 1) << round..(j_prime + 2) << round {
+                                let j_bound = j % (1 << round);
+                                let k = remap_address(
+                                    trace[j].ram_access().address() as u64,
+                                    &self.memory_layout,
+                                ) as usize;
+                                if ra[0][k].is_zero() && ra[1][k].is_zero() {
+                                    dirty_indices.push(k);
+                                }
+                                ra[1][k] += A[j_bound];
+                            }
+
+                            for &k in dirty_indices.iter() {
+                                val_j_r[0][k] = val_j_0[k];
+                            }
+                            let mut inc_iter = inc_chunk.iter().peekable();
+
+                            // First of the two rows
+                            loop {
+                                let (row, col, inc_lt, inc) = inc_iter.next().unwrap();
+                                debug_assert_eq!(*row, j_prime);
+                                val_j_r[0][*col] += *inc_lt;
+                                val_j_0[*col] += *inc;
+                                if inc_iter.peek().unwrap().0 != j_prime {
+                                    break;
+                                }
+                            }
+                            for &k in dirty_indices.iter() {
+                                val_j_r[1][k] = val_j_0[k];
+                            }
+
+                            // Second of the two rows
+                            for inc in inc_iter {
+                                let (row, col, inc_lt, inc) = *inc;
+                                debug_assert_eq!(row, j_prime + 1);
+                                val_j_r[1][col] += inc_lt;
+                                val_j_0[col] += inc;
+                            }
+
+                            let eq_r_prime_evals =
+                                eq_r_prime.sumcheck_evals(j_prime / 2, DEGREE, BindingOrder::LowToHigh);
+                            let inc_cycle_evals =
+                                inc_cycle.sumcheck_evals(j_prime / 2, DEGREE, BindingOrder::LowToHigh);
+
+                            let mut inner_sum_evals = [F::zero(); DEGREE];
+                            for k in dirty_indices.drain(..) {
+                                if !ra[0][k].is_zero() || !ra[1][k].is_zero() {
+                                    // let kj = k * (T >> (round - 1)) + j_prime / 2;
+                                    let m_ra = ra[1][k] - ra[0][k];
+                                    let ra_eval_2 = ra[1][k] + m_ra;
+                                    let ra_eval_3 = ra_eval_2 + m_ra;
+
+                                    let m_val = val_j_r[1][k] - val_j_r[0][k];
+                                    let val_eval_2 = val_j_r[1][k] + m_val;
+                                    let val_eval_3 = val_eval_2 + m_val;
+
+                                    inner_sum_evals[0] += ra[0][k].mul_0_optimized(
+                                        val_j_r[0][k] + self.z * (inc_cycle_evals[0] + val_j_r[0][k]),
+                                    );
+                                    inner_sum_evals[1] += ra_eval_2
+                                        * (val_eval_2 + self.z * (inc_cycle_evals[1] + val_eval_2));
+                                    inner_sum_evals[2] += ra_eval_3
+                                        * (val_eval_3 + self.z * (inc_cycle_evals[2] + val_eval_3));
+
+                                    ra[0][k] = F::zero();
+                                    ra[1][k] = F::zero();
+                                }
+
+                                val_j_r[0][k] = F::zero();
+                                val_j_r[1][k] = F::zero();
+                            }
+
+                            evals[0] += eq_r_prime_evals[0] * inner_sum_evals[0];
+                            evals[1] += eq_r_prime_evals[1] * inner_sum_evals[1];
+                            evals[2] += eq_r_prime_evals[2] * inner_sum_evals[2];
+                        });
+
+                    evals
+                })
+                .reduce(
+                    || [F::zero(); DEGREE],
+                    |running, new| {
+                        [
+                            running[0] + new[0],
+                            running[1] + new[1],
+                            running[2] + new[2],
+                        ]
+                    },
+                );
+
+            assert_eq!(univariate_poly_evals, test_univariate_poly_evals);
+        }
 
         univariate_poly_evals.into()
     }

--- a/jolt-core/src/jolt/vm/ram_read_write_checking.rs
+++ b/jolt-core/src/jolt/vm/ram_read_write_checking.rs
@@ -732,6 +732,9 @@ impl<F: JoltField> RamReadWriteChecking<F> {
                 .map(|((I_chunk, buffers), checkpoint)| {
                     let mut evals = [F::zero(), F::zero()];
 
+                    let mut evals_for_current_E_out = [F::zero(), F::zero()];
+                    let mut x_out_prev: Option<usize> = None;
+
                     let DataBuffers {
                         val_j_0,
                         val_j_r,
@@ -800,7 +803,6 @@ impl<F: JoltField> RamReadWriteChecking<F> {
                             let x_in = (j_prime / 2) & x_bitmask;
                             let x_out = (j_prime / 2) >> num_x_in_bits;
                             let E_in_eval = gruens_eq_r_prime.E_in_current()[x_in];
-                            let E_out_eval = gruens_eq_r_prime.E_out_current()[x_out];
 
                             let inc_cycle_evals = {
                                 let inc_cycle_0 = inc_cycle.get_bound_coeff(j_prime);
@@ -808,6 +810,22 @@ impl<F: JoltField> RamReadWriteChecking<F> {
                                 let inc_cycle_infty = inc_cycle_1 - inc_cycle_0;
                                 [inc_cycle_0, inc_cycle_infty]
                             };
+
+                            match x_out_prev {
+                                None => {
+                                    x_out_prev = Some(x_out);
+                                }
+                                Some(x) if x_out != x => {
+                                    x_out_prev = Some(x_out);
+
+                                    let E_out_eval = gruens_eq_r_prime.E_out_current()[x];
+                                    evals[0] += E_out_eval * evals_for_current_E_out[0];
+                                    evals[1] += E_out_eval * evals_for_current_E_out[1];
+
+                                    evals_for_current_E_out = [F::zero(), F::zero()];
+                                }
+                                _ => (),
+                            }
 
                             let mut inner_sum_evals = [F::zero(); DEGREE - 1];
                             for k in dirty_indices.drain(..) {
@@ -832,11 +850,15 @@ impl<F: JoltField> RamReadWriteChecking<F> {
                                 val_j_r[1][k] = F::zero();
                             }
 
-                            // TODO(hamlinb) Factor out multiplication by E_out_eval
-                            evals[0] += E_out_eval * E_in_eval * inner_sum_evals[0];
-                            evals[1] += E_out_eval * E_in_eval * inner_sum_evals[1];
+                            evals_for_current_E_out[0] += E_in_eval * inner_sum_evals[0];
+                            evals_for_current_E_out[1] += E_in_eval * inner_sum_evals[1];
                         });
 
+                    if let Some(x) = x_out_prev {
+                        let E_out_eval = gruens_eq_r_prime.E_out_current()[x];
+                        evals[0] += E_out_eval * evals_for_current_E_out[0];
+                        evals[1] += E_out_eval * evals_for_current_E_out[1];
+                    }
                     evals
                 })
                 .reduce(

--- a/jolt-core/src/jolt/vm/registers.rs
+++ b/jolt-core/src/jolt/vm/registers.rs
@@ -109,7 +109,7 @@ impl<F: JoltField, ProofTranscript: Transcript> BatchableSumcheckInstance<F, Pro
         self.claimed_evaluation
     }
 
-    fn compute_prover_message(&mut self, _round: usize) -> Vec<F> {
+    fn compute_prover_message(&mut self, _round: usize, _previous_claim: F) -> Vec<F> {
         let prover_state = self
             .prover_state
             .as_ref()

--- a/jolt-core/src/jolt/vm/registers_read_write_checking.rs
+++ b/jolt-core/src/jolt/vm/registers_read_write_checking.rs
@@ -929,7 +929,7 @@ impl<F: JoltField, ProofTranscript: Transcript> BatchableSumcheckInstance<F, Pro
         self.rd_wv_claim + self.z * self.rs1_rv_claim + self.z_squared * self.rs2_rv_claim
     }
 
-    fn compute_prover_message(&mut self, round: usize) -> Vec<F> {
+    fn compute_prover_message(&mut self, round: usize, _previous_claim: F) -> Vec<F> {
         let prover_state = self.prover_state.as_ref().unwrap();
         if round < prover_state.chunk_size.log_2() {
             self.phase1_compute_prover_message(round)

--- a/jolt-core/src/jolt/vm/registers_read_write_checking.rs
+++ b/jolt-core/src/jolt/vm/registers_read_write_checking.rs
@@ -591,7 +591,18 @@ impl<F: JoltField> RegistersReadWriteChecking<F> {
             ..
         } = self.prover_state.as_mut().unwrap();
 
+        // We use both Dao-Thaler and Gruen's optimizations here. See "Our optimization on top of
+        // Gruen's" from Sec. 3 of https://eprint.iacr.org/2024/1210.pdf.
+        //
+        // We compute the evaluations of the cubic polynomial s(X) = l(X) * q(X) at {0, 2, 3} by
+        // first computing the evaluations of the quadratic polynomial q(X) at 0 and infinity.
+        // Moreover, we split the evaluations of the eq polynomial into two groups, E_in and E_out.
+        // We use the GruenSplitEqPolynomial data structure to do this.
+        //
+        // Since E_in is bound first, we have two cases to handle: one where E_in is fully bound
+        // and one where it is not.
         let quadratic_coeffs: [F; DEGREE - 1] = if gruens_eq_r_prime.E_in_current_len() == 1 {
+            // Here E_in is fully bound, so we can ignore it and use the evaluations from E_out.
             I.par_iter()
                 .zip(data_buffers.par_iter_mut())
                 .zip(val_checkpoints.par_chunks(K))
@@ -768,6 +779,11 @@ impl<F: JoltField> RegistersReadWriteChecking<F> {
                     |running, new| [running[0] + new[0], running[1] + new[1]],
                 )
         } else {
+            // Here E_in is not fully bound, so our eq evaluation is E_in_eval * E_out_eval.
+            // However, we can factor out the multiplications by E_out_eval to decrease the total
+            // number of multiplications. Therefore, we keep a running sum evaluations multiplied
+            // by E_in_eval values and only multiply them by E_out_eval when the value of the
+            // latter changes.
             let num_x_in_bits = gruens_eq_r_prime.E_in_current_len().log_2();
             let x_bitmask = (1 << num_x_in_bits) - 1;
 
@@ -879,6 +895,8 @@ impl<F: JoltField> RegistersReadWriteChecking<F> {
                                 [inc_cycle_0, inc_cycle_infty]
                             };
 
+                            // Multiply the running sum by the previous value of E_out_eval when
+                            // its value changes and add the result to the total.
                             match x_out_prev {
                                 None => {
                                     x_out_prev = Some(x_out);
@@ -960,6 +978,8 @@ impl<F: JoltField> RegistersReadWriteChecking<F> {
                             evals_for_current_E_out[1] += E_in_eval * inner_sum_evals[1];
                         });
 
+                    // Multiply the final running sum by the final value of E_out_eval and add the
+                    // result to the total.
                     if let Some(x) = x_out_prev {
                         let E_out_eval = gruens_eq_r_prime.E_out_current()[x];
                         evals[0] += E_out_eval * evals_for_current_E_out[0];

--- a/jolt-core/src/jolt/vm/registers_read_write_checking.rs
+++ b/jolt-core/src/jolt/vm/registers_read_write_checking.rs
@@ -583,202 +583,397 @@ impl<F: JoltField> RegistersReadWriteChecking<F> {
             val_checkpoints,
             inc_cycle,
             eq_r_prime,
+            gruens_eq_r_prime,
             ..
         } = self.prover_state.as_mut().unwrap();
 
-        let cubic_evals: [F; DEGREE] = I
-            .par_iter()
-            .zip(data_buffers.par_iter_mut())
-            .zip(val_checkpoints.par_chunks(K))
-            .map(|((I_chunk, buffers), checkpoint)| {
-                let mut evals = [F::zero(), F::zero(), F::zero()];
+        let cubic_evals: [F; DEGREE] = if gruens_eq_r_prime.E_in_current_len() == 1 {
+            I.par_iter()
+                .zip(data_buffers.par_iter_mut())
+                .zip(val_checkpoints.par_chunks(K))
+                .map(|((I_chunk, buffers), checkpoint)| {
+                    let mut evals = [F::zero(), F::zero(), F::zero()];
 
-                let DataBuffers {
-                    val_j_0,
-                    val_j_r,
-                    rs1_ra,
-                    rs2_ra,
-                    rd_wa,
-                    dirty_indices,
-                } = buffers;
+                    let DataBuffers {
+                        val_j_0,
+                        val_j_r,
+                        rs1_ra,
+                        rs2_ra,
+                        rd_wa,
+                        dirty_indices,
+                    } = buffers;
 
-                val_j_0.as_mut_slice().copy_from_slice(checkpoint);
+                    val_j_0.as_mut_slice().copy_from_slice(checkpoint);
 
-                // Iterate over I_chunk, two rows at a time.
-                I_chunk
-                    .chunk_by(|a, b| a.0 / 2 == b.0 / 2)
-                    .for_each(|inc_chunk| {
-                        let j_prime = inc_chunk[0].0; // row index
+                    // Iterate over I_chunk, two rows at a time.
+                    I_chunk
+                        .chunk_by(|a, b| a.0 / 2 == b.0 / 2)
+                        .for_each(|inc_chunk| {
+                            let j_prime = inc_chunk[0].0; // row index
 
-                        for j in j_prime << round..(j_prime + 1) << round {
-                            let j_bound = j % (1 << round);
+                            for j in j_prime << round..(j_prime + 1) << round {
+                                let j_bound = j % (1 << round);
 
-                            let k = trace[j].rs1_read().0;
-                            unsafe {
-                                dirty_indices.insert_unchecked(k);
-                            }
-                            rs1_ra[0][k] += A[j_bound];
+                                let k = trace[j].rs1_read().0;
+                                unsafe {
+                                    dirty_indices.insert_unchecked(k);
+                                }
+                                rs1_ra[0][k] += A[j_bound];
 
-                            let k = trace[j].rs2_read().0;
-                            unsafe {
-                                dirty_indices.insert_unchecked(k);
-                            }
-                            rs2_ra[0][k] += A[j_bound];
+                                let k = trace[j].rs2_read().0;
+                                unsafe {
+                                    dirty_indices.insert_unchecked(k);
+                                }
+                                rs2_ra[0][k] += A[j_bound];
 
-                            let k = trace[j].rd_write().0;
-                            unsafe {
-                                dirty_indices.insert_unchecked(k);
-                            }
-                            rd_wa[0][k] += A[j_bound];
-                        }
-
-                        for j in (j_prime + 1) << round..(j_prime + 2) << round {
-                            let j_bound = j % (1 << round);
-
-                            let k = trace[j].rs1_read().0;
-                            unsafe {
-                                dirty_indices.insert_unchecked(k);
-                            }
-                            rs1_ra[1][k] += A[j_bound];
-
-                            let k = trace[j].rs2_read().0;
-                            unsafe {
-                                dirty_indices.insert_unchecked(k);
-                            }
-                            rs2_ra[1][k] += A[j_bound];
-
-                            let k = trace[j].rd_write().0;
-                            unsafe {
-                                dirty_indices.insert_unchecked(k);
-                            }
-                            rd_wa[1][k] += A[j_bound];
-                        }
-
-                        for k in dirty_indices.ones() {
-                            val_j_r[0][k] = val_j_0[k];
-                        }
-                        let mut inc_iter = inc_chunk.iter().peekable();
-
-                        // First of the two rows
-                        loop {
-                            let (row, col, inc_lt, inc) = inc_iter.next().unwrap();
-                            debug_assert_eq!(*row, j_prime);
-                            val_j_r[0][*col] += *inc_lt;
-                            val_j_0[*col] += *inc;
-                            if inc_iter.peek().unwrap().0 != j_prime {
-                                break;
-                            }
-                        }
-                        for k in dirty_indices.ones() {
-                            val_j_r[1][k] = val_j_0[k];
-                        }
-
-                        // Second of the two rows
-                        for inc in inc_iter {
-                            let (row, col, inc_lt, inc) = *inc;
-                            debug_assert_eq!(row, j_prime + 1);
-                            val_j_r[1][col] += inc_lt;
-                            val_j_0[col] += inc;
-                        }
-
-                        let eq_r_prime_evals =
-                            eq_r_prime.sumcheck_evals(j_prime / 2, DEGREE, BindingOrder::LowToHigh);
-                        let inc_cycle_evals =
-                            inc_cycle.sumcheck_evals(j_prime / 2, DEGREE, BindingOrder::LowToHigh);
-
-                        let mut inner_sum_evals = [F::zero(); 3];
-                        for k in dirty_indices.ones() {
-                            let mut m_val: Option<F> = None;
-                            let mut val_eval_2: Option<F> = None;
-                            let mut val_eval_3: Option<F> = None;
-
-                            // rs1 read-checking sumcheck
-                            if !rs1_ra[0][k].is_zero() || !rs1_ra[1][k].is_zero() {
-                                // Preemptively multiply by `z` to save a mult
-                                let ra_eval_0 = self.z * rs1_ra[0][k];
-                                let ra_eval_1 = self.z * rs1_ra[1][k];
-                                let m_ra = ra_eval_1 - ra_eval_0;
-                                let ra_eval_2 = ra_eval_1 + m_ra;
-                                let ra_eval_3 = ra_eval_2 + m_ra;
-
-                                m_val = Some(val_j_r[1][k] - val_j_r[0][k]);
-                                val_eval_2 = Some(val_j_r[1][k] + m_val.unwrap());
-                                val_eval_3 = Some(val_eval_2.unwrap() + m_val.unwrap());
-
-                                inner_sum_evals[0] += ra_eval_0.mul_0_optimized(val_j_r[0][k]);
-                                inner_sum_evals[1] += ra_eval_2 * val_eval_2.unwrap();
-                                inner_sum_evals[2] += ra_eval_3 * val_eval_3.unwrap();
-
-                                rs1_ra[0][k] = F::zero();
-                                rs1_ra[1][k] = F::zero();
+                                let k = trace[j].rd_write().0;
+                                unsafe {
+                                    dirty_indices.insert_unchecked(k);
+                                }
+                                rd_wa[0][k] += A[j_bound];
                             }
 
-                            // rs2 read-checking sumcheck
-                            if !rs2_ra[0][k].is_zero() || !rs2_ra[1][k].is_zero() {
-                                // Preemptively multiply by `z_squared` to save a mult
-                                let ra_eval_0 = self.z_squared * rs2_ra[0][k];
-                                let ra_eval_1 = self.z_squared * rs2_ra[1][k];
-                                let m_ra = ra_eval_1 - ra_eval_0;
-                                let ra_eval_2 = ra_eval_1 + m_ra;
-                                let ra_eval_3 = ra_eval_2 + m_ra;
+                            for j in (j_prime + 1) << round..(j_prime + 2) << round {
+                                let j_bound = j % (1 << round);
 
-                                m_val = m_val.or(Some(val_j_r[1][k] - val_j_r[0][k]));
-                                val_eval_2 = val_eval_2.or(Some(val_j_r[1][k] + m_val.unwrap()));
-                                val_eval_3 =
-                                    val_eval_3.or(Some(val_eval_2.unwrap() + m_val.unwrap()));
+                                let k = trace[j].rs1_read().0;
+                                unsafe {
+                                    dirty_indices.insert_unchecked(k);
+                                }
+                                rs1_ra[1][k] += A[j_bound];
 
-                                inner_sum_evals[0] += ra_eval_0.mul_0_optimized(val_j_r[0][k]);
-                                inner_sum_evals[1] += ra_eval_2 * val_eval_2.unwrap();
-                                inner_sum_evals[2] += ra_eval_3 * val_eval_3.unwrap();
+                                let k = trace[j].rs2_read().0;
+                                unsafe {
+                                    dirty_indices.insert_unchecked(k);
+                                }
+                                rs2_ra[1][k] += A[j_bound];
 
-                                rs2_ra[0][k] = F::zero();
-                                rs2_ra[1][k] = F::zero();
+                                let k = trace[j].rd_write().0;
+                                unsafe {
+                                    dirty_indices.insert_unchecked(k);
+                                }
+                                rd_wa[1][k] += A[j_bound];
                             }
 
-                            // Write-checking sumcheck
-                            if !rd_wa[0][k].is_zero() || !rd_wa[1][k].is_zero() {
-                                let wa_eval_0 = rd_wa[0][k];
-                                let wa_eval_1 = rd_wa[1][k];
-                                let m_wa = wa_eval_1 - wa_eval_0;
-                                let wa_eval_2 = wa_eval_1 + m_wa;
-                                let wa_eval_3 = wa_eval_2 + m_wa;
+                            for k in dirty_indices.ones() {
+                                val_j_r[0][k] = val_j_0[k];
+                            }
+                            let mut inc_iter = inc_chunk.iter().peekable();
 
-                                // TODO: can move val evals outside if statements.
-                                let m_val = m_val.unwrap_or(val_j_r[1][k] - val_j_r[0][k]);
-                                let val_eval_2 = val_eval_2.unwrap_or(val_j_r[1][k] + m_val);
-                                let val_eval_3 = val_eval_3.unwrap_or(val_eval_2 + m_val);
-
-                                inner_sum_evals[0] +=
-                                    wa_eval_0.mul_0_optimized(inc_cycle_evals[0] + val_j_r[0][k]);
-                                inner_sum_evals[1] += wa_eval_2 * (inc_cycle_evals[1] + val_eval_2);
-                                inner_sum_evals[2] += wa_eval_3 * (inc_cycle_evals[2] + val_eval_3);
-
-                                rd_wa[0][k] = F::zero();
-                                rd_wa[1][k] = F::zero();
+                            // First of the two rows
+                            loop {
+                                let (row, col, inc_lt, inc) = inc_iter.next().unwrap();
+                                debug_assert_eq!(*row, j_prime);
+                                val_j_r[0][*col] += *inc_lt;
+                                val_j_0[*col] += *inc;
+                                if inc_iter.peek().unwrap().0 != j_prime {
+                                    break;
+                                }
+                            }
+                            for k in dirty_indices.ones() {
+                                val_j_r[1][k] = val_j_0[k];
                             }
 
-                            val_j_r[0][k] = F::zero();
-                            val_j_r[1][k] = F::zero();
-                        }
-                        dirty_indices.clear();
+                            // Second of the two rows
+                            for inc in inc_iter {
+                                let (row, col, inc_lt, inc) = *inc;
+                                debug_assert_eq!(row, j_prime + 1);
+                                val_j_r[1][col] += inc_lt;
+                                val_j_0[col] += inc;
+                            }
 
-                        evals[0] += eq_r_prime_evals[0] * inner_sum_evals[0];
-                        evals[1] += eq_r_prime_evals[1] * inner_sum_evals[1];
-                        evals[2] += eq_r_prime_evals[2] * inner_sum_evals[2];
-                    });
+                            let eq_r_prime_evals =
+                                eq_r_prime.sumcheck_evals(j_prime / 2, DEGREE, BindingOrder::LowToHigh);
+                            let inc_cycle_evals =
+                                inc_cycle.sumcheck_evals(j_prime / 2, DEGREE, BindingOrder::LowToHigh);
 
-                evals
-            })
-            .reduce(
-                || [F::zero(); DEGREE],
-                |running, new| {
-                    [
-                        running[0] + new[0],
-                        running[1] + new[1],
-                        running[2] + new[2],
-                    ]
-                },
-            );
+                            let mut inner_sum_evals = [F::zero(); 3];
+                            for k in dirty_indices.ones() {
+                                let mut m_val: Option<F> = None;
+                                let mut val_eval_2: Option<F> = None;
+                                let mut val_eval_3: Option<F> = None;
+
+                                // rs1 read-checking sumcheck
+                                if !rs1_ra[0][k].is_zero() || !rs1_ra[1][k].is_zero() {
+                                    // Preemptively multiply by `z` to save a mult
+                                    let ra_eval_0 = self.z * rs1_ra[0][k];
+                                    let ra_eval_1 = self.z * rs1_ra[1][k];
+                                    let m_ra = ra_eval_1 - ra_eval_0;
+                                    let ra_eval_2 = ra_eval_1 + m_ra;
+                                    let ra_eval_3 = ra_eval_2 + m_ra;
+
+                                    m_val = Some(val_j_r[1][k] - val_j_r[0][k]);
+                                    val_eval_2 = Some(val_j_r[1][k] + m_val.unwrap());
+                                    val_eval_3 = Some(val_eval_2.unwrap() + m_val.unwrap());
+
+                                    inner_sum_evals[0] += ra_eval_0.mul_0_optimized(val_j_r[0][k]);
+                                    inner_sum_evals[1] += ra_eval_2 * val_eval_2.unwrap();
+                                    inner_sum_evals[2] += ra_eval_3 * val_eval_3.unwrap();
+
+                                    rs1_ra[0][k] = F::zero();
+                                    rs1_ra[1][k] = F::zero();
+                                }
+
+                                // rs2 read-checking sumcheck
+                                if !rs2_ra[0][k].is_zero() || !rs2_ra[1][k].is_zero() {
+                                    // Preemptively multiply by `z_squared` to save a mult
+                                    let ra_eval_0 = self.z_squared * rs2_ra[0][k];
+                                    let ra_eval_1 = self.z_squared * rs2_ra[1][k];
+                                    let m_ra = ra_eval_1 - ra_eval_0;
+                                    let ra_eval_2 = ra_eval_1 + m_ra;
+                                    let ra_eval_3 = ra_eval_2 + m_ra;
+
+                                    m_val = m_val.or(Some(val_j_r[1][k] - val_j_r[0][k]));
+                                    val_eval_2 = val_eval_2.or(Some(val_j_r[1][k] + m_val.unwrap()));
+                                    val_eval_3 =
+                                        val_eval_3.or(Some(val_eval_2.unwrap() + m_val.unwrap()));
+
+                                    inner_sum_evals[0] += ra_eval_0.mul_0_optimized(val_j_r[0][k]);
+                                    inner_sum_evals[1] += ra_eval_2 * val_eval_2.unwrap();
+                                    inner_sum_evals[2] += ra_eval_3 * val_eval_3.unwrap();
+
+                                    rs2_ra[0][k] = F::zero();
+                                    rs2_ra[1][k] = F::zero();
+                                }
+
+                                // Write-checking sumcheck
+                                if !rd_wa[0][k].is_zero() || !rd_wa[1][k].is_zero() {
+                                    let wa_eval_0 = rd_wa[0][k];
+                                    let wa_eval_1 = rd_wa[1][k];
+                                    let m_wa = wa_eval_1 - wa_eval_0;
+                                    let wa_eval_2 = wa_eval_1 + m_wa;
+                                    let wa_eval_3 = wa_eval_2 + m_wa;
+
+                                    // TODO: can move val evals outside if statements.
+                                    let m_val = m_val.unwrap_or(val_j_r[1][k] - val_j_r[0][k]);
+                                    let val_eval_2 = val_eval_2.unwrap_or(val_j_r[1][k] + m_val);
+                                    let val_eval_3 = val_eval_3.unwrap_or(val_eval_2 + m_val);
+
+                                    inner_sum_evals[0] +=
+                                        wa_eval_0.mul_0_optimized(inc_cycle_evals[0] + val_j_r[0][k]);
+                                    inner_sum_evals[1] += wa_eval_2 * (inc_cycle_evals[1] + val_eval_2);
+                                    inner_sum_evals[2] += wa_eval_3 * (inc_cycle_evals[2] + val_eval_3);
+
+                                    rd_wa[0][k] = F::zero();
+                                    rd_wa[1][k] = F::zero();
+                                }
+
+                                val_j_r[0][k] = F::zero();
+                                val_j_r[1][k] = F::zero();
+                            }
+                            dirty_indices.clear();
+
+                            evals[0] += eq_r_prime_evals[0] * inner_sum_evals[0];
+                            evals[1] += eq_r_prime_evals[1] * inner_sum_evals[1];
+                            evals[2] += eq_r_prime_evals[2] * inner_sum_evals[2];
+                        });
+
+                    evals
+                })
+                .reduce(
+                    || [F::zero(); DEGREE],
+                    |running, new| {
+                        [
+                            running[0] + new[0],
+                            running[1] + new[1],
+                            running[2] + new[2],
+                        ]
+                    },
+                )
+        } else {
+            I.par_iter()
+                .zip(data_buffers.par_iter_mut())
+                .zip(val_checkpoints.par_chunks(K))
+                .map(|((I_chunk, buffers), checkpoint)| {
+                    let mut evals = [F::zero(), F::zero(), F::zero()];
+
+                    let DataBuffers {
+                        val_j_0,
+                        val_j_r,
+                        rs1_ra,
+                        rs2_ra,
+                        rd_wa,
+                        dirty_indices,
+                    } = buffers;
+
+                    val_j_0.as_mut_slice().copy_from_slice(checkpoint);
+
+                    // Iterate over I_chunk, two rows at a time.
+                    I_chunk
+                        .chunk_by(|a, b| a.0 / 2 == b.0 / 2)
+                        .for_each(|inc_chunk| {
+                            let j_prime = inc_chunk[0].0; // row index
+
+                            for j in j_prime << round..(j_prime + 1) << round {
+                                let j_bound = j % (1 << round);
+
+                                let k = trace[j].rs1_read().0;
+                                unsafe {
+                                    dirty_indices.insert_unchecked(k);
+                                }
+                                rs1_ra[0][k] += A[j_bound];
+
+                                let k = trace[j].rs2_read().0;
+                                unsafe {
+                                    dirty_indices.insert_unchecked(k);
+                                }
+                                rs2_ra[0][k] += A[j_bound];
+
+                                let k = trace[j].rd_write().0;
+                                unsafe {
+                                    dirty_indices.insert_unchecked(k);
+                                }
+                                rd_wa[0][k] += A[j_bound];
+                            }
+
+                            for j in (j_prime + 1) << round..(j_prime + 2) << round {
+                                let j_bound = j % (1 << round);
+
+                                let k = trace[j].rs1_read().0;
+                                unsafe {
+                                    dirty_indices.insert_unchecked(k);
+                                }
+                                rs1_ra[1][k] += A[j_bound];
+
+                                let k = trace[j].rs2_read().0;
+                                unsafe {
+                                    dirty_indices.insert_unchecked(k);
+                                }
+                                rs2_ra[1][k] += A[j_bound];
+
+                                let k = trace[j].rd_write().0;
+                                unsafe {
+                                    dirty_indices.insert_unchecked(k);
+                                }
+                                rd_wa[1][k] += A[j_bound];
+                            }
+
+                            for k in dirty_indices.ones() {
+                                val_j_r[0][k] = val_j_0[k];
+                            }
+                            let mut inc_iter = inc_chunk.iter().peekable();
+
+                            // First of the two rows
+                            loop {
+                                let (row, col, inc_lt, inc) = inc_iter.next().unwrap();
+                                debug_assert_eq!(*row, j_prime);
+                                val_j_r[0][*col] += *inc_lt;
+                                val_j_0[*col] += *inc;
+                                if inc_iter.peek().unwrap().0 != j_prime {
+                                    break;
+                                }
+                            }
+                            for k in dirty_indices.ones() {
+                                val_j_r[1][k] = val_j_0[k];
+                            }
+
+                            // Second of the two rows
+                            for inc in inc_iter {
+                                let (row, col, inc_lt, inc) = *inc;
+                                debug_assert_eq!(row, j_prime + 1);
+                                val_j_r[1][col] += inc_lt;
+                                val_j_0[col] += inc;
+                            }
+
+                            let eq_r_prime_evals =
+                                eq_r_prime.sumcheck_evals(j_prime / 2, DEGREE, BindingOrder::LowToHigh);
+                            let inc_cycle_evals =
+                                inc_cycle.sumcheck_evals(j_prime / 2, DEGREE, BindingOrder::LowToHigh);
+
+                            let mut inner_sum_evals = [F::zero(); 3];
+                            for k in dirty_indices.ones() {
+                                let mut m_val: Option<F> = None;
+                                let mut val_eval_2: Option<F> = None;
+                                let mut val_eval_3: Option<F> = None;
+
+                                // rs1 read-checking sumcheck
+                                if !rs1_ra[0][k].is_zero() || !rs1_ra[1][k].is_zero() {
+                                    // Preemptively multiply by `z` to save a mult
+                                    let ra_eval_0 = self.z * rs1_ra[0][k];
+                                    let ra_eval_1 = self.z * rs1_ra[1][k];
+                                    let m_ra = ra_eval_1 - ra_eval_0;
+                                    let ra_eval_2 = ra_eval_1 + m_ra;
+                                    let ra_eval_3 = ra_eval_2 + m_ra;
+
+                                    m_val = Some(val_j_r[1][k] - val_j_r[0][k]);
+                                    val_eval_2 = Some(val_j_r[1][k] + m_val.unwrap());
+                                    val_eval_3 = Some(val_eval_2.unwrap() + m_val.unwrap());
+
+                                    inner_sum_evals[0] += ra_eval_0.mul_0_optimized(val_j_r[0][k]);
+                                    inner_sum_evals[1] += ra_eval_2 * val_eval_2.unwrap();
+                                    inner_sum_evals[2] += ra_eval_3 * val_eval_3.unwrap();
+
+                                    rs1_ra[0][k] = F::zero();
+                                    rs1_ra[1][k] = F::zero();
+                                }
+
+                                // rs2 read-checking sumcheck
+                                if !rs2_ra[0][k].is_zero() || !rs2_ra[1][k].is_zero() {
+                                    // Preemptively multiply by `z_squared` to save a mult
+                                    let ra_eval_0 = self.z_squared * rs2_ra[0][k];
+                                    let ra_eval_1 = self.z_squared * rs2_ra[1][k];
+                                    let m_ra = ra_eval_1 - ra_eval_0;
+                                    let ra_eval_2 = ra_eval_1 + m_ra;
+                                    let ra_eval_3 = ra_eval_2 + m_ra;
+
+                                    m_val = m_val.or(Some(val_j_r[1][k] - val_j_r[0][k]));
+                                    val_eval_2 = val_eval_2.or(Some(val_j_r[1][k] + m_val.unwrap()));
+                                    val_eval_3 =
+                                        val_eval_3.or(Some(val_eval_2.unwrap() + m_val.unwrap()));
+
+                                    inner_sum_evals[0] += ra_eval_0.mul_0_optimized(val_j_r[0][k]);
+                                    inner_sum_evals[1] += ra_eval_2 * val_eval_2.unwrap();
+                                    inner_sum_evals[2] += ra_eval_3 * val_eval_3.unwrap();
+
+                                    rs2_ra[0][k] = F::zero();
+                                    rs2_ra[1][k] = F::zero();
+                                }
+
+                                // Write-checking sumcheck
+                                if !rd_wa[0][k].is_zero() || !rd_wa[1][k].is_zero() {
+                                    let wa_eval_0 = rd_wa[0][k];
+                                    let wa_eval_1 = rd_wa[1][k];
+                                    let m_wa = wa_eval_1 - wa_eval_0;
+                                    let wa_eval_2 = wa_eval_1 + m_wa;
+                                    let wa_eval_3 = wa_eval_2 + m_wa;
+
+                                    // TODO: can move val evals outside if statements.
+                                    let m_val = m_val.unwrap_or(val_j_r[1][k] - val_j_r[0][k]);
+                                    let val_eval_2 = val_eval_2.unwrap_or(val_j_r[1][k] + m_val);
+                                    let val_eval_3 = val_eval_3.unwrap_or(val_eval_2 + m_val);
+
+                                    inner_sum_evals[0] +=
+                                        wa_eval_0.mul_0_optimized(inc_cycle_evals[0] + val_j_r[0][k]);
+                                    inner_sum_evals[1] += wa_eval_2 * (inc_cycle_evals[1] + val_eval_2);
+                                    inner_sum_evals[2] += wa_eval_3 * (inc_cycle_evals[2] + val_eval_3);
+
+                                    rd_wa[0][k] = F::zero();
+                                    rd_wa[1][k] = F::zero();
+                                }
+
+                                val_j_r[0][k] = F::zero();
+                                val_j_r[1][k] = F::zero();
+                            }
+                            dirty_indices.clear();
+
+                            evals[0] += eq_r_prime_evals[0] * inner_sum_evals[0];
+                            evals[1] += eq_r_prime_evals[1] * inner_sum_evals[1];
+                            evals[2] += eq_r_prime_evals[2] * inner_sum_evals[2];
+                        });
+
+                    evals
+                })
+                .reduce(
+                    || [F::zero(); DEGREE],
+                    |running, new| {
+                        [
+                            running[0] + new[0],
+                            running[1] + new[1],
+                            running[2] + new[2],
+                        ]
+                    },
+                )
+        };
 
         #[cfg(test)]
         {

--- a/jolt-core/src/jolt/vm/registers_read_write_checking.rs
+++ b/jolt-core/src/jolt/vm/registers_read_write_checking.rs
@@ -582,7 +582,6 @@ impl<F: JoltField> RegistersReadWriteChecking<F> {
             A,
             val_checkpoints,
             inc_cycle,
-            eq_r_prime,
             gruens_eq_r_prime,
             ..
         } = self.prover_state.as_mut().unwrap();
@@ -804,11 +803,14 @@ impl<F: JoltField> RegistersReadWriteChecking<F> {
 
             cubic_evals
         } else {
-            I.par_iter()
+            let num_x_in_bits = gruens_eq_r_prime.E_in_current_len().log_2();
+            let x_bitmask = (1 << num_x_in_bits) - 1;
+
+            let quadratic_coeffs = I.par_iter()
                 .zip(data_buffers.par_iter_mut())
                 .zip(val_checkpoints.par_chunks(K))
                 .map(|((I_chunk, buffers), checkpoint)| {
-                    let mut evals = [F::zero(), F::zero(), F::zero()];
+                    let mut evals = [F::zero(), F::zero()];
 
                     let DataBuffers {
                         val_j_0,
@@ -898,33 +900,34 @@ impl<F: JoltField> RegistersReadWriteChecking<F> {
                                 val_j_0[col] += inc;
                             }
 
-                            let eq_r_prime_evals =
-                                eq_r_prime.sumcheck_evals(j_prime / 2, DEGREE, BindingOrder::LowToHigh);
-                            let inc_cycle_evals =
-                                inc_cycle.sumcheck_evals(j_prime / 2, DEGREE, BindingOrder::LowToHigh);
 
-                            let mut inner_sum_evals = [F::zero(); 3];
+                            let x_in = (j_prime / 2) & x_bitmask;
+                            let x_out = (j_prime / 2) >> num_x_in_bits;
+                            let E_in_eval = gruens_eq_r_prime.E_in_current()[x_in];
+                            let E_out_eval = gruens_eq_r_prime.E_out_current()[x_out];
+
+                            let inc_cycle_evals = {
+                                let inc_cycle_0 = inc_cycle.get_bound_coeff(j_prime);
+                                let inc_cycle_1 = inc_cycle.get_bound_coeff(j_prime + 1);
+                                let inc_cycle_infty = inc_cycle_1 - inc_cycle_0;
+                                [inc_cycle_0, inc_cycle_infty]
+                            };
+
+                            let mut inner_sum_evals = [F::zero(); DEGREE - 1];
                             for k in dirty_indices.ones() {
-                                let mut m_val: Option<F> = None;
-                                let mut val_eval_2: Option<F> = None;
-                                let mut val_eval_3: Option<F> = None;
+                                let mut val_eval_infty: Option<F> = None;
 
                                 // rs1 read-checking sumcheck
                                 if !rs1_ra[0][k].is_zero() || !rs1_ra[1][k].is_zero() {
                                     // Preemptively multiply by `z` to save a mult
                                     let ra_eval_0 = self.z * rs1_ra[0][k];
                                     let ra_eval_1 = self.z * rs1_ra[1][k];
-                                    let m_ra = ra_eval_1 - ra_eval_0;
-                                    let ra_eval_2 = ra_eval_1 + m_ra;
-                                    let ra_eval_3 = ra_eval_2 + m_ra;
+                                    let ra_eval_infty = ra_eval_1 - ra_eval_0;
 
-                                    m_val = Some(val_j_r[1][k] - val_j_r[0][k]);
-                                    val_eval_2 = Some(val_j_r[1][k] + m_val.unwrap());
-                                    val_eval_3 = Some(val_eval_2.unwrap() + m_val.unwrap());
+                                    val_eval_infty = Some(val_j_r[1][k] - val_j_r[0][k]);
 
                                     inner_sum_evals[0] += ra_eval_0.mul_0_optimized(val_j_r[0][k]);
-                                    inner_sum_evals[1] += ra_eval_2 * val_eval_2.unwrap();
-                                    inner_sum_evals[2] += ra_eval_3 * val_eval_3.unwrap();
+                                    inner_sum_evals[1] += ra_eval_infty * val_eval_infty.unwrap();
 
                                     rs1_ra[0][k] = F::zero();
                                     rs1_ra[1][k] = F::zero();
@@ -935,18 +938,12 @@ impl<F: JoltField> RegistersReadWriteChecking<F> {
                                     // Preemptively multiply by `z_squared` to save a mult
                                     let ra_eval_0 = self.z_squared * rs2_ra[0][k];
                                     let ra_eval_1 = self.z_squared * rs2_ra[1][k];
-                                    let m_ra = ra_eval_1 - ra_eval_0;
-                                    let ra_eval_2 = ra_eval_1 + m_ra;
-                                    let ra_eval_3 = ra_eval_2 + m_ra;
+                                    let ra_eval_infty = ra_eval_1 - ra_eval_0;
 
-                                    m_val = m_val.or(Some(val_j_r[1][k] - val_j_r[0][k]));
-                                    val_eval_2 = val_eval_2.or(Some(val_j_r[1][k] + m_val.unwrap()));
-                                    val_eval_3 =
-                                        val_eval_3.or(Some(val_eval_2.unwrap() + m_val.unwrap()));
+                                    val_eval_infty = val_eval_infty.or(Some(val_j_r[1][k] - val_j_r[0][k]));
 
                                     inner_sum_evals[0] += ra_eval_0.mul_0_optimized(val_j_r[0][k]);
-                                    inner_sum_evals[1] += ra_eval_2 * val_eval_2.unwrap();
-                                    inner_sum_evals[2] += ra_eval_3 * val_eval_3.unwrap();
+                                    inner_sum_evals[1] += ra_eval_infty * val_eval_infty.unwrap();
 
                                     rs2_ra[0][k] = F::zero();
                                     rs2_ra[1][k] = F::zero();
@@ -956,19 +953,14 @@ impl<F: JoltField> RegistersReadWriteChecking<F> {
                                 if !rd_wa[0][k].is_zero() || !rd_wa[1][k].is_zero() {
                                     let wa_eval_0 = rd_wa[0][k];
                                     let wa_eval_1 = rd_wa[1][k];
-                                    let m_wa = wa_eval_1 - wa_eval_0;
-                                    let wa_eval_2 = wa_eval_1 + m_wa;
-                                    let wa_eval_3 = wa_eval_2 + m_wa;
+                                    let wa_eval_infty = wa_eval_1 - wa_eval_0;
 
                                     // TODO: can move val evals outside if statements.
-                                    let m_val = m_val.unwrap_or(val_j_r[1][k] - val_j_r[0][k]);
-                                    let val_eval_2 = val_eval_2.unwrap_or(val_j_r[1][k] + m_val);
-                                    let val_eval_3 = val_eval_3.unwrap_or(val_eval_2 + m_val);
+                                    let val_eval_infty = val_eval_infty.unwrap_or(val_j_r[1][k] - val_j_r[0][k]);
 
                                     inner_sum_evals[0] +=
                                         wa_eval_0.mul_0_optimized(inc_cycle_evals[0] + val_j_r[0][k]);
-                                    inner_sum_evals[1] += wa_eval_2 * (inc_cycle_evals[1] + val_eval_2);
-                                    inner_sum_evals[2] += wa_eval_3 * (inc_cycle_evals[2] + val_eval_3);
+                                    inner_sum_evals[1] += wa_eval_infty * (inc_cycle_evals[1] + val_eval_infty);
 
                                     rd_wa[0][k] = F::zero();
                                     rd_wa[1][k] = F::zero();
@@ -979,23 +971,62 @@ impl<F: JoltField> RegistersReadWriteChecking<F> {
                             }
                             dirty_indices.clear();
 
-                            evals[0] += eq_r_prime_evals[0] * inner_sum_evals[0];
-                            evals[1] += eq_r_prime_evals[1] * inner_sum_evals[1];
-                            evals[2] += eq_r_prime_evals[2] * inner_sum_evals[2];
+                            // TODO(hamlinb) Factor out multiplication by E_out_eval
+                            evals[0] += E_out_eval * E_in_eval * inner_sum_evals[0];
+                            evals[1] += E_out_eval * E_in_eval * inner_sum_evals[1];
                         });
 
                     evals
                 })
                 .reduce(
-                    || [F::zero(); DEGREE],
+                    || [F::zero(); DEGREE - 1],
                     |running, new| {
                         [
                             running[0] + new[0],
                             running[1] + new[1],
-                            running[2] + new[2],
                         ]
                     },
-                )
+                );
+
+            // We want to compute the evaluations of the cubic polynomial s(X) = l(X) * q(X), where
+            // l is linear, and q is quadratic, at the points {0, 2, 3}.
+            //
+            // At this point, we have
+            // - the linear polynomial, l(X) = a + bX
+            // - the quadratic polynomial, q(X) = c + dX + eX^2
+            // - the previous round's claim s(0) + s(1) = a * c + (a + b) * (c + d + e)
+            //
+            // Both l and q are represented by their evaluations at 0 and infinity. I.e., we have a, b, c,
+            // and e, but not d. We compute s by first computing l and t at points 2 and 3.
+
+            // Evaluations of the linear polynomial linear polynomial
+            let eq_eval_1 = gruens_eq_r_prime.current_scalar
+                * gruens_eq_r_prime.w[gruens_eq_r_prime.current_index - 1];
+            let eq_eval_0 = gruens_eq_r_prime.current_scalar - eq_eval_1;
+            let eq_m = eq_eval_1 - eq_eval_0;
+            let eq_eval_2 = eq_eval_1 + eq_m;
+            let eq_eval_3 = eq_eval_2 + eq_m;
+
+            // Evaluations of the quadratic polynomial
+            let quadratic_eval_0 = quadratic_coeffs[0];
+            let cubic_eval_0 = eq_eval_0 * quadratic_eval_0;
+            let cubic_eval_1 = previous_claim - cubic_eval_0;
+            // q(1) = c + d + e
+            let quadratic_eval_1 = cubic_eval_1 / eq_eval_1;
+            // q(2) = c + 2d + 4e = q(1) + q(1) - q(0) + 2e
+            let e_times_2 = quadratic_coeffs[1] + quadratic_coeffs[1];
+            let quadratic_eval_2 = quadratic_eval_1 + quadratic_eval_1 - quadratic_eval_0 + e_times_2;
+            // q(3) = c + 3d + 9e = q(2) + q(1) - q(0) + 4e
+            let quadratic_eval_3 =
+                quadratic_eval_2 + quadratic_eval_1 - quadratic_eval_0 + e_times_2 + e_times_2;
+
+            let cubic_evals = [
+                cubic_eval_0,
+                eq_eval_2 * quadratic_eval_2,
+                eq_eval_3 * quadratic_eval_3,
+            ];
+
+            cubic_evals
         };
 
         #[cfg(test)]

--- a/jolt-core/src/jolt/vm/registers_read_write_checking.rs
+++ b/jolt-core/src/jolt/vm/registers_read_write_checking.rs
@@ -6,7 +6,8 @@ use crate::{
         eq_poly::EqPolynomial,
         multilinear_polynomial::{
             BindingOrder, MultilinearPolynomial, PolynomialBinding, PolynomialEvaluation,
-        }, split_eq_poly::GruenSplitEqPolynomial,
+        },
+        split_eq_poly::GruenSplitEqPolynomial,
     },
     r1cs::inputs::JoltR1CSInputs,
     subprotocols::sumcheck::{BatchableSumcheckInstance, SumcheckInstanceProof},
@@ -573,7 +574,11 @@ impl<F: JoltField> RegistersReadWriteChecking<F> {
         univariate_poly_evals.into()
     }
 
-    fn phase1_compute_prover_message_quadratic(&mut self, round: usize, previous_claim: F) -> Vec<F> {
+    fn phase1_compute_prover_message_quadratic(
+        &mut self,
+        round: usize,
+        previous_claim: F,
+    ) -> Vec<F> {
         const DEGREE: usize = 3;
         let ReadWriteCheckingProverState {
             trace,
@@ -586,8 +591,8 @@ impl<F: JoltField> RegistersReadWriteChecking<F> {
             ..
         } = self.prover_state.as_mut().unwrap();
 
-        let cubic_evals: [F; DEGREE] = if gruens_eq_r_prime.E_in_current_len() == 1 {
-            let quadratic_coeffs = I.par_iter()
+        let quadratic_coeffs: [F; DEGREE - 1] = if gruens_eq_r_prime.E_in_current_len() == 1 {
+            I.par_iter()
                 .zip(data_buffers.par_iter_mut())
                 .zip(val_checkpoints.par_chunks(K))
                 .map(|((I_chunk, buffers), checkpoint)| {
@@ -695,15 +700,16 @@ impl<F: JoltField> RegistersReadWriteChecking<F> {
 
                                 // rs1 read-checking sumcheck
                                 if !rs1_ra[0][k].is_zero() || !rs1_ra[1][k].is_zero() {
-                                    // Preemptively multiply by `z` to save a mult
-                                    let ra_eval_0 = self.z * rs1_ra[0][k];
-                                    let ra_eval_1 = self.z * rs1_ra[1][k];
+                                    let ra_eval_0 = rs1_ra[0][k];
+                                    let ra_eval_1 = rs1_ra[1][k];
                                     let ra_eval_infty = ra_eval_1 - ra_eval_0;
 
                                     val_eval_infty = Some(val_j_r[1][k] - val_j_r[0][k]);
 
-                                    inner_sum_evals[0] += ra_eval_0.mul_0_optimized(val_j_r[0][k]);
-                                    inner_sum_evals[1] += ra_eval_infty * val_eval_infty.unwrap();
+                                    inner_sum_evals[0] +=
+                                        self.z * ra_eval_0.mul_0_optimized(val_j_r[0][k]);
+                                    inner_sum_evals[1] +=
+                                        self.z * ra_eval_infty * val_eval_infty.unwrap();
 
                                     rs1_ra[0][k] = F::zero();
                                     rs1_ra[1][k] = F::zero();
@@ -711,15 +717,17 @@ impl<F: JoltField> RegistersReadWriteChecking<F> {
 
                                 // rs2 read-checking sumcheck
                                 if !rs2_ra[0][k].is_zero() || !rs2_ra[1][k].is_zero() {
-                                    // Preemptively multiply by `z_squared` to save a mult
-                                    let ra_eval_0 = self.z_squared * rs2_ra[0][k];
-                                    let ra_eval_1 = self.z_squared * rs2_ra[1][k];
+                                    let ra_eval_0 = rs2_ra[0][k];
+                                    let ra_eval_1 = rs2_ra[1][k];
                                     let ra_eval_infty = ra_eval_1 - ra_eval_0;
 
-                                    val_eval_infty = val_eval_infty.or(Some(val_j_r[1][k] - val_j_r[0][k]));
+                                    val_eval_infty =
+                                        val_eval_infty.or(Some(val_j_r[1][k] - val_j_r[0][k]));
 
-                                    inner_sum_evals[0] += ra_eval_0.mul_0_optimized(val_j_r[0][k]);
-                                    inner_sum_evals[1] += ra_eval_infty * val_eval_infty.unwrap();
+                                    inner_sum_evals[0] +=
+                                        self.z_squared * ra_eval_0.mul_0_optimized(val_j_r[0][k]);
+                                    inner_sum_evals[1] +=
+                                        self.z_squared * ra_eval_infty * val_eval_infty.unwrap();
 
                                     rs2_ra[0][k] = F::zero();
                                     rs2_ra[1][k] = F::zero();
@@ -732,11 +740,13 @@ impl<F: JoltField> RegistersReadWriteChecking<F> {
                                     let wa_eval_infty = wa_eval_1 - wa_eval_0;
 
                                     // TODO: can move val evals outside if statements.
-                                    let val_eval_infty = val_eval_infty.unwrap_or(val_j_r[1][k] - val_j_r[0][k]);
+                                    let val_eval_infty =
+                                        val_eval_infty.unwrap_or(val_j_r[1][k] - val_j_r[0][k]);
 
-                                    inner_sum_evals[0] +=
-                                        wa_eval_0.mul_0_optimized(inc_cycle_evals[0] + val_j_r[0][k]);
-                                    inner_sum_evals[1] += wa_eval_infty * (inc_cycle_evals[1] + val_eval_infty);
+                                    inner_sum_evals[0] += wa_eval_0
+                                        .mul_0_optimized(inc_cycle_evals[0] + val_j_r[0][k]);
+                                    inner_sum_evals[1] +=
+                                        wa_eval_infty * (inc_cycle_evals[1] + val_eval_infty);
 
                                     rd_wa[0][k] = F::zero();
                                     rd_wa[1][k] = F::zero();
@@ -755,58 +765,13 @@ impl<F: JoltField> RegistersReadWriteChecking<F> {
                 })
                 .reduce(
                     || [F::zero(); DEGREE - 1],
-                    |running, new| {
-                        [
-                            running[0] + new[0],
-                            running[1] + new[1],
-                        ]
-                    },
-                );
-
-            // We want to compute the evaluations of the cubic polynomial s(X) = l(X) * q(X), where
-            // l is linear, and q is quadratic, at the points {0, 2, 3}.
-            //
-            // At this point, we have
-            // - the linear polynomial, l(X) = a + bX
-            // - the quadratic polynomial, q(X) = c + dX + eX^2
-            // - the previous round's claim s(0) + s(1) = a * c + (a + b) * (c + d + e)
-            //
-            // Both l and q are represented by their evaluations at 0 and infinity. I.e., we have a, b, c,
-            // and e, but not d. We compute s by first computing l and t at points 2 and 3.
-
-            // Evaluations of the linear polynomial linear polynomial
-            let eq_eval_1 = gruens_eq_r_prime.current_scalar
-                * gruens_eq_r_prime.w[gruens_eq_r_prime.current_index - 1];
-            let eq_eval_0 = gruens_eq_r_prime.current_scalar - eq_eval_1;
-            let eq_m = eq_eval_1 - eq_eval_0;
-            let eq_eval_2 = eq_eval_1 + eq_m;
-            let eq_eval_3 = eq_eval_2 + eq_m;
-
-            // Evaluations of the quadratic polynomial
-            let quadratic_eval_0 = quadratic_coeffs[0];
-            let cubic_eval_0 = eq_eval_0 * quadratic_eval_0;
-            let cubic_eval_1 = previous_claim - cubic_eval_0;
-            // q(1) = c + d + e
-            let quadratic_eval_1 = cubic_eval_1 / eq_eval_1;
-            // q(2) = c + 2d + 4e = q(1) + q(1) - q(0) + 2e
-            let e_times_2 = quadratic_coeffs[1] + quadratic_coeffs[1];
-            let quadratic_eval_2 = quadratic_eval_1 + quadratic_eval_1 - quadratic_eval_0 + e_times_2;
-            // q(3) = c + 3d + 9e = q(2) + q(1) - q(0) + 4e
-            let quadratic_eval_3 =
-                quadratic_eval_2 + quadratic_eval_1 - quadratic_eval_0 + e_times_2 + e_times_2;
-
-            let cubic_evals = [
-                cubic_eval_0,
-                eq_eval_2 * quadratic_eval_2,
-                eq_eval_3 * quadratic_eval_3,
-            ];
-
-            cubic_evals
+                    |running, new| [running[0] + new[0], running[1] + new[1]],
+                )
         } else {
             let num_x_in_bits = gruens_eq_r_prime.E_in_current_len().log_2();
             let x_bitmask = (1 << num_x_in_bits) - 1;
 
-            let quadratic_coeffs = I.par_iter()
+            I.par_iter()
                 .zip(data_buffers.par_iter_mut())
                 .zip(val_checkpoints.par_chunks(K))
                 .map(|((I_chunk, buffers), checkpoint)| {
@@ -900,7 +865,6 @@ impl<F: JoltField> RegistersReadWriteChecking<F> {
                                 val_j_0[col] += inc;
                             }
 
-
                             let x_in = (j_prime / 2) & x_bitmask;
                             let x_out = (j_prime / 2) >> num_x_in_bits;
                             let E_in_eval = gruens_eq_r_prime.E_in_current()[x_in];
@@ -940,7 +904,8 @@ impl<F: JoltField> RegistersReadWriteChecking<F> {
                                     let ra_eval_1 = self.z_squared * rs2_ra[1][k];
                                     let ra_eval_infty = ra_eval_1 - ra_eval_0;
 
-                                    val_eval_infty = val_eval_infty.or(Some(val_j_r[1][k] - val_j_r[0][k]));
+                                    val_eval_infty =
+                                        val_eval_infty.or(Some(val_j_r[1][k] - val_j_r[0][k]));
 
                                     inner_sum_evals[0] += ra_eval_0.mul_0_optimized(val_j_r[0][k]);
                                     inner_sum_evals[1] += ra_eval_infty * val_eval_infty.unwrap();
@@ -956,11 +921,13 @@ impl<F: JoltField> RegistersReadWriteChecking<F> {
                                     let wa_eval_infty = wa_eval_1 - wa_eval_0;
 
                                     // TODO: can move val evals outside if statements.
-                                    let val_eval_infty = val_eval_infty.unwrap_or(val_j_r[1][k] - val_j_r[0][k]);
+                                    let val_eval_infty =
+                                        val_eval_infty.unwrap_or(val_j_r[1][k] - val_j_r[0][k]);
 
-                                    inner_sum_evals[0] +=
-                                        wa_eval_0.mul_0_optimized(inc_cycle_evals[0] + val_j_r[0][k]);
-                                    inner_sum_evals[1] += wa_eval_infty * (inc_cycle_evals[1] + val_eval_infty);
+                                    inner_sum_evals[0] += wa_eval_0
+                                        .mul_0_optimized(inc_cycle_evals[0] + val_j_r[0][k]);
+                                    inner_sum_evals[1] +=
+                                        wa_eval_infty * (inc_cycle_evals[1] + val_eval_infty);
 
                                     rd_wa[0][k] = F::zero();
                                     rd_wa[1][k] = F::zero();
@@ -980,54 +947,47 @@ impl<F: JoltField> RegistersReadWriteChecking<F> {
                 })
                 .reduce(
                     || [F::zero(); DEGREE - 1],
-                    |running, new| {
-                        [
-                            running[0] + new[0],
-                            running[1] + new[1],
-                        ]
-                    },
-                );
-
-            // We want to compute the evaluations of the cubic polynomial s(X) = l(X) * q(X), where
-            // l is linear, and q is quadratic, at the points {0, 2, 3}.
-            //
-            // At this point, we have
-            // - the linear polynomial, l(X) = a + bX
-            // - the quadratic polynomial, q(X) = c + dX + eX^2
-            // - the previous round's claim s(0) + s(1) = a * c + (a + b) * (c + d + e)
-            //
-            // Both l and q are represented by their evaluations at 0 and infinity. I.e., we have a, b, c,
-            // and e, but not d. We compute s by first computing l and t at points 2 and 3.
-
-            // Evaluations of the linear polynomial linear polynomial
-            let eq_eval_1 = gruens_eq_r_prime.current_scalar
-                * gruens_eq_r_prime.w[gruens_eq_r_prime.current_index - 1];
-            let eq_eval_0 = gruens_eq_r_prime.current_scalar - eq_eval_1;
-            let eq_m = eq_eval_1 - eq_eval_0;
-            let eq_eval_2 = eq_eval_1 + eq_m;
-            let eq_eval_3 = eq_eval_2 + eq_m;
-
-            // Evaluations of the quadratic polynomial
-            let quadratic_eval_0 = quadratic_coeffs[0];
-            let cubic_eval_0 = eq_eval_0 * quadratic_eval_0;
-            let cubic_eval_1 = previous_claim - cubic_eval_0;
-            // q(1) = c + d + e
-            let quadratic_eval_1 = cubic_eval_1 / eq_eval_1;
-            // q(2) = c + 2d + 4e = q(1) + q(1) - q(0) + 2e
-            let e_times_2 = quadratic_coeffs[1] + quadratic_coeffs[1];
-            let quadratic_eval_2 = quadratic_eval_1 + quadratic_eval_1 - quadratic_eval_0 + e_times_2;
-            // q(3) = c + 3d + 9e = q(2) + q(1) - q(0) + 4e
-            let quadratic_eval_3 =
-                quadratic_eval_2 + quadratic_eval_1 - quadratic_eval_0 + e_times_2 + e_times_2;
-
-            let cubic_evals = [
-                cubic_eval_0,
-                eq_eval_2 * quadratic_eval_2,
-                eq_eval_3 * quadratic_eval_3,
-            ];
-
-            cubic_evals
+                    |running, new| [running[0] + new[0], running[1] + new[1]],
+                )
         };
+
+        // We want to compute the evaluations of the cubic polynomial s(X) = l(X) * q(X), where
+        // l is linear, and q is quadratic, at the points {0, 2, 3}.
+        //
+        // At this point, we have
+        // - the linear polynomial, l(X) = a + bX
+        // - the quadratic polynomial, q(X) = c + dX + eX^2
+        // - the previous round's claim s(0) + s(1) = a * c + (a + b) * (c + d + e)
+        //
+        // Both l and q are represented by their evaluations at 0 and infinity. I.e., we have a, b, c,
+        // and e, but not d. We compute s by first computing l and t at points 2 and 3.
+
+        // Evaluations of the linear polynomial linear polynomial
+        let eq_eval_1 = gruens_eq_r_prime.current_scalar
+            * gruens_eq_r_prime.w[gruens_eq_r_prime.current_index - 1];
+        let eq_eval_0 = gruens_eq_r_prime.current_scalar - eq_eval_1;
+        let eq_m = eq_eval_1 - eq_eval_0;
+        let eq_eval_2 = eq_eval_1 + eq_m;
+        let eq_eval_3 = eq_eval_2 + eq_m;
+
+        // Evaluations of the quadratic polynomial
+        let quadratic_eval_0 = quadratic_coeffs[0];
+        let cubic_eval_0 = eq_eval_0 * quadratic_eval_0;
+        let cubic_eval_1 = previous_claim - cubic_eval_0;
+        // q(1) = c + d + e
+        let quadratic_eval_1 = cubic_eval_1 / eq_eval_1;
+        // q(2) = c + 2d + 4e = q(1) + q(1) - q(0) + 2e
+        let e_times_2 = quadratic_coeffs[1] + quadratic_coeffs[1];
+        let quadratic_eval_2 = quadratic_eval_1 + quadratic_eval_1 - quadratic_eval_0 + e_times_2;
+        // q(3) = c + 3d + 9e = q(2) + q(1) - q(0) + 4e
+        let quadratic_eval_3 =
+            quadratic_eval_2 + quadratic_eval_1 - quadratic_eval_0 + e_times_2 + e_times_2;
+
+        let cubic_evals = [
+            cubic_eval_0,
+            eq_eval_2 * quadratic_eval_2,
+            eq_eval_3 * quadratic_eval_3,
+        ];
 
         #[cfg(test)]
         {

--- a/jolt-core/src/poly/opening_proof.rs
+++ b/jolt-core/src/poly/opening_proof.rs
@@ -206,7 +206,7 @@ where
         self.input_claim
     }
 
-    fn compute_prover_message(&mut self, round: usize) -> Vec<F> {
+    fn compute_prover_message(&mut self, round: usize, _previous_claim: F) -> Vec<F> {
         debug_assert!(round < self.num_rounds());
         let prover_state = self.prover_state.as_mut().unwrap();
         match prover_state {

--- a/jolt-core/src/r1cs/spartan.rs
+++ b/jolt-core/src/r1cs/spartan.rs
@@ -538,7 +538,7 @@ impl<F: JoltField, ProofTranscript: Transcript> BatchableSumcheckInstance<F, Pro
         self.input_claim
     }
 
-    fn compute_prover_message(&mut self, _round: usize) -> Vec<F> {
+    fn compute_prover_message(&mut self, _round: usize, _previous_claim: F) -> Vec<F> {
         let prover_state = self
             .prover_state
             .as_ref()
@@ -735,7 +735,7 @@ impl<F: JoltField, ProofTranscript: Transcript> BatchableSumcheckInstance<F, Pro
         self.input_claim
     }
 
-    fn compute_prover_message(&mut self, _round: usize) -> Vec<F> {
+    fn compute_prover_message(&mut self, _round: usize, _previous_claim: F) -> Vec<F> {
         let prover_state = self
             .prover_state
             .as_ref()

--- a/jolt-core/src/subprotocols/ra_virtual.rs
+++ b/jolt-core/src/subprotocols/ra_virtual.rs
@@ -236,7 +236,7 @@ impl<F: JoltField, ProofTranscript: Transcript, const D: usize>
         eq_eval * product
     }
 
-    fn compute_prover_message(&mut self, _round: usize) -> Vec<F> {
+    fn compute_prover_message(&mut self, _round: usize, _previous_claim: F) -> Vec<F> {
         let prover_state = self
             .prover_state
             .as_ref()

--- a/jolt-core/src/subprotocols/shout.rs
+++ b/jolt-core/src/subprotocols/shout.rs
@@ -163,7 +163,7 @@ impl<F: JoltField, ProofTranscript: Transcript> BatchableSumcheckInstance<F, Pro
     }
 
     #[tracing::instrument(skip_all)]
-    fn compute_prover_message(&mut self, _: usize) -> Vec<F> {
+    fn compute_prover_message(&mut self, _: usize, _previous_claim: F) -> Vec<F> {
         let ShoutProverState { ra, val, z, .. } = self.prover_state.as_ref().unwrap();
 
         let degree = <Self as BatchableSumcheckInstance<F, ProofTranscript>>::degree(self);
@@ -495,7 +495,7 @@ impl<F: JoltField, ProofTranscript: Transcript> BatchableSumcheckInstance<F, Pro
         F::zero()
     }
 
-    fn compute_prover_message(&mut self, round: usize) -> Vec<F> {
+    fn compute_prover_message(&mut self, round: usize, _previous_claim: F) -> Vec<F> {
         const DEGREE: usize = 3;
         let BooleanityProverState {
             K,

--- a/jolt-core/src/subprotocols/sumcheck.rs
+++ b/jolt-core/src/subprotocols/sumcheck.rs
@@ -99,7 +99,7 @@ pub trait BatchableSumcheckInstance<F: JoltField, ProofTranscript: Transcript> {
     /// Computes the prover's message for a specific round of the sumcheck protocol.
     /// Returns the evaluations of the sumcheck polynomial at 0, 2, 3, ..., degree.
     /// The point evaluation at 1 can be interpolated using the previous round's claim.
-    fn compute_prover_message(&mut self, round: usize) -> Vec<F>;
+    fn compute_prover_message(&mut self, round: usize, previous_claim: F) -> Vec<F>;
 
     /// Binds this sumcheck instance to the verifier's challenge from a specific round.
     /// This updates the internal state to prepare for the next round.
@@ -206,7 +206,7 @@ impl BatchedSumcheck {
                     } else {
                         let offset = max_num_rounds - sumcheck.num_rounds();
                         let mut univariate_poly_evals =
-                            sumcheck.compute_prover_message(round - offset);
+                            sumcheck.compute_prover_message(round - offset, *previous_claim);
                         univariate_poly_evals.insert(1, *previous_claim - univariate_poly_evals[0]);
                         UniPoly::from_evals(&univariate_poly_evals)
                     }


### PR DESCRIPTION
This PR uses `GruenSplitEqPolynomial` to add Dao-Thaler and Gruen's optimizations to some Twist and Shout sumchecks. The sumchecks currently handled are
- The read-write register sumcheck [here](https://github.com/a16z/jolt/blob/feat/twist-shout-integration/jolt-core/src/jolt/vm/registers_read_write_checking.rs#L362)
- The read-write RAM sumcheck [here](https://github.com/a16z/jolt/blob/feat/twist-shout-integration/jolt-core/src/jolt/vm/ram_read_write_checking.rs)

Some caveats:
- The optimization is only applied to phase 1 of the RAM and register sumchecks. Phases 2 and 3 use high-to-low binding, whereas `GruenSplitEqPolynomial` currently assumes low-to-high, so it would need to be modified to switch binding modes in the middle. This also means that some of the precomputed eq values in `GruenSplitEqPolynomial` are not actually needed, currently.
- The bind function for `GruenSplitEqPolynomial` is not currently parallelized.