### PR TITLE
fix: transcript zero-length challenges to avoid unnecessary rounds

### DIFF
--- a/jolt-core/src/transcripts/blake2b.rs
+++ b/jolt-core/src/transcripts/blake2b.rs
@@ -40,6 +40,9 @@ impl Blake2bTranscript {
     // Loads arbitrary byte lengths using ceil(out/32) invocations of 32 byte randoms
     // Discards top bits when the size is less than 32 bytes
     fn challenge_bytes(&mut self, out: &mut [u8]) {
+        if out.is_empty() {
+            return;
+        }
         let mut remaining_len = out.len();
         let mut start = 0;
         while remaining_len > 32 {
@@ -223,6 +226,9 @@ impl Transcript for Blake2bTranscript {
 
     // Compute powers of scalar q : (1, q, q^2, ..., q^(len-1))
     fn challenge_scalar_powers<F: JoltField>(&mut self, len: usize) -> Vec<F> {
+        if len == 0 {
+            return Vec::new();
+        }
         let q: F = self.challenge_scalar();
         let mut q_powers = vec![F::one(); len];
         for i in 1..len {

--- a/jolt-core/src/transcripts/keccak.rs
+++ b/jolt-core/src/transcripts/keccak.rs
@@ -38,6 +38,9 @@ impl KeccakTranscript {
     // Loads arbitrary byte lengths using ceil(out/32) invocations of 32 byte randoms
     // Discards top bits when the size is less than 32 bytes
     fn challenge_bytes(&mut self, out: &mut [u8]) {
+        if out.is_empty() {
+            return;
+        }
         let mut remaining_len = out.len();
         let mut start = 0;
         while remaining_len > 32 {
@@ -221,6 +224,9 @@ impl Transcript for KeccakTranscript {
 
     // Compute powers of scalar q : (1, q, q^2, ..., q^(len-1))
     fn challenge_scalar_powers<F: JoltField>(&mut self, len: usize) -> Vec<F> {
+        if len == 0 {
+            return Vec::new();
+        }
         let q: F = self.challenge_scalar();
         let mut q_powers = vec![F::one(); len];
         for i in 1..len {


### PR DESCRIPTION
The transcript advanced a round when challenge_bytes was called with out.len() == 0 and when challenge_scalar_powers was called with len == 0. This contradicts the stated behavior (“ceil(out/32) invocations”) and wastes entropy/rounds without producing output. It also made challenge_scalar_powers(0) inconsistent with challenge_vector(0), which does not advance the transcript.

Changes:

- Add early return in challenge_bytes for empty output.
- Add early return in challenge_scalar_powers when len == 0.
- Apply consistently to both Keccak and Blake2b transcripts.


These changes align implementation with the documented semantics, avoid needless transcript state updates