### PR TITLE
refactor: change elf_contents parameter from Vec<u8> to &[u8] for better performance

### DIFF
--- a/jolt-core/src/host/program.rs
+++ b/jolt-core/src/host/program.rs
@@ -211,7 +211,7 @@ impl Program {
             max_output_size: self.max_output_size,
             program_size: Some(program_size),
         };
-        tracer::trace(elf_contents, inputs, &memory_config)
+        tracer::trace(&elf_contents, inputs, &memory_config)
     }
 
     #[tracing::instrument(skip_all, name = "Program::trace_to_file")]
@@ -231,7 +231,7 @@ impl Program {
             max_output_size: self.max_output_size,
             program_size: Some(program_size),
         };
-        tracer::trace_to_file(elf_contents, inputs, &memory_config, trace_file)
+        tracer::trace_to_file(&elf_contents, inputs, &memory_config, trace_file)
     }
 
     pub fn trace_analyze<F: JoltField>(mut self, inputs: &[u8]) -> ProgramSummary {

--- a/tracer/src/emulator/elf_analyzer.rs
+++ b/tracer/src/emulator/elf_analyzer.rs
@@ -79,8 +79,10 @@ impl ElfAnalyzer {
     ///
     /// # Arguments
     /// * `data` ELF file content binary
-    pub fn new(data: Vec<u8>) -> Self {
-        ElfAnalyzer { data }
+    pub fn new(data: &[u8]) -> Self {
+        ElfAnalyzer {
+            data: data.to_vec(),
+        }
     }
 
     /// Checks if ELF file content is valid

--- a/tracer/src/emulator/mod.rs
+++ b/tracer/src/emulator/mod.rs
@@ -163,7 +163,7 @@ impl Emulator {
     /// * `data` Program binary
     // @TODO: Make ElfAnalyzer and move the core logic there.
     // @TODO: Returns `Err` if the passed contend doesn't seem ELF file
-    pub fn setup_program(&mut self, data: Vec<u8>) {
+    pub fn setup_program(&mut self, data: &[u8]) {
         let analyzer = ElfAnalyzer::new(data);
 
         if !analyzer.validate() {

--- a/tracer/src/lib.rs
+++ b/tracer/src/lib.rs
@@ -70,7 +70,7 @@ use crate::emulator::memory::Memory;
 ///
 #[tracing::instrument(skip_all)]
 pub fn trace(
-    elf_contents: Vec<u8>,
+    elf_contents: &[u8],
     inputs: &[u8],
     memory_config: &MemoryConfig,
 ) -> (Vec<RV32IMCycle>, Memory, JoltDevice) {
@@ -83,7 +83,7 @@ pub fn trace(
 use crate::utils::trace_writer::{TraceBatchCollector, TraceWriter, TraceWriterConfig};
 
 pub fn trace_to_file(
-    elf_contents: Vec<u8>,
+    elf_contents: &[u8],
     inputs: &[u8],
     memory_config: &MemoryConfig,
     out_path: &std::path::PathBuf,
@@ -111,7 +111,7 @@ pub fn trace_to_file(
 
 #[tracing::instrument(skip_all)]
 pub fn trace_lazy(
-    elf_contents: Vec<u8>,
+    elf_contents: &[u8],
     inputs: &[u8],
     memory_config: &MemoryConfig,
 ) -> LazyTraceIterator {
@@ -120,7 +120,7 @@ pub fn trace_lazy(
 
 #[tracing::instrument(skip_all)]
 pub fn trace_checkpoints(
-    elf_contents: Vec<u8>,
+    elf_contents: &[u8],
     inputs: &[u8],
     memory_config: &MemoryConfig,
     checkpoint_interval: usize,
@@ -153,7 +153,7 @@ fn step_emulator(emulator: &mut Emulator, prev_pc: &mut u64, trace: Option<&mut 
 }
 
 #[tracing::instrument(skip_all)]
-fn setup_emulator(elf_contents: Vec<u8>, inputs: &[u8], memory_config: &MemoryConfig) -> Emulator {
+fn setup_emulator(elf_contents: &[u8], inputs: &[u8], memory_config: &MemoryConfig) -> Emulator {
     let term = DefaultTerminal::default();
     let mut emulator = Emulator::new(Box::new(term));
     emulator.update_xlen(get_xlen());
@@ -772,8 +772,8 @@ mod test {
             program_size: Some(elf.len() as u64),
             ..Default::default()
         };
-        let (execution_trace, _, _) = trace(elf.clone(), &INPUTS, &memory_config);
-        let (checkpoints, _) = trace_checkpoints(elf, &INPUTS, &memory_config, n);
+        let (execution_trace, _, _) = trace(&elf, &INPUTS, &memory_config);
+        let (checkpoints, _) = trace_checkpoints(&elf, &INPUTS, &memory_config, n);
         assert_eq!(execution_trace.len(), expected_trace_length);
         assert_eq!(checkpoints.len(), 10);
 
@@ -795,8 +795,8 @@ mod test {
             ..Default::default()
         };
 
-        let (execution_trace, _, _) = trace(ELF_CONTENTS.to_vec(), &INPUTS, &memory_config);
-        let mut emulator = setup_emulator(ELF_CONTENTS.to_vec(), &INPUTS, &memory_config);
+        let (execution_trace, _, _) = trace(&elf, &INPUTS, &memory_config);
+        let mut emulator = setup_emulator(&elf, &INPUTS, &memory_config);
         let mut prev_pc: u64 = 0;
         let mut trace = vec![];
         let mut prev_trace_len = 0;

--- a/tracer/src/main.rs
+++ b/tracer/src/main.rs
@@ -41,7 +41,7 @@ fn main() {
 
     // Create and run the emulator
     let mut emulator = Emulator::new(Box::new(DefaultTerminal::default()));
-    emulator.setup_program(elf_content);
+    emulator.setup_program(&elf_content);
     emulator.run_test(args.trace.unwrap_or(false));
 
     // If signature file is specified, write the signature with specified granularity


### PR DESCRIPTION
- Eliminates unnecessary Vec<u8> allocations when ELF contents are already available as slices
- Reduces memory usage by avoiding duplicate storage of ELF data
- Maintains backward compatibility by converting to Vec<u8> only when required for analysis
- Improves performance by reducing data copying in hot paths