### PR TITLE
Misceallaneous cleanup

### DIFF
--- a/jolt-core/benches/commit.rs
+++ b/jolt-core/benches/commit.rs
@@ -9,7 +9,8 @@ use jolt_core::utils::transcript::{KeccakTranscript, Transcript};
 use rand_chacha::ChaCha20Rng;
 use rand_core::{RngCore, SeedableRng};
 
-const SRS_SIZE: usize = 1 << 10;
+const NUM_VARS: usize = 10;
+const SRS_SIZE: usize = 1 << NUM_VARS;
 
 // Sets up the benchmark by generating leaves and computing known products
 // and allows configuring the percentage of ones in the leaves
@@ -56,7 +57,7 @@ where
     // Compute known products (one per layer)
     let known_products: Vec<F> = leaves.iter().map(|layer| layer.iter().product()).collect();
 
-    let setup = PCS::setup_prover(SRS_SIZE);
+    let setup = PCS::setup_prover(NUM_VARS);
 
     (leaves, setup, known_products)
 }

--- a/jolt-core/src/poly/commitment/bmmtv/hyperbmmtv.rs
+++ b/jolt-core/src/poly/commitment/bmmtv/hyperbmmtv.rs
@@ -98,9 +98,10 @@ where
     type OpeningProofHint = ();
 
     #[tracing::instrument(skip_all, name = "HyperBmmtv::setup")]
