### PR TITLE
fix: prevent bounds error when bytecode is at higher address

### DIFF
--- a/jolt-core/src/jolt/vm/read_write_memory.rs
+++ b/jolt-core/src/jolt/vm/read_write_memory.rs
@@ -37,6 +37,7 @@ use super::{JoltPolynomials, JoltStuff, JoltTraceStep};
 #[derive(Clone, CanonicalSerialize, CanonicalDeserialize)]
 pub struct ReadWriteMemoryPreprocessing {
     min_bytecode_address: u64,
+    max_bytecode_address: u64,
     bytecode_words: Vec<u32>,
     // HACK: The verifier will populate this field by copying inputs/outputs from the
     // `ReadWriteMemoryProof` and the memory layout from preprocessing.
@@ -79,6 +80,7 @@ impl ReadWriteMemoryPreprocessing {
 
         Self {
             min_bytecode_address,
+            max_bytecode_address,
             bytecode_words,
             program_io: None,
         }
@@ -269,6 +271,12 @@ impl<F: JoltField> ReadWriteMemoryPolynomials<F> {
                 MemoryOp::Read(a) => remap_address(a, &program_io.memory_layout),
                 MemoryOp::Write(a, _) => remap_address(a, &program_io.memory_layout),
             })
+            .chain(std::iter::once(
+                memory_address_to_witness_index(
+                    preprocessing.max_bytecode_address,
+                    &program_io.memory_layout,
+                ) as u64
+            ))
             .max()
             .unwrap();
 


### PR DESCRIPTION
I also encountered the 2nd problem mentioned in https://github.com/a16z/jolt/issues/741 today.

Explanation:
> @moodlezoup We're running into the index out of bounds error when the guest bytecode is at a higher memory address than is ever accessed during the execution. Should be an easy fix.

-----

Before this PR:

(some debug outputs here:)
> max_trace_address: **3589**
> memory_size: **4096**
> REGISTER_COUNT: 64
> preprocessing.min_bytecode_address: 2147483648
> preprocessing.max_bytecode_address: 2147484086
> memory_layout.input_start: 2147467520
> v_init_index starts from: **4096** <---- out of bounds here!

error message here:
```
thread 'main' panicked at /home/ubuntu/jolt/jolt-core/src/jolt/vm/read_write_memory.rs:292:19:
index out of bounds: the len is 4096 but the index is 4096
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

After this PR:

(some debug outputs here:)
> max_trace_address: 4205
> memory_size: 8192
> REGISTER_COUNT: 64
> preprocessing.min_bytecode_address: 2147483648
> preprocessing.max_bytecode_address: 2147484086
> memory_layout.input_start: 2147467520
> v_init_index starts from: 4096

success message:
```
Prover runtime: 1.769510363 s
output: 3
valid: true
```
