### PR TITLE
fix: cycle tracking marker id length

### DIFF
--- a/examples/btreemap/host/src/main.rs
+++ b/examples/btreemap/host/src/main.rs
@@ -36,7 +36,7 @@ pub fn btreemap() {
     let (output, proof, io_device) = step!("Proving", { prove(n) });
     assert!(output >= 1);
 
-    let is_valid = step!("Verifying", { verify(n, output, io_device.panic,proof) });
+    let is_valid = step!("Verifying", { verify(n, output, io_device.panic, proof) });
     assert!(is_valid);
 }
 

--- a/jolt-sdk/src/cycle_tracking.rs
+++ b/jolt-sdk/src/cycle_tracking.rs
@@ -16,24 +16,35 @@ mod riscv_specific {
 
     pub fn start_cycle_tracking(marker_id_str: &str) {
         let marker_id_ptr = marker_id_str.as_ptr() as usize;
-        emit_jolt_cycle_marker_ecall(marker_id_ptr as i32, JOLT_CYCLE_MARKER_START);
+        let marker_len = marker_id_str.len();
+        emit_jolt_cycle_marker_ecall(
+            marker_id_ptr as i32,
+            marker_len as i32,
+            JOLT_CYCLE_MARKER_START,
+        );
     }
 
     pub fn end_cycle_tracking(marker_id_str: &str) {
         let marker_id_ptr = marker_id_str.as_ptr() as usize;
-        emit_jolt_cycle_marker_ecall(marker_id_ptr as i32, JOLT_CYCLE_MARKER_END);
+        let marker_len = marker_id_str.len();
+        emit_jolt_cycle_marker_ecall(
+            marker_id_ptr as i32,
+            marker_len as i32,
+            JOLT_CYCLE_MARKER_END,
+        );
     }
 
     // inserts an ECALL directly into the compiled code
     #[inline(always)]
-    fn emit_jolt_cycle_marker_ecall(marker_id: i32, event_type: i32) {
+    fn emit_jolt_cycle_marker_ecall(marker_id: i32, marker_len: i32, event_type: i32) {
         #[cfg(any(target_arch = "riscv32", target_arch = "riscv64"))]
         unsafe {
             core::arch::asm!(
                 ".word 0x00000073", // ECALL opcode
                 in("x10") JOLT_CYCLE_TRACK_ECALL_NUM, //
                 in("x11") marker_id, // we store ptr address of the label &str to recover it during emulation
-                in("x12") event_type, // either start or end
+                in("x12") marker_len, // length of the label &str
+                in("x13") event_type, // either start or end
                 options(nostack, nomem, preserves_flags)
             );
         }

--- a/jolt-sdk/src/lib.rs
+++ b/jolt-sdk/src/lib.rs
@@ -10,14 +10,15 @@ pub mod host_utils;
 #[cfg(feature = "host")]
 pub use host_utils::*;
 
-pub mod cycle_tracking;
-pub use cycle_tracking::*;
-
 pub mod alloc;
 pub use alloc::*;
 
+pub mod cycle_tracking;
+pub use cycle_tracking::*;
+
 #[cfg(feature = "sha256")]
 pub mod sha256;
+
 #[cfg(feature = "sha256")]
 pub use sha256::*;
 

--- a/jolt-verifier/tests/README.md
+++ b/jolt-verifier/tests/README.md
@@ -1,0 +1,9 @@
+# Test Fixtures
+
+These tests rely on fixtures that may break if the prover or verifier implementation changes.  
+If you encounter failing tests due to fixture mismatches, you can regenerate the fixtures:
+
+1. Run `cargo run --release -p fibonacci -- --save` in the root dir to generate new fixtures in the `/tmp` directory.
+2. Copy the new fixtures from `/tmp` and overwrite the existing ones in this directory.
+
+This will update the test data to match the latest prover/verifier output.


### PR DESCRIPTION
- Rust strings are not null terminated. This can cause the cycle tracking print to pickup random bytes as it tries to reconstruct a string from the pointer it has access to. 