### PR TITLE
fix: correct uninterleave length calculation for odd bit lengths

### DIFF
--- a/jolt-core/src/utils/lookup_bits.rs
+++ b/jolt-core/src/utils/lookup_bits.rs
@@ -22,8 +22,13 @@ impl LookupBits {
 
     pub fn uninterleave(&self) -> (Self, Self) {
         let (x_bits, y_bits) = uninterleave_bits(self.bits);
-        let x = Self::new(x_bits as u64, self.len / 2);
-        let y = Self::new(y_bits as u64, self.len - x.len);
+        // For odd lengths, we need to properly distribute the bits:
+        // - Even positions (0,2,4,...) get ceil(len/2) bits
+        // - Odd positions (1,3,5,...) get floor(len/2) bits
+        let x_len = (self.len + 1) / 2;
+        let y_len = self.len / 2;
+        let x = Self::new(x_bits as u64, x_len);
+        let y = Self::new(y_bits as u64, y_len);
         (x, y)
     }
 
@@ -119,5 +124,66 @@ impl std::ops::Rem<usize> for LookupBits {
 impl PartialEq for LookupBits {
     fn eq(&self, other: &Self) -> bool {
         u64::from(self) == u64::from(other)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_uninterleave_even_length() {
+        // Test with even length (should work as before)
+        let bits = LookupBits::new(0b1010, 4);
+        let (x, y) = bits.uninterleave();
+        
+        // For len=4: x should have 2 bits, y should have 2 bits
+        assert_eq!(x.len(), 2);
+        assert_eq!(y.len(), 2);
+        assert_eq!(x.len() + y.len(), bits.len());
+    }
+
+    #[test]
+    fn test_uninterleave_odd_length() {
+        // Test with odd length (this was the bug)
+        let bits = LookupBits::new(0b10101, 5);
+        let (x, y) = bits.uninterleave();
+        
+        // For len=5: x should have 3 bits (ceil(5/2)), y should have 2 bits (floor(5/2))
+        assert_eq!(x.len(), 3);
+        assert_eq!(y.len(), 2);
+        assert_eq!(x.len() + y.len(), bits.len());
+        
+        // Verify the bits are correctly distributed
+        // x should contain bits from even positions (0,2,4)
+        // y should contain bits from odd positions (1,3)
+        assert_eq!(x.bits, 0b101); // bits from positions 0,2,4
+        assert_eq!(y.bits, 0b10);  // bits from positions 1,3
+    }
+
+    #[test]
+    fn test_uninterleave_edge_cases() {
+        // Test edge cases
+        let bits1 = LookupBits::new(0b1, 1);
+        let (x1, y1) = bits1.uninterleave();
+        assert_eq!(x1.len(), 1); // ceil(1/2) = 1
+        assert_eq!(y1.len(), 0); // floor(1/2) = 0
+        assert_eq!(x1.len() + y1.len(), bits1.len());
+
+        let bits3 = LookupBits::new(0b111, 3);
+        let (x3, y3) = bits3.uninterleave();
+        assert_eq!(x3.len(), 2); // ceil(3/2) = 2
+        assert_eq!(y3.len(), 1); // floor(3/2) = 1
+        assert_eq!(x3.len() + y3.len(), bits3.len());
+    }
+
+    #[test]
+    fn test_uninterleave_roundtrip() {
+        // Test that the sum of lengths always equals the original length
+        for len in 1..=64 {
+            let bits = LookupBits::new(0x1234567890ABCDEF, len);
+            let (x, y) = bits.uninterleave();
+            assert_eq!(x.len() + y.len(), len, "Failed for len={}", len);
+        }
     }
 }


### PR DESCRIPTION
**Problem:**
LookupBits::uninterleave() incorrectly calculated bit lengths for odd lengths.
For len=5, it returned x.len=2, y.len=3, but uninterleave_bits() actually
distributes bits as 3 even + 2 odd positions.

**Solution:**
Fixed length calculation:
- x.len = (self.len + 1) / 2  (even positions)
- y.len = self.len / 2         (odd positions)

**Why:**
- Prevents bugs in lookup table operations
- Ensures correct bit distribution for all lengths
- Maintains x.len + y.len = self.len invariant

**Testing:**
Added tests for even/odd lengths, edge cases, and full range validation.