### PR TITLE
fix: trim trailing newline from toolchain tag in download URL

### DIFF
--- a/jolt-core/src/host/toolchain.rs
+++ b/jolt-core/src/host/toolchain.rs
@@ -226,8 +226,9 @@ fn remove_archive() -> Result<()> {
 
 fn toolchain_url(channel: &str) -> String {
     let target = target_lexicon::HOST;
+    let tag = TOOLCHAIN_TAG.trim();
     format!(
-        "https://github.com/a16z/rust/releases/download/{channel}-{TOOLCHAIN_TAG}/rust-toolchain-{channel}-{target}.tar.gz",
+        "https://github.com/a16z/rust/releases/download/{channel}-{tag}/rust-toolchain-{channel}-{target}.tar.gz",
     )
 }
 


### PR DESCRIPTION
TOOLCHAIN_TAG in URL: include_str! almost certainly picks up the final translation of the string from guest-toolchain-tag. In toolchain_url, this will end up in the URL and result in a 404 error.

The fix trims the TOOLCHAIN_TAG constant before using it in the URL formation,
ensuring clean URLs while maintaining the original tag content for local
toolchain verification.

this pr fixes toolchain download failures caused by malformed URLs.