-    fn setup_prover(max_len: usize) -> Self::ProverSetup {
+    fn setup_prover(max_num_vars: usize) -> Self::ProverSetup {
         let mut rng = ChaCha20Rng::from_seed(*b"HyperBMMTV_POLY_COMMITMENTSCHEME");
-        let srs = UnivariatePolynomialCommitment::<P>::setup(&mut rng, max_len - 1).unwrap();
+        let srs =
+            UnivariatePolynomialCommitment::<P>::setup(&mut rng, (1 << max_num_vars) - 1).unwrap();
         let powers_len = srs.g1_powers.len();
 
         SRS::trim(Arc::new(srs), powers_len - 1).0
@@ -109,10 +110,6 @@ where
     #[tracing::instrument(skip_all, name = "HyperBmmtv::setup_verifier")]
     fn setup_verifier(setup: &Self::ProverSetup) -> Self::VerifierSetup {
         KZGVerifierKey::<P>::from(setup)
-    }
-
-    fn srs_size(setup: &Self::ProverSetup) -> usize {
-        setup.g1_powers().len()
     }
 
     #[tracing::instrument(skip_all, name = "HyperBmmtv::commit")]

--- a/jolt-core/src/poly/commitment/dory.rs
+++ b/jolt-core/src/poly/commitment/dory.rs
@@ -940,10 +940,6 @@ impl CommitmentScheme for DoryCommitmentScheme {
         prover_setup.to_verifier_setup()
     }
 
-    fn srs_size(_setup: &Self::ProverSetup) -> usize {
-        todo!()
-    }
-
     #[tracing::instrument(skip_all, name = "DoryCommitmentScheme::commit")]
     fn commit(
         poly: &MultilinearPolynomial<Self::Field>,

--- a/jolt-core/src/poly/commitment/dory.rs
+++ b/jolt-core/src/poly/commitment/dory.rs
@@ -61,12 +61,11 @@ impl DoryGlobals {
     /// Initializes the static variables (`GLOBAL_T`, `MAX_NUM_ROWS`, and
     /// `NUM_COLUMNS`) used by Dory.
     pub fn initialize(K: usize, T: usize) -> Self {
-        println!("K_log {}, T_log {}", K.log_2(), T.log_2());
         let matrix_size = K as u128 * T as u128;
         let num_columns = matrix_size.isqrt().next_power_of_two();
         let num_rows = num_columns;
-        println!("# rows: {num_rows}");
-        println!("# cols: {num_columns}");
+        println!("[Dory PCS] # rows: {num_rows}");
+        println!("[Dory PCS] # cols: {num_columns}");
 
         unsafe {
             GLOBAL_T.set(T).expect("GLOBAL_T is already initialized");
@@ -879,13 +878,10 @@ where
     fn vector_matrix_product(
         &self,
         left_vec: &[JoltFieldWrapper<F>],
-        sigma: usize,
-        nu: usize,
+        _sigma: usize,
+        _nu: usize,
     ) -> Vec<JoltFieldWrapper<F>> {
         let num_columns = DoryGlobals::get_num_columns();
-        println!("sigma: {sigma}");
-        println!("nu: {nu}");
-        println!("num_columns: {num_columns}");
 
         match self {
             MultilinearPolynomial::LargeScalars(poly) => (0..num_columns)
@@ -1194,8 +1190,6 @@ impl CommitmentScheme for DoryCommitmentScheme {
             setup,
             dory_transcript,
         );
-
-        println!("{verify_result:?}");
 
         match verify_result {
             Ok(()) => Ok(()),

--- a/jolt-core/src/poly/commitment/hyperkzg.rs
+++ b/jolt-core/src/poly/commitment/hyperkzg.rs
@@ -406,13 +406,13 @@ where
     type BatchedProof = HyperKZGProof<P>;
     type OpeningProofHint = ();
 
-    fn setup_prover(max_len: usize) -> Self::ProverSetup {
+    fn setup_prover(max_num_vars: usize) -> Self::ProverSetup {
         HyperKZGSRS(Arc::new(SRS::setup(
             &mut ChaCha20Rng::from_seed(*b"HyperKZG_POLY_COMMITMENT_SCHEMEE"),
-            max_len,
+            1 << max_num_vars,
             2,
         )))
-        .trim(max_len)
+        .trim(1 << max_num_vars)
         .0
     }
 
@@ -420,10 +420,6 @@ where
         HyperKZGVerifierKey {
             kzg_vk: KZGVerifierKey::from(&setup.kzg_pk),
         }
-    }
-
-    fn srs_size(setup: &Self::ProverSetup) -> usize {
-        setup.kzg_pk.g1_powers().len()
     }
 
     #[tracing::instrument(skip_all, name = "HyperKZG::commit")]

--- a/jolt-core/src/poly/commitment/mock.rs
+++ b/jolt-core/src/poly/commitment/mock.rs
@@ -47,13 +47,9 @@ where
     type BatchedProof = MockProof<F>;
     type OpeningProofHint = ();
 
-    fn setup_prover(_max_len: usize) -> Self::ProverSetup {}
+    fn setup_prover(_num_vars: usize) -> Self::ProverSetup {}
 
     fn setup_verifier(_setup: &Self::ProverSetup) -> Self::VerifierSetup {}
-
-    fn srs_size(_setup: &Self::ProverSetup) -> usize {
-        1 << 10
-    }
 
     fn commit(
         _poly: &MultilinearPolynomial<Self::Field>,

--- a/jolt-core/src/poly/commitment/zeromorph.rs
+++ b/jolt-core/src/poly/commitment/zeromorph.rs
@@ -426,10 +426,11 @@ where
     type BatchedProof = ZeromorphProof<P>;
     type OpeningProofHint = ();
 
-    fn setup_prover(max_len: usize) -> Self::ProverSetup
+    fn setup_prover(max_num_vars: usize) -> Self::ProverSetup
     where
         P::ScalarField: JoltField,
     {
+        let max_len = 1 << max_num_vars;
         ZeromorphSRS(Arc::new(SRS::setup(
             &mut ChaCha20Rng::from_seed(*b"ZEROMORPH_POLY_COMMITMENT_SCHEME"),
             max_len,
@@ -441,10 +442,6 @@ where
 
     fn setup_verifier(setup: &Self::ProverSetup) -> Self::VerifierSetup {
         ZeromorphVerifierKey::from(setup)
-    }
-
-    fn srs_size(setup: &Self::ProverSetup) -> usize {
-        setup.commit_pp.g1_powers().len()
     }
 
     fn commit(

--- a/jolt-core/src/poly/compact_polynomial.rs
+++ b/jolt-core/src/poly/compact_polynomial.rs
@@ -1,9 +1,9 @@
 use std::ops::Index;
 
 use super::multilinear_polynomial::{BindingOrder, PolynomialBinding};
+use crate::field::JoltField;
 use crate::utils::math::Math;
 use crate::utils::thread::unsafe_allocate_zero_vec;
-use crate::{field::JoltField, utils};
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use num_integer::Integer;
 use rayon::prelude::*;
@@ -114,7 +114,7 @@ pub struct CompactPolynomial<T: SmallScalar, F: JoltField> {
 impl<T: SmallScalar, F: JoltField> CompactPolynomial<T, F> {
     pub fn from_coeffs(coeffs: Vec<T>) -> Self {
         assert!(
-            utils::is_power_of_two(coeffs.len()),
+            coeffs.len().is_power_of_two(),
             "Multilinear polynomials must be made from a power of 2 (not {})",
             coeffs.len()
         );

--- a/jolt-core/src/poly/dense_mlpoly.rs
+++ b/jolt-core/src/poly/dense_mlpoly.rs
@@ -3,7 +3,7 @@
 use crate::poly::eq_poly::EqPolynomial;
 use crate::poly::multilinear_polynomial::PolynomialEvaluation;
 use crate::utils::thread::unsafe_allocate_zero_vec;
-use crate::utils::{self, compute_dotproduct, compute_dotproduct_low_optimized};
+use crate::utils::{compute_dotproduct, compute_dotproduct_low_optimized};
 
 use crate::field::JoltField;
 use crate::utils::math::Math;
@@ -25,7 +25,7 @@ pub struct DensePolynomial<F: JoltField> {
 impl<F: JoltField> DensePolynomial<F> {
     pub fn new(Z: Vec<F>) -> Self {
         assert!(
-            utils::is_power_of_two(Z.len()),
+            Z.len().is_power_of_two(),
             "Dense multi-linear polynomials must be made from a power of 2 (not {})",
             Z.len()
         );
@@ -41,7 +41,7 @@ impl<F: JoltField> DensePolynomial<F> {
     pub fn new_padded(evals: Vec<F>) -> Self {
         // Pad non-power-2 evaluations to fill out the dense multilinear polynomial
         let mut poly_evals = evals;
-        while !(utils::is_power_of_two(poly_evals.len())) {
+        while !(poly_evals.len().is_power_of_two()) {
             poly_evals.push(F::zero());
         }
 

--- a/jolt-core/src/poly/one_hot_polynomial.rs
+++ b/jolt-core/src/poly/one_hot_polynomial.rs
@@ -349,7 +349,7 @@ impl<F: JoltField> OneHotPolynomial<F> {
         bases: &[G::Affine],
     ) -> Vec<JoltGroupWrapper<G>> {
         let num_rows = self.num_rows();
-        println!("# rows = {num_rows}");
+        println!("Committing to one-hot polynomial with {num_rows} rows");
         let row_len = DoryGlobals::get_num_columns();
         let T = DoryGlobals::get_T();
 

--- a/jolt-core/src/poly/opening_proof.rs
+++ b/jolt-core/src/poly/opening_proof.rs
@@ -724,7 +724,10 @@ where
         pcs_setup: &PCS::ProverSetup,
         transcript: &mut ProofTranscript,
     ) -> ReducedOpeningProof<F, PCS, ProofTranscript> {
-        println!("# instances: {}", self.sumchecks.len());
+        println!(
+            "{} sumcheck instances in batched opening proof reduction",
+            self.sumchecks.len()
+        );
 
         self.sumchecks
             .iter_mut()
@@ -1113,13 +1116,6 @@ where
                 *coeff * claim * lagrange_eval
             })
             .sum();
-
-        // #[cfg(test)]
-        // assert_eq!(
-        //     joint_claim,
-        //     reduced_opening_proof.joint_poly.evaluate(&r_sumcheck),
-        //     "joint claim mismatch"
-        // );
 
         // Verify the reduced opening proof
         PCS::verify(

--- a/jolt-core/src/poly/rlc_polynomial.rs
+++ b/jolt-core/src/poly/rlc_polynomial.rs
@@ -47,7 +47,7 @@ impl<F: JoltField> RLCPolynomial<F> {
         bases: &[G::Affine],
     ) -> Vec<JoltGroupWrapper<G>> {
         let num_rows = DoryGlobals::get_max_num_rows();
-        println!("# rows = {num_rows}");
+        println!("Committing to RLC polynomial with {num_rows} rows");
         let row_len = DoryGlobals::get_num_columns();
 
         let mut row_commitments = vec![JoltGroupWrapper(G::zero()); num_rows];

--- a/jolt-core/src/subprotocols/sumcheck.rs
+++ b/jolt-core/src/subprotocols/sumcheck.rs
@@ -3,9 +3,7 @@
 
 use crate::field::JoltField;
 use crate::poly::dense_mlpoly::DensePolynomial;
-use crate::poly::multilinear_polynomial::{
-    BindingOrder, MultilinearPolynomial, PolynomialBinding, PolynomialEvaluation,
-};
+use crate::poly::multilinear_polynomial::{BindingOrder, MultilinearPolynomial};
 use crate::poly::opening_proof::{
     OpeningPoint, ProverOpeningAccumulator, VerifierOpeningAccumulator, BIG_ENDIAN,
 };
@@ -375,115 +373,6 @@ impl BatchedSumcheck {
 }
 
 impl<F: JoltField, ProofTranscript: Transcript> SumcheckInstanceProof<F, ProofTranscript> {
-    /// Create a sumcheck proof for polynomial(s) of arbitrary degree.
-    ///
-    /// Params
-    /// - `claim`: Claimed sumcheck evaluation (note: currently unused)
-    /// - `num_rounds`: Number of rounds of sumcheck, or number of variables to bind
-    /// - `polys`: Dense polynomials to combine and sumcheck
-    /// - `comb_func`: Function used to combine each polynomial evaluation
-    /// - `transcript`: Fiat-shamir transcript
-    ///
-    /// Returns (SumcheckInstanceProof, r_eval_point, final_evals)
-    /// - `r_eval_point`: Final random point of evaluation
-    /// - `final_evals`: Each of the polys evaluated at `r_eval_point`
-    #[tracing::instrument(skip_all, name = "Sumcheck.prove")]
-    pub fn prove_arbitrary<Func>(
-        claim: &F,
-        num_rounds: usize,
-        polys: &mut Vec<MultilinearPolynomial<F>>,
-        comb_func: Func,
-        combined_degree: usize,
-        transcript: &mut ProofTranscript,
-    ) -> (Self, Vec<F>, Vec<F>)
-    where
-        Func: Fn(&[F]) -> F + std::marker::Sync,
-    {
-        let mut previous_claim = *claim;
-        let mut r: Vec<F> = Vec::new();
-        let mut compressed_polys: Vec<CompressedUniPoly<F>> = Vec::new();
-
-        #[cfg(test)]
-        {
-            for poly in polys.iter() {
-                assert_eq!(num_rounds, poly.get_num_vars());
-            }
-            let total_evals = 1 << num_rounds;
-            let mut sum = F::zero();
-            for i in 0..total_evals {
-                let params: Vec<F> = polys.iter().map(|poly| poly.get_coeff(i)).collect();
-                sum += comb_func(&params);
-            }
-            assert_eq!(&sum, claim, "Sumcheck claim is wrong");
-        }
-
-        for _round in 0..num_rounds {
-            // Vector storing evaluations of combined polynomials g(x) = P_0(x) * ... P_{num_polys} (x)
-            // for points {0, ..., |g(x)|}
-            let mut eval_points = vec![F::zero(); combined_degree];
-
-            let mle_half = polys[0].len() / 2;
-
-            let accum: Vec<Vec<F>> = (0..mle_half)
-                .into_par_iter()
-                .map(|poly_term_i| {
-                    let mut accum = vec![F::zero(); combined_degree];
-                    // TODO(moodlezoup): Optimize
-                    let evals: Vec<_> = polys
-                        .iter()
-                        .map(|poly| {
-                            poly.sumcheck_evals(
-                                poly_term_i,
-                                combined_degree,
-                                BindingOrder::HighToLow,
-                            )
-                        })
-                        .collect();
-                    for j in 0..combined_degree {
-                        let evals_j: Vec<_> = evals.iter().map(|x| x[j]).collect();
-                        accum[j] += comb_func(&evals_j);
-                    }
-
-                    accum
-                })
-                .collect();
-
-            eval_points
-                .par_iter_mut()
-                .enumerate()
-                .for_each(|(poly_i, eval_point)| {
-                    *eval_point = accum
-                        .par_iter()
-                        .take(mle_half)
-                        .map(|mle| mle[poly_i])
-                        .sum::<F>();
-                });
-
-            eval_points.insert(1, previous_claim - eval_points[0]);
-            let univariate_poly = UniPoly::from_evals(&eval_points);
-            let compressed_poly = univariate_poly.compress();
-
-            // append the prover's message to the transcript
-            compressed_poly.append_to_transcript(transcript);
-            let r_j = transcript.challenge_scalar();
-            r.push(r_j);
-
-            // bound all tables to the verifier's challenge
-            polys
-                .par_iter_mut()
-                .for_each(|poly| poly.bind(r_j, BindingOrder::HighToLow));
-            previous_claim = univariate_poly.evaluate(&r_j);
-            compressed_polys.push(compressed_poly);
-        }
-
-        let final_evals = polys
-            .iter()
-            .map(|poly| poly.final_sumcheck_claim())
-            .collect();
-
-        (SumcheckInstanceProof::new(compressed_polys), r, final_evals)
-    }
-
     #[tracing::instrument(skip_all, name = "Spartan::prove_spartan_small_value")]
     pub fn prove_spartan_small_value<const NUM_SVO_ROUNDS: usize>(
         num_rounds: usize,

--- a/jolt-core/src/utils/math.rs
+++ b/jolt-core/src/utils/math.rs
@@ -1,28 +1,13 @@
 pub trait Math {
-    fn square_root(self) -> usize;
     fn pow2(self) -> usize;
-    fn get_bits(self, num_bits: usize) -> Vec<bool>;
     fn log_2(self) -> usize;
-    fn num_bits(self) -> usize;
 }
 
 impl Math for usize {
     #[inline]
-    fn square_root(self) -> usize {
-        (self as f64).sqrt() as usize
-    }
-
-    #[inline]
     fn pow2(self) -> usize {
         let base: usize = 2;
         base.pow(self as u32)
-    }
-
-    /// Returns the num_bits from n in a canonical order
-    fn get_bits(self, num_bits: usize) -> Vec<bool> {
-        (0..num_bits)
-            .map(|shift_amount| ((self & (1 << (num_bits - shift_amount - 1))) > 0))
-            .collect::<Vec<bool>>()
     }
 
     fn log_2(self) -> usize {
@@ -33,9 +18,5 @@ impl Math for usize {
         } else {
             (0usize.leading_zeros() - self.leading_zeros()) as usize
         }
-    }
-
-    fn num_bits(self) -> usize {
-        (0usize.leading_zeros() - self.leading_zeros()) as usize
     }
 }

--- a/jolt-core/src/utils/mod.rs
+++ b/jolt-core/src/utils/mod.rs
@@ -1,7 +1,5 @@
-#![allow(dead_code)]
 use crate::field::JoltField;
 
-use ark_std::test_rng;
 use rayon::prelude::*;
 
 pub mod errors;
@@ -145,45 +143,6 @@ pub fn mul_0_optimized<F: JoltField>(likely_zero: &F, x: &F) -> F {
     }
 }
 
-/// Checks if `num` is a power of 2.
-pub fn is_power_of_two(num: usize) -> bool {
-    num != 0 && num.is_power_of_two()
-}
-
-/// Take the first two `num_bits` chunks of `item` (from the right / LSB) and return them as a tuple `(high_chunk, low_chunk)`.
-///
-/// If `item` is shorter than `2 * num_bits`, the remaining bits are zero-padded.
-///
-/// If `item` is longer than `2 * num_bits`, the remaining bits are discarded.
-///
-/// # Examples
-///
-/// ```
-/// use jolt_core::utils::split_bits;
-///
-/// assert_eq!(split_bits(0b101000, 2), (0b10, 0b00));
-/// assert_eq!(split_bits(0b101000, 3), (0b101, 0b000));
-/// assert_eq!(split_bits(0b101000, 4), (0b0010, 0b1000));
-/// ```
-pub fn split_bits(item: usize, num_bits: usize) -> (usize, usize) {
-    let max_value = (1 << num_bits) - 1; // Calculate the maximum value that can be represented with num_bits
-
-    let low_chunk = item & max_value; // Extract the lower bits
-    let high_chunk = (item >> num_bits) & max_value; // Shift the item to the right and extract the next set of bits
-
-    (high_chunk, low_chunk)
-}
-
-/// Generate a random point with `memory_bits` field elements.
-pub fn gen_random_point<F: JoltField>(memory_bits: usize) -> Vec<F> {
-    let mut rng = test_rng();
-    let mut r_i: Vec<F> = Vec::with_capacity(memory_bits);
-    for _ in 0..memory_bits {
-        r_i.push(F::random(&mut rng));
-    }
-    r_i
-}
-
 /// Splits a 64-bit value into two 32-bit values by separating even and odd bits.
 /// The even bits (indices 0,2,4,...) go into the first returned value, and odd bits (indices 1,3,5,...) into the second.
 ///
@@ -259,6 +218,7 @@ pub fn interleave_bits(even_bits: u32, odd_bits: u32) -> u64 {
 
 #[cfg(test)]
 mod tests {
+    use ark_std::test_rng;
     use rand_core::RngCore;
 
     use super::*;
@@ -277,11 +237,5 @@ mod tests {
             let odd = rng.next_u32();
             assert_eq!((even, odd), uninterleave_bits(interleave_bits(even, odd)));
         }
-    }
-
-    #[test]
-    fn split() {
-        assert_eq!(split_bits(0b00_01, 2), (0, 1));
-        assert_eq!(split_bits(0b10_01, 2), (2, 1));
     }
 }

--- a/jolt-core/src/zkvm/bytecode/mod.rs
+++ b/jolt-core/src/zkvm/bytecode/mod.rs
@@ -7,8 +7,7 @@ use crate::zkvm::bytecode::hamming_weight::HammingWeightSumcheck;
 use crate::zkvm::bytecode::read_raf_checking::ReadRafSumcheck;
 use crate::zkvm::dag::stage::SumcheckStages;
 use crate::zkvm::dag::state_manager::StateManager;
-use crate::zkvm::ram::compute_d_parameter;
-use crate::zkvm::witness::VirtualPolynomial;
+use crate::zkvm::witness::{compute_d_parameter, VirtualPolynomial};
 use crate::{
     field::JoltField,
     poly::{commitment::commitment_scheme::CommitmentScheme, eq_poly::EqPolynomial},

--- a/jolt-core/src/zkvm/bytecode/read_raf_checking.rs
+++ b/jolt-core/src/zkvm/bytecode/read_raf_checking.rs
@@ -823,13 +823,3 @@ impl<F: JoltField> ReadRafSumcheck<F> {
             });
     }
 }
-
-/// Computes the bit-length of the suffix, for the current (`j`th) round
-/// of sumcheck.
-pub fn current_suffix_len(log_K: usize, j: usize) -> usize {
-    // Number of sumcheck rounds per "phase" of sparse-dense sumcheck.
-    let phase_length = log_K / 4;
-    // The suffix length is 3/4 * log_K at the beginning and shrinks by
-    // log_K / 4 after each phase.
-    log_K - (j / phase_length + 1) * phase_length
-}

--- a/jolt-core/src/zkvm/dag/jolt_dag.rs
+++ b/jolt-core/src/zkvm/dag/jolt_dag.rs
@@ -14,7 +14,9 @@ use crate::zkvm::instruction_lookups::LookupsDag;
 use crate::zkvm::r1cs::spartan::SpartanDag;
 use crate::zkvm::ram::RamDag;
 use crate::zkvm::registers::RegistersDag;
-use crate::zkvm::witness::{AllCommittedPolynomials, CommittedPolynomial, DTH_ROOT_OF_K};
+use crate::zkvm::witness::{
+    compute_d_parameter, AllCommittedPolynomials, CommittedPolynomial, DTH_ROOT_OF_K,
+};
 use crate::zkvm::ProverDebugInfo;
 use anyhow::Context;
 use rayon::prelude::*;
@@ -51,7 +53,7 @@ impl JoltDAG {
         let bytecode_d = preprocessing.shared.bytecode.d;
         let _guard = (
             DoryGlobals::initialize(DTH_ROOT_OF_K, padded_trace_length),
-            AllCommittedPolynomials::initialize(ram_K, bytecode_d),
+            AllCommittedPolynomials::initialize(compute_d_parameter(ram_K), bytecode_d),
         );
 
         // Generate and commit to all witness polynomials
@@ -247,7 +249,7 @@ impl JoltDAG {
 
         let ram_K = state_manager.ram_K;
         let bytecode_d = state_manager.get_verifier_data().0.shared.bytecode.d;
-        let _guard = AllCommittedPolynomials::initialize(ram_K, bytecode_d);
+        let _guard = AllCommittedPolynomials::initialize(compute_d_parameter(ram_K), bytecode_d);
 
         // Append commitments to transcript
         let commitments = state_manager.get_commitments();

--- a/jolt-core/src/zkvm/dag/jolt_dag.rs
+++ b/jolt-core/src/zkvm/dag/jolt_dag.rs
@@ -12,9 +12,9 @@ use crate::zkvm::dag::stage::SumcheckStages;
 use crate::zkvm::dag::state_manager::{ProofData, ProofKeys, StateManager};
 use crate::zkvm::instruction_lookups::LookupsDag;
 use crate::zkvm::r1cs::spartan::SpartanDag;
-use crate::zkvm::ram::{RamDag, NUM_RA_I_VARS};
+use crate::zkvm::ram::RamDag;
 use crate::zkvm::registers::RegistersDag;
-use crate::zkvm::witness::{AllCommittedPolynomials, CommittedPolynomial};
+use crate::zkvm::witness::{AllCommittedPolynomials, CommittedPolynomial, DTH_ROOT_OF_K};
 use crate::zkvm::ProverDebugInfo;
 use anyhow::Context;
 use rayon::prelude::*;
@@ -50,7 +50,7 @@ impl JoltDAG {
         let ram_K = state_manager.ram_K;
         let bytecode_d = preprocessing.shared.bytecode.d;
         let _guard = (
-            DoryGlobals::initialize(1 << NUM_RA_I_VARS, padded_trace_length),
+            DoryGlobals::initialize(DTH_ROOT_OF_K, padded_trace_length),
             AllCommittedPolynomials::initialize(ram_K, bytecode_d),
         );
 

--- a/jolt-core/src/zkvm/instruction_lookups/read_raf_checking.rs
+++ b/jolt-core/src/zkvm/instruction_lookups/read_raf_checking.rs
@@ -889,6 +889,7 @@ mod tests {
             program_io,
             trace.len(),
             1 << 8,
+            prover_sm.twist_sumcheck_switch_index,
         );
 
         let r_cycle: Vec<Fr> = prover_sm.transcript.borrow_mut().challenge_vector(LOG_T);

--- a/jolt-core/src/zkvm/instruction_lookups/read_raf_checking.rs
+++ b/jolt-core/src/zkvm/instruction_lookups/read_raf_checking.rs
@@ -42,6 +42,16 @@ use crate::{
 
 const DEGREE: usize = D + 2;
 
+/// Computes the bit-length of the suffix, for the current (`j`th) round
+/// of sumcheck.
+pub fn current_suffix_len(log_K: usize, j: usize) -> usize {
+    // Number of sumcheck rounds per "phase" of sparse-dense sumcheck.
+    let phase_length = log_K / 4;
+    // The suffix length is 3/4 * log_K at the beginning and shrinks by
+    // log_K / 4 after each phase.
+    log_K - (j / phase_length + 1) * phase_length
+}
+
 struct ReadRafProverState<F: JoltField> {
     ra: Vec<MultilinearPolynomial<F>>,
     r: Vec<F>,

--- a/jolt-core/src/zkvm/lookup_table/prefixes/and.rs
+++ b/jolt-core/src/zkvm/lookup_table/prefixes/and.rs
@@ -1,5 +1,7 @@
-use crate::zkvm::bytecode::read_raf_checking::current_suffix_len;
-use crate::{field::JoltField, utils::lookup_bits::LookupBits};
+use crate::{
+    field::JoltField, utils::lookup_bits::LookupBits,
+    zkvm::instruction_lookups::read_raf_checking::current_suffix_len,
+};
 
 use super::{PrefixCheckpoint, Prefixes, SparseDensePrefix};
 

--- a/jolt-core/src/zkvm/lookup_table/prefixes/lower_word.rs
+++ b/jolt-core/src/zkvm/lookup_table/prefixes/lower_word.rs
@@ -1,4 +1,4 @@
-use crate::zkvm::bytecode::read_raf_checking::current_suffix_len;
+use crate::zkvm::instruction_lookups::read_raf_checking::current_suffix_len;
 use crate::{field::JoltField, utils::lookup_bits::LookupBits};
 
 use super::{PrefixCheckpoint, Prefixes, SparseDensePrefix};

--- a/jolt-core/src/zkvm/lookup_table/prefixes/lsb.rs
+++ b/jolt-core/src/zkvm/lookup_table/prefixes/lsb.rs
@@ -1,4 +1,4 @@
-use crate::zkvm::bytecode::read_raf_checking::current_suffix_len;
+use crate::zkvm::instruction_lookups::read_raf_checking::current_suffix_len;
 use crate::{field::JoltField, utils::lookup_bits::LookupBits};
 
 use super::{PrefixCheckpoint, SparseDensePrefix};

--- a/jolt-core/src/zkvm/lookup_table/prefixes/or.rs
+++ b/jolt-core/src/zkvm/lookup_table/prefixes/or.rs
@@ -1,4 +1,4 @@
-use crate::zkvm::bytecode::read_raf_checking::current_suffix_len;
+use crate::zkvm::instruction_lookups::read_raf_checking::current_suffix_len;
 use crate::{field::JoltField, utils::lookup_bits::LookupBits};
 
 use super::{PrefixCheckpoint, Prefixes, SparseDensePrefix};

--- a/jolt-core/src/zkvm/lookup_table/prefixes/pow2.rs
+++ b/jolt-core/src/zkvm/lookup_table/prefixes/pow2.rs
@@ -1,5 +1,5 @@
 use crate::utils::math::Math;
-use crate::zkvm::bytecode::read_raf_checking::current_suffix_len;
+use crate::zkvm::instruction_lookups::read_raf_checking::current_suffix_len;
 use crate::{field::JoltField, utils::lookup_bits::LookupBits};
 
 use super::{PrefixCheckpoint, Prefixes, SparseDensePrefix};

--- a/jolt-core/src/zkvm/lookup_table/prefixes/upper_word.rs
+++ b/jolt-core/src/zkvm/lookup_table/prefixes/upper_word.rs
@@ -1,4 +1,4 @@
-use crate::zkvm::bytecode::read_raf_checking::current_suffix_len;
+use crate::zkvm::instruction_lookups::read_raf_checking::current_suffix_len;
 use crate::{field::JoltField, utils::lookup_bits::LookupBits};
 
 use super::{PrefixCheckpoint, Prefixes, SparseDensePrefix};

--- a/jolt-core/src/zkvm/lookup_table/prefixes/xor.rs
+++ b/jolt-core/src/zkvm/lookup_table/prefixes/xor.rs
@@ -1,4 +1,4 @@
-use crate::zkvm::bytecode::read_raf_checking::current_suffix_len;
+use crate::zkvm::instruction_lookups::read_raf_checking::current_suffix_len;
 use crate::{field::JoltField, utils::lookup_bits::LookupBits};
 
 use super::{PrefixCheckpoint, Prefixes, SparseDensePrefix};

--- a/jolt-core/src/zkvm/mod.rs
+++ b/jolt-core/src/zkvm/mod.rs
@@ -188,7 +188,6 @@ where
 
         let max_T: usize = max_trace_length.next_power_of_two();
 
-        // TODO(moodlezoup): Change setup parameter to # variables everywhere
         let generators = PCS::setup_prover(DTH_ROOT_OF_K.log_2() + max_T.log_2());
 
         JoltProverPreprocessing {

--- a/jolt-core/src/zkvm/ram/mod.rs
+++ b/jolt-core/src/zkvm/ram/mod.rs
@@ -6,7 +6,7 @@ use crate::{
     field::JoltField,
     poly::commitment::commitment_scheme::CommitmentScheme,
     subprotocols::sumcheck::SumcheckInstance,
-    utils::{math::Math, transcript::Transcript},
+    utils::transcript::Transcript,
     zkvm::dag::{stage::SumcheckStages, state_manager::StateManager},
     zkvm::ram::{
         booleanity::BooleanitySumcheck,
@@ -34,13 +34,6 @@ pub mod ra_virtual;
 pub mod raf_evaluation;
 pub mod read_write_checking;
 pub mod val_evaluation;
-
-pub const NUM_RA_I_VARS: usize = 8;
-pub fn compute_d_parameter(K: usize) -> usize {
-    // Calculate D dynamically such that 2^8 = K^(1/D)
-    let log_K = K.log_2();
-    log_K.div_ceil(NUM_RA_I_VARS)
-}
 
 #[derive(Debug, Clone, CanonicalSerialize, CanonicalDeserialize)]
 pub struct RAMPreprocessing {

--- a/jolt-core/src/zkvm/witness.rs
+++ b/jolt-core/src/zkvm/witness.rs
@@ -53,12 +53,6 @@ pub enum CommittedPolynomial {
     /// Whether the current instruction triggers a jump
     ShouldJump,
     /*  Twist/Shout witnesses */
-    /// One-hot ra polynomial for the bytecode instance of Shout
-    BytecodeRa(usize),
-    /// One-hot ra/wa polynomial for the RAM instance of Twist
-    /// Note that for RAM, ra and wa are the same polynomial because
-    /// there is at most one load or store per cycle.
-    RamRa(usize),
     /// Inc polynomial for the registers instance of Twist
     RdInc,
     /// Inc polynomial for the RAM instance of Twist
@@ -66,13 +60,19 @@ pub enum CommittedPolynomial {
     /// One-hot ra polynomial for the instruction lookups instance of Shout.
     /// There are d=8 of these polynomials, `InstructionRa(0) .. InstructionRa(7)`
     InstructionRa(usize),
+    /// One-hot ra polynomial for the bytecode instance of Shout
+    BytecodeRa(usize),
+    /// One-hot ra/wa polynomial for the RAM instance of Twist
+    /// Note that for RAM, ra and wa are the same polynomial because
+    /// there is at most one load or store per cycle.
+    RamRa(usize),
 }
 
 pub static mut ALL_COMMITTED_POLYNOMIALS: OnceCell<Vec<CommittedPolynomial>> = OnceCell::new();
 
 pub struct AllCommittedPolynomials();
 impl AllCommittedPolynomials {
-    pub fn initialize(ram_K: usize, bytecode_d: usize) -> Self {
+    pub fn initialize(ram_d: usize, bytecode_d: usize) -> Self {
         let mut polynomials = vec![
             CommittedPolynomial::LeftInstructionInput,
             CommittedPolynomial::RightInstructionInput,
@@ -81,15 +81,6 @@ impl AllCommittedPolynomials {
             CommittedPolynomial::WritePCtoRD,
             CommittedPolynomial::ShouldBranch,
             CommittedPolynomial::ShouldJump,
-        ];
-        let ram_d = compute_d_parameter(ram_K);
-        for i in 0..ram_d {
-            polynomials.push(CommittedPolynomial::RamRa(i));
-        }
-        for i in 0..bytecode_d {
-            polynomials.push(CommittedPolynomial::BytecodeRa(i));
-        }
-        polynomials.extend([
             CommittedPolynomial::RdInc,
             CommittedPolynomial::RamInc,
             CommittedPolynomial::InstructionRa(0),
@@ -100,7 +91,13 @@ impl AllCommittedPolynomials {
             CommittedPolynomial::InstructionRa(5),
             CommittedPolynomial::InstructionRa(6),
             CommittedPolynomial::InstructionRa(7),
-        ]);
+        ];
+        for i in 0..ram_d {
+            polynomials.push(CommittedPolynomial::RamRa(i));
+        }
+        for i in 0..bytecode_d {
+            polynomials.push(CommittedPolynomial::BytecodeRa(i));
+        }
 
         unsafe {
             ALL_COMMITTED_POLYNOMIALS

--- a/tracer/src/lib.rs
+++ b/tracer/src/lib.rs
@@ -99,16 +99,6 @@ pub fn trace_checkpoints(
         LazyTraceIterator::new(setup_emulator(elf_contents, inputs, memory_config));
     let mut checkpoints = Vec::new();
 
-    // let mut trace = Vec::with_capacity(1 << 24); // TODO(moodlezoup): make configurable
-    // loop {
-    //     let mut trace_n = emulator_trace_iter.clone();
-    //     trace_n.set_length(checkpoint_interval);
-    //     checkpoints.push(trace_n);
-    //     emulator_trace_iter = emulator_trace_iter.dropping(checkpoint_interval);
-    //     if emulator_trace_iter.is_empty() {
-    //         break;
-    //     }
-    // }
     loop {
         let chkpt = emulator_trace_iter.clone().take(checkpoint_interval);
         checkpoints.push(chkpt);


### PR DESCRIPTION
- Makes the usage of the `CommitmentScheme::setup_prover` parameter consistent throughout (prior to this PR, Dory interpreted the parameter as max # variables, while other PCS interpreted it as max # coefficients)
- Removes unused code
- Various other cosmetic improvements