### PR TITLE
feat: Add RISC-V architecture test support

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -7,3 +7,10 @@ RUN <<-'EOF' bash
 	curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sed 's#/proc/self/exe#\/bin\/sh#g' | sh -s -- -y --no-update-default-toolchain 1>/dev/null
 	rm -rf /var/lib/apt/lists/*
 EOF
+
+RUN <<-'EOF' bash
+	set -eu -o pipefail
+	mkdir -p ~/.config/pip && printf "[global]\nbreak-system-packages = true\n" > ~/.config/pip/pip.conf
+EOF
+
+ENV PATH="/opt/riscv/bin/:$PATH"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,6 +7,12 @@
 		"dockerfile": "Dockerfile"
 	},
 	"features": {
+		"ghcr.io/devcontainers/features/docker-in-docker:2": {
+			"moby": true,
+			"installDockerBuildx": true,
+			"version": "latest",
+			"dockerDashComposeVersion": "v2"
+		},
 		"ghcr.io/devcontainers/features/common-utils:2": {
 			"installZsh": true,
 			"configureZshAsDefaultShell": true,

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ temp_file
 .vscode
 
 *.patch
+
+prebuilt-files/
+riscof_work/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,7 @@
 [submodule "jolt-evm-verifier/lib/forge-std"]
 	path = jolt-evm-verifier/lib/forge-std
 	url = https://github.com/foundry-rs/forge-std
+[submodule "third-party/riscv-arch-test"]
+	path = third-party/riscv-arch-test
+	url = https://github.com/riscv-non-isa/riscv-arch-test.git
+	shallow = true

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,40 @@
+.PHONY: bootstrap help
+
+MAKEFILE_DIR := $(abspath $(dir $(firstword $(MAKEFILE_LIST))))
+
+# Define a general macro for RISCOF test runs
+define RISCOF_RUN
+	export PATH=$(MAKEFILE_DIR)/target/release:$(PATH); \
+	export RUST_BACKTRACE=full; \
+	riscof run --no-browser --config tests/arch-tests/$(1).ini \
+		--suite third-party/riscv-arch-test/riscv-test-suite/ \
+		--env third-party/riscv-arch-test/riscv-test-suite/env
+endef
+
+help:
+	@echo "Available targets:"
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2}'
+
+bootstrap: ## Install required dependencies
+	scripts/bootstrap
+
+build-emulator: ## Build the emulator
+	cargo build --release -p tracer --bin jolt-emu
+
+arch-tests-32im: build-emulator
+	$(call RISCOF_RUN,jolt-32im)
+
+arch-tests-32imac: build-emulator
+	$(call RISCOF_RUN,jolt-32imac)
+
+arch-tests-32gc: build-emulator
+	$(call RISCOF_RUN,jolt-32gc)
+
+arch-tests-64im: build-emulator
+	$(call RISCOF_RUN,jolt-64im)
+
+arch-tests-64imac: build-emulator
+	$(call RISCOF_RUN,jolt-64imac)
+
+arch-tests-64gc: build-emulator
+	$(call RISCOF_RUN,jolt-64gc)

--- a/docker/Dockerfile.spike
+++ b/docker/Dockerfile.spike
@@ -1,0 +1,67 @@
+ARG OS_VERSION="noble"
+
+# Builder stage
+FROM ubuntu:${OS_VERSION} AS builder
+
+RUN <<-'EOF' bash
+    set -eu -o pipefail
+    apt-get update
+    apt-get install -y --no-install-recommends ca-certificates git
+EOF
+
+# Install Spike(the official RISC-V ISA simulator)
+RUN <<-'EOF' bash
+    set -eu -o pipefail
+    apt-get update
+    apt-get install -y --no-install-recommends build-essential device-tree-compiler
+    git clone --depth=1 https://github.com/riscv-software-src/riscv-isa-sim.git /tmp/riscv-isa-sim
+    cd /tmp/riscv-isa-sim
+    mkdir build
+    cd build
+    ../configure --prefix=/opt/riscv LDFLAGS="-s"
+    make -j$(nproc)
+    make install
+EOF
+
+# Install RISC-V Proxy Kernel
+RUN <<-'EOF' bash
+    set -eu -o pipefail
+    apt-get update
+    apt-get install -y --no-install-recommends binutils-riscv64-unknown-elf gcc-riscv64-unknown-elf picolibc-riscv64-unknown-elf
+    git clone --depth=1 -b gx/support-musl https://github.com/LayerResearch/riscv-pk.git /tmp/riscv-pk
+    cd /tmp/riscv-pk
+    mkdir build
+    cd build
+    
+    CC="riscv64-unknown-elf-gcc -specs=/usr/lib/picolibc/riscv64-unknown-elf/picolibc.specs" \
+    ../configure --prefix=/opt/riscv --host=riscv64-unknown-elf --with-arch=rv32gc --with-abi=ilp32
+    make clean
+    make -j$(nproc)
+    make install
+
+    CC="riscv64-unknown-elf-gcc -specs=/usr/lib/picolibc/riscv64-unknown-elf/picolibc.specs" \
+    ../configure --prefix=/opt/riscv --host=riscv64-unknown-elf --with-arch=rv64gc --with-abi=lp64
+    make clean
+    make -j$(nproc)
+    make install
+EOF
+
+# Spike stage
+FROM ubuntu:${OS_VERSION} AS spike
+COPY --from=builder /opt/riscv/ /opt/riscv/
+ENV PATH="/opt/riscv/bin/:$PATH"
+
+# Prepare prebuilt files stage
+FROM ubuntu:${OS_VERSION} AS prebuilt-stage0
+
+COPY --from=builder /opt/riscv/ /opt/riscv/
+
+ENV PATH="/opt/riscv/bin/:$PATH"
+RUN <<-'EOF' bash
+    set -eu -o pipefail
+    tar zcvf /srv/spike-$(spike --help 2>&1 | sed -n 's/.*\([0-9]\+\.[0-9]\+\.[0-9]\+\).*/\1/p')-$(uname -s)-$(uname -m).tar.gz -C /opt/riscv/ .
+EOF
+
+# Prebuilt stage
+FROM scratch AS prebuilt
+COPY --from=prebuilt-stage0 /srv/ /

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,14 @@
+## Build
+Build prebuilt files:
+```bash
+./build.sh build spike
+```
+
+## Publish
+Publish prebuilt files to the repository release:
+```bash
+gh repo set-default a16z/jolt
+gh release list
+gh release create spike-v1.1.1 --title "Spike v1.1.1" --notes "RISC-V ISA Simulator"
+find ../prebuilt-files/ -iname 'spike-*.tar.gz' -exec gh release upload spike-1.1.1 {} --clobber \;
+```

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -1,0 +1,291 @@
+#!/bin/bash
+set -e
+set -o pipefail
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+[ -f ${DIR}/../.versions ] && source ${DIR}/../.versions
+
+if [[ "$(uname -m)" == "aarch64" ]]; then
+    NATIVE_PLATFORM="linux/arm64"
+else
+    NATIVE_PLATFORM="linux/amd64"
+fi
+
+# Default values
+REGISTRY=${REGISTRY:-ghcr.io}
+BUILDER=${BUILDER:-local-builder}
+PLATFORMS=${PLATFORMS:-linux/arm64,linux/amd64}
+PUSH=${PUSH:-true}
+OS_VERSION=${OS_VERSION:-'noble'}
+NAMESPACE=${NAMESPACE:-"a16z"}
+PREBUILT_DIR="${DIR}/../prebuilt-files"
+RISC_V_DIR="/opt/riscv"
+
+function check_builder() {
+    if ! docker buildx ls | grep -q "^${BUILDER}"; then
+        local builder_available=false
+
+        if [[ "${BUILDER}" == "local-builder" ]]; then
+            echo "Builder '${BUILDER}' does not exist. Creating it automatically..."
+            docker buildx create --name local-builder --platform linux/amd64,linux/arm64
+
+            # Check again after creation
+            if docker buildx ls | grep -q "^${BUILDER}"; then
+                echo "Successfully created builder '${BUILDER}'"
+                builder_available=true
+            fi
+        fi
+
+        if [[ "$builder_available" == "false" ]]; then
+            echo "Error: Builder '${BUILDER}' does not exist"
+            echo "Available builders:"
+            docker buildx ls
+            echo ""
+            echo "Create local-builder:"
+            echo "docker buildx create --name local-builder --platform linux/amd64,linux/arm64"
+            exit 1
+        fi
+    fi
+}
+
+function publish_spike() {
+    # Create temporary directory for deps context
+    DEPS_CONTEXT="$(mktemp -d)"
+    trap 'rm -rf "${DEPS_CONTEXT}"' EXIT
+
+    # Create an empty temporary directory as the build context
+    TEMP_DIR=$(mktemp -d)
+    trap 'rm -rf "${TEMP_DIR}"' EXIT
+
+    local BUILD_OUTPUT_OPTION=""
+    if [[ "$PUBLISH_LOCAL" == "true" ]]; then
+        BUILD_OUTPUT_OPTION="--load"
+    else
+        BUILD_OUTPUT_OPTION="--push"
+    fi
+
+    docker buildx build \
+        --builder ${BUILDER} \
+        --progress=plain \
+        --platform=${PLATFORMS} \
+        --build-arg OS_VERSION=${OS_VERSION} \
+        --build-arg REGISTRY=${REGISTRY} \
+        --build-arg NAMESPACE=${NAMESPACE} \
+        --build-context deps="${DEPS_CONTEXT}" \
+        --target spike \
+        --tag ${REGISTRY}/${NAMESPACE}/spike:1.1.1-${OS_VERSION} \
+        -f ${DIR}/Dockerfile.spike ${TEMP_DIR} ${BUILD_OUTPUT_OPTION}
+}
+
+function build_spike() {
+    local platforms=${1:-$PLATFORMS}
+    local target_dir=${2:-$PREBUILT_DIR}
+    local OS_VERSION=noble
+
+    mkdir -p "$target_dir"
+
+    # Ensures the generated executable can run across multiple platforms, including Debian Bookworm, Ubuntu Jammy, and Ubuntu Noble, improving portability without requiring additional system dependencies.
+    for platform in $platforms; do
+        # Create temporary directory for deps context
+        DEPS_CONTEXT="$(mktemp -d)"
+        trap 'rm -rf "${DEPS_CONTEXT}"' EXIT
+
+        # Create an empty temporary directory as the build context
+        TEMP_DIR=$(mktemp -d)
+        trap 'rm -rf "${TEMP_DIR}"' EXIT
+
+        docker buildx build \
+            --builder ${BUILDER} \
+            --progress=plain \
+            --platform=${platforms} \
+            --build-arg OS_VERSION=${OS_VERSION} \
+            --build-arg REGISTRY=${REGISTRY} \
+            --build-arg NAMESPACE=${NAMESPACE} \
+            --build-context deps="${DEPS_CONTEXT}" \
+            --target prebuilt \
+            --output type=local,dest="$target_dir" \
+            -f ${DIR}/Dockerfile.spike ${TEMP_DIR}
+    done
+}
+
+function build_prebuilt() {
+    build_spike
+}
+
+function install_spike() {
+    local target_dir=$(mktemp -d)
+    trap 'rm -rf "${target_dir}"' EXIT
+
+    build_spike "$NATIVE_PLATFORM" "$target_dir"
+
+    local tar_file=$(find "$target_dir" -name "spike-*.tar.gz" -type f | head -n 1)
+    if [[ -z "$tar_file" ]]; then
+        echo "Error: No tar.gz file found in $target_dir directory"
+        exit 1
+    fi
+
+    mkdir -p "$RISC_V_DIR"
+    tar -xzf "$tar_file" -C "$RISC_V_DIR"
+
+    echo "Spike installed successfully to $RISC_V_DIR"
+}
+
+function install_all() {
+    install_spike
+}
+
+# Parse command line arguments
+COMMAND=""
+TARGET=""
+PUBLISH_LOCAL=false
+
+function parse_args() {
+    if [[ $# -eq 0 ]]; then
+        echo "No command specified"
+        usage
+        exit 1
+    fi
+
+    COMMAND="$1"
+    shift
+
+    case $COMMAND in
+    build)
+        if [[ $# -eq 0 ]]; then
+            echo "No target specified for build command"
+            usage
+            exit 1
+        fi
+        TARGET="$1"
+        shift
+        ;;
+    publish)
+        if [[ $# -eq 0 ]]; then
+            TARGET="prebuilt"
+        else
+            TARGET="$1"
+            shift
+        fi
+
+        # Parse remaining arguments
+        while [[ $# -gt 0 ]]; do
+            case $1 in
+            --builder)
+                BUILDER="$2"
+                shift 2
+                ;;
+            --registry)
+                REGISTRY="$2"
+                shift 2
+                ;;
+            --namespace)
+                NAMESPACE="$2"
+                shift 2
+                ;;
+            --platform)
+                PLATFORMS="$2"
+                shift 2
+                ;;
+            --local)
+                PUBLISH_LOCAL=true
+                PLATFORMS="$NATIVE_PLATFORM"
+                PUSH=false
+                shift
+                ;;
+            *)
+                echo "Unknown option: $1"
+                usage
+                exit 1
+                ;;
+            esac
+        done
+        ;;
+    install)
+        if [[ $# -eq 0 ]]; then
+            TARGET="all"
+        else
+            TARGET="$1"
+            shift
+        fi
+        ;;
+    help)
+        usage
+        exit 0
+        ;;
+    *)
+        echo "Unknown command: $COMMAND"
+        usage
+        exit 1
+        ;;
+    esac
+}
+
+function usage() {
+    cat <<EOF
+Usage: $0 <command> [target] [options]
+
+Commands:
+  build <target>     Build the specified target locally (target required)
+  publish [target]   Build and publish the specified target to registry (defaults to prebuilt)
+  install <target>   Install the specified target to system (target required)
+  help               Show this help message
+
+Targets:
+  spike              Build/install the spike image
+  prebuilt           Build the prebuilt files
+
+Options:
+  --builder <name>       Specify the builder to use (default: local-builder)
+  --registry <registry>  Specify the registry (default: ghcr.io)
+  --namespace <name>     Specify the namespace (default: a16z)
+  --platform <platforms> Specify platforms (default: linux/arm64,linux/amd64)
+  --local               Build only for native platform (implies --platform native)
+  --help, -h            Show this help message
+
+Examples:
+  $0 build prebuilt
+  $0 build spike
+  $0 publish                           # Publish prebuilt (default)
+  $0 publish spike --builder remote-builder --registry ghcr.io --namespace a16z --platform linux/arm64,linux/amd64
+  $0 publish spike --local
+  $0 install spike                     # Install spike to $RISC_V_DIR
+
+Environment variables:
+  BUILDER: the name of the builder to use (default: local-builder)
+  PUSH: whether to push to registry (default: true, only affects publish command)
+  PLATFORMS: platforms to build for (default: linux/arm64,linux/amd64)
+  REGISTRY: registry to push to (default: ghcr.io)
+  NAMESPACE: namespace to use (default: a16z)
+  OS_VERSION: OS version to use (default: noble)
+
+EOF
+}
+
+function execute() {
+    case "$COMMAND:$TARGET" in
+    build:spike)
+        build_spike
+        ;;
+    build:prebuilt)
+        build_prebuilt
+        ;;
+    publish:spike)
+        publish_spike
+        ;;
+    install:all)
+        install_all
+        ;;
+    install:spike)
+        install_spike
+        ;;
+    *)
+        echo "Error: Unsupported command/target combination '$COMMAND $TARGET'"
+        usage
+        exit 1
+        ;;
+    esac
+}
+
+parse_args "$@"
+check_builder
+execute

