### PR TITLE
chore(ci): upgrade peaceiris/actions-mdbook to v2

### DIFF
--- a/.github/workflows/deploy-mdbook.yml
+++ b/.github/workflows/deploy-mdbook.yml
@@ -21,7 +21,7 @@ jobs:
       uses: google-github-actions/setup-gcloud@v2
 
     - name: Setup mdBook
-      uses: peaceiris/actions-mdbook@v1
+      uses: peaceiris/actions-mdbook@v2
       with:
         mdbook-version: '0.4.10'
 
@@ -39,7 +39,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - name: Setup mdBook
-        uses: peaceiris/actions-mdbook@v1
+        uses: peaceiris/actions-mdbook@v2
         with:
           mdbook-version: '0.4.10'
       - name: Install mdbook-katex


### PR DESCRIPTION
Updated mdBook GitHub Action from v1 to v2 to leverage latest enhancements, bug fixes, and maintain compatibility with current workflows
https://github.com/peaceiris/actions-mdbook/releases/tag/v2.0.0