### PR TITLE
Feat/verifier memory layout checks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ temp_file
 .vscode
 
 *.patch
+
+# Spike tarballs
+/prebuilt-files/

--- a/examples/btreemap/host/src/main.rs
+++ b/examples/btreemap/host/src/main.rs
@@ -36,7 +36,7 @@ pub fn btreemap() {
     let (output, proof, io_device) = step!("Proving", { prove(n) });
     assert!(output >= 1);
 
-    let is_valid = step!("Verifying", { verify(n, output, io_device.panic,proof) });
+    let is_valid = step!("Verifying", { verify(n, output, io_device.panic, proof) });
     assert!(is_valid);
 }
 

--- a/jolt-core/src/utils/errors.rs
+++ b/jolt-core/src/utils/errors.rs
@@ -7,6 +7,10 @@ pub enum ProofVerifyError {
     InvalidInputLength(usize, usize),
     #[error("Input too large")]
     InputTooLarge,
+    #[error("Output too large")]
+    OutputTooLarge,
+    #[error("Memory layout mismatch")]
+    MemoryLayoutMismatch,
     #[error("Proof verification failed")]
     #[default]
     InternalError,

--- a/jolt-core/src/zkvm/mod.rs
+++ b/jolt-core/src/zkvm/mod.rs
@@ -263,6 +263,17 @@ where
         #[cfg(test)]
         let _guard = DoryGlobals::initialize(DTH_ROOT_OF_K, T);
 
+        // Memory layout checks
+        if program_io.memory_layout != preprocessing.shared.memory_layout {
+            return Err(ProofVerifyError::MemoryLayoutMismatch);
+        }
+        if program_io.inputs.len() > preprocessing.shared.memory_layout.max_input_size as usize {
+            return Err(ProofVerifyError::InputTooLarge);
+        }
+        if program_io.outputs.len() > preprocessing.shared.memory_layout.max_output_size as usize {
+            return Err(ProofVerifyError::OutputTooLarge);
+        }
+
         // truncate trailing zeros on device outputs
         program_io.outputs.truncate(
             program_io


### PR DESCRIPTION
Previously, it was somewhat ambiguous whether (or which fields) in the verifier's `JoltDevice` are trusted vs untrusted. This PR adds checks to enforce that the `JoltDevice` has the same `MemoryLayout` as the verifier preprocessing