--- a/scripts/bootstrap
+++ b/scripts/bootstrap
@@ -1,0 +1,17 @@
+#!/bin/bash
+git submodule update --init --recursive
+
+apt-get update && apt-get install -y --no-install-recommends gh python3 python3-pip device-tree-compiler gcc-riscv64-unknown-elf binutils-riscv64-unknown-elf
+
+if ! gh auth status >/dev/null 2>&1; then
+    echo "GitHub authentication required. Please login:"
+    gh auth login
+fi
+
+mkdir -p /opt/riscv/
+gh release download --clobber spike-1.1.1 --repo a16z/jolt --pattern "spike-1.1.1-$(uname -s)-$(uname -m).tar.gz" -O /tmp/spike.tar.gz && tar -xzf /tmp/spike.tar.gz -C /opt/riscv/
+
+pushd third-party/riscv-arch-test/riscv-ctg && pip3 install -e . && popd
+pushd third-party/riscv-arch-test/riscv-isac && pip3 install -e . && popd
+pip3 install git+https://github.com/riscv/riscof.git@dev
+riscof --version

--- a/tests/arch-tests/.gitignore
+++ b/tests/arch-tests/.gitignore
@@ -1,0 +1,2 @@
+riscof_work/
+*.pyc

--- a/tests/arch-tests/jolt-32gc.ini
+++ b/tests/arch-tests/jolt-32gc.ini
@@ -1,0 +1,15 @@
+[RISCOF]
+ReferencePlugin=spike
+ReferencePluginPath=./tests/arch-tests/spike
+DUTPlugin=jolt
+DUTPluginPath=./tests/arch-tests/jolt
+
+[jolt]
+pluginpath=./tests/arch-tests/jolt
+ispec=./tests/arch-tests/jolt/jolt_isa_32gc.yaml
+pspec=./tests/arch-tests/jolt/jolt_platform.yaml
+target_run=1
+trace=true
+
+[spike]
+pluginpath=./tests/arch-tests/spike

