### PR TITLE
Draft: Apply Gruens to phase 2 of RAM and register sumchecks

### DIFF
--- a/jolt-core/src/poly/split_eq_poly.rs
+++ b/jolt-core/src/poly/split_eq_poly.rs
@@ -1,6 +1,5 @@
 //! Implements the Dao-Thaler optimization for EQ polynomial evaluations
 //! https://eprint.iacr.org/2024/1210.pdf
-#[cfg(test)]
 use super::dense_mlpoly::DensePolynomial;
 use crate::{field::JoltField, poly::eq_poly::EqPolynomial};
 
@@ -264,7 +263,6 @@ impl<F: JoltField> GruenSplitEqPolynomial<F> {
         }
     }
 
-    #[cfg(test)]
     pub fn merge(&self) -> DensePolynomial<F> {
         let evals = EqPolynomial::evals(&self.w[..self.current_index])
             .iter()


### PR DESCRIPTION
This PR is an attempt to create a version of `GruenSplitEqPolynomial` that uses high-to-low binding order and apply it to phase 2 of the RAM and register sumchecks. **Note:** I'm not currently getting an equivalent result.

You currently need to pick a binding order in the constructor, meaning that we would need to maintain two split polynomials in the RAM and register sumchecks, which isn't ideal. However, my hope is that implementing it this way will make it easy to swap in a version of `GruenSplitEqPolynomial` with switchable binding order, if we can implement it.

Current progress:
- Changing the binding order of `GruenSplitEqPolynomial` is implemented. There's a (passing) test for equivalence to binding `DensePolynomial` in high-to-low order [here](https://github.com/GaloisInc/jolt/blob/0788f79ee4eef589d3414d99fb45b850e0d9c252/jolt-core/src/poly/split_eq_poly.rs#L411).
- I've attempted to apply the high-to-low poly to the RAM sumcheck phase 2 [here](https://github.com/GaloisInc/jolt/blob/0788f79ee4eef589d3414d99fb45b850e0d9c252/jolt-core/src/jolt/vm/ram_read_write_checking.rs#L981). This isn't currently working, however.