### PR TITLE
Optimisations/polynomial evaluations

### DIFF
--- a/jolt-core/examples/polynomial_evaluation.rs
+++ b/jolt-core/examples/polynomial_evaluation.rs
@@ -73,8 +73,8 @@ fn benchmark_batch_polynomial_evaluation(batch_size: usize) {
         "exp,num_vars,c,algorithm,time_ms,mults,trial,batch_size"
     )
     .unwrap();
-    let num_trials = 1;
-    for exp in [14, 16, 18, 20] {
+    let num_trials = 10;
+    for exp in [14, 16, 18, 20, 22] {
         let num_evals = 1 << exp;
 
         for c in [0.005, 0.20, 0.50, 0.75] {

--- a/jolt-core/examples/polynomial_evaluation.rs
+++ b/jolt-core/examples/polynomial_evaluation.rs
@@ -92,7 +92,7 @@ fn benchmark_batch_polynomial_evaluation(batch_size: usize) {
                 // --- Algorithm 1: Dot Product ---
                 reset_mult_count();
                 let start = Instant::now();
-                MultilinearPolynomial::batch_evaluate(&poly_refs, &eval_point);
+                MultilinearPolynomial::batch_evaluate_with_eq(&poly_refs, &eval_point);
                 let time_ms = start.elapsed().as_millis();
                 let mults = get_mult_count();
                 writeln!(
@@ -116,10 +116,7 @@ fn benchmark_batch_polynomial_evaluation(batch_size: usize) {
                 // --- Algorithm 3: Sparse Dot Product ---
                 reset_mult_count();
                 let start = Instant::now();
-                MultilinearPolynomial::batch_evaluate_optimised_for_sparse_polynomials(
-                    &poly_refs,
-                    &eval_point,
-                );
+                MultilinearPolynomial::batch_evaluate(&poly_refs, &eval_point);
                 let time_ms = start.elapsed().as_millis();
                 let mults = get_mult_count();
                 writeln!(
@@ -174,7 +171,7 @@ fn benchmark_single_polynomial_evaluation() {
                 // --- Algorithm 2: Inside-Out Product ---
                 reset_mult_count();
                 let start = Instant::now();
-                let inside_out_prod = poly.evaluate(&eval_point);
+                let inside_out_prod = poly.evaluate_inside_out(&eval_point);
                 let time_ms = start.elapsed().as_millis();
                 let mults = get_mult_count();
                 writeln!(
@@ -187,7 +184,7 @@ fn benchmark_single_polynomial_evaluation() {
                 // --- Algorithm 3: Sparse Dot Product ---
                 reset_mult_count();
                 let start = Instant::now();
-                let sparse_prod = poly.evaluate_sparse_dot_product(&eval_point);
+                let sparse_prod = poly.evaluate(&eval_point);
                 let time_ms = start.elapsed().as_millis();
                 let mults = get_mult_count();
                 writeln!(

--- a/jolt-core/examples/polynomial_evaluation.rs
+++ b/jolt-core/examples/polynomial_evaluation.rs
@@ -59,7 +59,7 @@ fn sparse_inputs(n: usize, c: f64) -> (MultilinearPolynomial<Fr>, Vec<Fr>) {
 
     (poly, eval_point)
 }
-fn benchmark_batch_polynomial_evaluation() {
+fn benchmark_batch_polynomial_evaluation(batch_size: usize) {
     let mut file = OpenOptions::new()
         .create(true)
         .write(true)
@@ -67,7 +67,6 @@ fn benchmark_batch_polynomial_evaluation() {
         .open("batch_results.csv")
         .expect("Unable to open file");
 
-    let batch_size = 10;
     // Write CSV header
     writeln!(
         file,
@@ -191,5 +190,5 @@ fn benchmark_single_polynomial_evaluation() {
 
 fn main() {
     //benchmark_single_polynomial_evaluation();
-    benchmark_batch_polynomial_evaluation();
+    benchmark_batch_polynomial_evaluation(49);
 }

--- a/jolt-core/examples/polynomial_evaluation.rs
+++ b/jolt-core/examples/polynomial_evaluation.rs
@@ -78,7 +78,7 @@ fn benchmark_batch_polynomial_evaluation() {
     for exp in [14, 16, 18, 20] {
         let num_evals = 1 << exp;
 
-        for c in [0.20, 0.50, 0.75] {
+        for c in [0.005, 0.20, 0.50, 0.75] {
             for trial in 0..num_trials {
                 let (polys, eval_point) = setup_batch_inputs(num_evals, batch_size, c);
                 let poly_refs: Vec<&MultilinearPolynomial<Fr>> = polys.iter().collect();
@@ -190,6 +190,6 @@ fn benchmark_single_polynomial_evaluation() {
 }
 
 fn main() {
-    benchmark_single_polynomial_evaluation();
+    //benchmark_single_polynomial_evaluation();
     benchmark_batch_polynomial_evaluation();
 }

--- a/jolt-core/src/field/mod.rs
+++ b/jolt-core/src/field/mod.rs
@@ -177,3 +177,4 @@ where
 }
 
 pub mod ark;
+pub mod tracked_ark;

--- a/jolt-core/src/field/tracked_ark.rs
+++ b/jolt-core/src/field/tracked_ark.rs
@@ -1,0 +1,329 @@
+use super::{FieldOps, JoltField};
+use crate::utils::counters::MULT_COUNT;
+use ark_bn254::Fr;
+use ark_ff::UniformRand;
+use ark_ff::{One, Zero};
+use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
+use ark_std::rand::Rng;
+use std::default::Default;
+use std::fmt;
+use std::iter::{Product, Sum};
+use std::ops::{Add, Deref, DerefMut, Div, Mul, Sub};
+use std::ops::{AddAssign, MulAssign, Neg, SubAssign};
+use std::sync::atomic::Ordering;
+
+#[derive(
+    Clone, Default, Copy, PartialEq, Eq, Hash, Debug, CanonicalSerialize, CanonicalDeserialize,
+)]
+pub struct TrackedFr(pub ark_bn254::Fr);
+impl Deref for TrackedFr {
+    type Target = Fr;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl UniformRand for TrackedFr {
+    fn rand<R: Rng + ?Sized>(rng: &mut R) -> Self {
+        TrackedFr(ark_bn254::Fr::rand(rng))
+    }
+}
+impl DerefMut for TrackedFr {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+// Owned + Owned
+impl Add for TrackedFr {
+    type Output = Self;
+    fn add(self, rhs: Self) -> Self::Output {
+        // No MULT_COUNT increment for add, but add if you want
+        Self(self.0 + rhs.0)
+    }
+}
+
+// Owned + Borrowed
+impl<'a> Add<&'a TrackedFr> for TrackedFr {
+    type Output = Self;
+    fn add(self, rhs: &'a TrackedFr) -> Self::Output {
+        Self(self.0 + rhs.0)
+    }
+}
+
+// Owned - Owned
+impl Sub for TrackedFr {
+    type Output = Self;
+    fn sub(self, rhs: Self) -> Self::Output {
+        Self(self.0 - rhs.0)
+    }
+}
+
+// Owned - Borrowed
+impl<'a> Sub<&'a TrackedFr> for TrackedFr {
+    type Output = Self;
+    fn sub(self, rhs: &'a TrackedFr) -> Self::Output {
+        Self(self.0 - rhs.0)
+    }
+}
+
+// Owned * owned
+impl Mul<TrackedFr> for TrackedFr {
+    type Output = TrackedFr;
+    fn mul(self, rhs: TrackedFr) -> Self::Output {
+        MULT_COUNT.fetch_add(1, Ordering::Relaxed);
+        TrackedFr(self.0 * rhs.0)
+    }
+}
+
+// Owned * borrowed
+impl<'a> Mul<&'a TrackedFr> for TrackedFr {
+    type Output = TrackedFr;
+    fn mul(self, rhs: &'a TrackedFr) -> Self::Output {
+        MULT_COUNT.fetch_add(1, Ordering::Relaxed);
+        TrackedFr(self.0 * rhs.0)
+    }
+}
+
+// Borrowed * owned
+impl Mul<TrackedFr> for &TrackedFr {
+    type Output = TrackedFr;
+
+    fn mul(self, rhs: TrackedFr) -> Self::Output {
+        MULT_COUNT.fetch_add(1, Ordering::Relaxed);
+        TrackedFr(self.0 * rhs.0)
+    }
+}
+
+// Owned / Owned
+#[allow(clippy::suspicious_arithmetic_impl)]
+impl Div<TrackedFr> for TrackedFr {
+    type Output = TrackedFr;
+    fn div(self, rhs: TrackedFr) -> Self::Output {
+        MULT_COUNT.fetch_add(1, Ordering::Relaxed);
+        let inv = rhs.0.inverse().expect("division by zero");
+        TrackedFr(self.0 * inv)
+    }
+}
+// Owned / Borrowed
+#[allow(clippy::suspicious_arithmetic_impl)]
+impl<'a> Div<&'a TrackedFr> for TrackedFr {
+    type Output = TrackedFr;
+    fn div(self, rhs: &'a TrackedFr) -> Self::Output {
+        MULT_COUNT.fetch_add(1, Ordering::Relaxed);
+        TrackedFr(self.0 * ark_ff::Field::inverse(&rhs.0).unwrap())
+    }
+}
+
+// Borrowed / Owned
+#[allow(clippy::suspicious_arithmetic_impl)]
+impl Div<TrackedFr> for &TrackedFr {
+    type Output = TrackedFr;
+    fn div(self, rhs: TrackedFr) -> Self::Output {
+        MULT_COUNT.fetch_add(1, Ordering::Relaxed);
+        TrackedFr(self.0 * ark_ff::Field::inverse(&rhs.0).unwrap())
+    }
+}
+
+impl PartialEq<Fr> for TrackedFr {
+    fn eq(&self, other: &Fr) -> bool {
+        self.0 == *other
+    }
+}
+impl PartialEq<TrackedFr> for Fr {
+    fn eq(&self, other: &TrackedFr) -> bool {
+        *self == other.0
+    }
+}
+
+// Display delegates to Debug or inner Display
+impl fmt::Display for TrackedFr {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+// Negation
+impl Neg for TrackedFr {
+    type Output = Self;
+    fn neg(self) -> Self::Output {
+        Self(-self.0)
+    }
+}
+
+// AddAssign, SubAssign, MulAssign
+impl AddAssign for TrackedFr {
+    fn add_assign(&mut self, other: Self) {
+        self.0 += other.0;
+    }
+}
+
+impl SubAssign for TrackedFr {
+    fn sub_assign(&mut self, other: Self) {
+        self.0 -= other.0;
+    }
+}
+
+impl MulAssign for TrackedFr {
+    fn mul_assign(&mut self, other: Self) {
+        self.0 *= other.0;
+    }
+}
+
+// Zero and One
+impl Zero for TrackedFr {
+    fn zero() -> Self {
+        Self(Fr::zero())
+    }
+    fn is_zero(&self) -> bool {
+        self.0.is_zero()
+    }
+}
+
+impl One for TrackedFr {
+    fn one() -> Self {
+        Self(Fr::one())
+    }
+    fn is_one(&self) -> bool {
+        self.0.is_one()
+    }
+}
+
+// Sum and Product for iterators
+impl Sum for TrackedFr {
+    fn sum<I: Iterator<Item = Self>>(iter: I) -> Self {
+        iter.fold(Self::zero(), |a, b| Self(a.0 + b.0))
+    }
+}
+
+impl<'a> Sum<&'a Self> for TrackedFr {
+    fn sum<I: Iterator<Item = &'a Self>>(iter: I) -> Self {
+        iter.fold(Self::zero(), |a, b| Self(a.0 + b.0))
+    }
+}
+
+impl Product for TrackedFr {
+    fn product<I: Iterator<Item = Self>>(iter: I) -> Self {
+        iter.fold(Self::one(), |a, b| Self(a.0 * b.0))
+    }
+}
+
+impl<'a> Product<&'a Self> for TrackedFr {
+    fn product<I: Iterator<Item = &'a Self>>(iter: I) -> Self {
+        iter.fold(Self::one(), |a, b| Self(a.0 * b.0))
+    }
+}
+
+// &TrackedFr + &TrackedFr
+#[allow(clippy::needless_lifetimes)]
+impl<'a, 'b> Add<&'b TrackedFr> for &'a TrackedFr {
+    type Output = TrackedFr;
+    fn add(self, rhs: &'b TrackedFr) -> Self::Output {
+        TrackedFr(self.0 + rhs.0)
+    }
+}
+
+// &TrackedFr - &TrackedFr
+#[allow(clippy::needless_lifetimes)]
+impl<'a, 'b> Sub<&'b TrackedFr> for &'a TrackedFr {
+    type Output = TrackedFr;
+    fn sub(self, rhs: &'b TrackedFr) -> Self::Output {
+        TrackedFr(self.0 - rhs.0)
+    }
+}
+
+// &TrackedFr * &TrackedFr
+#[allow(clippy::needless_lifetimes)]
+impl<'a, 'b> Mul<&'b TrackedFr> for &'a TrackedFr {
+    type Output = TrackedFr;
+    fn mul(self, rhs: &'b TrackedFr) -> Self::Output {
+        MULT_COUNT.fetch_add(1, Ordering::Relaxed);
+        TrackedFr(self.0 * rhs.0)
+    }
+}
+
+// &TrackedFr / &TrackedFr[allow(clippy::needless_lifetimes)]
+#[allow(clippy::needless_lifetimes)]
+#[allow(clippy::suspicious_arithmetic_impl)]
+impl<'a, 'b> Div<&'b TrackedFr> for &'a TrackedFr {
+    type Output = TrackedFr;
+    fn div(self, rhs: &'b TrackedFr) -> Self::Output {
+        MULT_COUNT.fetch_add(1, Ordering::Relaxed);
+        TrackedFr(self.0 * ark_ff::Field::inverse(&rhs.0).unwrap())
+    }
+}
+
+impl FieldOps for TrackedFr {}
+impl FieldOps<&TrackedFr, TrackedFr> for TrackedFr {}
+
+impl JoltField for TrackedFr {
+    const NUM_BYTES: usize = <ark_bn254::Fr as JoltField>::NUM_BYTES;
+    type SmallValueLookupTables = <ark_bn254::Fr as JoltField>::SmallValueLookupTables;
+
+    fn random<R: rand_core::RngCore>(rng: &mut R) -> Self {
+        TrackedFr(<ark_bn254::Fr as JoltField>::random(rng))
+    }
+
+    fn compute_lookup_tables() -> Self::SmallValueLookupTables {
+        <ark_bn254::Fr as JoltField>::compute_lookup_tables()
+    }
+
+    fn initialize_lookup_tables(init: Self::SmallValueLookupTables) {
+        <ark_bn254::Fr as JoltField>::initialize_lookup_tables(init)
+    }
+
+    fn from_u8(n: u8) -> Self {
+        TrackedFr(<ark_bn254::Fr as JoltField>::from_u8(n))
+    }
+
+    fn from_u16(n: u16) -> Self {
+        TrackedFr(<ark_bn254::Fr as JoltField>::from_u16(n))
+    }
+
+    fn from_u32(n: u32) -> Self {
+        TrackedFr(<ark_bn254::Fr as JoltField>::from_u32(n))
+    }
+
+    fn from_u64(n: u64) -> Self {
+        TrackedFr(<ark_bn254::Fr as JoltField>::from_u64(n))
+    }
+
+    fn from_i64(n: i64) -> Self {
+        TrackedFr(<ark_bn254::Fr as JoltField>::from_i64(n))
+    }
+
+    fn from_i128(n: i128) -> Self {
+        TrackedFr(<ark_bn254::Fr as JoltField>::from_i128(n))
+    }
+
+    fn to_u64(&self) -> Option<u64> {
+        self.0.to_u64()
+    }
+
+    fn square(&self) -> Self {
+        MULT_COUNT.fetch_add(1, Ordering::Relaxed);
+        TrackedFr(self.0.square())
+    }
+
+    fn inverse(&self) -> Option<Self> {
+        self.0.inverse().map(TrackedFr)
+    }
+
+    fn from_bytes(bytes: &[u8]) -> Self {
+        TrackedFr(<ark_bn254::Fr as JoltField>::from_bytes(bytes))
+    }
+
+    fn num_bits(&self) -> u32 {
+        self.0.num_bits()
+    }
+
+    fn mul_u64(&self, n: u64) -> Self {
+        MULT_COUNT.fetch_add(1, Ordering::Relaxed);
+        TrackedFr(self.0.mul_u64(n))
+    }
+
+    fn mul_i128(&self, n: i128) -> Self {
+        MULT_COUNT.fetch_add(1, Ordering::Relaxed);
+        TrackedFr(self.0.mul_i128(n))
+    }
+}

--- a/jolt-core/src/poly/dense_mlpoly.rs
+++ b/jolt-core/src/poly/dense_mlpoly.rs
@@ -371,13 +371,13 @@ impl<F: JoltField> PolynomialEvaluation<F> for DensePolynomial<F> {
         self.evaluate(r)
     }
 
-    fn batch_evaluate(polys: &[&Self], r: &[F]) -> (Vec<F>, Vec<F>) {
+    fn batch_evaluate(polys: &[&Self], r: &[F]) -> Vec<F> {
         let eq = EqPolynomial::evals(r);
         let evals: Vec<F> = polys
             .into_par_iter()
             .map(|&poly| poly.evaluate_at_chi_low_optimized(&eq))
             .collect();
-        (evals, eq)
+        evals
     }
 
     fn sumcheck_evals(&self, index: usize, degree: usize, order: BindingOrder) -> Vec<F> {

--- a/jolt-core/src/poly/dense_mlpoly.rs
+++ b/jolt-core/src/poly/dense_mlpoly.rs
@@ -5,7 +5,7 @@ use crate::poly::multilinear_polynomial::PolynomialEvaluation;
 use crate::utils::thread::unsafe_allocate_zero_vec;
 use crate::utils::{compute_dotproduct, compute_dotproduct_low_optimized};
 
-use crate::field::JoltField;
+use crate::field::{JoltField, OptimizedMul};
 use crate::utils::math::Math;
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use core::ops::Index;
@@ -249,6 +249,25 @@ impl<F: JoltField> DensePolynomial<F> {
         let chis = EqPolynomial::evals(r);
         assert_eq!(chis.len(), self.Z.len());
         compute_dotproduct(&self.Z, &chis)
+    }
+    pub fn evaluate_at_chi_split_eq(&self, eq_one: &[F], eq_two: &[F]) -> F {
+        // Serial and parallel based on the size of the the problem
+        // Neeed to handle case by case
+        let eval: F = (0..eq_one.len())
+            .flat_map(|x1| (0..eq_two.len()).map(move |x2| (x1, x2)))
+            .collect::<Vec<_>>()
+            .into_par_iter()
+            .map(|(x1, x2)| {
+                let idx = x1 * eq_two.len() + x2;
+                if self.Z[idx].is_zero() || eq_one[x1].is_zero() || eq_two[x2].is_zero() {
+                    F::zero()
+                } else {
+                    let coef = OptimizedMul::mul_01_optimized(self.Z[idx], eq_two[x2]);
+                    OptimizedMul::mul_01_optimized(eq_one[x1], coef)
+                }
+            })
+            .reduce(|| F::zero(), |acc, v| acc + v);
+        eval
     }
 
     // Faster evaluation based on

--- a/jolt-core/src/poly/identity_poly.rs
+++ b/jolt-core/src/poly/identity_poly.rs
@@ -67,7 +67,7 @@ impl<F: JoltField> PolynomialEvaluation<F> for IdentityPolynomial<F> {
         (0..len).map(|i| r[i].mul_u64(1u64 << (len - 1 - i))).sum()
     }
 
-    fn batch_evaluate(_polys: &[&Self], _r: &[F]) -> (Vec<F>, Vec<F>) {
+    fn batch_evaluate(_polys: &[&Self], _r: &[F]) -> Vec<F> {
         unimplemented!("Currently unused")
     }
 
@@ -236,7 +236,7 @@ impl<F: JoltField> PolynomialEvaluation<F> for OperandPolynomial<F> {
         }
     }
 
-    fn batch_evaluate(_polys: &[&Self], _r: &[F]) -> (Vec<F>, Vec<F>) {
+    fn batch_evaluate(_polys: &[&Self], _r: &[F]) -> Vec<F> {
         unimplemented!("Currently unused")
     }
 
@@ -404,7 +404,7 @@ impl<F: JoltField> PolynomialEvaluation<F> for UnmapRamAddressPolynomial<F> {
         self.int_poly.evaluate(r).mul_u64(4) + F::from_u64(self.start_address - 4)
     }
 
-    fn batch_evaluate(_polys: &[&Self], _r: &[F]) -> (Vec<F>, Vec<F>) {
+    fn batch_evaluate(_polys: &[&Self], _r: &[F]) -> Vec<F> {
         unimplemented!("Unused")
     }
 

--- a/jolt-core/src/poly/multilinear_polynomial.rs
+++ b/jolt-core/src/poly/multilinear_polynomial.rs
@@ -520,7 +520,7 @@ pub trait PolynomialEvaluation<F: JoltField> {
     /// Returns: (evals, EQ table)
     /// where EQ table is EQ(x, r) for x \in {0, 1}^|r|. This is used for
     /// batched opening proofs (see opening_proof.rs)
-    fn batch_evaluate(polys: &[&Self], r: &[F]) -> (Vec<F>, Vec<F>)
+    fn batch_evaluate(polys: &[&Self], r: &[F]) -> Vec<F>
     where
         Self: Sized;
     /// Computes this polynomial's contribution to the computation of a prover
@@ -599,7 +599,7 @@ impl<F: JoltField> PolynomialEvaluation<F> for MultilinearPolynomial<F> {
     }
 
     #[tracing::instrument(skip_all, name = "MultilinearPolynomial::batch_evaluate")]
-    fn batch_evaluate(polys: &[&Self], r: &[F]) -> (Vec<F>, Vec<F>) {
+    fn batch_evaluate(polys: &[&Self], r: &[F]) -> Vec<F> {
         let eq = EqPolynomial::evals(r);
         let evals: Vec<F> = polys
             .into_par_iter()
@@ -610,7 +610,7 @@ impl<F: JoltField> PolynomialEvaluation<F> for MultilinearPolynomial<F> {
                 _ => poly.dot_product(&eq),
             })
             .collect();
-        (evals, eq)
+        evals
     }
 
     #[inline]

--- a/jolt-core/src/poly/multilinear_polynomial.rs
+++ b/jolt-core/src/poly/multilinear_polynomial.rs
@@ -583,6 +583,45 @@ impl<F: JoltField> PolynomialBinding<F> for MultilinearPolynomial<F> {
     }
 }
 
+impl<F: JoltField> MultilinearPolynomial<F> {
+    #[tracing::instrument(skip_all, name = "MultilinearPolynomial::batch_evaluate_sparse")]
+    pub fn batch_evaluate_optimised_for_sparse_polynomials(polys: &[&Self], r: &[F]) -> Vec<F> {
+        let m = r.len() / 2;
+        let (r2, r1) = r.split_at(m);
+        let (eq_one, eq_two) = rayon::join(|| EqPolynomial::evals(r2), || EqPolynomial::evals(r1));
+
+        let evals: Vec<F> = polys
+            .into_par_iter()
+            .map(|&poly| match poly {
+                MultilinearPolynomial::LargeScalars(poly) => {
+                    poly.evaluate_at_chi_split_eq(&eq_one, &eq_two)
+                }
+                MultilinearPolynomial::U8Scalars(poly) => {
+                    poly.split_eq_evaluate(r, &eq_one, &eq_two)
+                }
+                MultilinearPolynomial::U16Scalars(poly) => {
+                    poly.split_eq_evaluate(r, &eq_one, &eq_two)
+                }
+                MultilinearPolynomial::U32Scalars(poly) => {
+                    poly.split_eq_evaluate(r, &eq_one, &eq_two)
+                }
+                MultilinearPolynomial::U64Scalars(poly) => {
+                    poly.split_eq_evaluate(r, &eq_one, &eq_two)
+                }
+                MultilinearPolynomial::I64Scalars(poly) => {
+                    poly.split_eq_evaluate(r, &eq_one, &eq_two)
+                }
+
+                _ => {
+                    // THIS SHOULD BE DIFFERENT
+                    let eq = EqPolynomial::evals(r);
+                    poly.dot_product(&eq)
+                }
+            })
+            .collect();
+        evals
+    }
+}
 impl<F: JoltField> PolynomialEvaluation<F> for MultilinearPolynomial<F> {
     #[tracing::instrument(skip_all, name = "MultilinearPolynomial::evaluate")]
     fn evaluate(&self, r: &[F]) -> F {

--- a/jolt-core/src/poly/multilinear_polynomial.rs
+++ b/jolt-core/src/poly/multilinear_polynomial.rs
@@ -654,7 +654,7 @@ impl<F: JoltField> MultilinearPolynomial<F> {
         let (eq_one, eq_two) = rayon::join(|| EqPolynomial::evals(r2), || EqPolynomial::evals(r1));
 
         let evals: Vec<F> = polys
-            .into_par_iter()
+            .iter()
             .map(|&poly| match poly {
                 MultilinearPolynomial::LargeScalars(poly) => {
                     poly.evaluate_at_chi_split_eq(&eq_one, &eq_two)
@@ -676,7 +676,6 @@ impl<F: JoltField> MultilinearPolynomial<F> {
                 }
 
                 _ => {
-                    // THIS SHOULD BE DIFFERENT
                     let eq = EqPolynomial::evals(r);
                     poly.dot_product(&eq)
                 }

--- a/jolt-core/src/poly/prefix_suffix.rs
+++ b/jolt-core/src/poly/prefix_suffix.rs
@@ -88,7 +88,7 @@ impl<F: JoltField> PolynomialEvaluation<F> for CachedPolynomial<F> {
         self.inner.evaluate(x)
     }
 
-    fn batch_evaluate(_polys: &[&Self], _r: &[F]) -> (Vec<F>, Vec<F>) {
+    fn batch_evaluate(_polys: &[&Self], _r: &[F]) -> Vec<F> {
         unimplemented!("Currently unused")
     }
 

--- a/jolt-core/src/utils/counters.rs
+++ b/jolt-core/src/utils/counters.rs
@@ -1,0 +1,13 @@
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+// A global counter that tracks how many times we've use a*b where a, b are ark_bn254::Fr types
+// see jolt-core::field::tracked_fr::TrackedFr for more details
+pub static MULT_COUNT: AtomicUsize = AtomicUsize::new(0);
+
+pub fn reset_mult_count() {
+    MULT_COUNT.store(0, Ordering::Relaxed);
+}
+
+pub fn get_mult_count() -> usize {
+    MULT_COUNT.load(Ordering::Relaxed)
+}

--- a/jolt-core/src/utils/mod.rs
+++ b/jolt-core/src/utils/mod.rs
@@ -2,6 +2,7 @@ use crate::field::JoltField;
 
 use rayon::prelude::*;
 
+pub mod counters;
 pub mod errors;
 pub mod expanding_table;
 pub mod gaussian_elimination;
@@ -11,7 +12,6 @@ pub mod profiling;
 pub mod small_value;
 pub mod thread;
 pub mod transcript;
-
 /// Macros that determine the optimal iterator type based on the feature flags.
 ///
 /// For some cases (ex. offloading to GPU), we may not want to use a parallel iterator.

--- a/jolt-core/src/zkvm/r1cs/spartan.rs
+++ b/jolt-core/src/zkvm/r1cs/spartan.rs
@@ -720,7 +720,7 @@ impl<F: JoltField, ProofTranscript: Transcript, PCS: CommitmentScheme<Field = F>
         // Evaluate all witness polynomials P_i at r_cycle for the verifier
         // Verifier computes: z(r_inner, r_cycle) = Σ_i eq(r_inner, i) * P_i(r_cycle)
         let flattened_polys_ref: Vec<_> = input_polys.iter().collect();
-        let (claimed_witness_evals, _) =
+        let claimed_witness_evals =
             MultilinearPolynomial::batch_evaluate(&flattened_polys_ref, r_cycle);
 
         // Only non-virtual (i.e. committed) polynomials' openings are


### PR DESCRIPTION
See [Blog](https://randomwalks.xyz/publish/fast_polynomial_evaluation.html) exact details.

Contributions:

## Tracked Data Types

We now have the ability to track actual arithmetic operations see `field/tracked_ark.rs`

Blog has more details, but this allows us to test and and check for optimality.

## Faster Polynomial Evaluations

+ Split Eq polynomial evaluation speeds up single polynomial evaluation for sparse and non sparse cases (old dot product code had an inefficiency, see blog, not that it matters now)

<img width="1145" height="419" alt="single_poly_evals_num_vars" src="https://github.com/user-attachments/assets/2f554a51-804a-4711-9681-d6cdbe61f8fa" />

<img width="1121" height="597" alt="single_poly_eval_sparsity" src="https://github.com/user-attachments/assets/0e2efdc7-7496-4e8d-993f-51227b992162" />

+ Batched Split Eq polynomial evaluation also speeds up batched polynomial evaluation but not as much as batch size * sparsity domin
<img width="1069" height="591" alt="batch_poly_eval_sparsity" src="https://github.com/user-attachments/assets/29b9e13d-5e45-4179-a574-09e865cd5458" />
ates

<img width="1126" height="432" alt="batch_poly_evals_num_vars" src="https://github.com/user-attachments/assets/7dd0829c-5611-49e8-9567-7130609c382d" />