--- a/tests/arch-tests/jolt-32im.ini
+++ b/tests/arch-tests/jolt-32im.ini
@@ -1,0 +1,15 @@
+[RISCOF]
+ReferencePlugin=spike
+ReferencePluginPath=./tests/arch-tests/spike
+DUTPlugin=jolt
+DUTPluginPath=./tests/arch-tests/jolt
+
+[jolt]
+pluginpath=./tests/arch-tests/jolt
+ispec=./tests/arch-tests/jolt/jolt_isa_32im.yaml
+pspec=./tests/arch-tests/jolt/jolt_platform.yaml
+target_run=1
+trace=true
+
+[spike]
+pluginpath=./tests/arch-tests/spike

--- a/tests/arch-tests/jolt-32imac.ini
+++ b/tests/arch-tests/jolt-32imac.ini
@@ -1,0 +1,15 @@
+[RISCOF]
+ReferencePlugin=spike
+ReferencePluginPath=./tests/arch-tests/spike
+DUTPlugin=jolt
+DUTPluginPath=./tests/arch-tests/jolt
+
+[jolt]
+pluginpath=./tests/arch-tests/jolt
+ispec=./tests/arch-tests/jolt/jolt_isa_32imac.yaml
+pspec=./tests/arch-tests/jolt/jolt_platform.yaml
+target_run=1
+trace=true
+
+[spike]
+pluginpath=./tests/arch-tests/spike

--- a/tests/arch-tests/jolt-64gc.ini
+++ b/tests/arch-tests/jolt-64gc.ini
@@ -1,0 +1,15 @@
+[RISCOF]
+ReferencePlugin=spike
+ReferencePluginPath=./tests/arch-tests/spike
+DUTPlugin=jolt
+DUTPluginPath=./tests/arch-tests/jolt
+
+[jolt]
+pluginpath=./tests/arch-tests/jolt
+ispec=./tests/arch-tests/jolt/jolt_isa_64gc.yaml
+pspec=./tests/arch-tests/jolt/jolt_platform.yaml
+target_run=1
+trace=true
+
+[spike]
+pluginpath=./tests/arch-tests/spike

--- a/tests/arch-tests/jolt-64im.ini
+++ b/tests/arch-tests/jolt-64im.ini
@@ -1,0 +1,15 @@
+[RISCOF]
+ReferencePlugin=spike
+ReferencePluginPath=./tests/arch-tests/spike
+DUTPlugin=jolt
+DUTPluginPath=./tests/arch-tests/jolt
+
+[jolt]
+pluginpath=./tests/arch-tests/jolt
+ispec=./tests/arch-tests/jolt/jolt_isa_64im.yaml
+pspec=./tests/arch-tests/jolt/jolt_platform.yaml
+target_run=1
+trace=true
+
+[spike]
+pluginpath=./tests/arch-tests/spike

