### PR TITLE
ci: bump actions/checkout to v5

### DIFF
--- a/.github/workflows/ci-bench.yml
+++ b/.github/workflows/ci-bench.yml
@@ -19,7 +19,7 @@ jobs:
     name: Performance benchmarks
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - uses: actions-rust-lang/setup-rust-toolchain@v1
     - uses: actions/cache@v4 # From: https://github.com/actions/cache/blob/main/examples.md#rust---cargo
       with:

--- a/.github/workflows/deploy-mdbook.yml
+++ b/.github/workflows/deploy-mdbook.yml
@@ -9,7 +9,7 @@ jobs:
   deploy_gcloud:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - uses: dtolnay/rust-toolchain@stable
 
     - id: 'auth'
@@ -36,7 +36,7 @@ jobs:
   deploy_firebase:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
       - name: Setup mdBook
         uses: peaceiris/actions-mdbook@v1

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -18,7 +18,7 @@ jobs:
   fmt:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           components: rustfmt
@@ -28,7 +28,7 @@ jobs:
   clippy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           components: clippy
@@ -46,7 +46,7 @@ jobs:
     name: Build Wasm
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions-rust-lang/setup-rust-toolchain@v1
       - name: Install wasm32 target
         run: rustup target add wasm32-unknown-unknown
@@ -57,7 +57,7 @@ jobs:
   test-core:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions-rust-lang/setup-rust-toolchain@v1
       - name: Cache Jolt RISC-V Rust toolchain
         uses: actions/cache@v4
@@ -74,7 +74,7 @@ jobs:
   typos:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: crate-ci/typos@v1.30.0
         with:
           files: .
@@ -83,7 +83,7 @@ jobs:
     name: jolt binary check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions-rust-lang/setup-rust-toolchain@v1
       - name: Build the `jolt` binary
         run: cargo build --release --bin jolt
@@ -99,7 +99,7 @@ jobs:
     name: Jolt Verifier Tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions-rust-lang/setup-rust-toolchain@v1
       - name: Install Jolt RISC-V Rust toolchain
         run: cargo run install-toolchain
@@ -112,7 +112,7 @@ jobs:
     name: Jolt Tracer Tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions-rust-lang/setup-rust-toolchain@v1
       - name: Install Jolt RISC-V Rust toolchain
         run: cargo run install-toolchain
@@ -125,7 +125,7 @@ jobs:
   #   name: ZkLean extractor tests
   #   runs-on: ubuntu-latest
   #   steps:
-  #     - uses: actions/checkout@v4
+  #     - uses: actions/checkout@v5
   #     - name: Run extractor tests
   #       working-directory: ./zklean-extractor
   #       run: cargo test
@@ -134,7 +134,7 @@ jobs:
   #   name: Compile extracted Lean
   #   runs-on: ubuntu-latest
   #   steps:
-  #     - uses: actions/checkout@v4
+  #     - uses: actions/checkout@v5
   #     - name: Extract Jolt ZkLean package
   #       working-directory: ./zklean-extractor
   #       run: cargo run --release -- -o -p jolt-zklean


### PR DESCRIPTION
Bumps checkout to v5 for future-proofing against Node 24 runner updates. Requires runner v2.327.1+. Workflows compile the same.

More info: https://github.com/actions/checkout/releases/tag/v5.0.0