### PR TITLE
Renaming polynomial evaluation function names

### DIFF
--- a/jolt-core/benches/compact_poly_bench.rs
+++ b/jolt-core/benches/compact_poly_bench.rs
@@ -29,10 +29,12 @@ fn bench_u8(c: &mut Criterion) {
         let (poly, eval_point) = setup_u8_inputs(num_vars);
 
         let id_dot = format!("u8-dot-product-{}", exp);
-        group.bench_function(&id_dot, |b| b.iter(|| poly.evaluate(&eval_point)));
+        group.bench_function(&id_dot, |b| {
+            b.iter(|| poly.evaluate_dot_product(&eval_point))
+        });
 
         let id_opt = format!("u8-inside-out-{}", exp);
-        group.bench_function(&id_opt, |b| b.iter(|| poly.optimised_evaluate(&eval_point)));
+        group.bench_function(&id_opt, |b| b.iter(|| poly.evaluate(&eval_point)));
     }
 
     group.finish();

--- a/jolt-core/benches/poly_bench.rs
+++ b/jolt-core/benches/poly_bench.rs
@@ -29,12 +29,12 @@ fn bench_all(c: &mut Criterion) {
         let (poly, eval_point) = setup_inputs(num_vars as u64);
 
         let id_dot = format!("dot-product-{}", exp);
-        group.bench_function(&id_dot, |b| b.iter(|| poly.evaluate(eval_point.as_slice())));
+        group.bench_function(&id_dot, |b| {
+            b.iter(|| poly.evaluate_dot_product(eval_point.as_slice()))
+        });
 
         let id_opt = format!("inside-out-{}", exp);
-        group.bench_function(&id_opt, |b| {
-            b.iter(|| poly.optimised_evaluate(eval_point.as_slice()))
-        });
+        group.bench_function(&id_opt, |b| b.iter(|| poly.evaluate(eval_point.as_slice())));
     }
 
     group.finish();

--- a/jolt-core/src/poly/multilinear_polynomial.rs
+++ b/jolt-core/src/poly/multilinear_polynomial.rs
@@ -300,15 +300,18 @@ impl<F: JoltField> MultilinearPolynomial<F> {
         }
     }
 
-    pub fn optimised_evaluate(&self, r: &[F]) -> F {
+    // This is the old polynomial evaluation code that uses
+    // the dot product with langrange bases as the algorithm
+    // This might be eventually removed from the code base
+    pub fn evaluate_dot_product(&self, r: &[F]) -> F {
         match self {
-            MultilinearPolynomial::LargeScalars(poly) => poly.optimised_evaluate(r),
-            MultilinearPolynomial::U8Scalars(poly) => poly.optimised_evaluate(r),
-            MultilinearPolynomial::U16Scalars(poly) => poly.optimised_evaluate(r),
-            MultilinearPolynomial::U32Scalars(poly) => poly.optimised_evaluate(r),
-            MultilinearPolynomial::U64Scalars(poly) => poly.optimised_evaluate(r),
-            MultilinearPolynomial::I64Scalars(poly) => poly.optimised_evaluate(r),
-            MultilinearPolynomial::RLC(_) => F::zero(),
+            MultilinearPolynomial::LargeScalars(poly) => poly.evaluate(r),
+            MultilinearPolynomial::RLC(_) => {
+                // TODO(moodlezoup): This case is only hit in the Dory opening proof,
+                // which doesn't actually do anything with this value. We should
+                // remove that call from Dory.
+                F::zero()
+            }
             _ => {
                 let chis = EqPolynomial::evals(r);
                 self.dot_product(&chis)
@@ -501,7 +504,10 @@ pub trait PolynomialBinding<F: JoltField> {
 
 pub trait PolynomialEvaluation<F: JoltField> {
     /// Returns the final sumcheck claim about the polynomial.
+    /// This uses the algorithm in Lemma 4.3 in Thaler, Proofs and
+    /// Arguments -- the inside out processing
     fn evaluate(&self, r: &[F]) -> F;
+
     /// Evaluates a batch of polynomials on the same point `r`.
     /// Returns: (evals, EQ table)
     /// where EQ table is EQ(x, r) for x \in {0, 1}^|r|. This is used for
@@ -573,13 +579,13 @@ impl<F: JoltField> PolynomialEvaluation<F> for MultilinearPolynomial<F> {
     #[tracing::instrument(skip_all, name = "MultilinearPolynomial::evaluate")]
     fn evaluate(&self, r: &[F]) -> F {
         match self {
-            MultilinearPolynomial::LargeScalars(poly) => poly.evaluate(r),
-            MultilinearPolynomial::RLC(_) => {
-                // TODO(moodlezoup): This case is only hit in the Dory opening proof,
-                // which doesn't actually do anything with this value. We should
-                // remove that call from Dory.
-                F::zero()
-            }
+            MultilinearPolynomial::LargeScalars(poly) => poly.optimised_evaluate(r),
+            MultilinearPolynomial::U8Scalars(poly) => poly.optimised_evaluate(r),
+            MultilinearPolynomial::U16Scalars(poly) => poly.optimised_evaluate(r),
+            MultilinearPolynomial::U32Scalars(poly) => poly.optimised_evaluate(r),
+            MultilinearPolynomial::U64Scalars(poly) => poly.optimised_evaluate(r),
+            MultilinearPolynomial::I64Scalars(poly) => poly.optimised_evaluate(r),
+            MultilinearPolynomial::RLC(_) => F::zero(),
             _ => {
                 let chis = EqPolynomial::evals(r);
                 self.dot_product(&chis)


### PR DESCRIPTION
Renamed 

MultilinearPoly.evaluate --> MultilinearPoly.evaluate_dot_product
MultiLinearPoly.optimised_evaluate --> MultilinearPoly.evaluate

This is makes sure all functions calling optimised polynomial evaluate get the constant factor speedups without having to change how they invoke polynomial evaluation.

The bench code is also changed to accommodate naming changes