--- a/tests/arch-tests/jolt-64imac.ini
+++ b/tests/arch-tests/jolt-64imac.ini
@@ -1,0 +1,15 @@
+[RISCOF]
+ReferencePlugin=spike
+ReferencePluginPath=./tests/arch-tests/spike
+DUTPlugin=jolt
+DUTPluginPath=./tests/arch-tests/jolt
+
+[jolt]
+pluginpath=./tests/arch-tests/jolt
+ispec=./tests/arch-tests/jolt/jolt_isa_64imac.yaml
+pspec=./tests/arch-tests/jolt/jolt_platform.yaml
+target_run=1
+trace=true
+
+[spike]
+pluginpath=./tests/arch-tests/spike

--- a/tests/arch-tests/jolt/env/link.ld
+++ b/tests/arch-tests/jolt/env/link.ld
@@ -1,0 +1,46 @@
+OUTPUT_ARCH( "riscv" )
+ENTRY(rvtest_entry_point)
+
+MEMORY {
+  program (rwx) : ORIGIN = 0x80000000, LENGTH = 0xA00000  /* 10MB of memory (DEFAULT_MEMORY_SIZE) */
+}
+
+SECTIONS {
+  .text.boot : {
+    *(.text.boot)
+  } > program
+
+  .text.init : {
+    *(.text.init)
+  } > program
+
+  .tohost : {
+    KEEP(*(.tohost))  /* Needed by RISCOF pass/fail detection */
+  } > program
+
+  .text : {
+    *(.text)
+  } > program
+
+  .data : {
+    *(.data)
+  } > program
+
+  .data.string : {
+    *(.data.string)
+  } > program
+
+  .bss : {
+    *(.bss)
+  } > program
+
+  . = ALIGN(8);
+  /* Reserve 4 KiB for stack */
+  . = . + 4096;
+  _STACK_PTR = .;
+
+  . = ALIGN(8);
+  /* Reserve 4 KiB for heap */
+  _HEAP_PTR = .;
+  _end = .;
+}

--- a/tests/arch-tests/jolt/env/model_test.h
+++ b/tests/arch-tests/jolt/env/model_test.h
@@ -1,0 +1,60 @@
+#ifndef _COMPLIANCE_MODEL_H
+#define _COMPLIANCE_MODEL_H
+#define RVMODEL_DATA_SECTION \
+        .pushsection .tohost,"aw",@progbits;                            \
+        .align 8; .global tohost; tohost: .dword 0;                     \
+        .align 8; .global fromhost; fromhost: .dword 0;                 \
+        .popsection;                                                    \
+        .align 8; .global begin_regstate; begin_regstate:               \
+        .word 128;                                                      \
+        .align 8; .global end_regstate; end_regstate:                   \
+        .word 4;
+
+//RV_COMPLIANCE_HALT
+#define RVMODEL_HALT                                              \
+  li x1, 1;                                                                   \
+  write_tohost:                                                               \
+    sw x1, tohost, t5;                                                        \
+    j write_tohost;
+
+#define RVMODEL_BOOT
+
+//RV_COMPLIANCE_DATA_BEGIN
+#define RVMODEL_DATA_BEGIN                                              \
+  RVMODEL_DATA_SECTION                                                        \
+  .align 4;\
+  .global begin_signature; begin_signature:
+
+//RV_COMPLIANCE_DATA_END
+#define RVMODEL_DATA_END                                                      \
+  .align 4;\
+  .global end_signature; end_signature:  
+
+//RVTEST_IO_INIT
+#define RVMODEL_IO_INIT
+//RVTEST_IO_WRITE_STR
+#define RVMODEL_IO_WRITE_STR(_R, _STR)
+//RVTEST_IO_CHECK
+#define RVMODEL_IO_CHECK()
+//RVTEST_IO_ASSERT_GPR_EQ
+#define RVMODEL_IO_ASSERT_GPR_EQ(_S, _R, _I)
+//RVTEST_IO_ASSERT_SFPR_EQ
+#define RVMODEL_IO_ASSERT_SFPR_EQ(_F, _R, _I)
+//RVTEST_IO_ASSERT_DFPR_EQ
+#define RVMODEL_IO_ASSERT_DFPR_EQ(_D, _R, _I)
+
+#define RVMODEL_SET_MSW_INT       \
+ li t1, 1;                         \
+ li t2, 0x2000000;                 \
+ sw t1, 0(t2);
+
+#define RVMODEL_CLEAR_MSW_INT     \
+ li t2, 0x2000000;                 \
+ sw x0, 0(t2);
+
+#define RVMODEL_CLEAR_MTIMER_INT
+
+#define RVMODEL_CLEAR_MEXT_INT
+
+
+#endif // _COMPLIANCE_MODEL_H

--- a/tests/arch-tests/jolt/jolt_isa_32gc.yaml
+++ b/tests/arch-tests/jolt/jolt_isa_32gc.yaml
@@ -1,0 +1,28 @@
+hart_ids: [0]
+hart0:
+  ISA: RV32GC
+  physical_addr_sz: 32
+  User_Spec_Version: '2.3'
+  supported_xlen: [32]
+  misa:
+   reset-val: 0x4000112d
+   rv32:
+     accessible: true
+     mxl:
+       implemented: true
+       type:
+           warl:
+              dependency_fields: []
+              legal:
+                - mxl[1:0] in [0x1]
+              wr_illegal:
+                - Unchanged
+     extensions:
+       implemented: true
+       type:
+           warl:
+              dependency_fields: []
+              legal:
+                - extensions[25:0] bitmask [0x000112d, 0x0000000]
+              wr_illegal:
+                - Unchanged

--- a/tests/arch-tests/jolt/jolt_isa_32im.yaml
+++ b/tests/arch-tests/jolt/jolt_isa_32im.yaml
@@ -1,0 +1,28 @@
+hart_ids: [0]
+hart0:
+  ISA: RV32IM
+  physical_addr_sz: 32
+  User_Spec_Version: '2.3'
+  supported_xlen: [32]
+  misa:
+   reset-val: 0x40001100
+   rv32:
+     accessible: true
+     mxl:
+       implemented: true
+       type:
+           warl:
+              dependency_fields: []
+              legal:
+                - mxl[1:0] in [0x1]
+              wr_illegal:
+                - Unchanged
+     extensions:
+       implemented: true
+       type:
+           warl:
+              dependency_fields: []
+              legal:
+                - extensions[25:0] bitmask [0x0001100, 0x0000000]
+              wr_illegal:
+                - Unchanged

--- a/tests/arch-tests/jolt/jolt_isa_32imac.yaml
+++ b/tests/arch-tests/jolt/jolt_isa_32imac.yaml
@@ -1,0 +1,28 @@
+hart_ids: [0]
+hart0:
+  ISA: RV32IMAC
+  physical_addr_sz: 32
+  User_Spec_Version: '2.3'
+  supported_xlen: [32]
+  misa:
+   reset-val: 0x40001105
+   rv32:
+     accessible: true
+     mxl:
+       implemented: true
+       type:
+           warl:
+              dependency_fields: []
+              legal:
+                - mxl[1:0] in [0x1]
+              wr_illegal:
+                - Unchanged
+     extensions:
+       implemented: true
+       type:
+           warl:
+              dependency_fields: []
+              legal:
+                - extensions[25:0] bitmask [0x0001105, 0x0000000]
+              wr_illegal:
+                - Unchanged

