### PR TITLE
fix: prevent index out of bounds in UniPoly operations

### DIFF
--- a/jolt-core/src/poly/unipoly.rs
+++ b/jolt-core/src/poly/unipoly.rs
@@ -73,10 +73,16 @@ impl<F: JoltField> UniPoly<F> {
             // Now we know that self.degree() >= divisor.degree();
             let mut quotient = vec![F::zero(); self.degree() - divisor.degree() + 1];
             let mut remainder: Self = self.clone();
-            // Can unwrap here because we know self is not zero.
-            let divisor_leading_inv = divisor.leading_coefficient().unwrap().inverse().unwrap();
+            
+            // Get the leading coefficient and its inverse safely
+            let leading_coeff = divisor.leading_coefficient()?; // Return None if no leading coefficient
+            if leading_coeff.is_zero() {
+                return None; // Cannot divide by polynomial with zero leading coefficient
+            }
+            let divisor_leading_inv = leading_coeff.inverse()?; // Return None if no inverse exists
+            
             while !remainder.is_zero() && remainder.degree() >= divisor.degree() {
-                let cur_q_coeff = *remainder.leading_coefficient().unwrap() * divisor_leading_inv;
+                let cur_q_coeff = *remainder.leading_coefficient()? * divisor_leading_inv;
                 let cur_q_degree = remainder.degree() - divisor.degree();
                 quotient[cur_q_degree] = cur_q_coeff;
 
@@ -105,7 +111,11 @@ impl<F: JoltField> UniPoly<F> {
     }
 
     pub fn degree(&self) -> usize {
-        self.coeffs.len() - 1
+        if self.coeffs.is_empty() {
+            0  // По соглашению, степень нулевого полинома равна 0
+        } else {
+            self.coeffs.len() - 1
+        }
     }
 
     pub fn as_vec(&self) -> Vec<F> {
@@ -113,7 +123,11 @@ impl<F: JoltField> UniPoly<F> {
     }
 
     pub fn eval_at_zero(&self) -> F {
-        self.coeffs[0]
+        if self.coeffs.is_empty() {
+            F::zero()
+        } else {
+            self.coeffs[0]
+        }
     }
 
     pub fn eval_at_one(&self) -> F {


### PR DESCRIPTION
Description:

- fix potential panics due to empty coeffs in eval_at_zero, degree

- add safe checks for division by zero polynomials