### PR TITLE
fix: Assumptions about stack and heap locations in MemoryLayout

### DIFF
--- a/common/src/constants.rs
+++ b/common/src/constants.rs
@@ -5,7 +5,12 @@ pub const REGISTER_COUNT: u64 = RISCV_REGISTER_COUNT + VIRTUAL_REGISTER_COUNT;
 pub const BYTES_PER_INSTRUCTION: usize = 4;
 
 pub const RAM_START_ADDRESS: u64 = 0x80000000;
-pub const DEFAULT_MEMORY_SIZE: u64 = 10 * 1024 * 1024;
+
+// big enough to run Linux and xv6
+pub const EMULATOR_MEMORY_CAPACITY: u64 = 1024 * 1024 * 128;
+
+pub const DEFAULT_MEMORY_SIZE: u64 = 32 * 1024 * 1024;
+
 pub const DEFAULT_STACK_SIZE: u64 = 4096;
 pub const DEFAULT_MAX_INPUT_SIZE: u64 = 4096;
 pub const DEFAULT_MAX_OUTPUT_SIZE: u64 = 4096;

--- a/common/src/jolt_device.rs
+++ b/common/src/jolt_device.rs
@@ -114,6 +114,7 @@ pub struct MemoryConfig {
     pub max_output_size: u64,
     pub stack_size: u64,
     pub memory_size: u64,
+    pub bytecode_size: Option<u64>,
 }
 
 impl Default for MemoryConfig {
@@ -123,6 +124,7 @@ impl Default for MemoryConfig {
             max_output_size: DEFAULT_MAX_OUTPUT_SIZE,
             stack_size: DEFAULT_STACK_SIZE,
             memory_size: DEFAULT_MEMORY_SIZE,
+            bytecode_size: None,
         }
     }
 }