--- a/tests/arch-tests/jolt/jolt_isa_64gc.yaml
+++ b/tests/arch-tests/jolt/jolt_isa_64gc.yaml
@@ -1,0 +1,28 @@
+hart_ids: [0]
+hart0:
+  ISA: RV64GC
+  physical_addr_sz: 56
+  User_Spec_Version: '2.3'
+  supported_xlen: [64]
+  misa:
+   reset-val: 0x800000000000112d
+   rv64:
+     accessible: true
+     mxl:
+       implemented: true
+       type:
+           warl:
+              dependency_fields: []
+              legal:
+                - mxl[1:0] in [0x2]
+              wr_illegal:
+                - Unchanged
+     extensions:
+       implemented: true
+       type:
+           warl:
+              dependency_fields: []
+              legal:
+                - extensions[25:0] bitmask [0x000112d, 0x0000000]
+              wr_illegal:
+                - Unchanged

--- a/tests/arch-tests/jolt/jolt_isa_64im.yaml
+++ b/tests/arch-tests/jolt/jolt_isa_64im.yaml
@@ -1,0 +1,28 @@
+hart_ids: [0]
+hart0:
+  ISA: RV64IM
+  physical_addr_sz: 56
+  User_Spec_Version: '2.3'
+  supported_xlen: [64]
+  misa:
+   reset-val: 0x8000000000001100
+   rv64:
+     accessible: true
+     mxl:
+       implemented: true
+       type:
+           warl:
+              dependency_fields: []
+              legal:
+                - mxl[1:0] in [0x2]
+              wr_illegal:
+                - Unchanged
+     extensions:
+       implemented: true
+       type:
+           warl:
+              dependency_fields: []
+              legal:
+                - extensions[25:0] bitmask [0x0001100, 0x0000000]
+              wr_illegal:
+                - Unchanged

--- a/tests/arch-tests/jolt/jolt_isa_64imac.yaml
+++ b/tests/arch-tests/jolt/jolt_isa_64imac.yaml
@@ -1,0 +1,28 @@
+hart_ids: [0]
+hart0:
+  ISA: RV64IMAC
+  physical_addr_sz: 56
+  User_Spec_Version: '2.3'
+  supported_xlen: [64]
+  misa:
+   reset-val: 0x8000000000001105
+   rv64:
+     accessible: true
+     mxl:
+       implemented: true
+       type:
+           warl:
+              dependency_fields: []
+              legal:
+                - mxl[1:0] in [0x2]
+              wr_illegal:
+                - Unchanged
+     extensions:
+       implemented: true
+       type:
+           warl:
+              dependency_fields: []
+              legal:
+                - extensions[25:0] bitmask [0x0001105, 0x0000000]
+              wr_illegal:
+                - Unchanged

--- a/tests/arch-tests/jolt/jolt_platform.yaml
+++ b/tests/arch-tests/jolt/jolt_platform.yaml
@@ -1,0 +1,10 @@
+mtime:
+  implemented: true
+  address: 0xbff8
+mtimecmp:
+  implemented: true
+  address: 0x4000
+nmi:
+  label: nmi_vector
+reset:
+  label: reset_vector

