### PR TITLE
fix: modify matching values for several RISC-V instructions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ MAKEFILE_DIR := $(abspath $(dir $(firstword $(MAKEFILE_LIST))))
 
 # Define a general macro for RISCOF test runs
 define RISCOF_RUN
-	export PATH=$(MAKEFILE_DIR)/target/release:$(PATH); \
+	export PATH=$(MAKEFILE_DIR)/target/debug:$(PATH); \
 	export RUST_BACKTRACE=full; \
 	riscof --verbose info run --no-browser --config tests/arch-tests/$(1).ini \
 		--suite third-party/riscv-arch-test/riscv-test-suite/ \
@@ -20,7 +20,8 @@ bootstrap: ## Install required dependencies
 	./scripts/apply-patches || true
 
 build-emulator: ## Build the emulator
-	cargo build --release -p tracer --bin jolt-emu
+	# SHOULD NOT USE RELEASE BUILD FOR ARCH TESTS
+	cargo build -p tracer --bin jolt-emu
 
 arch-tests-32im: build-emulator
 	$(call RISCOF_RUN,jolt-32im)

--- a/tracer/src/instruction/amomaxuw.rs
+++ b/tracer/src/instruction/amomaxuw.rs
@@ -20,7 +20,7 @@ use super::{format::format_r::FormatR, RISCVInstruction, RISCVTrace, RV32IMCycle
 declare_riscv_instr!(
     name   = AMOMAXUW,
     mask   = 0xf800707f,
-    match  = 0xe000302f,
+    match  = 0xe000202f,
     format = FormatR,
     ram    = ()
 );

--- a/tracer/src/instruction/amominuw.rs
+++ b/tracer/src/instruction/amominuw.rs
@@ -20,7 +20,7 @@ use super::{format::format_r::FormatR, RISCVInstruction, RISCVTrace, RV32IMCycle
 declare_riscv_instr!(
     name   = AMOMINUW,
     mask   = 0xf800707f,
-    match  = 0xc000302f,
+    match  = 0xc000202f,
     format = FormatR,
     ram    = ()
 );

--- a/tracer/src/instruction/divuw.rs
+++ b/tracer/src/instruction/divuw.rs
@@ -18,7 +18,7 @@ use super::{
 declare_riscv_instr!(
     name   = DIVUW,
     mask   = 0xfe00707f,
-    match  = 0x1b00003b,
+    match  = 0x200503b,
     format = FormatR,
     ram    = ()
 );

--- a/tracer/src/instruction/divw.rs
+++ b/tracer/src/instruction/divw.rs
@@ -25,7 +25,7 @@ use super::{
 declare_riscv_instr!(
     name   = DIVW,
     mask   = 0xfe00707f,
-    match  = 0x1a00003b,
+    match  = 0x200403b,
     format = FormatR,
     ram    = ()
 );

--- a/tracer/src/instruction/remuw.rs
+++ b/tracer/src/instruction/remuw.rs
@@ -19,7 +19,7 @@ use super::{
 declare_riscv_instr!(
     name   = REMUW,
     mask   = 0xfe00707f,
-    match  = 0x1f00003b,
+    match  = 0x200703b,
     format = FormatR,
     ram    = ()
 );

--- a/tracer/src/instruction/remw.rs
+++ b/tracer/src/instruction/remw.rs
@@ -22,7 +22,7 @@ use super::{
 declare_riscv_instr!(
     name   = REMW,
     mask   = 0xfe00707f,
-    match  = 0x1e00003b,
+    match  = 0x200603b,
     format = FormatR,
     ram    = ()
 );

--- a/tracer/src/utils/instruction_macros.rs
+++ b/tracer/src/utils/instruction_macros.rs
@@ -30,14 +30,14 @@ macro_rules! declare_riscv_instr {
             }
 
             fn new(word: u32, address: u64, validate: bool, compressed: bool) -> Self {
+              if validate {
+                debug_assert_eq!(word & Self::MASK, Self::MATCH, "word: {:x}, mask: {:x}, word & mask: {:x}, match: {:x}", word, Self::MASK, word & Self::MASK, Self::MATCH);
+              }
               if declare_riscv_instr!(@is_virtual $( $virt )?) {
                     panic!(
                         "virtual instruction `{}` cannot be built from a machine word",
                         stringify!($name)
                     );
-                }
-                if validate {
-                    debug_assert_eq!(word & Self::MASK, Self::MATCH);
                 }
                 Self {
                     address,


### PR DESCRIPTION
- Correct instruction definitions of AMOMAXUW, AMOMINUW, DIVUW, DIVW, REMUW, REMW
- Update the instruction macros to include validation checks for matching values.
- Build jolt-emu with debug profile to flush as many as possible issues.