### PR TITLE
fix: add option to deserialize Serializable objects without validation

### DIFF
--- a/examples/verifier/guest/src/lib.rs
+++ b/examples/verifier/guest/src/lib.rs
@@ -19,11 +19,14 @@ fn verifier() {
         .unwrap();
     end_cycle_tracking("preprocessing");
     start_cycle_tracking("proof");
-    let proof = RV32IMJoltProof::deserialize_from_bytes_unchecked(fib_proof_bytes::FIB_PROOF_BYTES).unwrap();
+    let proof = RV32IMJoltProof::deserialize_from_bytes_unchecked(fib_proof_bytes::FIB_PROOF_BYTES)
+        .unwrap();
     end_cycle_tracking("proof");
     start_cycle_tracking("device");
-    let device =
-        jolt::JoltDevice::deserialize_from_bytes_unchecked(fib_io_device_bytes::FIB_IO_DEVICE_BYTES).unwrap();
+    let device = jolt::JoltDevice::deserialize_from_bytes_unchecked(
+        fib_io_device_bytes::FIB_IO_DEVICE_BYTES,
+    )
+    .unwrap();
     end_cycle_tracking("device");
     // assert!(device.memory_layout.stack_size > 1024);
     // assert!(proof.trace_length > 0);

--- a/examples/verifier/guest/src/lib.rs
+++ b/examples/verifier/guest/src/lib.rs
@@ -1,4 +1,4 @@
-use jolt::{end_cycle_tracking, start_cycle_tracking, Jolt, PCS};
+use jolt::{end_cycle_tracking, jolt_println, start_cycle_tracking, Jolt, PCS};
 use jolt::{JoltRV32IM, JoltVerifierPreprocessing, RV32IMJoltProof, Serializable};
 
 mod fib_io_device_bytes;
@@ -13,17 +13,17 @@ mod jolt_verifier_preprocessing_bytes;
 fn verifier() {
     start_cycle_tracking("preprocessing");
     let preprocessing: JoltVerifierPreprocessing<ark_bn254::Fr, PCS> =
-        JoltVerifierPreprocessing::deserialize_from_bytes(
+        JoltVerifierPreprocessing::deserialize_from_bytes_unchecked(
             jolt_verifier_preprocessing_bytes::JOLT_VERIFIER_PREPROCESSING_BYTES,
         )
         .unwrap();
     end_cycle_tracking("preprocessing");
     start_cycle_tracking("proof");
-    let proof = RV32IMJoltProof::deserialize_from_bytes(fib_proof_bytes::FIB_PROOF_BYTES).unwrap();
+    let proof = RV32IMJoltProof::deserialize_from_bytes_unchecked(fib_proof_bytes::FIB_PROOF_BYTES).unwrap();
     end_cycle_tracking("proof");
     start_cycle_tracking("device");
     let device =
-        jolt::JoltDevice::deserialize_from_bytes(fib_io_device_bytes::FIB_IO_DEVICE_BYTES).unwrap();
+        jolt::JoltDevice::deserialize_from_bytes_unchecked(fib_io_device_bytes::FIB_IO_DEVICE_BYTES).unwrap();
     end_cycle_tracking("device");
     // assert!(device.memory_layout.stack_size > 1024);
     // assert!(proof.trace_length > 0);

--- a/examples/verifier/guest/src/lib.rs
+++ b/examples/verifier/guest/src/lib.rs
@@ -1,4 +1,4 @@
-use jolt::{end_cycle_tracking, jolt_println, start_cycle_tracking, Jolt, PCS};
+use jolt::{end_cycle_tracking, start_cycle_tracking, Jolt, PCS};
 use jolt::{JoltRV32IM, JoltVerifierPreprocessing, RV32IMJoltProof, Serializable};
 
 mod fib_io_device_bytes;

--- a/jolt-core/src/zkvm/mod.rs
+++ b/jolt-core/src/zkvm/mod.rs
@@ -345,7 +345,11 @@ pub trait Serializable: CanonicalSerialize + CanonicalDeserialize + Sized {
     /// Deserializes data from bytes but skips checks for performance
     fn deserialize_from_bytes_unchecked(bytes: &[u8]) -> Result<Self> {
         let cursor = Cursor::new(bytes);
-        Ok(Self::deserialize_with_mode(cursor, ark_serialize::Compress::Yes, ark_serialize::Validate::No)?)
+        Ok(Self::deserialize_with_mode(
+            cursor,
+            ark_serialize::Compress::Yes,
+            ark_serialize::Validate::No,
+        )?)
     }
 }
 

--- a/jolt-core/src/zkvm/mod.rs
+++ b/jolt-core/src/zkvm/mod.rs
@@ -341,6 +341,12 @@ pub trait Serializable: CanonicalSerialize + CanonicalDeserialize + Sized {
         let cursor = Cursor::new(bytes);
         Ok(Self::deserialize_compressed(cursor)?)
     }
+
+    /// Deserializes data from bytes but skips checks for performance
+    fn deserialize_from_bytes_unchecked(bytes: &[u8]) -> Result<Self> {
+        let cursor = Cursor::new(bytes);
+        Ok(Self::deserialize_with_mode(cursor, ark_serialize::Compress::Yes, ark_serialize::Validate::No)?)
+    }
 }
 
 impl Serializable for RV32IMJoltProof {}


### PR DESCRIPTION
- This reduces deserialization cost down to 89M from 436M by turning off validation. Still exploring zero copy.