--- a/tests/arch-tests/jolt/riscof_jolt.py
+++ b/tests/arch-tests/jolt/riscof_jolt.py
@@ -1,0 +1,253 @@
+import os
+import re
+import shutil
+import subprocess
+import shlex
+import logging
+import random
+import string
+from string import Template
+import sys
+
+import riscof.utils as utils
+import riscof.constants as constants
+from riscof.pluginTemplate import pluginTemplate
+
+logger = logging.getLogger()
+
+class jolt(pluginTemplate):
+    __model__ = "jolt"
+
+    #TODO: please update the below to indicate family, version, etc of your DUT.
+    __version__ = "XXX"
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        config = kwargs.get('config')
+
+        # If the config node for this DUT is missing or empty. Raise an error. At minimum we need
+        # the paths to the ispec and pspec files
+        if config is None:
+            print("Please enter input file paths in configuration.")
+            raise SystemExit(1)
+
+        # In case of an RTL based DUT, this would be point to the final binary executable of your
+        # test-bench produced by a simulator (like verilator, vcs, incisive, etc). In case of an iss or
+        # emulator, this variable could point to where the iss binary is located. If 'PATH variable
+        # is missing in the config.ini we can hardcode the alternate here.
+        self.dut_exe = os.path.join(config['PATH'] if 'PATH' in config else "","jolt-emu")
+
+        # Number of parallel jobs that can be spawned off by RISCOF
+        # for various actions performed in later functions, specifically to run the tests in
+        # parallel on the DUT executable. Can also be used in the build function if required.
+        self.num_jobs = str(config['jobs'] if 'jobs' in config else 1)
+
+        # Whether run the program in trace mode
+        self.trace = config['trace'] if 'trace' in config else False
+
+        # Path to the directory where this python file is located. Collect it from the config.ini
+        self.pluginpath=os.path.abspath(config['pluginpath'])
+
+        # Collect the paths to the riscv-config based ISA and platform yaml files. One can choose
+        # to hardcode these here itself instead of picking it from the config.ini file.
+        self.isa_spec = os.path.abspath(config['ispec'])
+        self.platform_spec = os.path.abspath(config['pspec'])
+
+        #We capture if the user would like the run the tests on the target or
+        #not. If you are interested in just compiling the tests and not running
+        #them on the target, then following variable should be set to False
+        if 'target_run' in config and config['target_run']=='0':
+            self.target_run = False
+        else:
+            self.target_run = True
+
+    def initialise(self, suite, work_dir, archtest_env):
+
+       # capture the working directory. Any artifacts that the DUT creates should be placed in this
+       # directory. Other artifacts from the framework and the Reference plugin will also be placed
+       # here itself.
+       self.work_dir = work_dir
+
+       # capture the architectural test-suite directory.
+       self.suite_dir = suite
+
+       # Note the march is not hardwired here, because it will change for each
+       # test. Similarly the output elf name and compile macros will be assigned later in the
+       # runTests function
+       self.compile_cmd = 'riscv64-unknown-elf-gcc -march={0} \
+         -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -g\
+         -T '+self.pluginpath+'/env/link.ld\
+         -I '+self.pluginpath+'/env/\
+         -I ' + archtest_env + ' {2} -o {3} {4}'
+
+       # add more utility snippets here
+
+    def build(self, isa_yaml, platform_yaml):
+
+      # load the isa yaml as a dictionary in python.
+      ispec = utils.load_yaml(isa_yaml)['hart0']
+
+      # capture the XLEN value by picking the max value in 'supported_xlen' field of isa yaml. This
+      # will be useful in setting integer value in the compiler string (if not already hardcoded);
+      self.xlen = ('64' if 64 in ispec['supported_xlen'] else '32')
+
+      # for jolt start building the '--isa' argument. the self.isa is dutnmae specific and may not be
+      # useful for all DUTs
+      self.isa = 'rv' + self.xlen
+      if "I" in ispec["ISA"]:
+          self.isa += 'i'
+      if "M" in ispec["ISA"]:
+          self.isa += 'm'
+      if "F" in ispec["ISA"]:
+          self.isa += 'f'
+      if "D" in ispec["ISA"]:
+          self.isa += 'd'
+      if "C" in ispec["ISA"]:
+          self.isa += 'c'
+
+      #TODO: The following assumes you are using the riscv-gcc toolchain. If
+      #      not please change appropriately
+      self.compile_cmd = self.compile_cmd+' -mabi='+('lp64 ' if 64 in ispec['supported_xlen'] else 'ilp32 ')
+
+    def runTests(self, testList):
+
+      # Delete Makefile if it already exists.
+      if os.path.exists(self.work_dir+ "/Makefile." + self.name[:-1]):
+            os.remove(self.work_dir+ "/Makefile." + self.name[:-1])
+      # create an instance the makeUtil class that we will use to create targets.
+      make = utils.makeUtil(makefilePath=os.path.join(self.work_dir, "Makefile." + self.name[:-1]))
+
+      # set the make command that will be used. The num_jobs parameter was set in the __init__
+      # function earlier
+      make.makeCommand = 'make -k -j' + self.num_jobs
+
+      # we will iterate over each entry in the testList. Each entry node will be referred to by the
+      # variable testname.
+      for testname in testList:
+
+          # for each testname we get all its fields (as described by the testList format)
+          testentry = testList[testname]
+
+          # we capture the path to the assembly file of this test
+          test = testentry['test_path']
+
+          # capture the directory where the artifacts of this test will be dumped/created. RISCOF is
+          # going to look into this directory for the signature files
+          test_dir = testentry['work_dir']
+
+          # name of the elf file after compilation of the test
+          elf = 'my.elf'
+
+          # name of the signature file as per requirement of RISCOF. RISCOF expects the signature to
+          # be named as DUT-<dut-name>.signature. The below variable creates an absolute path of
+          # signature file.
+          sig_file = os.path.join(test_dir, self.name[:-1] + ".signature")
+
+          # for each test there are specific compile macros that need to be enabled. The macros in
+          # the testList node only contain the macros/values. For the gcc toolchain we need to
+          # prefix with "-D". The following does precisely that.
+          compile_macros= ' -D' + " -D".join(testentry['macros'])
+
+          # substitute all variables in the compile command that we created in the initialize
+          # function
+          cmd = self.compile_cmd.format(testentry['isa'].lower(), self.xlen, test, elf, compile_macros)
+
+	  # if the user wants to disable running the tests and only compile the tests, then
+	  # the "else" clause is executed below assigning the sim command to simple no action
+	  # echo statement.
+          if self.target_run:
+            # set up the simulation command. Template is for spike. Please change.
+            simcmd = self.dut_exe + ' --trace {3} --signature {1} {2}'.format(self.trace, sig_file, elf, str(self.trace).lower())
+          else:
+            simcmd = 'echo "NO RUN"'
+
+          # concatenate all commands that need to be executed within a make-target.
+          execute = '@cd {0}; {1}; {2};'.format(testentry['work_dir'], cmd, simcmd)
+
+          # create a target. The makeutil will create a target with the name "TARGET<num>" where num
+          # starts from 0 and increments automatically for each new target that is added
+          make.add_target(execute)
+
+      # if you would like to exit the framework once the makefile generation is complete uncomment the
+      # following line. Note this will prevent any signature checking or report generation.
+      #raise SystemExit
+
+      # once the make-targets are done and the makefile has been created, run all the targets in
+      # parallel using the make command set above.
+      make.execute_all(self.work_dir)
+
+      # if target runs are not required then we simply exit as this point after running all
+      # the makefile targets.
+      if not self.target_run:
+          raise SystemExit(0)
+
+#The following is an alternate template that can be used instead of the above.
+#The following template only uses shell commands to compile and run the tests.
+
+#    def runTests(self, testList):
+#
+#      # we will iterate over each entry in the testList. Each entry node will be referred to by the
+#      # variable testname.
+#      for testname in testList:
+#
+#          logger.debug('Running Test: {0} on DUT'.format(testname))
+#          # for each testname we get all its fields (as described by the testList format)
+#          testentry = testList[testname]
+#
+#          # we capture the path to the assembly file of this test
+#          test = testentry['test_path']
+#
+#          # capture the directory where the artifacts of this test will be dumped/created.
+#          test_dir = testentry['work_dir']
+#
+#          # name of the elf file after compilation of the test
+#          elf = 'my.elf'
+#
+#          # name of the signature file as per requirement of RISCOF. RISCOF expects the signature to
+#          # be named as DUT-<dut-name>.signature. The below variable creates an absolute path of
+#          # signature file.
+#          sig_file = os.path.join(test_dir, self.name[:-1] + ".signature")
+#
+#          # for each test there are specific compile macros that need to be enabled. The macros in
+#          # the testList node only contain the macros/values. For the gcc toolchain we need to
+#          # prefix with "-D". The following does precisely that.
+#          compile_macros= ' -D' + " -D".join(testentry['macros'])
+#
+#          # collect the march string required for the compiler
+#          marchstr = testentry['isa'].lower()
+#
+#          # substitute all variables in the compile command that we created in the initialize
+#          # function
+#          cmd = self.compile_cmd.format(marchstr, self.xlen, test, elf, compile_macros)
+#
+#          # just a simple logger statement that shows up on the terminal
+#          logger.debug('Compiling test: ' + test)
+#
+#          # the following command spawns a process to run the compile command. Note here, we are
+#          # changing the directory for this command to that pointed by test_dir. If you would like
+#          # the artifacts to be dumped else where change the test_dir variable to the path of your
+#          # choice.
+#          utils.shellCommand(cmd).run(cwd=test_dir)
+#
+#          # for debug purposes if you would like stop the DUT plugin after compilation, you can
+#          # comment out the lines below and raise a SystemExit
+#
+#          if self.target_run:
+#            # build the command for running the elf on the DUT. In this case we use spike and indicate
+#            # the isa arg that we parsed in the build stage, elf filename and signature filename.
+#            # Template is for spike. Please change for your DUT
+#            execute = self.dut_exe + ' --isa={0} +signature={1} +signature-granularity=4 {2}'.format(self.isa, sig_file, elf)
+#            logger.debug('Executing on Spike ' + execute)
+#
+#          # launch the execute command. Change the test_dir if required.
+#          utils.shellCommand(execute).run(cwd=test_dir)
+#
+#          # post-processing steps can be added here in the template below
+#          #postprocess = 'mv {0} temp.sig'.format(sig_file)'
+#          #utils.shellCommand(postprocess).run(cwd=test_dir)
+#
+#      # if target runs are not required then we simply exit as this point after running all
+#      # the makefile targets.
+#      if not self.target_run:
+#          raise SystemExit

