### PR TITLE
Drop sumcheck data structures

### DIFF
--- a/jolt-core/src/poly/one_hot_polynomial.rs
+++ b/jolt-core/src/poly/one_hot_polynomial.rs
@@ -165,28 +165,15 @@ impl<F: JoltField> OneHotPolynomialProverOpening<F> {
                         .skip(k_prime)
                         .step_by(B.len() / 2)
                         .map(|(k, &G_k)| {
-                            // k_m is the bit corresponding to the variable we'll be binding next
                             let k_m = (k >> (num_unbound_address_variables - 1)) & 1;
-                            // We then index into F using the high order bits of k
                             let F_k = F[k >> num_unbound_address_variables];
-
-                            // G_times_F := G[k] * F[k_1, ...., k_{m-1}]
                             let G_times_F = G_k * F_k;
 
-                            // For c \in {0, 2} compute:
-                            //    G[k] * F[k_1, ...., k_{m-1}, c]
-                            //    = G[k] * F[k_1, ...., k_{m-1}] * eq(k_m, c)
-                            //    = G_times_F * eq(k_m, c)
-                            let eval_c0 = match k_m {
-                                0 => G_times_F, // eq(0, 0) = 0 * 0 + (1 - 0) * (1 - 0) = 1,
-                                1 => F::zero(), // eq(1, 0) = 1 * 0 + (1 - 1) * (1 - 0) = 0
-                                _ => unreachable!(),
-                            };
-
-                            let eval_c2 = match k_m {
-                                0 => -G_times_F,            // eq(0, 2) = 0 * 2 + (1 - 0) * (1 - 2) = -1,
-                                1 => G_times_F + G_times_F, // eq(1, 2) = 1 * 2 + (1 - 1) * (1 - 2) = 2
-                                _ => unreachable!(),
+                            let eval_c0 = if k_m == 0 { G_times_F } else { F::zero() };
+                            let eval_c2 = if k_m == 0 {
+                                -G_times_F
+                            } else {
+                                G_times_F + G_times_F
                             };
                             [eval_c0, eval_c2]
                         })
@@ -203,90 +190,42 @@ impl<F: JoltField> OneHotPolynomialProverOpening<F> {
                 );
 
             univariate_poly_evals.to_vec()
-        } else if round == polynomial.K.log_2() {
-            // First t-variable round: use F directly without initializing H
-            let B = &shared_eq.B;
-            let d_gruen = &shared_eq.D;
-            let F = &shared_eq.F;
-
-            // Compute using F directly for the first t-variable round
-            let gruen_eval_0 = if d_gruen.E_in_current_len() == 1 {
-                // E_in is fully bound
-                (0..d_gruen.len() / 2)
-                    .into_par_iter()
-                    .map(|j| {
-                        let d_eval = d_gruen.E_out_current()[j];
-                        // Use F directly instead of H
-                        let f_eval = polynomial.nonzero_indices.as_ref().unwrap()[j]
-                            .map_or(F::zero(), |k| F[k]);
-                        d_eval * f_eval
-                    })
-                    .sum()
-            } else {
-                // E_in has not been fully bound
-                let num_x_out = d_gruen.E_out_current_len();
-                let num_x_out_bits = num_x_out.log_2();
-                let d_e_in = d_gruen.E_in_current();
-                let d_e_out = d_gruen.E_out_current();
-                let max_j = d_gruen.len() / 2;
-
-                (0..max_j)
-                    .into_par_iter()
-                    .map(|j| {
-                        let x_out = j & ((1 << num_x_out_bits) - 1);
-                        let x_in = j >> num_x_out_bits;
-                        // Use F directly instead of H
-                        let f_eval = polynomial.nonzero_indices.as_ref().unwrap()[j]
-                            .map_or(F::zero(), |k| F[k]);
-                        d_e_in[x_in] * d_e_out[x_out] * f_eval
-                    })
-                    .sum()
-            };
-
-            let eq_r_address_claim = B.final_sumcheck_claim();
-            let gruen_univariate_evals: [F; 2] =
-                d_gruen.gruen_evals_deg_2(gruen_eval_0, previous_claim / eq_r_address_claim);
-
-            vec![
-                eq_r_address_claim * gruen_univariate_evals[0],
-                eq_r_address_claim * gruen_univariate_evals[1],
-            ]
         } else {
-            // Subsequent t-variable rounds: use H as before
-            let H = polynomial.H.as_ref().unwrap();
+            // T-variable rounds
             let B = &shared_eq.B;
             let d_gruen = &shared_eq.D;
+            let eq_r_address_claim = B.final_sumcheck_claim();
+
+            // Retrieve ra(j , r') for first round using F, and H otherwise
+            let ra_eval = |j: usize| -> F {
+                if round == polynomial.K.log_2() {
+                    polynomial.nonzero_indices.as_ref().unwrap()[j]
+                        .map_or(F::zero(), |k| shared_eq.F[k])
+                } else {
+                    polynomial.H.as_ref().unwrap().Z[j]
+                }
+            };
 
             let gruen_eval_0 = if d_gruen.E_in_current_len() == 1 {
-                // E_in is fully bound
                 (0..d_gruen.len() / 2)
                     .into_par_iter()
-                    .map(|j| {
-                        let d_eval = d_gruen.E_out_current()[j];
-                        let h_eval = H.Z[j];
-                        d_eval * h_eval
-                    })
+                    .map(|j| d_gruen.E_out_current()[j] * ra_eval(j))
                     .sum()
             } else {
-                // E_in has not been fully bound
-                let num_x_out = d_gruen.E_out_current_len();
-                let num_x_out_bits = num_x_out.log_2();
+                let num_x_out_bits = d_gruen.E_out_current_len().log_2();
                 let d_e_in = d_gruen.E_in_current();
                 let d_e_out = d_gruen.E_out_current();
-                let max_j = d_gruen.len() / 2;
 
-                (0..max_j)
+                (0..d_gruen.len() / 2)
                     .into_par_iter()
                     .map(|j| {
                         let x_out = j & ((1 << num_x_out_bits) - 1);
                         let x_in = j >> num_x_out_bits;
-                        let h_eval = H.Z[j];
-                        d_e_in[x_in] * d_e_out[x_out] * h_eval
+                        d_e_in[x_in] * d_e_out[x_out] * ra_eval(j)
                     })
                     .sum()
             };
 
-            let eq_r_address_claim = B.final_sumcheck_claim();
             let gruen_univariate_evals: [F; 2] =
                 d_gruen.gruen_evals_deg_2(gruen_eval_0, previous_claim / eq_r_address_claim);
 
@@ -302,67 +241,48 @@ impl<F: JoltField> OneHotPolynomialProverOpening<F> {
         let mut shared_eq = self.eq_state.lock().unwrap();
         let polynomial = self.polynomial.as_mut().unwrap();
         let num_variables_bound = shared_eq.num_variables_bound;
-        if round < polynomial.K.log_2() {
-            if num_variables_bound <= round {
+
+        // Bind shared state if not already bound
+        if num_variables_bound <= round {
+            if round < polynomial.K.log_2() {
                 shared_eq.B.bind_parallel(r, BindingOrder::HighToLow);
-                // Update F for this round (see Equation 55)
                 shared_eq.F.update(r);
-                shared_eq.num_variables_bound += 1;
-            }
-
-            // H initialization moved to after first t-variable round
-        } else {
-            // Last log(T) rounds of sumcheck
-
-            if round == polynomial.K.log_2() {
-                // First t-variable round: initialize H with special binding
-                let F = &shared_eq.F;
-                let T = polynomial.nonzero_indices.as_ref().unwrap().len();
-                let half_T = T / 2;
-
-                // Initialize H by applying the binding relation:
-                // H[j] = H[0, j] + r(H[1, j] - H[0, j])
-                // where H[0, j] = F[k_j] and H[1, j] = F[k_{j+T/2}]
-                polynomial.H = Some(DensePolynomial::new(
-                    (0..half_T)
-                        .into_par_iter()
-                        .map(|j| {
-                            let h_0 = polynomial.nonzero_indices.as_ref().unwrap()[j]
-                                .map_or(F::zero(), |k| F[k]);
-                            let h_1 = polynomial.nonzero_indices.as_ref().unwrap()[j + half_T]
-                                .map_or(F::zero(), |k| F[k]);
-                            h_0 + r * (h_1 - h_0)
-                        })
-                        .collect::<Vec<_>>(),
-                ));
-
-                // Drop data structures not needed for phase 2
-                if let Some(g) = polynomial.G.take() {
-                    drop_in_background_thread(g);
-                }
-
-                // Explicitly drop the lock before re-acquiring
-                drop(shared_eq);
-                self.eq_state.lock().unwrap().D_coeffs_for_G = None;
-
-                let mut shared_eq = self.eq_state.lock().unwrap();
-                if num_variables_bound <= round {
-                    shared_eq.D.bind(r);
-                    shared_eq.num_variables_bound += 1;
-                }
-            } else if num_variables_bound <= round {
+            } else {
                 shared_eq.D.bind(r);
-                shared_eq.num_variables_bound += 1;
             }
+            shared_eq.num_variables_bound += 1;
+        }
 
-            // Only bind H in subsequent rounds
-            if round > polynomial.K.log_2() {
-                polynomial
-                    .H
-                    .as_mut()
-                    .unwrap()
-                    .bind_parallel(r, BindingOrder::HighToLow)
+        // For the first log T round we want to use F stil
+        if round == polynomial.K.log_2() {
+            let F = &shared_eq.F;
+            let nonzero_indices = polynomial.nonzero_indices.as_ref().unwrap();
+            let half_T = nonzero_indices.len() / 2;
+
+            // Initialize H by binding F values
+            polynomial.H = Some(DensePolynomial::new(
+                (0..half_T)
+                    .into_par_iter()
+                    .map(|j| {
+                        let h_0 = nonzero_indices[j].map_or(F::zero(), |k| F[k]);
+                        let h_1 = nonzero_indices[j + half_T].map_or(F::zero(), |k| F[k]);
+                        h_0 + r * (h_1 - h_0)
+                    })
+                    .collect(),
+            ));
+
+            if let Some(g) = polynomial.G.take() {
+                drop_in_background_thread(g);
             }
+            drop(shared_eq);
+            self.eq_state.lock().unwrap().D_coeffs_for_G = None;
+        } else if round > polynomial.K.log_2() {
+            // Bind H for subsequent T rounds
+            polynomial
+                .H
+                .as_mut()
+                .unwrap()
+                .bind_parallel(r, BindingOrder::HighToLow);
         }
     }
 

--- a/jolt-core/src/poly/one_hot_polynomial.rs
+++ b/jolt-core/src/poly/one_hot_polynomial.rs
@@ -258,7 +258,7 @@ impl<F: JoltField> OneHotPolynomialProverOpening<F> {
             shared_eq.num_variables_bound += 1;
         }
 
-        // For the first log T round we want to use F stil
+        // For the first log T round we want to use F still
         if round == polynomial.K.log_2() {
             let F = &shared_eq.F;
             let nonzero_indices = &polynomial.nonzero_indices;

--- a/jolt-core/src/poly/one_hot_polynomial.rs
+++ b/jolt-core/src/poly/one_hot_polynomial.rs
@@ -279,21 +279,18 @@ impl<F: JoltField> OneHotPolynomialProverOpening<F> {
                         .collect::<Vec<_>>(),
                 ));
 
-                // Drop G array as it's no longer needed in phase 2
+                // Drop data structures not needed for phase 2
                 if let Some(g) = polynomial.G.take() {
                     drop_in_background_thread(g);
                 }
 
-                // Drop nonzero_indices as it's no longer needed in phase 2
                 drop_in_background_thread(nonzero_indices);
 
-                // Also drop D_coeffs_for_G since we're done with initialization
                 drop(shared_eq);
                 self.eq_state.lock().unwrap().D_coeffs_for_G = None;
             }
         } else {
             // Last log(T) rounds of sumcheck
-
             if num_variables_bound <= round {
                 shared_eq.D.bind(r);
 

--- a/jolt-core/src/poly/one_hot_polynomial.rs
+++ b/jolt-core/src/poly/one_hot_polynomial.rs
@@ -114,8 +114,8 @@ impl<F: JoltField> OneHotPolynomialProverOpening<F> {
         let num_chunks = rayon::current_num_threads().next_power_of_two().min(T);
         let chunk_size = (T / num_chunks).max(1);
 
-        let binding = self.eq_state.lock().unwrap();
-        let D_coeffs_for_G = &binding.D_coeffs_for_G;
+        let eq = self.eq_state.lock().unwrap();
+        let D_coeffs_for_G = &eq.D_coeffs_for_G;
 
         // Compute G as described in Section 6.3
         let G = nonzero_indices
@@ -205,8 +205,7 @@ impl<F: JoltField> OneHotPolynomialProverOpening<F> {
             // Retrieve ra(j , r') for first round using F, and H otherwise
             let ra_eval = |j: usize| -> F {
                 if round == polynomial.K.log_2() {
-                    polynomial.nonzero_indices[j]
-                        .map_or(F::zero(), |k| shared_eq.F[k])
+                    polynomial.nonzero_indices[j].map_or(F::zero(), |k| shared_eq.F[k])
                 } else {
                     polynomial.H.Z[j]
                 }

--- a/jolt-core/src/zkvm/bytecode/booleanity.rs
+++ b/jolt-core/src/zkvm/bytecode/booleanity.rs
@@ -7,7 +7,6 @@ use crate::poly::opening_proof::{
 use crate::zkvm::bytecode::BytecodePreprocessing;
 use crate::zkvm::dag::state_manager::StateManager;
 use crate::zkvm::witness::{CommittedPolynomial, VirtualPolynomial};
-use std::mem;
 
 use crate::{
     field::JoltField,

--- a/jolt-core/src/zkvm/instruction_lookups/booleanity.rs
+++ b/jolt-core/src/zkvm/instruction_lookups/booleanity.rs
@@ -197,17 +197,16 @@ impl<F: JoltField> SumcheckInstance<F> for BooleanitySumcheck<F> {
                 // Replace G with empty vectors
                 let g: [Vec<F>; D] = std::array::from_fn(|i| std::mem::take(&mut ps.G[i]));
                 drop_in_background_thread(g);
-                
+
                 let f = std::mem::take(&mut ps.F);
                 drop_in_background_thread(f);
-                
+
                 drop_in_background_thread(h_indices);
             }
         } else {
             // Phase 2: Bind D and H
             ps.D.bind(r_j);
-            ps.H
-                .par_iter_mut()
+            ps.H.par_iter_mut()
                 .for_each(|poly| poly.bind_parallel(r_j, BindingOrder::LowToHigh));
         }
     }
@@ -259,8 +258,7 @@ impl<F: JoltField> SumcheckInstance<F> for BooleanitySumcheck<F> {
     ) {
         let ps = self.prover_state.as_ref().unwrap();
         let ra_claims =
-            ps.H
-                .iter()
+            ps.H.iter()
                 .map(|ra| ra.final_sumcheck_claim())
                 .collect::<Vec<F>>();
 

--- a/jolt-core/src/zkvm/instruction_lookups/booleanity.rs
+++ b/jolt-core/src/zkvm/instruction_lookups/booleanity.rs
@@ -1,5 +1,5 @@
 use rayon::prelude::*;
-use std::{cell::RefCell, mem, rc::Rc};
+use std::{cell::RefCell, rc::Rc};
 use tracer::instruction::RV32IMCycle;
 
 use super::{D, K_CHUNK, LOG_K_CHUNK};

--- a/jolt-core/src/zkvm/ram/booleanity.rs
+++ b/jolt-core/src/zkvm/ram/booleanity.rs
@@ -96,13 +96,11 @@ impl<F: JoltField> BooleanitySumcheck<F> {
         // TODO(moodlezoup): `G_arrays` is identical to `F_arrays` in `hamming_weight.rs`
         let mut G_arrays = Vec::with_capacity(d);
 
-        // First pass: extract addresses in parallel
         let addresses: Vec<Option<u64>> = trace
             .par_iter()
             .map(|cycle| remap_address(cycle.ram_access().address() as u64, memory_layout))
             .collect();
 
-        // Second pass: compute G arrays using extracted addresses
         for i in 0..d {
             let G: Vec<F> = addresses
                 .par_chunks(chunk_size)

--- a/jolt-core/src/zkvm/ram/booleanity.rs
+++ b/jolt-core/src/zkvm/ram/booleanity.rs
@@ -274,7 +274,7 @@ impl<F: JoltField> SumcheckInstance<F> for BooleanitySumcheck<F> {
                 // Drop G arrays and F array as they're no longer needed in phase 2
                 let g = std::mem::take(&mut prover_state.G);
                 drop_in_background_thread(g);
-                
+
                 let f = std::mem::take(&mut prover_state.F);
                 drop_in_background_thread(f);
 
@@ -287,7 +287,8 @@ impl<F: JoltField> SumcheckInstance<F> for BooleanitySumcheck<F> {
 
             // Bind D and all H polynomials
             prover_state.D.bind(r_j);
-            prover_state.H
+            prover_state
+                .H
                 .par_iter_mut()
                 .for_each(|h_poly| h_poly.bind_parallel(r_j, BindingOrder::LowToHigh));
         }
@@ -348,7 +349,8 @@ impl<F: JoltField> SumcheckInstance<F> for BooleanitySumcheck<F> {
             .as_ref()
             .expect("Prover state not initialized");
 
-        let claims: Vec<F> = prover_state.H
+        let claims: Vec<F> = prover_state
+            .H
             .iter()
             .map(|h_poly| h_poly.final_sumcheck_claim())
             .collect();
@@ -461,8 +463,7 @@ impl<F: JoltField> BooleanitySumcheck<F> {
                                     .enumerate()
                                     .map(|(k, &G_k)| {
                                         let k_m = k >> (m - 1);
-                                        let F_k =
-                                            prover_state.F[k % (1 << (m - 1))];
+                                        let F_k = prover_state.F[k % (1 << (m - 1))];
                                         let G_times_F = G_k * F_k;
 
                                         let eval_infty = G_times_F * F_k;


### PR DESCRIPTION
- drops various data structures when they are not needed
- Optimizes batching sumcheck sparse case to use F for the first round of T variables to avoid materializing H to save memory
- Otherwise cuts most of the memory across the board by half and we observe more or less the theoretical 1 GiB / 2^20 cycles (other than spartan which is known, a constant spike in instructions and some overhead still in batching sumcheck)