### PR TITLE
chore: enhance devcontainer with oh-my-zsh plugins and dependencies

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -2,8 +2,10 @@ FROM mcr.microsoft.com/devcontainers/base:noble
 
 RUN <<-'EOF' bash
 	set -eu -o pipefail
+	printf "\npath-include=/usr/share/doc/*/examples/*\n" >> /etc/dpkg/dpkg.cfg.d/excludes
 	apt-get update
-	apt-get install -y --no-install-recommends ca-certificates pkg-config libssl-dev
+	apt-get install -y --no-install-recommends ca-certificates pkg-config libssl-dev python3 fzf
+	sed -i 's/plugins=(.*)/plugins=(git git-prompt fzf)/g' ~/.zshrc
 	curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sed 's#/proc/self/exe#\/bin\/sh#g' | sh -s -- -y --no-update-default-toolchain 1>/dev/null
 	rm -rf /var/lib/apt/lists/*
 EOF


### PR DESCRIPTION
This PR enhances the development container with git-prompt and fzf plugins.

- Add dpkg configuration to include examples directory (required by fzf plugins)
- Install python3 and fzf packages for oh-my-zsh plugin support
- Configure oh-my-zsh with git, git-prompt, and fzf plugins
- git-prompt plugin requires python3 to run git status scripts
- fzf plugin requires fzf binary and examples for proper functionality