--- a/tests/arch-tests/spike/env/link.ld
+++ b/tests/arch-tests/spike/env/link.ld
@@ -1,0 +1,18 @@
+OUTPUT_ARCH( "riscv" )
+ENTRY(rvtest_entry_point)
+
+SECTIONS
+{
+  . = 0x80000000;
+  .text.init : { *(.text.init) }
+  . = ALIGN(0x1000);
+  .tohost : { *(.tohost) }
+  . = ALIGN(0x1000);
+  .text : { *(.text) }
+  . = ALIGN(0x1000);
+  .data : { *(.data) }
+  .data.string : { *(.data.string)}
+  .bss : { *(.bss) }
+  _end = .;
+}
+

--- a/tests/arch-tests/spike/env/model_test.h
+++ b/tests/arch-tests/spike/env/model_test.h
@@ -1,0 +1,53 @@
+#ifndef _COMPLIANCE_MODEL_H
+#define _COMPLIANCE_MODEL_H
+#define RVMODEL_DATA_SECTION \
+        .pushsection .tohost,"aw",@progbits;                            \
+        .align 8; .global tohost; tohost: .dword 0;                     \
+        .align 8; .global fromhost; fromhost: .dword 0;                 \
+        .popsection;                                                    \
+        .align 8; .global begin_regstate; begin_regstate:               \
+        .word 128;                                                      \
+        .align 8; .global end_regstate; end_regstate:                   \
+        .word 4;
+
+//RV_COMPLIANCE_HALT
+#define RVMODEL_HALT                                              \
+  li x1, 1;                                                                   \
+  write_tohost:                                                               \
+    sw x1, tohost, t5;                                                        \
+    j write_tohost;
+
+#define RVMODEL_BOOT
+
+//RV_COMPLIANCE_DATA_BEGIN
+#define RVMODEL_DATA_BEGIN                                              \
+  .align 4; .global begin_signature; begin_signature:
+
+//RV_COMPLIANCE_DATA_END
+#define RVMODEL_DATA_END                                                      \
+  .align 4; .global end_signature; end_signature:  \
+  RVMODEL_DATA_SECTION                                                        \
+
+//RVTEST_IO_INIT
+#define RVMODEL_IO_INIT
+//RVTEST_IO_WRITE_STR
+#define RVMODEL_IO_WRITE_STR(_R, _STR)
+//RVTEST_IO_CHECK
+#define RVMODEL_IO_CHECK()
+//RVTEST_IO_ASSERT_GPR_EQ
+#define RVMODEL_IO_ASSERT_GPR_EQ(_S, _R, _I)
+//RVTEST_IO_ASSERT_SFPR_EQ
+#define RVMODEL_IO_ASSERT_SFPR_EQ(_F, _R, _I)
+//RVTEST_IO_ASSERT_DFPR_EQ
+#define RVMODEL_IO_ASSERT_DFPR_EQ(_D, _R, _I)
+
+#define RVMODEL_SET_MSW_INT
+
+#define RVMODEL_CLEAR_MSW_INT
+
+#define RVMODEL_CLEAR_MTIMER_INT
+
+#define RVMODEL_CLEAR_MEXT_INT
+
+
+#endif // _COMPLIANCE_MODEL_H

--- a/tests/arch-tests/spike/riscof_spike.py
+++ b/tests/arch-tests/spike/riscof_spike.py
@@ -1,0 +1,129 @@
+import os
+import re
+import shutil
+import subprocess
+import shlex
+import logging
+import random
+import string
+from string import Template
+import sys
+
+import riscof.utils as utils
+import riscof.constants as constants
+from riscof.pluginTemplate import pluginTemplate
+
+logger = logging.getLogger()
+
+class spike(pluginTemplate):
+    __model__ = "spike"
+
+    #TODO: please update the below to indicate family, version, etc of your DUT.
+    __version__ = "XXX"
+
+    def __init__(self, *args, **kwargs):
+        sclass = super().__init__(*args, **kwargs)
+
+        config = kwargs.get('config')
+
+        self.ref_exe = os.path.join(config['PATH'] if 'PATH' in config else "","spike")
+        self.num_jobs = str(config['jobs'] if 'jobs' in config else 1)
+        self.pluginpath=os.path.abspath(config['pluginpath'])
+        self.isa_spec = os.path.abspath(config['ispec']) if 'ispec' in config else ''
+        self.platform_spec = os.path.abspath(config['pspec']) if 'ispec' in config else ''
+        self.make = config['make'] if 'make' in config else 'make'
+        logger.debug("spike plugin initialised using the following configuration.")
+        for entry in config:
+            logger.debug(entry+' : '+config[entry])
+        return sclass
+
+    def initialise(self, suite, work_dir, archtest_env):
+        self.suite = suite
+        if shutil.which(self.ref_exe) is None:
+            logger.error('Please install Executable for DUTNAME to proceed further')
+            raise SystemExit(1)
+        self.work_dir = work_dir
+
+        #TODO: The following assumes you are using the riscv-gcc toolchain. If
+        #      not please change appropriately
+        self.objdump_cmd = 'riscv64-unknown-elf-objdump -D {0} > {2};'
+        self.compile_cmd = 'riscv64-unknown-elf-gcc -march={0} \
+         -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles\
+         -T '+self.pluginpath+'/env/link.ld\
+         -I '+self.pluginpath+'/env/\
+         -I ' + archtest_env
+
+        # set all the necessary variables like compile command, elf2hex
+        # commands, objdump cmds. etc whichever you feel necessary and required
+        # for your plugin.
+
+    def build(self, isa_yaml, platform_yaml):
+        ispec = utils.load_yaml(isa_yaml)['hart0']
+        self.xlen = ('64' if 64 in ispec['supported_xlen'] else '32')
+        self.isa = 'rv' + self.xlen
+        #TODO: The following assumes you are using the riscv-gcc toolchain. If
+        #      not please change appropriately
+        self.compile_cmd = self.compile_cmd+' -mabi='+('lp64 ' if 64 in ispec['supported_xlen'] else 'ilp32 ')
+        if "I" in ispec["ISA"]:
+            self.isa += 'i'
+        if "M" in ispec["ISA"]:
+            self.isa += 'm'
+        if "C" in ispec["ISA"]:
+            self.isa += 'c'
+        if "F" in ispec["ISA"]:
+            self.isa += 'f'
+        if "D" in ispec["ISA"]:
+            self.isa += 'd'
+
+        # based on the validated isa and platform configure your simulator or
+        # build your RTL here
+
+    def runTests(self, testList, cgf_file=None):
+        if os.path.exists(self.work_dir+ "/Makefile." + self.name[:-1]):
+            os.remove(self.work_dir+ "/Makefile." + self.name[:-1])
+        make = utils.makeUtil(makefilePath=os.path.join(self.work_dir, "Makefile." + self.name[:-1]))
+        make.makeCommand = self.make + ' -j' + self.num_jobs
+        for file in testList:
+            testentry = testList[file]
+            test = testentry['test_path']
+            test_dir = testentry['work_dir']
+            test_name = test.rsplit('/',1)[1][:-2]
+
+            elf = 'ref.elf'
+
+            execute = "@cd "+testentry['work_dir']+";"
+
+            cmd = self.compile_cmd.format(testentry['isa'].lower(), self.xlen) + ' ' + test + ' -o ' + elf
+
+            #TODO: we are using -D to enable compile time macros. If your
+            #      toolchain is not riscv-gcc you may want to change the below code
+            compile_cmd = cmd + ' -D' + " -D".join(testentry['macros'])
+            execute+=compile_cmd+";"
+
+            execute += self.objdump_cmd.format(elf, self.xlen, 'ref.disass')
+            sig_file = os.path.join(test_dir, self.name[:-1] + ".signature")
+
+            #TODO: You will need to add any other arguments to your DUT
+            #      executable if any in the quotes below
+            execute += self.ref_exe + ' --misaligned --isa={0} +signature={1} +signature-granularity=4 {2}'.format(self.isa, sig_file, elf)
+
+            #TODO: The following is useful only if your reference model can
+            #      support coverage extraction from riscv-isac. Else leave it
+            #      commented out
+
+            #cov_str = ' '
+            #for label in testentry['coverage_labels']:
+            #    cov_str+=' -l '+label
+            #if cgf_file is not None:
+            #    coverage_cmd = 'riscv_isac --verbose info coverage -d \
+            #            -t {0}.log --parser-name c_sail -o coverage.rpt  \
+            #            --sig-label begin_signature  end_signature \
+            #            --test-label rvtest_code_begin rvtest_code_end \
+            #            -e {0}.elf -c {1} -x{2} {3};'.format(\
+            #            test_name, ' -c '.join(cgf_file), self.xlen, cov_str)
+            #else:
+            #    coverage_cmd = ''
+            #execute+=coverage_cmd
+
+            make.add_target(execute)
+        make.execute_all(self.work_dir)

