### PR TITLE
Fix off-by-one in r_constr length check in evaluate_small_matrix_rlc

### DIFF
--- a/jolt-core/src/zkvm/r1cs/key.rs
+++ b/jolt-core/src/zkvm/r1cs/key.rs
@@ -136,7 +136,7 @@ impl<F: JoltField> UniformSpartanKey<F> {
     pub fn evaluate_small_matrix_rlc(&self, r_constr: &[F], r_rlc: F) -> Vec<F> {
         assert_eq!(
             r_constr.len(),
-            (self.uniform_r1cs.num_rows + 1).next_power_of_two().log_2()
+            self.uniform_r1cs.num_rows.next_power_of_two().log_2()
         );
 
         let eq_rx_constr = EqPolynomial::evals(r_constr);


### PR DESCRIPTION
Reason: The assert used (num_rows + 1).next_power_of_two().log_2(), which mismatched the caller-provided rx_var length when num_rows was already a power of two. There is no “constant row” in the small matrices; constants are handled via a dedicated column.
Goal: Align row-bit sizing with rx_var construction and prevent unnecessary assertion failures, ensuring consistency with the inner sumcheck flow.

I know you don't accept small changes, but maybe this will be useful