### PR TITLE
fix: prevent overflow in negative i64/i128 field conversions

### DIFF
--- a/jolt-core/src/field/ark.rs
+++ b/jolt-core/src/field/ark.rs
@@ -70,7 +70,7 @@ impl JoltField for ark_bn254::Fr {
 
     fn from_i64(val: i64) -> Self {
         if val.is_negative() {
-            let val = (-val) as u64;
+            let val = val.unsigned_abs();
             if val <= u16::MAX as u64 {
                 -<Self as JoltField>::from_u16(val as u16)
             } else if val <= u32::MAX as u64 {
@@ -92,7 +92,7 @@ impl JoltField for ark_bn254::Fr {
 
     fn from_i128(val: i128) -> Self {
         if val.is_negative() {
-            let val = (-val) as u128;
+            let val = val.unsigned_abs();
             if val <= u16::MAX as u128 {
                 -<Self as JoltField>::from_u16(val as u16)
             } else if val <= u32::MAX as u128 {


### PR DESCRIPTION
Fix potential overflow when converting negative i64::MIN and i128::MIN values to field elements.

The previous implementation used (-val) as u64/u128 which would overflow on the minimum values:
- i64::MIN (-9,223,372,036,854,775,808) causes panic in debug builds
- i128::MIN (-170,141,183,460,469,231,731,687,303,715,884,105,728) causes panic in debug builds

Changes:
- Replace (-val) as u64 with val.unsigned_abs() in from_i64 negative branch
- Replace (-val) as u128 with val.unsigned_abs() in from_i128 negative branch

This maintains the same performance characteristics while ensuring safe handling of all possible input values. The fix aligns with the project's existing use of unsigned_abs() in other modules for similar signed-to-unsigned conversions.
