### PR TITLE
feat: modify small value optimization to work with RV64

### DIFF
--- a/jolt-core/src/utils/small_value.rs
+++ b/jolt-core/src/utils/small_value.rs
@@ -255,7 +255,6 @@ pub mod svo_helpers {
                     temp_tA.is_empty(),
                     "temp_tA should be empty for 0 SVO rounds"
                 );
-                return;
             }
             1 => {
                 compute_and_update_tA_inplace_1(binary_az_evals, binary_bz_evals, e_in_val, temp_tA)
@@ -672,7 +671,6 @@ pub mod svo_helpers {
             );
             // M_NON_BINARY_POINTS_CONST would be 0, NUM_TERNARY_POINTS_CONST would be 1.
             // The loops below would not run.
-            return;
         }
 
         // Verify consistency of const generic arguments with NUM_SVO_ROUNDS
@@ -780,7 +778,6 @@ pub mod svo_helpers {
                     tA_accums.is_empty(),
                     "tA_accums should be empty for 0 SVO rounds"
                 );
-                return;
             }
             1 => distribute_tA_to_svo_accumulators_1(
                 tA_accums,
@@ -1119,7 +1116,6 @@ pub mod svo_helpers {
                 accums_infty.is_empty(),
                 "accums_infty should be empty for N=0"
             );
-            return;
         }
 
         // Assert that the provided M_NON_BINARY_POINTS is correct.


### PR DESCRIPTION
When moving to RV64, the values in Spartan first sum-check roughly doubles in bit-size.

This means that the small-value optimization must also change. Before, we could fit `az_eval` and `bz_eval` in i64 (really about 33 bits), and so their product fits in i128. Now each of them is `i128` (really about 65 bits), but their product would overflow i128.

The solution is to replace `E_in.mul_i128( az_eval * bz_eval)` with `E_in.mul_i128(az_eval).mul_i128(bz_eval)`. This doubles the number of field times i128 mults, but recovers correctness. Should be fine since we expect things to slow down by ~2x when we move to RV64 anyway. Also, it slows down just the SVO part, which is not too much.