--- a/tracer/src/instruction/amoaddw.rs
+++ b/tracer/src/instruction/amoaddw.rs
@@ -81,7 +81,7 @@ impl AMOADDW {
         let v_rs2 = virtual_register_index(8) as usize;
 
         let mut sequence = vec![];
-        let mut remaining = 5;
+        let mut remaining = 4;
         remaining = amo_pre32(
             &mut sequence,
             self.address,

--- a/tracer/src/instruction/amoandw.rs
+++ b/tracer/src/instruction/amoandw.rs
@@ -81,7 +81,7 @@ impl AMOANDW {
         let v_rs2 = virtual_register_index(8) as usize;
 
         let mut sequence = vec![];
-        let mut remaining = 5;
+        let mut remaining = 4;
         remaining = amo_pre32(
             &mut sequence,
             self.address,

--- a/tracer/src/instruction/amomaxuw.rs
+++ b/tracer/src/instruction/amomaxuw.rs
@@ -93,7 +93,7 @@ impl AMOMAXUW {
         let v_tmp = virtual_register_index(11) as usize;
 
         let mut sequence = vec![];
-        let mut virtual_sequence_remaining = self.virtual_sequence_remaining.unwrap_or(19);
+        let mut virtual_sequence_remaining = self.virtual_sequence_remaining.unwrap_or(10);
 
         virtual_sequence_remaining = amo_pre32(
             &mut sequence,

--- a/tracer/src/instruction/amomaxw.rs
+++ b/tracer/src/instruction/amomaxw.rs
@@ -93,7 +93,7 @@ impl AMOMAXW {
         let v_tmp = virtual_register_index(11) as usize;
 
         let mut sequence = vec![];
-        let mut remaining = 11;
+        let mut remaining = 10;
         remaining = amo_pre32(
             &mut sequence,
             self.address,

--- a/tracer/src/instruction/amominuw.rs
+++ b/tracer/src/instruction/amominuw.rs
@@ -93,7 +93,7 @@ impl AMOMINUW {
         let v_tmp = virtual_register_index(11) as usize;
 
         let mut sequence = vec![];
-        let mut remaining = 11;
+        let mut remaining = 10;
         remaining = amo_pre32(
             &mut sequence,
             self.address,

--- a/tracer/src/instruction/amominw.rs
+++ b/tracer/src/instruction/amominw.rs
@@ -93,7 +93,7 @@ impl AMOMINW {
         let v_tmp = virtual_register_index(11) as usize;
 
         let mut sequence = vec![];
-        let mut remaining = 11;
+        let mut remaining = 10;
         remaining = amo_pre32(
             &mut sequence,
             self.address,

--- a/tracer/src/instruction/amoorw.rs
+++ b/tracer/src/instruction/amoorw.rs
@@ -81,7 +81,7 @@ impl AMOORW {
         let v_rs2 = virtual_register_index(8) as usize;
 
         let mut sequence = vec![];
-        let mut virtual_sequence_remaining = self.virtual_sequence_remaining.unwrap_or(9);
+        let mut virtual_sequence_remaining = self.virtual_sequence_remaining.unwrap_or(4);
 
         virtual_sequence_remaining = amo_pre32(
             &mut sequence,

--- a/tracer/src/instruction/amoswapw.rs
+++ b/tracer/src/instruction/amoswapw.rs
@@ -79,7 +79,7 @@ impl AMOSWAPW {
         let v_rd = virtual_register_index(7) as usize;
 
         let mut sequence = vec![];
-        let mut remaining = 4;
+        let mut remaining = 3;
         remaining = amo_pre32(
             &mut sequence,
             self.address,

--- a/tracer/src/instruction/amoxorw.rs
+++ b/tracer/src/instruction/amoxorw.rs
@@ -81,7 +81,7 @@ impl AMOXORW {
         let v_rs2 = virtual_register_index(8) as usize;
 
         let mut sequence = vec![];
-        let mut remaining = 5;
+        let mut remaining = 4;
         remaining = amo_pre32(
             &mut sequence,
             self.address,


### PR DESCRIPTION
This PR adds comprehensive RISC-V architecture test support.

## Key Changes:

### Architecture Test Support
- Added RISCOF integration: Complete test framework for RISC-V compliance testing
- Multiple ISA configurations: Support for 32-bit and 64-bit variants (32gc, 32im, 32imac, 64gc, 64im, 64imac)
- Test harness implementation: Comprehensive test infrastructure in `tests/arch-tests/`
- Spike simulator integration: Reference implementation for comparison testing

### Docker Build Infrastructure  
- Docker build system: Complete Docker-based build pipeline for RISC-V Spike simulator
- Multi-platform support: Build for both ARM64 and AMD64 architectures
- Automated installation: Scripts for building and installing Spike to `/opt/riscv/`

### Development Environment
- DevContainer configuration: Docker-in-Docker support for development