@@ -131,6 +133,7 @@ impl Default for MemoryConfig {
     Default, Clone, PartialEq, Serialize, Deserialize, CanonicalSerialize, CanonicalDeserialize,
 )]
 pub struct MemoryLayout {
+    pub bytecode_size: u64,
     pub max_input_size: u64,
     pub max_output_size: u64,
     pub input_start: u64,
@@ -138,10 +141,10 @@ pub struct MemoryLayout {
     pub output_start: u64,
     pub output_end: u64,
     pub stack_size: u64,
-    /// Stack starts at the IO inputs and goes "down" from there by `stack_size` bytes.
+    /// Stack starts from (RAM_START_ADDRESS + `bytecode_size` + `stack_size`) and grows in descending addresses by `stack_size` bytes.
     pub stack_end: u64,
     pub memory_size: u64,
-    /// Heap starts at RAM_START_ADDRESS and is `memory_size` bytes.
+    /// Heap starts just after the start of the stack and is `memory_size` bytes.
     pub memory_end: u64,
     pub panic: u64,
     pub termination: u64,
@@ -153,6 +156,7 @@ pub struct MemoryLayout {
 impl core::fmt::Debug for MemoryLayout {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("MemoryLayout")
+            .field("bytecode_size", &self.bytecode_size)
             .field("max_input_size", &self.max_input_size)
             .field("max_output_size", &self.max_output_size)
             .field("input_start", &format_args!("{:#X}", self.input_start))
@@ -171,6 +175,10 @@ impl core::fmt::Debug for MemoryLayout {
 
 impl MemoryLayout {
     pub fn new(config: &MemoryConfig) -> Self {
+        assert!(
+            config.bytecode_size.is_some(),
+            "MemoryLayout requires bytecode size to be set"
+        );
         // helper to align ‘val’ *up* to a multiple of ‘align’, panicking on overflow
         #[inline]
         fn align_up(val: u64, align: u64) -> u64 {
@@ -221,17 +229,22 @@ impl MemoryLayout {
         let termination = panic.checked_add(4).expect("termination overflow");
         let io_end = termination.checked_add(4).expect("io_end overflow");
 
-        // stack grows *down* from input_start
-        let stack_end = input_start
-            .checked_sub(stack_size)
-            .expect("stack region exceeds I/O region");
+        let bytecode_size = config.bytecode_size.unwrap();
+        // stack grows downwards (decreasing addresses) from the bytecode_end + stack_size up to bytecode_end
+        let stack_end = RAM_START_ADDRESS
+            .checked_add(bytecode_size)
+            .expect("stack_end overflow");
+        let stack_start = stack_end
+            .checked_add(stack_size)
+            .expect("stack_start overflow");
 
-        // heap grows *up* from RAM_START_ADDRESS
-        let memory_end = RAM_START_ADDRESS
+        // heap grows *up* (increasing addresses) from the stack of the stack
+        let memory_end = stack_start
             .checked_add(memory_size)
             .expect("memory_end overflow");
 
         Self {
+            bytecode_size,
             max_input_size,
             max_output_size,
             input_start,

--- a/jolt-core/src/benches/bench.rs
+++ b/jolt-core/src/benches/bench.rs
@@ -128,7 +128,7 @@ fn prove_example(
 ) -> Vec<(tracing::Span, Box<dyn FnOnce()>)> {
     let mut tasks = Vec::new();
     let mut program = host::Program::new(example_name);
-    let (bytecode, init_memory_state) = program.decode();
+    let (bytecode, init_memory_state, _) = program.decode();
     let (_, _, program_io) = program.trace(&serialized_input);
 
     let task = move || {

--- a/jolt-core/src/zkvm/dag/mod.rs
+++ b/jolt-core/src/zkvm/dag/mod.rs
@@ -20,7 +20,7 @@ mod tests {
     #[should_panic]
     fn truncated_trace() {
         let mut program = host::Program::new("fibonacci-guest");
-        let (bytecode, init_memory_state) = program.decode();
+        let (bytecode, init_memory_state, _) = program.decode();
         let inputs = postcard::to_stdvec(&9u8).unwrap();
         let (mut trace, final_memory_state, mut program_io) = program.trace(&inputs);
         trace.truncate(100);
@@ -66,7 +66,7 @@ mod tests {
     fn malicious_trace() {
         let mut program = host::Program::new("fibonacci-guest");
         let inputs = postcard::to_stdvec(&1u8).unwrap();
-        let (bytecode, init_memory_state) = program.decode();
+        let (bytecode, init_memory_state, _) = program.decode();
         let (mut trace, final_memory_state, mut program_io) = program.trace(&inputs);
 
         // Since the preprocessing is done with the original memory layout, the verifier should fail

--- a/jolt-core/src/zkvm/mod.rs
+++ b/jolt-core/src/zkvm/mod.rs
@@ -347,7 +347,7 @@ mod tests {
     fn fib_e2e_mock() {
         let mut program = host::Program::new("fibonacci-guest");
         let inputs = postcard::to_stdvec(&9u32).unwrap();
-        let (bytecode, init_memory_state) = program.decode();
+        let (bytecode, init_memory_state, _) = program.decode();
         let (_, _, io_device) = program.trace(&inputs);
 
         let preprocessing = JoltRV32IMMockPCS::prover_preprocess(
@@ -374,7 +374,7 @@ mod tests {
     fn fib_e2e_dory() {
         let mut program = host::Program::new("fibonacci-guest");
         let inputs = postcard::to_stdvec(&100u32).unwrap();
-        let (bytecode, init_memory_state) = program.decode();
+        let (bytecode, init_memory_state, _) = program.decode();
         let (_, _, io_device) = program.trace(&inputs);
 
         let preprocessing = JoltRV32IM::prover_preprocess(
@@ -400,7 +400,7 @@ mod tests {
     #[serial]
     fn sha3_e2e_dory() {
         let mut program = host::Program::new("sha3-guest");
-        let (bytecode, init_memory_state) = program.decode();
+        let (bytecode, init_memory_state, _) = program.decode();
         let inputs = postcard::to_stdvec(&[5u8; 32]).unwrap();
         let (_, _, io_device) = program.trace(&inputs);
 
@@ -427,7 +427,7 @@ mod tests {
     #[serial]
     fn sha2_e2e_dory() {
         let mut program = host::Program::new("sha2-guest");
-        let (bytecode, init_memory_state) = program.decode();
+        let (bytecode, init_memory_state, _) = program.decode();
         let inputs = postcard::to_stdvec(&[5u8; 32]).unwrap();
         let (_, _, io_device) = program.trace(&inputs);
 
@@ -454,7 +454,7 @@ mod tests {
     #[serial]
     fn memory_ops_e2e_dory() {
         let mut program = host::Program::new("memory-ops-guest");
-        let (bytecode, init_memory_state) = program.decode();
+        let (bytecode, init_memory_state, _) = program.decode();
         let (_, _, io_device) = program.trace(&[]);
 
         let preprocessing = JoltRV32IM::prover_preprocess(

--- a/jolt-sdk/macros/src/lib.rs
+++ b/jolt-sdk/macros/src/lib.rs
@@ -167,6 +167,7 @@ impl MacroBuilder {
                         max_output_size: preprocessing.shared.memory_layout.max_output_size,
                         stack_size: preprocessing.shared.memory_layout.stack_size,
                         memory_size: preprocessing.shared.memory_layout.memory_size,
+                        bytecode_size: Some(preprocessing.shared.memory_layout.bytecode_size),
                     };
                     let mut io_device = JoltDevice::new(&memory_config);
 
@@ -274,12 +275,13 @@ impl MacroBuilder {
             {
                 #imports
 
-                let (bytecode, memory_init) = program.decode();
+                let (bytecode, memory_init, bytecode_size) = program.decode();
                 let memory_config = MemoryConfig {
                     max_input_size: #max_input_size,
                     max_output_size: #max_output_size,
                     stack_size: #stack_size,
                     memory_size: #memory_size,
+                    bytecode_size: Some(bytecode_size),
                 };
                 let memory_layout = MemoryLayout::new(&memory_config);
 
@@ -316,12 +318,13 @@ impl MacroBuilder {
             {
                 #imports
 
-                let (bytecode, memory_init) = program.decode();
+                let (bytecode, memory_init, bytecode_size) = program.decode();
                 let memory_config = MemoryConfig {
                     max_input_size: #max_input_size,
                     max_output_size: #max_output_size,
                     stack_size: #stack_size,
                     memory_size: #memory_size,
+                    bytecode_size: Some(bytecode_size),
                 };
                 let memory_layout = MemoryLayout::new(&memory_config);
 
@@ -417,6 +420,8 @@ impl MacroBuilder {
             max_output_size: attributes.max_output_size,
             stack_size: attributes.stack_size,
             memory_size: attributes.memory_size,
+            // Not needed for the main function, but we need the io region information from MemoryLayout.
+            bytecode_size: Some(0),
         });
         let input_start = memory_layout.input_start;
         let output_start = memory_layout.output_start;

--- a/src/build_wasm.rs
+++ b/src/build_wasm.rs
@@ -35,7 +35,7 @@ fn preprocess_and_save(func_name: &str, attributes: &Attributes, is_std: bool) -
     program.set_max_input_size(attributes.max_input_size);
     program.set_max_output_size(attributes.max_output_size);
 
-    let (bytecode, memory_init) = program.decode();
+    let (bytecode, memory_init, _) = program.decode();
     let decoded_data = DecodedData {
         bytecode,
         memory_init,

--- a/tracer/src/emulator/mmu.rs
+++ b/tracer/src/emulator/mmu.rs
@@ -1,9 +1,10 @@
 /// DRAM base address. Offset from this base address
 /// is the address in main memory.
-pub const DRAM_BASE: u64 = 0x80000000;
+pub const DRAM_BASE: u64 = RAM_START_ADDRESS;
 
 use crate::instruction::{RAMRead, RAMWrite};
-use common::jolt_device::{JoltDevice, MemoryConfig};
+use common::constants::RAM_START_ADDRESS;
+use common::jolt_device::JoltDevice;
 
 use super::cpu::{get_privilege_mode, PrivilegeMode, Trap, TrapType, Xlen};
 use super::memory::Memory;
@@ -23,7 +24,7 @@ pub struct Mmu {
     privilege_mode: PrivilegeMode,
     pub memory: MemoryWrapper,
 
-    pub jolt_device: JoltDevice,
+    pub jolt_device: Option<JoltDevice>,
 
     /// Address translation can be affected `mstatus` (MPRV, MPP in machine mode)
     /// then `Mmu` has copy of it.
@@ -68,7 +69,7 @@ impl Mmu {
             addressing_mode: AddressingMode::None,
             privilege_mode: PrivilegeMode::Machine,
             memory: MemoryWrapper::new(),
-            jolt_device: JoltDevice::new(&MemoryConfig::default()),
+            jolt_device: None,
             mstatus: 0,
         }
     }
@@ -151,7 +152,8 @@ impl Mmu {
     /// * `effective_address` Effective memory address to validate
     #[inline]
     fn assert_effective_address(&self, ea: u64, is_write: bool) {
-        let layout = &self.jolt_device.memory_layout;
+        let jolt_device = self.jolt_device.as_ref().expect("JoltDevice not set");
+        let layout = &jolt_device.memory_layout;
         // helper strings
         let (action, verb) = if is_write {
             ("Store", "write to")
@@ -160,29 +162,29 @@ impl Mmu {
         };
 
         if ea < DRAM_BASE {
-            // below DRAM_BASE => stack or I/O
-            // bounds‐check against the termination (top) of the stack or I/O region
+            // below DRAM_BASE => I/O
+            // bounds‐check against the termination (top) of the I/O region
             assert!(
-                ea < layout.io_end,
-                "Stack underflow: Attempted to {verb} 0x{ea:X}. Out of bounds.\n{layout:#?}",
+                ea <= layout.io_end,
+                "I/O overflow: Attempted to {verb} 0x{ea:X}. Out of bounds.\n{layout:#?}",
             );
-            // bounds-check against the bottom of the stack
             assert!(
-                ea >= layout.stack_end,
-                "Stack overflow: Attempted to {verb} 0x{ea:X}. Stack too small.\n{layout:#?}",
+                ea >= layout.input_start,
+                "I/O underflow: Attempted to {verb} 0x{ea:X}. Out of bounds.\n{layout:#?}",
             );
+
             // then check for device I/O pages
             let ok = if is_write {
                 // stores only to output/panic/termination
-                self.jolt_device.is_output(ea)
-                    || self.jolt_device.is_panic(ea)
-                    || self.jolt_device.is_termination(ea)
+                jolt_device.is_output(ea)
+                    || jolt_device.is_panic(ea)
+                    || jolt_device.is_termination(ea)
             } else {
                 // loads also from input
-                self.jolt_device.is_input(ea)
-                    || self.jolt_device.is_output(ea)
-                    || self.jolt_device.is_panic(ea)
-                    || self.jolt_device.is_termination(ea)
+                jolt_device.is_input(ea)
+                    || jolt_device.is_output(ea)
+                    || jolt_device.is_panic(ea)
+                    || jolt_device.is_termination(ea)
             };
             assert!(
                 ok,
@@ -190,11 +192,25 @@ impl Mmu {
                 action.to_lowercase(),
             );
         } else {
-            // above DRAM_BASE ⇒ heap
-            assert!(
-                self.memory.validate_address(ea),
-                "Heap overflow: Attempted to {verb} 0x{ea:X}",
-            );
+            // check within RAM
+            if is_write {
+                // These errors aren't necessarily correct as there's no way to distinguish between an
+                // attempt to write to the stack vs heap, but they're trying their best
+                assert!(
+                    ea > layout.stack_end,
+                    "Stack overflow: Attempted to {verb} 0x{ea:X}. Stack too small.\n{layout:#?}",
+                );
+                assert!(
+                    ea <= layout.memory_end,
+                    "Heap overflow: Attempted to {verb} 0x{ea:X}. Heap too small.\n{layout:#?}",
+                );
+            } else {
+                // allow reads across the whole designated memory region as long as the address is valid
+                assert!(
+                    ea <= layout.memory_end,
+                    "Illegal Memory Access: Attempted to {verb} 0x{ea:X}.\n{layout:#?}",
+                );
+            }
         }
     }
 
@@ -465,6 +481,7 @@ impl Mmu {
     /// # Arguments
     /// * `p_address` Physical address
     pub fn load_raw(&mut self, p_address: u64) -> u8 {
+        let jolt_device = self.jolt_device.as_ref().expect("JoltDevice not set");
         let effective_address = self.get_effective_address(p_address);
         self.assert_effective_load_address(effective_address);
         // @TODO: Mapping should be configurable with dtb
@@ -480,12 +497,12 @@ impl Mmu {
                 0x10000000..=0x100000ff => panic!("load_raw:UART is unsupported."),
                 0x10001000..=0x10001FFF => panic!("load_raw:disk is unsupported."),
                 _ => {
-                    if self.jolt_device.is_input(effective_address)
-                        || self.jolt_device.is_output(effective_address)
-                        || self.jolt_device.is_panic(effective_address)
-                        || self.jolt_device.is_termination(effective_address)
+                    if jolt_device.is_input(effective_address)
+                        || jolt_device.is_output(effective_address)
+                        || jolt_device.is_panic(effective_address)
+                        || jolt_device.is_termination(effective_address)
                     {
-                        self.jolt_device.load(effective_address)
+                        jolt_device.load(effective_address)
                     } else {
                         panic!("Load Failed: Unknown memory mapping {effective_address:X}.");
                     }
@@ -505,7 +522,11 @@ impl Mmu {
         if word_address < DRAM_BASE {
             let mut value_bytes = [0u8; 8];
             for i in 0..bytes {
-                value_bytes[i as usize] = self.jolt_device.load(word_address + i);
+                value_bytes[i as usize] = self
+                    .jolt_device
+                    .as_ref()
+                    .expect("JoltDevice not set")
+                    .load(word_address + i);
             }
             RAMRead {
                 address: word_address,
@@ -537,7 +558,11 @@ impl Mmu {
         let pre_value = if effective_address < DRAM_BASE {
             let mut pre_value_bytes = [0u8; 8];
             for i in 0..bytes {
-                pre_value_bytes[i as usize] = self.jolt_device.load(word_address + i);
+                pre_value_bytes[i as usize] = self
+                    .jolt_device
+                    .as_ref()
+                    .expect("JoltDevice not set")
+                    .load(word_address + i);
             }
             u64::from_le_bytes(pre_value_bytes)
         } else {
@@ -578,7 +603,11 @@ impl Mmu {
         let pre_value = if effective_address < DRAM_BASE {
             let mut pre_value_bytes = [0u8; 8];
             for i in 0..bytes {
-                pre_value_bytes[i as usize] = self.jolt_device.load(word_address + i);
+                pre_value_bytes[i as usize] = self
+                    .jolt_device
+                    .as_ref()
+                    .expect("JoltDevice not set")
+                    .load(word_address + i);
             }
             u64::from_le_bytes(pre_value_bytes)
         } else {
@@ -618,7 +647,11 @@ impl Mmu {
         if effective_address < DRAM_BASE {
             let mut pre_value_bytes = [0u8; 8];
             for i in 0..bytes {
-                pre_value_bytes[i as usize] = self.jolt_device.load(effective_address + i);
+                pre_value_bytes[i as usize] = self
+                    .jolt_device
+                    .as_ref()
+                    .expect("JoltDevice not set")
+                    .load(effective_address + i);
             }
             let pre_value = u64::from_le_bytes(pre_value_bytes);
             RAMWrite {
@@ -736,10 +769,28 @@ impl Mmu {
                 0x10001000..=0x10001FFF => panic!("store_raw:disk is unsupported."),
                 _ => {
                     self.assert_effective_store_address(effective_address);
-                    self.jolt_device.store(effective_address, value);
+                    self.jolt_device
+                        .as_mut()
+                        .expect("JoltDevice not set")
+                        .store(effective_address, value);
                 }
             },
         };
+    }
+
+    pub fn setup_bytecode(&mut self, p_address: u64, value: u8) {
+        let effective_address = self.get_effective_address(p_address);
+
+        assert!(
+            effective_address >= DRAM_BASE,
+            "setup_bytecode: Effective address must be >= DRAM_BASE, got {effective_address:X}."
+        );
+        assert!(
+            effective_address <= self.jolt_device.as_ref().unwrap().memory_layout.stack_end,
+            "setup_bytecode: Effective address must be < stack_end, got {effective_address:X}."
+        );
+
+        self.memory.write_byte(effective_address, value)
     }
 
     /// Stores two bytes to main memory or peripheral devices depending on
@@ -1183,7 +1234,7 @@ mod test_mmu {
     #[should_panic(expected = "Unknown memory mapping")]
     fn test_unknown_memory_mapping() {
         let mut mmu = setup_mmu(MEM_CAPACITY);
-        let over_stack_addr = mmu.jolt_device.memory_layout.input_start + 5;
+        let over_stack_addr = mmu.jolt_device.as_ref().unwrap().memory_layout.input_start + 5;
         // illegal write to inputs
         mmu.store_bytes(over_stack_addr, 0xc50513, 2).unwrap();
     }

--- a/tracer/src/lib.rs
+++ b/tracer/src/lib.rs
@@ -140,7 +140,7 @@ fn setup_emulator(elf_contents: Vec<u8>, inputs: &[u8], memory_config: &MemoryCo
 
     let mut jolt_device = JoltDevice::new(memory_config);
     jolt_device.inputs = inputs.to_vec();
-    emulator.get_mut_cpu().get_mut_mmu().jolt_device = jolt_device;
+    emulator.get_mut_cpu().get_mut_mmu().jolt_device = Some(jolt_device);
 
     emulator.setup_program(elf_contents);
     emulator
@@ -195,8 +195,12 @@ impl LazyTraceIterator {
 
     pub fn get_jolt_device(self) -> JoltDevice {
         let mut final_emulator_state = self.get_emulator_state();
-        let mut_jolt_device = &mut final_emulator_state.get_mut_cpu().get_mut_mmu().jolt_device;
-        std::mem::take(mut_jolt_device)
+        final_emulator_state
+            .get_mut_cpu()
+            .get_mut_mmu()
+            .jolt_device
+            .take()
+            .expect("JoltDevice was not initialized")
     }
 
     pub fn is_empty(&self) -> bool {


### PR DESCRIPTION
- aligned linker and emulator memory region sizes
- ensure bytecode size is known before constructing MemoryLayout so that bounds checks can be enforced
- aligned DRAM_BASE and RAM_START_ADDRESS
- made JoltDevice optional in mmu instead of initializing it with a dummy memory layout