### PR TITLE
Remove unused variable offset from generated guest main function

### DIFF
--- a/jolt-sdk/macros/src/lib.rs
+++ b/jolt-sdk/macros/src/lib.rs
@@ -467,7 +467,6 @@ impl MacroBuilder {
             #[cfg(feature = "guest")]
             #[no_mangle]
             pub extern "C" fn main() {
-                let mut offset = 0;
                 #get_input_slice
                 #(#args_fetch;)*
                 #check_input_len


### PR DESCRIPTION
This commit removes the unused variable offset from the main function generated by the make_main_func macro in jolt-sdk/macros/src/lib.rs. The variable was declared but never used, and its removal cleans up the code and eliminates unnecessary compiler warnings. No functional changes are introduced.