### PR TITLE
feat: custom type for right instruction input and product

### DIFF
--- a/jolt-core/src/zkvm/instruction/add.rs
+++ b/jolt-core/src/zkvm/instruction/add.rs
@@ -2,7 +2,7 @@ use tracer::instruction::{add::ADD, RISCVCycle};
 
 use crate::zkvm::lookup_table::{range_check::RangeCheckTable, LookupTables};
 
-use super::{CircuitFlags, InstructionFlags, InstructionLookup, LookupQuery, NUM_CIRCUIT_FLAGS};
+use super::{CircuitFlags, InstructionFlags, InstructionLookup, LookupQuery, RightInputValue, NUM_CIRCUIT_FLAGS};
 
 impl<const XLEN: usize> InstructionLookup<XLEN> for ADD {
     fn lookup_table(&self) -> Option<LookupTables<XLEN>> {
@@ -29,25 +29,25 @@ impl InstructionFlags for ADD {
 impl<const XLEN: usize> LookupQuery<XLEN> for RISCVCycle<ADD> {
     fn to_lookup_operands(&self) -> (u64, u128) {
         let (x, y) = LookupQuery::<XLEN>::to_instruction_inputs(self);
-        (0, x as u128 + y as u64 as u128)
+        (0, x as u128 + y.as_u64() as u128)
     }
 
     fn to_lookup_index(&self) -> u128 {
         LookupQuery::<XLEN>::to_lookup_operands(self).1
     }
 
-    fn to_instruction_inputs(&self) -> (u64, i128) {
+    fn to_instruction_inputs(&self) -> (u64, RightInputValue) {
         match XLEN {
             #[cfg(test)]
             8 => (
                 self.register_state.rs1 as u8 as u64,
-                self.register_state.rs2 as u8 as i128,
+                RightInputValue::Unsigned(self.register_state.rs2 as u8 as u64),
             ),
             32 => (
                 self.register_state.rs1 as u32 as u64,
-                self.register_state.rs2 as u32 as i128,
+                RightInputValue::Unsigned(self.register_state.rs2 as u32 as u64),
             ),
-            64 => (self.register_state.rs1, self.register_state.rs2 as i128),
+            64 => (self.register_state.rs1, RightInputValue::Unsigned(self.register_state.rs2)),
             _ => panic!("{XLEN}-bit word size is unsupported"),
         }
     }
@@ -56,9 +56,9 @@ impl<const XLEN: usize> LookupQuery<XLEN> for RISCVCycle<ADD> {
         let (x, y) = LookupQuery::<XLEN>::to_instruction_inputs(self);
         match XLEN {
             #[cfg(test)]
-            8 => (x as u8).overflowing_add(y as u8).0.into(),
-            32 => (x as u32).overflowing_add(y as u32).0.into(),
-            64 => x.overflowing_add(y as u64).0,
+            8 => (x as u8).overflowing_add(y.as_u8()).0.into(),
+            32 => (x as u32).overflowing_add(y.as_u32()).0.into(),
+            64 => x.overflowing_add(y.as_u64()).0,
             _ => panic!("{XLEN}-bit word size is unsupported"),
         }
     }

--- a/jolt-core/src/zkvm/instruction/and.rs
+++ b/jolt-core/src/zkvm/instruction/and.rs
@@ -2,7 +2,7 @@ use tracer::instruction::{and::AND, RISCVCycle};
 
 use crate::zkvm::lookup_table::{and::AndTable, LookupTables};
 
-use super::{CircuitFlags, InstructionFlags, InstructionLookup, LookupQuery, NUM_CIRCUIT_FLAGS};
+use super::{CircuitFlags, InstructionFlags, InstructionLookup, LookupQuery, RightInputValue, NUM_CIRCUIT_FLAGS};
 
 impl<const XLEN: usize> InstructionLookup<XLEN> for AND {
     fn lookup_table(&self) -> Option<LookupTables<XLEN>> {
@@ -26,18 +26,18 @@ impl InstructionFlags for AND {
 }
 
 impl<const XLEN: usize> LookupQuery<XLEN> for RISCVCycle<AND> {
-    fn to_instruction_inputs(&self) -> (u64, i128) {
+    fn to_instruction_inputs(&self) -> (u64, RightInputValue) {
         match XLEN {
             #[cfg(test)]
             8 => (
                 self.register_state.rs1 as u8 as u64,
-                self.register_state.rs2 as u8 as i128,
+                RightInputValue::Unsigned(self.register_state.rs2 as u8 as u64),
             ),
             32 => (
                 self.register_state.rs1 as u32 as u64,
-                self.register_state.rs2 as u32 as i128,
+                RightInputValue::Unsigned(self.register_state.rs2 as u32 as u64),
             ),
-            64 => (self.register_state.rs1, self.register_state.rs2 as i128),
+            64 => (self.register_state.rs1, RightInputValue::Unsigned(self.register_state.rs2)),
             _ => panic!("{XLEN}-bit word size is unsupported"),
         }
     }
@@ -46,9 +46,9 @@ impl<const XLEN: usize> LookupQuery<XLEN> for RISCVCycle<AND> {
         let (x, y) = LookupQuery::<XLEN>::to_instruction_inputs(self);
         match XLEN {
             #[cfg(test)]
-            8 => (x as u8 & y as u8).into(),
-            32 => (x as u32 & y as u32).into(),
-            64 => x & y as u64,
+            8 => (x as u8 & y.as_u8()).into(),
+            32 => (x as u32 & y.as_u32()).into(),
+            64 => x & y.as_u64(),
             _ => panic!("{XLEN}-bit word size is unsupported"),
         }
     }

--- a/jolt-core/src/zkvm/instruction/andi.rs
+++ b/jolt-core/src/zkvm/instruction/andi.rs
@@ -2,7 +2,7 @@ use tracer::instruction::{andi::ANDI, RISCVCycle};
 
 use crate::zkvm::lookup_table::{and::AndTable, LookupTables};
 
-use super::{CircuitFlags, InstructionFlags, InstructionLookup, LookupQuery, NUM_CIRCUIT_FLAGS};
+use super::{CircuitFlags, InstructionFlags, InstructionLookup, LookupQuery, RightInputValue, NUM_CIRCUIT_FLAGS};
 
 impl<const XLEN: usize> InstructionLookup<XLEN> for ANDI {
     fn lookup_table(&self) -> Option<LookupTables<XLEN>> {
@@ -26,20 +26,20 @@ impl InstructionFlags for ANDI {
 }
 
 impl<const XLEN: usize> LookupQuery<XLEN> for RISCVCycle<ANDI> {
-    fn to_instruction_inputs(&self) -> (u64, i128) {
+    fn to_instruction_inputs(&self) -> (u64, RightInputValue) {
         match XLEN {
             #[cfg(test)]
             8 => (
                 self.register_state.rs1 as u8 as u64,
-                self.instruction.operands.imm as u8 as i128,
+                RightInputValue::Unsigned(self.instruction.operands.imm as u8 as u64),
             ),
             32 => (
                 self.register_state.rs1 as u32 as u64,
-                self.instruction.operands.imm as u32 as i128,
+                RightInputValue::Unsigned(self.instruction.operands.imm as u32 as u64),
             ),
             64 => (
                 self.register_state.rs1,
-                self.instruction.operands.imm as i128,
+                RightInputValue::Unsigned(self.instruction.operands.imm as u64),
             ),
             _ => panic!("{XLEN}-bit word size is unsupported"),
         }
@@ -49,9 +49,9 @@ impl<const XLEN: usize> LookupQuery<XLEN> for RISCVCycle<ANDI> {
         let (x, y) = LookupQuery::<XLEN>::to_instruction_inputs(self);
         match XLEN {
             #[cfg(test)]
-            8 => (x as u8 & y as u8) as u64,
-            32 => (x as u32 & y as u32) as u64,
-            64 => x & y as u64,
+            8 => (x as u8 & y.as_u8()) as u64,
+            32 => (x as u32 & y.as_u32()) as u64,
+            64 => x & y.as_u64(),
             _ => panic!("{XLEN}-bit word size is unsupported"),
         }
     }

--- a/jolt-core/src/zkvm/instruction/andn.rs
+++ b/jolt-core/src/zkvm/instruction/andn.rs
@@ -2,7 +2,7 @@ use tracer::instruction::{andn::ANDN, RISCVCycle};
 
 use crate::zkvm::lookup_table::{andn::AndnTable, LookupTables};
 
-use super::{CircuitFlags, InstructionFlags, InstructionLookup, LookupQuery, NUM_CIRCUIT_FLAGS};
+use super::{CircuitFlags, InstructionFlags, InstructionLookup, LookupQuery, RightInputValue, NUM_CIRCUIT_FLAGS};
 
 impl<const XLEN: usize> InstructionLookup<XLEN> for ANDN {
     fn lookup_table(&self) -> Option<LookupTables<XLEN>> {
@@ -26,18 +26,18 @@ impl InstructionFlags for ANDN {
 }
 
 impl<const XLEN: usize> LookupQuery<XLEN> for RISCVCycle<ANDN> {
-    fn to_instruction_inputs(&self) -> (u64, i128) {
+    fn to_instruction_inputs(&self) -> (u64, RightInputValue) {
         match XLEN {
             #[cfg(test)]
             8 => (
                 self.register_state.rs1 as u8 as u64,
-                self.register_state.rs2 as u8 as i128,
+                RightInputValue::Unsigned(self.register_state.rs2 as u8 as u64),
             ),
             32 => (
                 self.register_state.rs1 as u32 as u64,
-                self.register_state.rs2 as u32 as i128,
+                RightInputValue::Unsigned(self.register_state.rs2 as u32 as u64),
             ),
-            64 => (self.register_state.rs1, self.register_state.rs2 as i128),
+            64 => (self.register_state.rs1, RightInputValue::Unsigned(self.register_state.rs2)),
             _ => panic!("{XLEN}-bit word size is unsupported"),
         }
     }
@@ -46,9 +46,9 @@ impl<const XLEN: usize> LookupQuery<XLEN> for RISCVCycle<ANDN> {
         let (x, y) = LookupQuery::<XLEN>::to_instruction_inputs(self);
         match XLEN {
             #[cfg(test)]
-            8 => (x as u8 & !(y as u8)).into(),
-            32 => (x as u32 & !(y as u32)).into(),
-            64 => x & !(y as u64),
+            8 => (x as u8 & !(y.as_u8())).into(),
+            32 => (x as u32 & !(y.as_u32())).into(),
+            64 => x & !(y.as_u64()),
             _ => panic!("{XLEN}-bit word size is unsupported"),
         }
     }

--- a/jolt-core/src/zkvm/instruction/auipc.rs
+++ b/jolt-core/src/zkvm/instruction/auipc.rs
@@ -2,7 +2,7 @@ use tracer::instruction::{auipc::AUIPC, RISCVCycle};
 
 use crate::zkvm::lookup_table::{range_check::RangeCheckTable, LookupTables};
 
-use super::{CircuitFlags, InstructionFlags, InstructionLookup, LookupQuery, NUM_CIRCUIT_FLAGS};
+use super::{CircuitFlags, InstructionFlags, InstructionLookup, LookupQuery, RightInputValue, NUM_CIRCUIT_FLAGS};
 
 impl<const XLEN: usize> InstructionLookup<XLEN> for AUIPC {
     fn lookup_table(&self) -> Option<LookupTables<XLEN>> {
@@ -29,27 +29,27 @@ impl InstructionFlags for AUIPC {
 impl<const XLEN: usize> LookupQuery<XLEN> for RISCVCycle<AUIPC> {
     fn to_lookup_operands(&self) -> (u64, u128) {
         let (pc, imm) = LookupQuery::<XLEN>::to_instruction_inputs(self);
-        (0, (pc as i128 + imm) as u128)
+        (0, (pc as i128 + imm.as_i128()) as u128)
     }
 
     fn to_lookup_index(&self) -> u128 {
         LookupQuery::<XLEN>::to_lookup_operands(self).1
     }
 
-    fn to_instruction_inputs(&self) -> (u64, i128) {
+    fn to_instruction_inputs(&self) -> (u64, RightInputValue) {
         match XLEN {
             #[cfg(test)]
             8 => (
                 self.instruction.address as u8 as u64,
-                self.instruction.operands.imm as u8 as u64 as i128,
+                RightInputValue::Unsigned(self.instruction.operands.imm as u8 as u64),
             ),
             32 => (
                 self.instruction.address as u32 as u64,
-                self.instruction.operands.imm as u32 as u64 as i128,
+                RightInputValue::Unsigned(self.instruction.operands.imm as u32 as u64),
             ),
             64 => (
                 self.instruction.address,
-                self.instruction.operands.imm as i128,
+                RightInputValue::Unsigned(self.instruction.operands.imm),
             ),
             _ => panic!("{XLEN}-bit word size is unsupported"),
         }
@@ -59,9 +59,9 @@ impl<const XLEN: usize> LookupQuery<XLEN> for RISCVCycle<AUIPC> {
         let (pc, imm) = LookupQuery::<XLEN>::to_instruction_inputs(self);
         match XLEN {
             #[cfg(test)]
-            8 => (pc as i8).overflowing_add(imm as i8).0 as u8 as u64,
-            32 => (pc as i32).overflowing_add(imm as i32).0 as u32 as u64,
-            64 => (pc as i64).overflowing_add(imm as i64).0 as u64,
+            8 => (pc as i8).overflowing_add(imm.as_i8()).0 as u8 as u64,
+            32 => (pc as i32).overflowing_add(imm.as_i32()).0 as u32 as u64,
+            64 => (pc as i64).overflowing_add(imm.as_i64()).0 as u64,
             _ => panic!("{XLEN}-bit word size is unsupported"),
         }
     }

--- a/jolt-core/src/zkvm/instruction/beq.rs
+++ b/jolt-core/src/zkvm/instruction/beq.rs
@@ -2,7 +2,7 @@ use tracer::instruction::{beq::BEQ, RISCVCycle};
 
 use crate::zkvm::lookup_table::{equal::EqualTable, LookupTables};
 
-use super::{CircuitFlags, InstructionFlags, InstructionLookup, LookupQuery, NUM_CIRCUIT_FLAGS};
+use super::{CircuitFlags, InstructionFlags, InstructionLookup, LookupQuery, RightInputValue, NUM_CIRCUIT_FLAGS};
 
 impl<const XLEN: usize> InstructionLookup<XLEN> for BEQ {
     fn lookup_table(&self) -> Option<LookupTables<XLEN>> {
@@ -26,25 +26,25 @@ impl InstructionFlags for BEQ {
 }
 
 impl<const XLEN: usize> LookupQuery<XLEN> for RISCVCycle<BEQ> {
-    fn to_instruction_inputs(&self) -> (u64, i128) {
+    fn to_instruction_inputs(&self) -> (u64, RightInputValue) {
         match XLEN {
             #[cfg(test)]
             8 => (
                 self.register_state.rs1 as u8 as u64,
-                self.register_state.rs2 as u8 as i128,
+                RightInputValue::Unsigned(self.register_state.rs2 as u8 as u64),
             ),
             32 => (
                 self.register_state.rs1 as u32 as u64,
-                self.register_state.rs2 as u32 as i128,
+                RightInputValue::Unsigned(self.register_state.rs2 as u32 as u64),
             ),
-            64 => (self.register_state.rs1, self.register_state.rs2 as i128),
+            64 => (self.register_state.rs1, RightInputValue::Unsigned(self.register_state.rs2)),
             _ => panic!("{XLEN}-bit word size is unsupported"),
         }
     }
 
     fn to_lookup_output(&self) -> u64 {
         let (x, y) = LookupQuery::<XLEN>::to_instruction_inputs(self);
-        (x == y as u64).into()
+        (x == y.as_u64()).into()
     }
 }
 

--- a/jolt-core/src/zkvm/instruction/bge.rs
+++ b/jolt-core/src/zkvm/instruction/bge.rs
@@ -4,7 +4,7 @@ use crate::zkvm::lookup_table::{
     signed_greater_than_equal::SignedGreaterThanEqualTable, LookupTables,
 };
 
-use super::{CircuitFlags, InstructionFlags, InstructionLookup, LookupQuery, NUM_CIRCUIT_FLAGS};
+use super::{CircuitFlags, InstructionFlags, InstructionLookup, LookupQuery, RightInputValue, NUM_CIRCUIT_FLAGS};
 
 impl<const XLEN: usize> InstructionLookup<XLEN> for BGE {
     fn lookup_table(&self) -> Option<LookupTables<XLEN>> {
@@ -28,18 +28,18 @@ impl InstructionFlags for BGE {
 }
 
 impl<const XLEN: usize> LookupQuery<XLEN> for RISCVCycle<BGE> {
-    fn to_instruction_inputs(&self) -> (u64, i128) {
+    fn to_instruction_inputs(&self) -> (u64, RightInputValue) {
         match XLEN {
             #[cfg(test)]
             8 => (
                 self.register_state.rs1 as u8 as u64,
-                self.register_state.rs2 as u8 as i128,
+                RightInputValue::Unsigned(self.register_state.rs2 as u8 as u64),
             ),
             32 => (
                 self.register_state.rs1 as u32 as u64,
-                self.register_state.rs2 as u32 as i128,
+                RightInputValue::Unsigned(self.register_state.rs2 as u32 as u64),
             ),
-            64 => (self.register_state.rs1, self.register_state.rs2 as i128),
+            64 => (self.register_state.rs1, RightInputValue::Unsigned(self.register_state.rs2)),
             _ => panic!("{XLEN}-bit word size is unsupported"),
         }
     }
@@ -48,9 +48,9 @@ impl<const XLEN: usize> LookupQuery<XLEN> for RISCVCycle<BGE> {
         let (x, y) = LookupQuery::<XLEN>::to_instruction_inputs(self);
         match XLEN {
             #[cfg(test)]
-            8 => ((x as i8) >= (y as i8)) as u64,
-            32 => ((x as i32) >= (y as i32)) as u64,
-            64 => ((x as i64) >= (y as i64)) as u64,
+            8 => ((x as i8) >= (y.as_i8())) as u64,
+            32 => ((x as i32) >= (y.as_i32())) as u64,
+            64 => ((x as i64) >= (y.as_i64())) as u64,
             _ => panic!("{XLEN}-bit word size is unsupported"),
         }
     }

--- a/jolt-core/src/zkvm/instruction/bgeu.rs
+++ b/jolt-core/src/zkvm/instruction/bgeu.rs
@@ -4,7 +4,7 @@ use crate::zkvm::lookup_table::{
     unsigned_greater_than_equal::UnsignedGreaterThanEqualTable, LookupTables,
 };
 
-use super::{CircuitFlags, InstructionFlags, InstructionLookup, LookupQuery, NUM_CIRCUIT_FLAGS};
+use super::{CircuitFlags, InstructionFlags, InstructionLookup, LookupQuery, RightInputValue, NUM_CIRCUIT_FLAGS};
 
 impl<const XLEN: usize> InstructionLookup<XLEN> for BGEU {
     fn lookup_table(&self) -> Option<LookupTables<XLEN>> {
@@ -28,25 +28,25 @@ impl InstructionFlags for BGEU {
 }
 
 impl<const XLEN: usize> LookupQuery<XLEN> for RISCVCycle<BGEU> {
-    fn to_instruction_inputs(&self) -> (u64, i128) {
+    fn to_instruction_inputs(&self) -> (u64, RightInputValue) {
         match XLEN {
             #[cfg(test)]
             8 => (
                 self.register_state.rs1 as u8 as u64,
-                self.register_state.rs2 as u8 as i128,
+                RightInputValue::Unsigned(self.register_state.rs2 as u8 as u64),
             ),
             32 => (
                 self.register_state.rs1 as u32 as u64,
-                self.register_state.rs2 as u32 as i128,
+                RightInputValue::Unsigned(self.register_state.rs2 as u32 as u64),
             ),
-            64 => (self.register_state.rs1, self.register_state.rs2 as i128),
+            64 => (self.register_state.rs1, RightInputValue::Unsigned(self.register_state.rs2)),
             _ => panic!("{XLEN}-bit word size is unsupported"),
         }
     }
 
     fn to_lookup_output(&self) -> u64 {
         let (x, y) = LookupQuery::<XLEN>::to_instruction_inputs(self);
-        (x >= y as u64).into()
+        (x >= y.as_u64()).into()
     }
 }
 

--- a/jolt-core/src/zkvm/instruction/blt.rs
+++ b/jolt-core/src/zkvm/instruction/blt.rs
@@ -2,7 +2,7 @@ use tracer::instruction::{blt::BLT, RISCVCycle};
 
 use crate::zkvm::lookup_table::{signed_less_than::SignedLessThanTable, LookupTables};
 
-use super::{CircuitFlags, InstructionFlags, InstructionLookup, LookupQuery, NUM_CIRCUIT_FLAGS};
+use super::{CircuitFlags, InstructionFlags, InstructionLookup, LookupQuery, RightInputValue, NUM_CIRCUIT_FLAGS};
 
 impl<const XLEN: usize> InstructionLookup<XLEN> for BLT {
     fn lookup_table(&self) -> Option<LookupTables<XLEN>> {
@@ -26,18 +26,18 @@ impl InstructionFlags for BLT {
 }
 
 impl<const XLEN: usize> LookupQuery<XLEN> for RISCVCycle<BLT> {
-    fn to_instruction_inputs(&self) -> (u64, i128) {
+    fn to_instruction_inputs(&self) -> (u64, RightInputValue) {
         match XLEN {
             #[cfg(test)]
             8 => (
                 self.register_state.rs1 as u8 as u64,
-                self.register_state.rs2 as u8 as i128,
+                RightInputValue::Unsigned(self.register_state.rs2 as u8 as u64),
             ),
             32 => (
                 self.register_state.rs1 as u32 as u64,
-                self.register_state.rs2 as u32 as i128,
+                RightInputValue::Unsigned(self.register_state.rs2 as u32 as u64),
             ),
-            64 => (self.register_state.rs1, self.register_state.rs2 as i128),
+            64 => (self.register_state.rs1, RightInputValue::Unsigned(self.register_state.rs2)),
             _ => panic!("{XLEN}-bit word size is unsupported"),
         }
     }
@@ -46,9 +46,9 @@ impl<const XLEN: usize> LookupQuery<XLEN> for RISCVCycle<BLT> {
         let (x, y) = LookupQuery::<XLEN>::to_instruction_inputs(self);
         match XLEN {
             #[cfg(test)]
-            8 => ((x as i8) < (y as i8)) as u64,
-            32 => ((x as i32) < (y as i32)) as u64,
-            64 => ((x as i64) < (y as i64)) as u64,
+            8 => ((x as i8) < (y.as_i8())) as u64,
+            32 => ((x as i32) < (y.as_i32())) as u64,
+            64 => ((x as i64) < (y.as_i64())) as u64,
             _ => panic!("{XLEN}-bit word size is unsupported"),
         }
     }

--- a/jolt-core/src/zkvm/instruction/bne.rs
+++ b/jolt-core/src/zkvm/instruction/bne.rs
@@ -2,7 +2,7 @@ use tracer::instruction::{bne::BNE, RISCVCycle};
 
 use crate::zkvm::lookup_table::{not_equal::NotEqualTable, LookupTables};
 
-use super::{CircuitFlags, InstructionFlags, InstructionLookup, LookupQuery, NUM_CIRCUIT_FLAGS};
+use super::{CircuitFlags, InstructionFlags, InstructionLookup, LookupQuery, RightInputValue, NUM_CIRCUIT_FLAGS};
 
 impl<const XLEN: usize> InstructionLookup<XLEN> for BNE {
     fn lookup_table(&self) -> Option<LookupTables<XLEN>> {
@@ -26,25 +26,25 @@ impl InstructionFlags for BNE {
 }
 
 impl<const XLEN: usize> LookupQuery<XLEN> for RISCVCycle<BNE> {
-    fn to_instruction_inputs(&self) -> (u64, i128) {
+    fn to_instruction_inputs(&self) -> (u64, RightInputValue) {
         match XLEN {
             #[cfg(test)]
             8 => (
                 self.register_state.rs1 as u8 as u64,
-                self.register_state.rs2 as u8 as i128,
+                RightInputValue::Unsigned(self.register_state.rs2 as u8 as u64),
             ),
             32 => (
                 self.register_state.rs1 as u32 as u64,
-                self.register_state.rs2 as u32 as i128,
+                RightInputValue::Unsigned(self.register_state.rs2 as u32 as u64),
             ),
-            64 => (self.register_state.rs1, self.register_state.rs2 as i128),
+            64 => (self.register_state.rs1, RightInputValue::Unsigned(self.register_state.rs2)),
             _ => panic!("{XLEN}-bit word size is unsupported"),
         }
     }
 
     fn to_lookup_output(&self) -> u64 {
         let (x, y) = LookupQuery::<XLEN>::to_instruction_inputs(self);
-        (x != y as u64).into()
+        (x != y.as_u64()).into()
     }
 }
 

--- a/jolt-core/src/zkvm/instruction/ecall.rs
+++ b/jolt-core/src/zkvm/instruction/ecall.rs
@@ -2,7 +2,7 @@ use tracer::instruction::{ecall::ECALL, RISCVCycle};
 
 use crate::zkvm::lookup_table::LookupTables;
 
-use super::{CircuitFlags, InstructionFlags, InstructionLookup, LookupQuery, NUM_CIRCUIT_FLAGS};
+use super::{CircuitFlags, InstructionFlags, InstructionLookup, LookupQuery, RightInputValue, NUM_CIRCUIT_FLAGS};
 
 impl<const XLEN: usize> InstructionLookup<XLEN> for ECALL {
     fn lookup_table(&self) -> Option<LookupTables<XLEN>> {
@@ -19,8 +19,8 @@ impl InstructionFlags for ECALL {
 }
 
 impl<const XLEN: usize> LookupQuery<XLEN> for RISCVCycle<ECALL> {
-    fn to_instruction_inputs(&self) -> (u64, i128) {
-        (0, 0)
+    fn to_instruction_inputs(&self) -> (u64, RightInputValue) {
+        (0, RightInputValue::Unsigned(0))
     }
 
     fn to_lookup_output(&self) -> u64 {

--- a/jolt-core/src/zkvm/instruction/fence.rs
+++ b/jolt-core/src/zkvm/instruction/fence.rs
@@ -2,7 +2,7 @@ use tracer::instruction::{fence::FENCE, RISCVCycle};
 
 use crate::zkvm::lookup_table::LookupTables;
 
-use super::{CircuitFlags, InstructionFlags, InstructionLookup, LookupQuery, NUM_CIRCUIT_FLAGS};
+use super::{CircuitFlags, InstructionFlags, InstructionLookup, LookupQuery, RightInputValue, NUM_CIRCUIT_FLAGS};
 
 impl<const XLEN: usize> InstructionLookup<XLEN> for FENCE {
     fn lookup_table(&self) -> Option<LookupTables<XLEN>> {
@@ -19,8 +19,8 @@ impl InstructionFlags for FENCE {
 }
 
 impl<const XLEN: usize> LookupQuery<XLEN> for RISCVCycle<FENCE> {
-    fn to_instruction_inputs(&self) -> (u64, i128) {
-        (0, 0)
+    fn to_instruction_inputs(&self) -> (u64, RightInputValue) {
+        (0, RightInputValue::Unsigned(0))
     }
 
     fn to_lookup_output(&self) -> u64 {

--- a/jolt-core/src/zkvm/instruction/jal.rs
+++ b/jolt-core/src/zkvm/instruction/jal.rs
@@ -2,7 +2,7 @@ use tracer::instruction::{jal::JAL, RISCVCycle};
 
 use crate::zkvm::lookup_table::{range_check::RangeCheckTable, LookupTables};
 
-use super::{CircuitFlags, InstructionFlags, InstructionLookup, LookupQuery, NUM_CIRCUIT_FLAGS};
+use super::{CircuitFlags, InstructionFlags, InstructionLookup, LookupQuery, RightInputValue, NUM_CIRCUIT_FLAGS};
 
 impl<const XLEN: usize> InstructionLookup<XLEN> for JAL {
     fn lookup_table(&self) -> Option<LookupTables<XLEN>> {
@@ -29,27 +29,27 @@ impl InstructionFlags for JAL {
 impl<const XLEN: usize> LookupQuery<XLEN> for RISCVCycle<JAL> {
     fn to_lookup_operands(&self) -> (u64, u128) {
         let (pc, imm) = LookupQuery::<XLEN>::to_instruction_inputs(self);
-        (0, (pc as i128 + imm) as u128)
+        (0, (pc as i128 + imm.as_i128()) as u128)
     }
 
     fn to_lookup_index(&self) -> u128 {
         LookupQuery::<XLEN>::to_lookup_operands(self).1
     }
 
-    fn to_instruction_inputs(&self) -> (u64, i128) {
+    fn to_instruction_inputs(&self) -> (u64, RightInputValue) {
         match XLEN {
             #[cfg(test)]
             8 => (
                 self.instruction.address as u8 as u64,
-                self.instruction.operands.imm as u8 as u64 as i128,
+                RightInputValue::Unsigned(self.instruction.operands.imm as u8 as u64),
             ),
             32 => (
                 self.instruction.address as u32 as u64,
-                self.instruction.operands.imm as u32 as u64 as i128,
+                RightInputValue::Unsigned(self.instruction.operands.imm as u32 as u64),
             ),
             64 => (
                 self.instruction.address,
-                self.instruction.operands.imm as i128,
+                RightInputValue::Unsigned(self.instruction.operands.imm),
             ),
             _ => panic!("{XLEN}-bit word size is unsupported"),
         }
@@ -59,9 +59,9 @@ impl<const XLEN: usize> LookupQuery<XLEN> for RISCVCycle<JAL> {
         let (pc, imm) = LookupQuery::<XLEN>::to_instruction_inputs(self);
         match XLEN {
             #[cfg(test)]
-            8 => (pc as i8).overflowing_add(imm as i8).0 as u8 as u64,
-            32 => (pc as i32).overflowing_add(imm as i32).0 as u32 as u64,
-            64 => (pc as i64).overflowing_add(imm as i64).0 as u64,
+            8 => (pc as i8).overflowing_add(imm.as_i8()).0 as u8 as u64,
+            32 => (pc as i32).overflowing_add(imm.as_i32()).0 as u32 as u64,
+            64 => (pc as i64).overflowing_add(imm.as_i64()).0 as u64,
             _ => panic!("{XLEN}-bit word size is unsupported"),
         }
     }

--- a/jolt-core/src/zkvm/instruction/ld.rs
+++ b/jolt-core/src/zkvm/instruction/ld.rs
@@ -2,7 +2,7 @@ use tracer::instruction::{ld::LD, RISCVCycle};
 
 use crate::zkvm::lookup_table::LookupTables;
 
-use super::{CircuitFlags, InstructionFlags, InstructionLookup, LookupQuery, NUM_CIRCUIT_FLAGS};
+use super::{CircuitFlags, InstructionFlags, InstructionLookup, LookupQuery, RightInputValue, NUM_CIRCUIT_FLAGS};
 
 impl<const XLEN: usize> InstructionLookup<XLEN> for LD {
     fn lookup_table(&self) -> Option<LookupTables<XLEN>> {
@@ -24,8 +24,8 @@ impl InstructionFlags for LD {
 }
 
 impl<const XLEN: usize> LookupQuery<XLEN> for RISCVCycle<LD> {
-    fn to_instruction_inputs(&self) -> (u64, i128) {
-        (0, 0)
+    fn to_instruction_inputs(&self) -> (u64, RightInputValue) {
+        (0, RightInputValue::Unsigned(0))
     }
 
     fn to_lookup_output(&self) -> u64 {

--- a/jolt-core/src/zkvm/instruction/lui.rs
+++ b/jolt-core/src/zkvm/instruction/lui.rs
@@ -2,7 +2,7 @@ use tracer::instruction::{lui::LUI, RISCVCycle};
 
 use crate::zkvm::lookup_table::{range_check::RangeCheckTable, LookupTables};
 
-use super::{CircuitFlags, InstructionFlags, InstructionLookup, LookupQuery, NUM_CIRCUIT_FLAGS};
+use super::{CircuitFlags, InstructionFlags, InstructionLookup, LookupQuery, RightInputValue, NUM_CIRCUIT_FLAGS};
 
 impl<const XLEN: usize> InstructionLookup<XLEN> for LUI {
     fn lookup_table(&self) -> Option<LookupTables<XLEN>> {
@@ -26,12 +26,12 @@ impl InstructionFlags for LUI {
 }
 
 impl<const XLEN: usize> LookupQuery<XLEN> for RISCVCycle<LUI> {
-    fn to_instruction_inputs(&self) -> (u64, i128) {
+    fn to_instruction_inputs(&self) -> (u64, RightInputValue) {
         match XLEN {
             #[cfg(test)]
-            8 => (0, self.instruction.operands.imm as u8 as i128),
-            32 => (0, self.instruction.operands.imm as u32 as i128),
-            64 => (0, self.instruction.operands.imm as i128),
+            8 => (0, RightInputValue::Unsigned(self.instruction.operands.imm as u8 as u64)),
+            32 => (0, RightInputValue::Unsigned(self.instruction.operands.imm as u32 as u64)),
+            64 => (0, RightInputValue::Unsigned(self.instruction.operands.imm)),
             _ => panic!("{XLEN}-bit word size is unsupported"),
         }
     }

--- a/jolt-core/src/zkvm/instruction/mul.rs
+++ b/jolt-core/src/zkvm/instruction/mul.rs
@@ -2,7 +2,7 @@ use tracer::instruction::{mul::MUL, RISCVCycle};
 
 use crate::zkvm::lookup_table::{range_check::RangeCheckTable, LookupTables};
 
-use super::{CircuitFlags, InstructionFlags, InstructionLookup, LookupQuery, NUM_CIRCUIT_FLAGS};
+use super::{CircuitFlags, InstructionFlags, InstructionLookup, LookupQuery, RightInputValue, NUM_CIRCUIT_FLAGS};
 
 impl<const XLEN: usize> InstructionLookup<XLEN> for MUL {
     fn lookup_table(&self) -> Option<LookupTables<XLEN>> {
@@ -29,25 +29,25 @@ impl InstructionFlags for MUL {
 impl<const XLEN: usize> LookupQuery<XLEN> for RISCVCycle<MUL> {
     fn to_lookup_operands(&self) -> (u64, u128) {
         let (x, y) = LookupQuery::<XLEN>::to_instruction_inputs(self);
-        (0, x as u128 * y as u64 as u128)
+        (0, x as u128 * y.as_u64() as u128)
     }
 
     fn to_lookup_index(&self) -> u128 {
         LookupQuery::<XLEN>::to_lookup_operands(self).1
     }
 
-    fn to_instruction_inputs(&self) -> (u64, i128) {
+    fn to_instruction_inputs(&self) -> (u64, RightInputValue) {
         match XLEN {
             #[cfg(test)]
             8 => (
                 self.register_state.rs1 as u8 as u64,
-                self.register_state.rs2 as u8 as i128,
+                RightInputValue::Unsigned(self.register_state.rs2 as u8 as u64),
             ),
             32 => (
                 self.register_state.rs1 as u32 as u64,
-                self.register_state.rs2 as u32 as i128,
+                RightInputValue::Unsigned(self.register_state.rs2 as u32 as u64),
             ),
-            64 => (self.register_state.rs1, self.register_state.rs2 as i128),
+            64 => (self.register_state.rs1, RightInputValue::Unsigned(self.register_state.rs2)),
             _ => panic!("{XLEN}-bit word size is unsupported"),
         }
     }
@@ -56,9 +56,9 @@ impl<const XLEN: usize> LookupQuery<XLEN> for RISCVCycle<MUL> {
         let (x, y) = LookupQuery::<XLEN>::to_instruction_inputs(self);
         match XLEN {
             #[cfg(test)]
-            8 => (x as i8).wrapping_mul(y as i8) as u8 as u64,
-            32 => (x as i32).wrapping_mul(y as i32) as u32 as u64,
-            64 => (x as i64).wrapping_mul(y as i64) as u64,
+            8 => (x as i8).wrapping_mul(y.as_i8()) as u8 as u64,
+            32 => (x as i32).wrapping_mul(y.as_i32()) as u32 as u64,
+            64 => (x as i64).wrapping_mul(y.as_i64()) as u64,
             _ => panic!("{XLEN}-bit word size is unsupported"),
         }
     }

--- a/jolt-core/src/zkvm/instruction/or.rs
+++ b/jolt-core/src/zkvm/instruction/or.rs
@@ -2,7 +2,7 @@ use tracer::instruction::{or::OR, RISCVCycle};
 
 use crate::zkvm::lookup_table::{or::OrTable, LookupTables};
 
-use super::{CircuitFlags, InstructionFlags, InstructionLookup, LookupQuery, NUM_CIRCUIT_FLAGS};
+use super::{CircuitFlags, InstructionFlags, InstructionLookup, LookupQuery, RightInputValue, NUM_CIRCUIT_FLAGS};
 
 impl<const XLEN: usize> InstructionLookup<XLEN> for OR {
     fn lookup_table(&self) -> Option<LookupTables<XLEN>> {
@@ -26,18 +26,21 @@ impl InstructionFlags for OR {
 }
 
 impl<const XLEN: usize> LookupQuery<XLEN> for RISCVCycle<OR> {
-    fn to_instruction_inputs(&self) -> (u64, i128) {
+    fn to_instruction_inputs(&self) -> (u64, RightInputValue) {
         match XLEN {
             #[cfg(test)]
             8 => (
                 self.register_state.rs1 as u8 as u64,
-                self.register_state.rs2 as u8 as i128,
+                RightInputValue::Unsigned(self.register_state.rs2 as u8 as u64),
             ),
             32 => (
                 self.register_state.rs1 as u32 as u64,
-                self.register_state.rs2 as u32 as i128,
+                RightInputValue::Unsigned(self.register_state.rs2 as u32 as u64),
             ),
-            64 => (self.register_state.rs1, self.register_state.rs2 as i128),
+            64 => (
+                self.register_state.rs1,
+                RightInputValue::Unsigned(self.register_state.rs2),
+            ),
             _ => panic!("{XLEN}-bit word size is unsupported"),
         }
     }
@@ -46,9 +49,9 @@ impl<const XLEN: usize> LookupQuery<XLEN> for RISCVCycle<OR> {
         let (x, y) = LookupQuery::<XLEN>::to_instruction_inputs(self);
         match XLEN {
             #[cfg(test)]
-            8 => (x as u8 | y as u8).into(),
-            32 => (x as u32 | y as u32).into(),
-            64 => x | y as u64,
+            8 => (x as u8 | y.as_u8()).into(),
+            32 => (x as u32 | y.as_u32()).into(),
+            64 => x | y.as_u64(),
             _ => panic!("{XLEN}-bit word size is unsupported"),
         }
     }

--- a/jolt-core/src/zkvm/instruction/ori.rs
+++ b/jolt-core/src/zkvm/instruction/ori.rs
@@ -2,7 +2,7 @@ use tracer::instruction::{ori::ORI, RISCVCycle};
 
 use crate::zkvm::lookup_table::{or::OrTable, LookupTables};
 
-use super::{CircuitFlags, InstructionFlags, InstructionLookup, LookupQuery, NUM_CIRCUIT_FLAGS};
+use super::{CircuitFlags, InstructionFlags, InstructionLookup, LookupQuery, RightInputValue, NUM_CIRCUIT_FLAGS};
 
 impl<const XLEN: usize> InstructionLookup<XLEN> for ORI {
     fn lookup_table(&self) -> Option<LookupTables<XLEN>> {
@@ -26,20 +26,20 @@ impl InstructionFlags for ORI {
 }
 
 impl<const XLEN: usize> LookupQuery<XLEN> for RISCVCycle<ORI> {
-    fn to_instruction_inputs(&self) -> (u64, i128) {
+    fn to_instruction_inputs(&self) -> (u64, RightInputValue) {
         match XLEN {
             #[cfg(test)]
             8 => (
                 self.register_state.rs1 as u8 as u64,
-                self.instruction.operands.imm as u8 as i128,
+                RightInputValue::Unsigned(self.instruction.operands.imm as u8 as u64),
             ),
             32 => (
                 self.register_state.rs1 as u32 as u64,
-                self.instruction.operands.imm as u32 as i128,
+                RightInputValue::Unsigned(self.instruction.operands.imm as u32 as u64),
             ),
             64 => (
                 self.register_state.rs1,
-                self.instruction.operands.imm as i128,
+                RightInputValue::Unsigned(self.instruction.operands.imm as u64),
             ),
             _ => panic!("{XLEN}-bit word size is unsupported"),
         }
@@ -49,9 +49,9 @@ impl<const XLEN: usize> LookupQuery<XLEN> for RISCVCycle<ORI> {
         let (x, y) = LookupQuery::<XLEN>::to_instruction_inputs(self);
         match XLEN {
             #[cfg(test)]
-            8 => (x as u8 | y as u8).into(),
-            32 => (x as u32 | y as u32).into(),
-            64 => x | y as u64,
+            8 => (x as u8 | y.as_u8()).into(),
+            32 => (x as u32 | y.as_u32()).into(),
+            64 => x | y.as_u64(),
             _ => panic!("{XLEN}-bit word size is unsupported"),
         }
     }

--- a/jolt-core/src/zkvm/instruction/sd.rs
+++ b/jolt-core/src/zkvm/instruction/sd.rs
@@ -2,7 +2,7 @@ use tracer::instruction::{sd::SD, RISCVCycle};
 
 use crate::zkvm::lookup_table::LookupTables;
 
-use super::{CircuitFlags, InstructionFlags, InstructionLookup, LookupQuery, NUM_CIRCUIT_FLAGS};
+use super::{CircuitFlags, InstructionFlags, InstructionLookup, LookupQuery, RightInputValue, NUM_CIRCUIT_FLAGS};
 
 impl<const XLEN: usize> InstructionLookup<XLEN> for SD {
     fn lookup_table(&self) -> Option<LookupTables<XLEN>> {
@@ -24,8 +24,8 @@ impl InstructionFlags for SD {
 }
 
 impl<const XLEN: usize> LookupQuery<XLEN> for RISCVCycle<SD> {
-    fn to_instruction_inputs(&self) -> (u64, i128) {
-        (0, 0)
+    fn to_instruction_inputs(&self) -> (u64, RightInputValue) {
+        (0, RightInputValue::Unsigned(0))
     }
 
     fn to_lookup_output(&self) -> u64 {

--- a/jolt-core/src/zkvm/instruction/slt.rs
+++ b/jolt-core/src/zkvm/instruction/slt.rs
@@ -2,7 +2,7 @@ use tracer::instruction::{slt::SLT, RISCVCycle};
 
 use crate::zkvm::lookup_table::{signed_less_than::SignedLessThanTable, LookupTables};
 
-use super::{CircuitFlags, InstructionFlags, InstructionLookup, LookupQuery, NUM_CIRCUIT_FLAGS};
+use super::{CircuitFlags, InstructionFlags, InstructionLookup, LookupQuery, RightInputValue, NUM_CIRCUIT_FLAGS};
 
 impl<const XLEN: usize> InstructionLookup<XLEN> for SLT {
     fn lookup_table(&self) -> Option<LookupTables<XLEN>> {
@@ -26,18 +26,18 @@ impl InstructionFlags for SLT {
 }
 
 impl<const XLEN: usize> LookupQuery<XLEN> for RISCVCycle<SLT> {
-    fn to_instruction_inputs(&self) -> (u64, i128) {
+    fn to_instruction_inputs(&self) -> (u64, RightInputValue) {
         match XLEN {
             #[cfg(test)]
             8 => (
                 self.register_state.rs1 as u8 as u64,
-                self.register_state.rs2 as u8 as i128,
+                RightInputValue::Unsigned(self.register_state.rs2 as u8 as u64),
             ),
             32 => (
                 self.register_state.rs1 as u32 as u64,
-                self.register_state.rs2 as u32 as i128,
+                RightInputValue::Unsigned(self.register_state.rs2 as u32 as u64),
             ),
-            64 => (self.register_state.rs1, self.register_state.rs2 as i128),
+            64 => (self.register_state.rs1, RightInputValue::Unsigned(self.register_state.rs2)),
             _ => panic!("{XLEN}-bit word size is unsupported"),
         }
     }
@@ -46,9 +46,9 @@ impl<const XLEN: usize> LookupQuery<XLEN> for RISCVCycle<SLT> {
         let (x, y) = LookupQuery::<XLEN>::to_instruction_inputs(self);
         match XLEN {
             #[cfg(test)]
-            8 => ((x as i8) < (y as i8)).into(),
-            32 => ((x as i32) < (y as i32)).into(),
-            64 => ((x as i64) < (y as i64)).into(),
+            8 => ((x as i8) < (y.as_i8())).into(),
+            32 => ((x as i32) < (y.as_i32())).into(),
+            64 => ((x as i64) < (y.as_i64())).into(),
             _ => panic!("{XLEN}-bit word size is unsupported"),
         }
     }

--- a/jolt-core/src/zkvm/instruction/sltiu.rs
+++ b/jolt-core/src/zkvm/instruction/sltiu.rs
@@ -2,7 +2,7 @@ use tracer::instruction::{sltiu::SLTIU, RISCVCycle};
 
 use crate::zkvm::lookup_table::{unsigned_less_than::UnsignedLessThanTable, LookupTables};
 
-use super::{CircuitFlags, InstructionFlags, InstructionLookup, LookupQuery, NUM_CIRCUIT_FLAGS};
+use super::{CircuitFlags, InstructionFlags, InstructionLookup, LookupQuery, RightInputValue, NUM_CIRCUIT_FLAGS};
 
 impl<const XLEN: usize> InstructionLookup<XLEN> for SLTIU {
     fn lookup_table(&self) -> Option<LookupTables<XLEN>> {
@@ -26,20 +26,20 @@ impl InstructionFlags for SLTIU {
 }
 
 impl<const XLEN: usize> LookupQuery<XLEN> for RISCVCycle<SLTIU> {
-    fn to_instruction_inputs(&self) -> (u64, i128) {
+    fn to_instruction_inputs(&self) -> (u64, RightInputValue) {
         match XLEN {
             #[cfg(test)]
             8 => (
                 self.register_state.rs1 as u8 as u64,
-                self.instruction.operands.imm as u8 as i128,
+                RightInputValue::Unsigned(self.instruction.operands.imm as u8 as u64),
             ),
             32 => (
                 self.register_state.rs1 as u32 as u64,
-                self.instruction.operands.imm as u32 as i128,
+                RightInputValue::Unsigned(self.instruction.operands.imm as u32 as u64),
             ),
             64 => (
                 self.register_state.rs1,
-                self.instruction.operands.imm as i128,
+                RightInputValue::Unsigned(self.instruction.operands.imm),
             ),
             _ => panic!("{XLEN}-bit word size is unsupported"),
         }
@@ -49,9 +49,9 @@ impl<const XLEN: usize> LookupQuery<XLEN> for RISCVCycle<SLTIU> {
         let (x, y) = LookupQuery::<XLEN>::to_instruction_inputs(self);
         match XLEN {
             #[cfg(test)]
-            8 => ((x as u8) < y as u8).into(),
-            32 => ((x as u32) < y as u32).into(),
-            64 => (x < y as u64).into(),
+            8 => ((x as u8) < y.as_u8()).into(),
+            32 => ((x as u32) < y.as_u32()).into(),
+            64 => (x < y.as_u64()).into(),
             _ => panic!("{XLEN}-bit word size is unsupported"),
         }
     }

--- a/jolt-core/src/zkvm/instruction/sltu.rs
+++ b/jolt-core/src/zkvm/instruction/sltu.rs
@@ -2,7 +2,7 @@ use tracer::instruction::{sltu::SLTU, RISCVCycle};
 
 use crate::zkvm::lookup_table::{unsigned_less_than::UnsignedLessThanTable, LookupTables};
 
-use super::{CircuitFlags, InstructionFlags, InstructionLookup, LookupQuery, NUM_CIRCUIT_FLAGS};
+use super::{CircuitFlags, InstructionFlags, InstructionLookup, LookupQuery, RightInputValue, NUM_CIRCUIT_FLAGS};
 
 impl<const XLEN: usize> InstructionLookup<XLEN> for SLTU {
     fn lookup_table(&self) -> Option<LookupTables<XLEN>> {
@@ -26,18 +26,18 @@ impl InstructionFlags for SLTU {
 }
 
 impl<const XLEN: usize> LookupQuery<XLEN> for RISCVCycle<SLTU> {
-    fn to_instruction_inputs(&self) -> (u64, i128) {
+    fn to_instruction_inputs(&self) -> (u64, RightInputValue) {
         match XLEN {
             #[cfg(test)]
             8 => (
                 self.register_state.rs1 as u8 as u64,
-                self.register_state.rs2 as u8 as i128,
+                RightInputValue::Unsigned(self.register_state.rs2 as u8 as u64),
             ),
             32 => (
                 self.register_state.rs1 as u32 as u64,
-                self.register_state.rs2 as u32 as i128,
+                RightInputValue::Unsigned(self.register_state.rs2 as u32 as u64),
             ),
-            64 => (self.register_state.rs1, self.register_state.rs2 as i128),
+            64 => (self.register_state.rs1, RightInputValue::Unsigned(self.register_state.rs2)),
             _ => panic!("{XLEN}-bit word size is unsupported"),
         }
     }
@@ -46,9 +46,9 @@ impl<const XLEN: usize> LookupQuery<XLEN> for RISCVCycle<SLTU> {
         let (x, y) = LookupQuery::<XLEN>::to_instruction_inputs(self);
         match XLEN {
             #[cfg(test)]
-            8 => ((x as u8) < (y as u8)).into(),
-            32 => ((x as u32) < (y as u32)).into(),
-            64 => (x < y as u64).into(),
+            8 => ((x as u8) < (y.as_u8())).into(),
+            32 => ((x as u32) < (y.as_u32())).into(),
+            64 => (x < y.as_u64()).into(),
             _ => panic!("{XLEN}-bit word size is unsupported"),
         }
     }

--- a/jolt-core/src/zkvm/instruction/sub.rs
+++ b/jolt-core/src/zkvm/instruction/sub.rs
@@ -2,7 +2,7 @@ use tracer::instruction::{sub::SUB, RISCVCycle};
 
 use crate::zkvm::lookup_table::{range_check::RangeCheckTable, LookupTables};
 
-use super::{CircuitFlags, InstructionFlags, InstructionLookup, LookupQuery, NUM_CIRCUIT_FLAGS};
+use super::{CircuitFlags, InstructionFlags, InstructionLookup, LookupQuery, RightInputValue, NUM_CIRCUIT_FLAGS};
 
 impl<const XLEN: usize> InstructionLookup<XLEN> for SUB {
     fn lookup_table(&self) -> Option<LookupTables<XLEN>> {
@@ -30,7 +30,7 @@ impl<const XLEN: usize> LookupQuery<XLEN> for RISCVCycle<SUB> {
     fn to_lookup_operands(&self) -> (u64, u128) {
         let (x, y) = LookupQuery::<XLEN>::to_instruction_inputs(self);
         let x = x as u128;
-        let y = (1u128 << XLEN) - y as u128;
+        let y = (1u128 << XLEN) - (y.as_i128() as u128);
         (0, x + y)
     }
 
@@ -38,18 +38,18 @@ impl<const XLEN: usize> LookupQuery<XLEN> for RISCVCycle<SUB> {
         LookupQuery::<XLEN>::to_lookup_operands(self).1
     }
 
-    fn to_instruction_inputs(&self) -> (u64, i128) {
+    fn to_instruction_inputs(&self) -> (u64, RightInputValue) {
         match XLEN {
             #[cfg(test)]
             8 => (
                 self.register_state.rs1 as u8 as u64,
-                self.register_state.rs2 as u8 as i128,
+                RightInputValue::Unsigned(self.register_state.rs2 as u8 as u64),
             ),
             32 => (
                 self.register_state.rs1 as u32 as u64,
-                self.register_state.rs2 as u32 as i128,
+                RightInputValue::Unsigned(self.register_state.rs2 as u32 as u64),
             ),
-            64 => (self.register_state.rs1, self.register_state.rs2 as i128),
+            64 => (self.register_state.rs1, RightInputValue::Unsigned(self.register_state.rs2)),
             _ => panic!("{XLEN}-bit word size is unsupported"),
         }
     }
@@ -58,9 +58,9 @@ impl<const XLEN: usize> LookupQuery<XLEN> for RISCVCycle<SUB> {
         let (x, y) = LookupQuery::<XLEN>::to_instruction_inputs(self);
         match XLEN {
             #[cfg(test)]
-            8 => (x as u8).overflowing_sub(y as u8).0.into(),
-            32 => (x as u32).overflowing_sub(y as u32).0.into(),
-            64 => x.overflowing_sub(y as u64).0,
+            8 => (x as u8).overflowing_sub(y.as_u8()).0.into(),
+            32 => (x as u32).overflowing_sub(y.as_u32()).0.into(),
+            64 => x.overflowing_sub(y.as_u64()).0,
             _ => panic!("{XLEN}-bit word size is unsupported"),
         }
     }

--- a/jolt-core/src/zkvm/instruction/types.rs
+++ b/jolt-core/src/zkvm/instruction/types.rs
@@ -1,0 +1,155 @@
+/// Right-hand instruction input value used by zkVM instruction logic.
+///
+/// Captures the semantic signedness of the right operand at XLEN width.
+/// - `Unsigned(u64)`: operand is interpreted as an XLEN-bit unsigned word
+/// - `Signed(i64)`: operand is interpreted as an XLEN-bit two's-complement signed word
+///
+/// Helper methods provide width-aware projections to `u64`/`i64` and a
+/// canonical unsigned representation for lookup key construction.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum RightInputValue {
+    Unsigned(u64),
+    Signed(i64),
+}
+
+impl RightInputValue {
+    /// Return the value as an unsigned 64-bit word (XLEN=64 view).
+    #[inline]
+    pub fn as_u64(&self) -> u64 {
+        match *self {
+            RightInputValue::Unsigned(u) => u,
+            RightInputValue::Signed(s) => s as u64,
+        }
+    }
+
+    /// Return the value as an unsigned 32-bit word (XLEN=32 view).
+    #[inline]
+    pub fn as_u32(&self) -> u32 {
+        match *self {
+            RightInputValue::Unsigned(u) => u as u32,
+            RightInputValue::Signed(s) => s as u32,
+        }
+    }
+
+    /// Return the value as an unsigned 8-bit word (XLEN=8 view).
+    #[inline]
+    pub fn as_u8(&self) -> u8 {
+        match *self {
+            RightInputValue::Unsigned(u) => u as u8,
+            RightInputValue::Signed(s) => s as u8,
+        }
+    }
+
+    /// Return the value as a signed 64-bit word (XLEN=64 view).
+    #[inline]
+    pub fn as_i64(&self) -> i64 {
+        match *self {
+            RightInputValue::Unsigned(u) => u as i64,
+            RightInputValue::Signed(s) => s,
+        }
+    }
+
+    /// Return the value as a signed 32-bit word (XLEN=32 view).
+    /// This is a truncating conversion.
+    #[inline]
+    pub fn as_i32(&self) -> i32 {
+        match *self {
+            RightInputValue::Unsigned(u) => u as i32,
+            RightInputValue::Signed(s) => s as i32,
+        }
+    }
+
+    /// Return the value as a signed 8-bit word (XLEN=8 view).
+    /// This is a truncating conversion.
+    #[inline]
+    pub fn as_i8(&self) -> i8 {
+        match *self {
+            RightInputValue::Unsigned(u) => u as i8,
+            RightInputValue::Signed(s) => s as i8,
+        }
+    }
+
+    /// Return the value widened to i128.
+    #[inline]
+    pub fn as_i128(&self) -> i128 {
+        match *self {
+            RightInputValue::Unsigned(u) => u as i128,
+            RightInputValue::Signed(s) => s as i128,
+        }
+    }
+
+    /// Return a canonical unsigned representation suitable for lookup keys.
+    ///
+    /// This is the XLEN-masked view of the value, promoted to `u128`.
+    #[inline]
+    pub fn to_u128_lookup<const XLEN: usize>(&self) -> u128 {
+        match XLEN {
+            64 => self.as_u64() as u128,
+            32 => self.as_u32() as u128,
+            8 => self.as_u8() as u128,
+            _ => panic!("{XLEN}-bit word size is unsupported"),
+        }
+    }
+}
+
+#[cfg(test)]
+/// Validate that specialized projections as_{u,i}{8,32,64} are equivalent to
+/// widening to i128 and narrowing back for both Unsigned and Signed variants
+/// under XLEN views 8, 32, and 64.
+mod tests {
+    use super::RightInputValue as RIV;
+
+    fn check_equivalence(v: RIV) {
+        let i128_wide = v.as_i128();
+
+        // XLEN=8
+        assert_eq!(i128_wide as u8, v.as_u8());
+        assert_eq!(i128_wide as i8, v.as_i8());
+
+        // XLEN=32
+        assert_eq!(i128_wide as u32, v.as_u32());
+        assert_eq!(i128_wide as i32, v.as_i32());
+
+        // XLEN=64
+        assert_eq!(i128_wide as u64, v.as_u64());
+        assert_eq!(i128_wide as i64, v.as_i64());
+    }
+
+    #[test]
+    fn projections_match_i128_path_unsigned() {
+        let cases: &[u64] = &[
+            0,
+            1,
+            0x7F,
+            0x80,
+            0xFF,
+            0x7FFF_FFFF,
+            0x8000_0000,
+            0xFFFF_FFFF,
+            0x7FFF_FFFF_FFFF_FFFF,
+            0x8000_0000_0000_0000,
+            0xFFFF_FFFF_FFFF_FFFF,
+        ];
+        for &u in cases {
+            check_equivalence(RIV::Unsigned(u));
+        }
+    }
+
+    #[test]
+    fn projections_match_i128_path_signed() {
+        let cases: &[i64] = &[
+            0,
+            1,
+            -1,
+            i64::MIN,
+            i64::MAX,
+            -128,
+            127,
+            -0x8000_0000,
+            0x7FFF_FFFF,
+        ];
+        for &s in cases {
+            check_equivalence(RIV::Signed(s));
+        }
+    }
+}

--- a/jolt-core/src/zkvm/instruction/virtual_advice.rs
+++ b/jolt-core/src/zkvm/instruction/virtual_advice.rs
@@ -2,7 +2,7 @@ use tracer::instruction::{virtual_advice::VirtualAdvice, RISCVCycle};
 
 use crate::zkvm::lookup_table::{range_check::RangeCheckTable, LookupTables};
 
-use super::{CircuitFlags, InstructionFlags, InstructionLookup, LookupQuery, NUM_CIRCUIT_FLAGS};
+use super::{CircuitFlags, InstructionFlags, InstructionLookup, LookupQuery, RightInputValue, NUM_CIRCUIT_FLAGS};
 
 impl<const XLEN: usize> InstructionLookup<XLEN> for VirtualAdvice {
     fn lookup_table(&self) -> Option<LookupTables<XLEN>> {
@@ -25,8 +25,8 @@ impl InstructionFlags for VirtualAdvice {
 }
 
 impl<const XLEN: usize> LookupQuery<XLEN> for RISCVCycle<VirtualAdvice> {
-    fn to_instruction_inputs(&self) -> (u64, i128) {
-        (0, 0)
+    fn to_instruction_inputs(&self) -> (u64, RightInputValue) {
+        (0, RightInputValue::Unsigned(0))
     }
 
     fn to_lookup_operands(&self) -> (u64, u128) {

--- a/jolt-core/src/zkvm/instruction/virtual_assert_eq.rs
+++ b/jolt-core/src/zkvm/instruction/virtual_assert_eq.rs
@@ -2,7 +2,7 @@ use tracer::instruction::{virtual_assert_eq::VirtualAssertEQ, RISCVCycle};
 
 use crate::zkvm::lookup_table::{equal::EqualTable, LookupTables};
 
-use super::{CircuitFlags, InstructionFlags, InstructionLookup, LookupQuery, NUM_CIRCUIT_FLAGS};
+use super::{CircuitFlags, InstructionFlags, InstructionLookup, LookupQuery, RightInputValue, NUM_CIRCUIT_FLAGS};
 
 impl<const XLEN: usize> InstructionLookup<XLEN> for VirtualAssertEQ {
     fn lookup_table(&self) -> Option<LookupTables<XLEN>> {
@@ -26,25 +26,25 @@ impl InstructionFlags for VirtualAssertEQ {
 }
 
 impl<const XLEN: usize> LookupQuery<XLEN> for RISCVCycle<VirtualAssertEQ> {
-    fn to_instruction_inputs(&self) -> (u64, i128) {
+    fn to_instruction_inputs(&self) -> (u64, RightInputValue) {
         match XLEN {
             #[cfg(test)]
             8 => (
                 self.register_state.rs1 as u8 as u64,
-                self.register_state.rs2 as u8 as i128,
+                RightInputValue::Unsigned(self.register_state.rs2 as u8 as u64),
             ),
             32 => (
                 self.register_state.rs1 as u32 as u64,
-                self.register_state.rs2 as u32 as i128,
+                RightInputValue::Unsigned(self.register_state.rs2 as u32 as u64),
             ),
-            64 => (self.register_state.rs1, self.register_state.rs2 as i128),
+            64 => (self.register_state.rs1, RightInputValue::Unsigned(self.register_state.rs2)),
             _ => panic!("{XLEN}-bit word size is unsupported"),
         }
     }
 
     fn to_lookup_output(&self) -> u64 {
         let (x, y) = LookupQuery::<XLEN>::to_instruction_inputs(self);
-        (x == y as u64).into()
+        (x == y.as_u64()).into()
     }
 }
 

--- a/jolt-core/src/zkvm/instruction/virtual_assert_halfword_alignment.rs
+++ b/jolt-core/src/zkvm/instruction/virtual_assert_halfword_alignment.rs
@@ -4,7 +4,7 @@ use tracer::instruction::{
 
 use crate::zkvm::lookup_table::{halfword_alignment::HalfwordAlignmentTable, LookupTables};
 
-use super::{CircuitFlags, InstructionFlags, InstructionLookup, LookupQuery, NUM_CIRCUIT_FLAGS};
+use super::{CircuitFlags, InstructionFlags, InstructionLookup, LookupQuery, RightInputValue, NUM_CIRCUIT_FLAGS};
 
 impl<const XLEN: usize> InstructionLookup<XLEN> for VirtualAssertHalfwordAlignment {
     fn lookup_table(&self) -> Option<LookupTables<XLEN>> {
@@ -31,27 +31,27 @@ impl InstructionFlags for VirtualAssertHalfwordAlignment {
 impl<const XLEN: usize> LookupQuery<XLEN> for RISCVCycle<VirtualAssertHalfwordAlignment> {
     fn to_lookup_operands(&self) -> (u64, u128) {
         let (address, offset) = LookupQuery::<XLEN>::to_instruction_inputs(self);
-        (0, (address as i128 + offset) as u128)
+        (0, (address as i128 + offset.as_i128()) as u128)
     }
 
     fn to_lookup_index(&self) -> u128 {
         LookupQuery::<XLEN>::to_lookup_operands(self).1
     }
 
-    fn to_instruction_inputs(&self) -> (u64, i128) {
+    fn to_instruction_inputs(&self) -> (u64, RightInputValue) {
         match XLEN {
             #[cfg(test)]
             8 => (
                 self.register_state.rs1 as u8 as u64,
-                self.instruction.operands.imm as u8 as i128,
+                RightInputValue::Signed(self.instruction.operands.imm as u8 as i64),
             ),
             32 => (
                 self.register_state.rs1 as u32 as u64,
-                self.instruction.operands.imm as u32 as i128,
+                RightInputValue::Signed(self.instruction.operands.imm as u32 as i64),
             ),
             64 => (
                 self.register_state.rs1,
-                self.instruction.operands.imm as i128,
+                RightInputValue::Signed(self.instruction.operands.imm),
             ),
             _ => panic!("{XLEN}-bit word size is unsupported"),
         }

--- a/jolt-core/src/zkvm/instruction/virtual_assert_lte.rs
+++ b/jolt-core/src/zkvm/instruction/virtual_assert_lte.rs
@@ -4,7 +4,7 @@ use crate::zkvm::lookup_table::{
     unsigned_less_than_equal::UnsignedLessThanEqualTable, LookupTables,
 };
 
-use super::{CircuitFlags, InstructionFlags, InstructionLookup, LookupQuery, NUM_CIRCUIT_FLAGS};
+use super::{CircuitFlags, InstructionFlags, InstructionLookup, LookupQuery, RightInputValue, NUM_CIRCUIT_FLAGS};
 
 impl<const XLEN: usize> InstructionLookup<XLEN> for VirtualAssertLTE {
     fn lookup_table(&self) -> Option<LookupTables<XLEN>> {
@@ -28,25 +28,25 @@ impl InstructionFlags for VirtualAssertLTE {
 }
 
 impl<const XLEN: usize> LookupQuery<XLEN> for RISCVCycle<VirtualAssertLTE> {
-    fn to_instruction_inputs(&self) -> (u64, i128) {
+    fn to_instruction_inputs(&self) -> (u64, RightInputValue) {
         match XLEN {
             #[cfg(test)]
             8 => (
                 self.register_state.rs1 as u8 as u64,
-                self.register_state.rs2 as u8 as i128,
+                RightInputValue::Unsigned(self.register_state.rs2 as u8 as u64),
             ),
             32 => (
                 self.register_state.rs1 as u32 as u64,
-                self.register_state.rs2 as u32 as i128,
+                RightInputValue::Unsigned(self.register_state.rs2 as u32 as u64),
             ),
-            64 => (self.register_state.rs1, self.register_state.rs2 as i128),
+            64 => (self.register_state.rs1, RightInputValue::Unsigned(self.register_state.rs2)),
             _ => panic!("{XLEN}-bit word size is unsupported"),
         }
     }
 
     fn to_lookup_output(&self) -> u64 {
         let (x, y) = LookupQuery::<XLEN>::to_instruction_inputs(self);
-        (x <= y as u64).into()
+        (x <= y.as_u64()).into()
     }
 }
 

--- a/jolt-core/src/zkvm/instruction/virtual_assert_valid_unsigned_remainder.rs
+++ b/jolt-core/src/zkvm/instruction/virtual_assert_valid_unsigned_remainder.rs
@@ -6,7 +6,7 @@ use crate::zkvm::lookup_table::{
     valid_unsigned_remainder::ValidUnsignedRemainderTable, LookupTables,
 };
 
-use super::{CircuitFlags, InstructionFlags, InstructionLookup, LookupQuery, NUM_CIRCUIT_FLAGS};
+use super::{CircuitFlags, InstructionFlags, InstructionLookup, LookupQuery, RightInputValue, NUM_CIRCUIT_FLAGS};
 
 impl<const XLEN: usize> InstructionLookup<XLEN> for VirtualAssertValidUnsignedRemainder {
     fn lookup_table(&self) -> Option<LookupTables<XLEN>> {
@@ -30,25 +30,26 @@ impl InstructionFlags for VirtualAssertValidUnsignedRemainder {
 }
 
 impl<const XLEN: usize> LookupQuery<XLEN> for RISCVCycle<VirtualAssertValidUnsignedRemainder> {
-    fn to_instruction_inputs(&self) -> (u64, i128) {
+    fn to_instruction_inputs(&self) -> (u64, RightInputValue) {
         match XLEN {
             #[cfg(test)]
             8 => (
                 self.register_state.rs1 as u8 as u64,
-                self.register_state.rs2 as u8 as i128,
+                RightInputValue::Unsigned(self.register_state.rs2 as u8 as u64),
             ),
             32 => (
                 self.register_state.rs1 as u32 as u64,
-                self.register_state.rs2 as u32 as i128,
+                RightInputValue::Unsigned(self.register_state.rs2 as u32 as u64),
             ),
-            64 => (self.register_state.rs1, self.register_state.rs2 as i128),
+            64 => (self.register_state.rs1, RightInputValue::Unsigned(self.register_state.rs2)),
             _ => panic!("{XLEN}-bit word size is unsupported"),
         }
     }
 
     fn to_lookup_output(&self) -> u64 {
         let (remainder, divisor) = LookupQuery::<XLEN>::to_instruction_inputs(self);
-        (divisor == 0 || remainder < divisor as u64).into()
+        let divisor_u64 = divisor.as_u64();
+        (divisor_u64 == 0 || remainder < divisor_u64).into()
     }
 }
 

--- a/jolt-core/src/zkvm/instruction/virtual_assert_word_alignment.rs
+++ b/jolt-core/src/zkvm/instruction/virtual_assert_word_alignment.rs
@@ -4,7 +4,7 @@ use tracer::instruction::RISCVCycle;
 use crate::zkvm::lookup_table::word_alignment::WordAlignmentTable;
 use crate::zkvm::lookup_table::LookupTables;
 
-use super::{CircuitFlags, InstructionFlags, InstructionLookup, LookupQuery, NUM_CIRCUIT_FLAGS};
+use super::{CircuitFlags, InstructionFlags, InstructionLookup, LookupQuery, RightInputValue, NUM_CIRCUIT_FLAGS};
 
 impl<const XLEN: usize> InstructionLookup<XLEN> for VirtualAssertWordAlignment {
     fn lookup_table(&self) -> Option<LookupTables<XLEN>> {
@@ -31,27 +31,27 @@ impl InstructionFlags for VirtualAssertWordAlignment {
 impl<const XLEN: usize> LookupQuery<XLEN> for RISCVCycle<VirtualAssertWordAlignment> {
     fn to_lookup_operands(&self) -> (u64, u128) {
         let (address, offset) = LookupQuery::<XLEN>::to_instruction_inputs(self);
-        (0, (address as i128 + offset) as u128)
+        (0, (address as i128 + offset.as_i128()) as u128)
     }
 
     fn to_lookup_index(&self) -> u128 {
         LookupQuery::<XLEN>::to_lookup_operands(self).1
     }
 
-    fn to_instruction_inputs(&self) -> (u64, i128) {
+    fn to_instruction_inputs(&self) -> (u64, RightInputValue) {
         match XLEN {
             #[cfg(test)]
             8 => (
                 self.register_state.rs1 as u8 as u64,
-                self.instruction.operands.imm as u8 as i128,
+                RightInputValue::Signed(self.instruction.operands.imm as u8 as i64),
             ),
             32 => (
                 self.register_state.rs1 as u32 as u64,
-                self.instruction.operands.imm as u32 as i128,
+                RightInputValue::Signed(self.instruction.operands.imm as u32 as i64),
             ),
             64 => (
                 self.register_state.rs1,
-                self.instruction.operands.imm as i128,
+                RightInputValue::Signed(self.instruction.operands.imm),
             ),
             _ => panic!("{XLEN}-bit word size is unsupported"),
         }

--- a/jolt-core/src/zkvm/instruction/virtual_change_divisor.rs
+++ b/jolt-core/src/zkvm/instruction/virtual_change_divisor.rs
@@ -3,7 +3,7 @@ use tracer::instruction::{virtual_change_divisor::VirtualChangeDivisor, RISCVCyc
 use crate::zkvm::lookup_table::virtual_change_divisor::VirtualChangeDivisorTable;
 use crate::zkvm::lookup_table::LookupTables;
 
-use super::{CircuitFlags, InstructionFlags, InstructionLookup, LookupQuery, NUM_CIRCUIT_FLAGS};
+use super::{CircuitFlags, InstructionFlags, InstructionLookup, LookupQuery, RightInputValue, NUM_CIRCUIT_FLAGS};
 
 impl<const XLEN: usize> InstructionLookup<XLEN> for VirtualChangeDivisor {
     fn lookup_table(&self) -> Option<LookupTables<XLEN>> {
@@ -27,18 +27,18 @@ impl InstructionFlags for VirtualChangeDivisor {
 }
 
 impl<const XLEN: usize> LookupQuery<XLEN> for RISCVCycle<VirtualChangeDivisor> {
-    fn to_instruction_inputs(&self) -> (u64, i128) {
+    fn to_instruction_inputs(&self) -> (u64, RightInputValue) {
         match XLEN {
             #[cfg(test)]
             8 => (
                 self.register_state.rs1 as u8 as u64,
-                self.register_state.rs2 as u8 as i128,
+                RightInputValue::Unsigned(self.register_state.rs2 as u8 as u64),
             ),
             32 => (
                 self.register_state.rs1 as u32 as u64,
-                self.register_state.rs2 as u32 as i128,
+                RightInputValue::Unsigned(self.register_state.rs2 as u32 as u64),
             ),
-            64 => (self.register_state.rs1, self.register_state.rs2 as i128),
+            64 => (self.register_state.rs1, RightInputValue::Unsigned(self.register_state.rs2)),
             _ => panic!("{XLEN}-bit word size is unsupported"),
         }
     }
@@ -49,7 +49,7 @@ impl<const XLEN: usize> LookupQuery<XLEN> for RISCVCycle<VirtualChangeDivisor> {
             #[cfg(test)]
             8 => {
                 let remainder = remainder as i8;
-                let divisor = divisor as i8;
+                let divisor = divisor.as_i8();
                 if remainder == i8::MIN && divisor == -1 {
                     1
                 } else {
@@ -58,7 +58,7 @@ impl<const XLEN: usize> LookupQuery<XLEN> for RISCVCycle<VirtualChangeDivisor> {
             }
             32 => {
                 let remainder = remainder as i32;
-                let divisor = divisor as i32;
+                let divisor = divisor.as_i32();
                 if remainder == i32::MIN && divisor == -1 {
                     1
                 } else {
@@ -67,10 +67,10 @@ impl<const XLEN: usize> LookupQuery<XLEN> for RISCVCycle<VirtualChangeDivisor> {
             }
             64 => {
                 let remainder = remainder as i64;
-                if remainder == i64::MIN && divisor == -1 {
+                if remainder == i64::MIN && divisor.as_i64() == -1 {
                     1
                 } else {
-                    divisor as u64
+                    divisor.as_u64()
                 }
             }
             _ => panic!("{XLEN}-bit word size is unsupported"),

--- a/jolt-core/src/zkvm/instruction/virtual_change_divisor_w.rs
+++ b/jolt-core/src/zkvm/instruction/virtual_change_divisor_w.rs
@@ -3,7 +3,7 @@ use tracer::instruction::{virtual_change_divisor_w::VirtualChangeDivisorW, RISCV
 use crate::zkvm::lookup_table::virtual_change_divisor_w::VirtualChangeDivisorWTable;
 use crate::zkvm::lookup_table::LookupTables;
 
-use super::{CircuitFlags, InstructionFlags, InstructionLookup, LookupQuery, NUM_CIRCUIT_FLAGS};
+use super::{CircuitFlags, InstructionFlags, InstructionLookup, LookupQuery, RightInputValue, NUM_CIRCUIT_FLAGS};
 
 impl<const XLEN: usize> InstructionLookup<XLEN> for VirtualChangeDivisorW {
     fn lookup_table(&self) -> Option<LookupTables<XLEN>> {
@@ -27,18 +27,18 @@ impl InstructionFlags for VirtualChangeDivisorW {
 }
 
 impl<const XLEN: usize> LookupQuery<XLEN> for RISCVCycle<VirtualChangeDivisorW> {
-    fn to_instruction_inputs(&self) -> (u64, i128) {
+    fn to_instruction_inputs(&self) -> (u64, RightInputValue) {
         // Always treat as 32-bit values for W instructions
         (
             self.register_state.rs1 as u32 as u64,
-            self.register_state.rs2 as i32 as i128,
+            RightInputValue::Signed(self.register_state.rs2 as i32 as i64),
         )
     }
 
     fn to_lookup_output(&self) -> u64 {
         let (remainder, divisor) = LookupQuery::<XLEN>::to_instruction_inputs(self);
         let remainder = remainder as i32;
-        let divisor = divisor as i32;
+        let divisor = divisor.as_i32();
 
         if remainder == i32::MIN && divisor == -1 {
             1

--- a/jolt-core/src/zkvm/instruction/virtual_move.rs
+++ b/jolt-core/src/zkvm/instruction/virtual_move.rs
@@ -2,7 +2,7 @@ use tracer::instruction::{virtual_move::VirtualMove, RISCVCycle};
 
 use crate::zkvm::lookup_table::{range_check::RangeCheckTable, LookupTables};
 
-use super::{CircuitFlags, InstructionFlags, InstructionLookup, LookupQuery, NUM_CIRCUIT_FLAGS};
+use super::{CircuitFlags, InstructionFlags, InstructionLookup, LookupQuery, RightInputValue, NUM_CIRCUIT_FLAGS};
 
 impl<const XLEN: usize> InstructionLookup<XLEN> for VirtualMove {
     fn lookup_table(&self) -> Option<LookupTables<XLEN>> {
@@ -27,19 +27,19 @@ impl InstructionFlags for VirtualMove {
 }
 
 impl<const XLEN: usize> LookupQuery<XLEN> for RISCVCycle<VirtualMove> {
-    fn to_instruction_inputs(&self) -> (u64, i128) {
+    fn to_instruction_inputs(&self) -> (u64, RightInputValue) {
         match XLEN {
             #[cfg(test)]
-            8 => (self.register_state.rs1 as u8 as u64, 0),
-            32 => (self.register_state.rs1 as u32 as u64, 0),
-            64 => (self.register_state.rs1, 0),
+            8 => (self.register_state.rs1 as u8 as u64, RightInputValue::Unsigned(0)),
+            32 => (self.register_state.rs1 as u32 as u64, RightInputValue::Unsigned(0)),
+            64 => (self.register_state.rs1, RightInputValue::Unsigned(0)),
             _ => panic!("{XLEN}-bit word size is unsupported"),
         }
     }
 
     fn to_lookup_operands(&self) -> (u64, u128) {
         let (x, y) = LookupQuery::<XLEN>::to_instruction_inputs(self);
-        (0, x as u128 + y as u128)
+        (0, x as u128 + y.as_i128() as u128)
     }
 
     fn to_lookup_index(&self) -> u128 {

--- a/jolt-core/src/zkvm/instruction/virtual_movsign.rs
+++ b/jolt-core/src/zkvm/instruction/virtual_movsign.rs
@@ -2,7 +2,7 @@ use tracer::instruction::{virtual_movsign::VirtualMovsign, RISCVCycle};
 
 use crate::zkvm::lookup_table::{movsign::MovsignTable, LookupTables};
 
-use super::{CircuitFlags, InstructionFlags, InstructionLookup, LookupQuery, NUM_CIRCUIT_FLAGS};
+use super::{CircuitFlags, InstructionFlags, InstructionLookup, LookupQuery, RightInputValue, NUM_CIRCUIT_FLAGS};
 
 impl<const XLEN: usize> InstructionLookup<XLEN> for VirtualMovsign {
     fn lookup_table(&self) -> Option<LookupTables<XLEN>> {
@@ -26,20 +26,20 @@ impl InstructionFlags for VirtualMovsign {
 }
 
 impl<const XLEN: usize> LookupQuery<XLEN> for RISCVCycle<VirtualMovsign> {
-    fn to_instruction_inputs(&self) -> (u64, i128) {
+    fn to_instruction_inputs(&self) -> (u64, RightInputValue) {
         match XLEN {
             #[cfg(test)]
             8 => (
                 self.register_state.rs1 as u8 as u64,
-                self.instruction.operands.imm as u8 as i128, // Unused
+                RightInputValue::Unsigned(self.instruction.operands.imm as u8 as u64), // Unused
             ),
             32 => (
                 self.register_state.rs1 as u32 as u64,
-                self.instruction.operands.imm as u32 as i128, // Unused
+                RightInputValue::Unsigned(self.instruction.operands.imm as u32 as u64), // Unused
             ),
             64 => (
                 self.register_state.rs1,
-                self.instruction.operands.imm as i128, // Unused
+                RightInputValue::Unsigned(self.instruction.operands.imm), // Unused
             ),
             _ => panic!("{XLEN}-bit word size is unsupported"),
         }

--- a/jolt-core/src/zkvm/instruction/virtual_muli.rs
+++ b/jolt-core/src/zkvm/instruction/virtual_muli.rs
@@ -3,7 +3,7 @@ use tracer::instruction::{virtual_muli::VirtualMULI, RISCVCycle};
 use crate::zkvm::lookup_table::range_check::RangeCheckTable;
 use crate::zkvm::lookup_table::LookupTables;
 
-use super::{CircuitFlags, InstructionFlags, InstructionLookup, LookupQuery, NUM_CIRCUIT_FLAGS};
+use super::{CircuitFlags, InstructionFlags, InstructionLookup, LookupQuery, RightInputValue, NUM_CIRCUIT_FLAGS};
 
 impl<const XLEN: usize> InstructionLookup<XLEN> for VirtualMULI {
     fn lookup_table(&self) -> Option<LookupTables<XLEN>> {
@@ -30,27 +30,27 @@ impl InstructionFlags for VirtualMULI {
 impl<const XLEN: usize> LookupQuery<XLEN> for RISCVCycle<VirtualMULI> {
     fn to_lookup_operands(&self) -> (u64, u128) {
         let (x, y) = LookupQuery::<XLEN>::to_instruction_inputs(self);
-        (0, x as u128 * y as u64 as u128)
+        (0, x as u128 * y.as_u64() as u128)
     }
 
     fn to_lookup_index(&self) -> u128 {
         LookupQuery::<XLEN>::to_lookup_operands(self).1
     }
 
-    fn to_instruction_inputs(&self) -> (u64, i128) {
+    fn to_instruction_inputs(&self) -> (u64, RightInputValue) {
         match XLEN {
             #[cfg(test)]
             8 => (
                 self.register_state.rs1 as u8 as u64,
-                self.instruction.operands.imm as u8 as i128,
+                RightInputValue::Unsigned(self.instruction.operands.imm as u8 as u64),
             ),
             32 => (
                 self.register_state.rs1 as u32 as u64,
-                self.instruction.operands.imm as u32 as i128,
+                RightInputValue::Unsigned(self.instruction.operands.imm as u32 as u64),
             ),
             64 => (
                 self.register_state.rs1,
-                self.instruction.operands.imm as i128,
+                RightInputValue::Unsigned(self.instruction.operands.imm),
             ),
             _ => panic!("{XLEN}-bit word size is unsupported"),
         }
@@ -60,9 +60,9 @@ impl<const XLEN: usize> LookupQuery<XLEN> for RISCVCycle<VirtualMULI> {
         let (x, y) = LookupQuery::<XLEN>::to_instruction_inputs(self);
         match XLEN {
             #[cfg(test)]
-            8 => (x as i8).wrapping_mul(y as i8) as u8 as u64,
-            32 => (x as i32).wrapping_mul(y as i32) as u32 as u64,
-            64 => (x as i64).wrapping_mul(y as i64) as u64,
+            8 => (x as i8).wrapping_mul(y.as_i8()) as u8 as u64,
+            32 => (x as i32).wrapping_mul(y.as_i32()) as u32 as u64,
+            64 => (x as i64).wrapping_mul(y.as_i64()) as u64,
             _ => panic!("{XLEN}-bit word size is unsupported"),
         }
     }

--- a/jolt-core/src/zkvm/instruction/virtual_pow2.rs
+++ b/jolt-core/src/zkvm/instruction/virtual_pow2.rs
@@ -2,7 +2,7 @@ use tracer::instruction::{virtual_pow2::VirtualPow2, RISCVCycle};
 
 use crate::zkvm::lookup_table::{pow2::Pow2Table, LookupTables};
 
-use super::{CircuitFlags, InstructionFlags, InstructionLookup, LookupQuery, NUM_CIRCUIT_FLAGS};
+use super::{CircuitFlags, InstructionFlags, InstructionLookup, LookupQuery, RightInputValue, NUM_CIRCUIT_FLAGS};
 
 impl<const XLEN: usize> InstructionLookup<XLEN> for VirtualPow2 {
     fn lookup_table(&self) -> Option<LookupTables<XLEN>> {
@@ -27,19 +27,19 @@ impl InstructionFlags for VirtualPow2 {
 }
 
 impl<const XLEN: usize> LookupQuery<XLEN> for RISCVCycle<VirtualPow2> {
-    fn to_instruction_inputs(&self) -> (u64, i128) {
+    fn to_instruction_inputs(&self) -> (u64, RightInputValue) {
         match XLEN {
             #[cfg(test)]
-            8 => (self.register_state.rs1 as u8 as u64, 0),
-            32 => (self.register_state.rs1 as u32 as u64, 0),
-            64 => (self.register_state.rs1, 0),
+            8 => (self.register_state.rs1 as u8 as u64, RightInputValue::Unsigned(0)),
+            32 => (self.register_state.rs1 as u32 as u64, RightInputValue::Unsigned(0)),
+            64 => (self.register_state.rs1, RightInputValue::Unsigned(0)),
             _ => panic!("{XLEN}-bit word size is unsupported"),
         }
     }
 
     fn to_lookup_operands(&self) -> (u64, u128) {
         let (x, y) = LookupQuery::<XLEN>::to_instruction_inputs(self);
-        (0, x as u128 + y as u64 as u128)
+        (0, x as u128 + y.as_u64() as u128)
     }
 
     fn to_lookup_index(&self) -> u128 {

--- a/jolt-core/src/zkvm/instruction/virtual_pow2i.rs
+++ b/jolt-core/src/zkvm/instruction/virtual_pow2i.rs
@@ -2,7 +2,7 @@ use tracer::instruction::{virtual_pow2i::VirtualPow2I, RISCVCycle};
 
 use crate::zkvm::lookup_table::{pow2::Pow2Table, LookupTables};
 
-use super::{CircuitFlags, InstructionFlags, InstructionLookup, LookupQuery, NUM_CIRCUIT_FLAGS};
+use super::{CircuitFlags, InstructionFlags, InstructionLookup, LookupQuery, RightInputValue, NUM_CIRCUIT_FLAGS};
 
 impl<const XLEN: usize> InstructionLookup<XLEN> for VirtualPow2I {
     fn lookup_table(&self) -> Option<LookupTables<XLEN>> {
@@ -26,19 +26,19 @@ impl InstructionFlags for VirtualPow2I {
 }
 
 impl<const XLEN: usize> LookupQuery<XLEN> for RISCVCycle<VirtualPow2I> {
-    fn to_instruction_inputs(&self) -> (u64, i128) {
+    fn to_instruction_inputs(&self) -> (u64, RightInputValue) {
         match XLEN {
             #[cfg(test)]
-            8 => (0, self.instruction.operands.imm as u8 as i128),
-            32 => (0, self.instruction.operands.imm as u32 as i128),
-            64 => (0, self.instruction.operands.imm as i128),
+            8 => (0, RightInputValue::Unsigned(self.instruction.operands.imm as u8 as u64)),
+            32 => (0, RightInputValue::Unsigned(self.instruction.operands.imm as u32 as u64)),
+            64 => (0, RightInputValue::Unsigned(self.instruction.operands.imm)),
             _ => panic!("{XLEN}-bit word size is unsupported"),
         }
     }
 
     fn to_lookup_operands(&self) -> (u64, u128) {
         let (x, y) = LookupQuery::<XLEN>::to_instruction_inputs(self);
-        (0, x as u128 + y as u64 as u128)
+        (0, x as u128 + y.as_u64() as u128)
     }
 
     fn to_lookup_index(&self) -> u128 {

--- a/jolt-core/src/zkvm/instruction/virtual_pow2iw.rs
+++ b/jolt-core/src/zkvm/instruction/virtual_pow2iw.rs
@@ -2,7 +2,7 @@ use tracer::instruction::{virtual_pow2i_w::VirtualPow2IW, RISCVCycle};
 
 use crate::zkvm::lookup_table::{pow2_w::Pow2WTable, LookupTables};
 
-use super::{CircuitFlags, InstructionFlags, InstructionLookup, LookupQuery, NUM_CIRCUIT_FLAGS};
+use super::{CircuitFlags, InstructionFlags, InstructionLookup, LookupQuery, RightInputValue, NUM_CIRCUIT_FLAGS};
 
 impl<const XLEN: usize> InstructionLookup<XLEN> for VirtualPow2IW {
     fn lookup_table(&self) -> Option<LookupTables<XLEN>> {
@@ -26,14 +26,14 @@ impl InstructionFlags for VirtualPow2IW {
 }
 
 impl<const XLEN: usize> LookupQuery<XLEN> for RISCVCycle<VirtualPow2IW> {
-    fn to_instruction_inputs(&self) -> (u64, i128) {
+    fn to_instruction_inputs(&self) -> (u64, RightInputValue) {
         // Only use immediate value
-        (0, self.instruction.operands.imm as i128)
+        (0, RightInputValue::Unsigned(self.instruction.operands.imm))
     }
 
     fn to_lookup_operands(&self) -> (u64, u128) {
         let (x, y) = LookupQuery::<XLEN>::to_instruction_inputs(self);
-        (0, x as u128 + y as u64 as u128)
+        (0, x as u128 + y.as_u64() as u128)
     }
 
     fn to_lookup_index(&self) -> u128 {

--- a/jolt-core/src/zkvm/instruction/virtual_pow2w.rs
+++ b/jolt-core/src/zkvm/instruction/virtual_pow2w.rs
@@ -2,7 +2,7 @@ use tracer::instruction::{virtual_pow2_w::VirtualPow2W, RISCVCycle};
 
 use crate::zkvm::lookup_table::{pow2_w::Pow2WTable, LookupTables};
 
-use super::{CircuitFlags, InstructionFlags, InstructionLookup, LookupQuery, NUM_CIRCUIT_FLAGS};
+use super::{CircuitFlags, InstructionFlags, InstructionLookup, LookupQuery, RightInputValue, NUM_CIRCUIT_FLAGS};
 
 impl<const XLEN: usize> InstructionLookup<XLEN> for VirtualPow2W {
     fn lookup_table(&self) -> Option<LookupTables<XLEN>> {
@@ -26,14 +26,14 @@ impl InstructionFlags for VirtualPow2W {
 }
 
 impl<const XLEN: usize> LookupQuery<XLEN> for RISCVCycle<VirtualPow2W> {
-    fn to_instruction_inputs(&self) -> (u64, i128) {
+    fn to_instruction_inputs(&self) -> (u64, RightInputValue) {
         // Only use rs1 value
-        (self.register_state.rs1, 0)
+        (self.register_state.rs1, RightInputValue::Unsigned(0))
     }
 
     fn to_lookup_operands(&self) -> (u64, u128) {
         let (x, y) = LookupQuery::<XLEN>::to_instruction_inputs(self);
-        (0, x as u128 + y as u64 as u128)
+        (0, x as u128 + y.as_u64() as u128)
     }
 
     fn to_lookup_index(&self) -> u128 {

--- a/jolt-core/src/zkvm/instruction/virtual_rotri.rs
+++ b/jolt-core/src/zkvm/instruction/virtual_rotri.rs
@@ -2,7 +2,7 @@ use tracer::instruction::{virtual_rotri::VirtualROTRI, RISCVCycle};
 
 use crate::zkvm::lookup_table::{virtual_rotr::VirtualRotrTable, LookupTables};
 
-use super::{CircuitFlags, InstructionFlags, InstructionLookup, LookupQuery, NUM_CIRCUIT_FLAGS};
+use super::{CircuitFlags, InstructionFlags, InstructionLookup, LookupQuery, RightInputValue, NUM_CIRCUIT_FLAGS};
 
 impl<const XLEN: usize> InstructionLookup<XLEN> for VirtualROTRI {
     fn lookup_table(&self) -> Option<LookupTables<XLEN>> {
@@ -26,10 +26,10 @@ impl InstructionFlags for VirtualROTRI {
 }
 
 impl<const XLEN: usize> LookupQuery<XLEN> for RISCVCycle<VirtualROTRI> {
-    fn to_instruction_inputs(&self) -> (u64, i128) {
+    fn to_instruction_inputs(&self) -> (u64, RightInputValue) {
         (
             self.register_state.rs1,
-            self.instruction.operands.imm as i128,
+            RightInputValue::Unsigned(self.instruction.operands.imm),
         )
     }
 
@@ -37,9 +37,9 @@ impl<const XLEN: usize> LookupQuery<XLEN> for RISCVCycle<VirtualROTRI> {
         let (x, y) = LookupQuery::<XLEN>::to_instruction_inputs(self);
         match XLEN {
             #[cfg(test)]
-            8 => (x as u8).rotate_right((y as u8).trailing_zeros()) as u64,
-            32 => (x as u32).rotate_right((y as u32).trailing_zeros()) as u64,
-            64 => x.rotate_right((y as u64).trailing_zeros()),
+            8 => (x as u8).rotate_right((y.as_u8()).trailing_zeros()) as u64,
+            32 => (x as u32).rotate_right((y.as_u32()).trailing_zeros()) as u64,
+            64 => x.rotate_right((y.as_u64()).trailing_zeros()),
             _ => panic!("{XLEN}-bit word size is unsupported"),
         }
     }

--- a/jolt-core/src/zkvm/instruction/virtual_shift_right_bitmask.rs
+++ b/jolt-core/src/zkvm/instruction/virtual_shift_right_bitmask.rs
@@ -2,7 +2,7 @@ use tracer::instruction::{virtual_shift_right_bitmask::VirtualShiftRightBitmask,
 
 use crate::zkvm::lookup_table::{shift_right_bitmask::ShiftRightBitmaskTable, LookupTables};
 
-use super::{CircuitFlags, InstructionFlags, InstructionLookup, LookupQuery, NUM_CIRCUIT_FLAGS};
+use super::{CircuitFlags, InstructionFlags, InstructionLookup, LookupQuery, RightInputValue, NUM_CIRCUIT_FLAGS};
 
 impl<const XLEN: usize> InstructionLookup<XLEN> for VirtualShiftRightBitmask {
     fn lookup_table(&self) -> Option<LookupTables<XLEN>> {
@@ -27,19 +27,19 @@ impl InstructionFlags for VirtualShiftRightBitmask {
 }
 
 impl<const XLEN: usize> LookupQuery<XLEN> for RISCVCycle<VirtualShiftRightBitmask> {
-    fn to_instruction_inputs(&self) -> (u64, i128) {
+    fn to_instruction_inputs(&self) -> (u64, RightInputValue) {
         match XLEN {
             #[cfg(test)]
-            8 => (self.register_state.rs1 as u8 as u64, 0),
-            32 => (self.register_state.rs1 as u32 as u64, 0),
-            64 => (self.register_state.rs1, 0),
+            8 => (self.register_state.rs1 as u8 as u64, RightInputValue::Unsigned(0)),
+            32 => (self.register_state.rs1 as u32 as u64, RightInputValue::Unsigned(0)),
+            64 => (self.register_state.rs1, RightInputValue::Unsigned(0)),
             _ => panic!("{XLEN}-bit word size is unsupported"),
         }
     }
 
     fn to_lookup_operands(&self) -> (u64, u128) {
         let (x, y) = LookupQuery::<XLEN>::to_instruction_inputs(self);
-        (0, x as u128 + y as u64 as u128)
+        (0, x as u128 + y.as_u64() as u128)
     }
 
     fn to_lookup_index(&self) -> u128 {

--- a/jolt-core/src/zkvm/instruction/virtual_shift_right_bitmaski.rs
+++ b/jolt-core/src/zkvm/instruction/virtual_shift_right_bitmaski.rs
@@ -2,7 +2,7 @@ use tracer::instruction::{virtual_shift_right_bitmaski::VirtualShiftRightBitmask
 
 use crate::zkvm::lookup_table::{shift_right_bitmask::ShiftRightBitmaskTable, LookupTables};
 
-use super::{CircuitFlags, InstructionFlags, InstructionLookup, LookupQuery, NUM_CIRCUIT_FLAGS};
+use super::{CircuitFlags, InstructionFlags, InstructionLookup, LookupQuery, RightInputValue, NUM_CIRCUIT_FLAGS};
 
 impl<const XLEN: usize> InstructionLookup<XLEN> for VirtualShiftRightBitmaskI {
     fn lookup_table(&self) -> Option<LookupTables<XLEN>> {
@@ -25,19 +25,19 @@ impl InstructionFlags for VirtualShiftRightBitmaskI {
 }
 
 impl<const XLEN: usize> LookupQuery<XLEN> for RISCVCycle<VirtualShiftRightBitmaskI> {
-    fn to_instruction_inputs(&self) -> (u64, i128) {
+    fn to_instruction_inputs(&self) -> (u64, RightInputValue) {
         match XLEN {
             #[cfg(test)]
-            8 => (0, self.instruction.operands.imm as u8 as i128),
-            32 => (0, self.instruction.operands.imm as u32 as i128),
-            64 => (0, self.instruction.operands.imm as i128),
+            8 => (0, RightInputValue::Unsigned(self.instruction.operands.imm as u8 as u64)),
+            32 => (0, RightInputValue::Unsigned(self.instruction.operands.imm as u32 as u64)),
+            64 => (0, RightInputValue::Unsigned(self.instruction.operands.imm)),
             _ => panic!("{XLEN}-bit word size is unsupported"),
         }
     }
 
     fn to_lookup_operands(&self) -> (u64, u128) {
         let (x, y) = LookupQuery::<XLEN>::to_instruction_inputs(self);
-        (0, x as u128 + y as u64 as u128)
+        (0, x as u128 + y.as_u64() as u128)
     }
 
     fn to_lookup_index(&self) -> u128 {

--- a/jolt-core/src/zkvm/instruction/virtual_sign_extend_word.rs
+++ b/jolt-core/src/zkvm/instruction/virtual_sign_extend_word.rs
@@ -2,7 +2,7 @@ use tracer::instruction::{virtual_sign_extend_word::VirtualSignExtendWord, RISCV
 
 use crate::zkvm::lookup_table::{sign_extend_half_word::SignExtendHalfWordTable, LookupTables};
 
-use super::{CircuitFlags, InstructionFlags, InstructionLookup, LookupQuery, NUM_CIRCUIT_FLAGS};
+use super::{CircuitFlags, InstructionFlags, InstructionLookup, LookupQuery, RightInputValue, NUM_CIRCUIT_FLAGS};
 
 impl<const XLEN: usize> InstructionLookup<XLEN> for VirtualSignExtendWord {
     fn lookup_table(&self) -> Option<LookupTables<XLEN>> {
@@ -28,11 +28,11 @@ impl InstructionFlags for VirtualSignExtendWord {
 impl<const XLEN: usize> LookupQuery<XLEN> for RISCVCycle<VirtualSignExtendWord> {
     fn to_lookup_operands(&self) -> (u64, u128) {
         let (x, y) = LookupQuery::<XLEN>::to_instruction_inputs(self);
-        (0, x as u128 + y as u64 as u128)
+        (0, x as u128 + y.as_u64() as u128)
     }
 
-    fn to_instruction_inputs(&self) -> (u64, i128) {
-        (self.register_state.rs1, 0)
+    fn to_instruction_inputs(&self) -> (u64, RightInputValue) {
+        (self.register_state.rs1, RightInputValue::Unsigned(0))
     }
 
     fn to_lookup_index(&self) -> u128 {

--- a/jolt-core/src/zkvm/instruction/virtual_sra.rs
+++ b/jolt-core/src/zkvm/instruction/virtual_sra.rs
@@ -2,7 +2,7 @@ use tracer::instruction::{virtual_sra::VirtualSRA, RISCVCycle};
 
 use crate::zkvm::lookup_table::{virtual_sra::VirtualSRATable, LookupTables};
 
-use super::{CircuitFlags, InstructionFlags, InstructionLookup, LookupQuery, NUM_CIRCUIT_FLAGS};
+use super::{CircuitFlags, InstructionFlags, InstructionLookup, LookupQuery, RightInputValue, NUM_CIRCUIT_FLAGS};
 
 impl<const XLEN: usize> InstructionLookup<XLEN> for VirtualSRA {
     fn lookup_table(&self) -> Option<LookupTables<XLEN>> {
@@ -26,18 +26,18 @@ impl InstructionFlags for VirtualSRA {
 }
 
 impl<const XLEN: usize> LookupQuery<XLEN> for RISCVCycle<VirtualSRA> {
-    fn to_instruction_inputs(&self) -> (u64, i128) {
+    fn to_instruction_inputs(&self) -> (u64, RightInputValue) {
         match XLEN {
             #[cfg(test)]
             8 => (
                 self.register_state.rs1 as u8 as u64,
-                self.register_state.rs2 as u8 as i128,
+                RightInputValue::Unsigned(self.register_state.rs2 as u8 as u64),
             ),
             32 => (
                 self.register_state.rs1 as u32 as u64,
-                self.register_state.rs2 as u32 as i128,
+                RightInputValue::Unsigned(self.register_state.rs2 as u32 as u64),
             ),
-            64 => (self.register_state.rs1, self.register_state.rs2 as i128),
+            64 => (self.register_state.rs1, RightInputValue::Unsigned(self.register_state.rs2)),
             _ => panic!("{XLEN}-bit word size is unsupported"),
         }
     }
@@ -46,7 +46,7 @@ impl<const XLEN: usize> LookupQuery<XLEN> for RISCVCycle<VirtualSRA> {
         use crate::utils::lookup_bits::LookupBits;
         let (x, y) = LookupQuery::<XLEN>::to_instruction_inputs(self);
         let mut x = LookupBits::new(x as u128, XLEN);
-        let mut y = LookupBits::new(y as u64 as u128, XLEN);
+        let mut y = LookupBits::new(y.as_u64() as u128, XLEN);
 
         let sign_bit = if x.leading_ones() == 0 { 0 } else { 1 };
         let mut entry = 0;

--- a/jolt-core/src/zkvm/instruction/virtual_srli.rs
+++ b/jolt-core/src/zkvm/instruction/virtual_srli.rs
@@ -2,7 +2,7 @@ use tracer::instruction::{virtual_srli::VirtualSRLI, RISCVCycle};
 
 use crate::zkvm::lookup_table::{virtual_srl::VirtualSRLTable, LookupTables};
 
-use super::{CircuitFlags, InstructionFlags, InstructionLookup, LookupQuery, NUM_CIRCUIT_FLAGS};
+use super::{CircuitFlags, InstructionFlags, InstructionLookup, LookupQuery, RightInputValue, NUM_CIRCUIT_FLAGS};
 
 impl<const XLEN: usize> InstructionLookup<XLEN> for VirtualSRLI {
     fn lookup_table(&self) -> Option<LookupTables<XLEN>> {
@@ -26,20 +26,20 @@ impl InstructionFlags for VirtualSRLI {
 }
 
 impl<const XLEN: usize> LookupQuery<XLEN> for RISCVCycle<VirtualSRLI> {
-    fn to_instruction_inputs(&self) -> (u64, i128) {
+    fn to_instruction_inputs(&self) -> (u64, RightInputValue) {
         match XLEN {
             #[cfg(test)]
             8 => (
                 self.register_state.rs1 as u8 as u64,
-                self.instruction.operands.imm as u8 as i128,
+                RightInputValue::Unsigned(self.instruction.operands.imm as u8 as u64),
             ),
             32 => (
                 self.register_state.rs1 as u32 as u64,
-                self.instruction.operands.imm as u32 as i128,
+                RightInputValue::Unsigned(self.instruction.operands.imm as u32 as u64),
             ),
             64 => (
                 self.register_state.rs1,
-                self.instruction.operands.imm as i128,
+                RightInputValue::Unsigned(self.instruction.operands.imm),
             ),
             _ => panic!("{XLEN}-bit word size is unsupported"),
         }
@@ -49,7 +49,7 @@ impl<const XLEN: usize> LookupQuery<XLEN> for RISCVCycle<VirtualSRLI> {
         use crate::utils::lookup_bits::LookupBits;
         let (x, y) = LookupQuery::<XLEN>::to_instruction_inputs(self);
         let mut x = LookupBits::new(x as u128, XLEN);
-        let mut y = LookupBits::new(y as u128, XLEN);
+        let mut y = LookupBits::new(y.as_i128() as u128, XLEN);
 
         let mut entry = 0;
         for _ in 0..XLEN {

--- a/jolt-core/src/zkvm/instruction/virtual_zero_extend_word.rs
+++ b/jolt-core/src/zkvm/instruction/virtual_zero_extend_word.rs
@@ -2,7 +2,7 @@ use tracer::instruction::{virtual_zero_extend_word::VirtualZeroExtendWord, RISCV
 
 use crate::zkvm::lookup_table::{lower_half_word::LowerHalfWordTable, LookupTables};
 
-use super::{CircuitFlags, InstructionFlags, InstructionLookup, LookupQuery, NUM_CIRCUIT_FLAGS};
+use super::{CircuitFlags, InstructionFlags, InstructionLookup, LookupQuery, RightInputValue, NUM_CIRCUIT_FLAGS};
 
 impl<const XLEN: usize> InstructionLookup<XLEN> for VirtualZeroExtendWord {
     fn lookup_table(&self) -> Option<LookupTables<XLEN>> {
@@ -28,11 +28,11 @@ impl InstructionFlags for VirtualZeroExtendWord {
 impl<const XLEN: usize> LookupQuery<XLEN> for RISCVCycle<VirtualZeroExtendWord> {
     fn to_lookup_operands(&self) -> (u64, u128) {
         let (x, y) = LookupQuery::<XLEN>::to_instruction_inputs(self);
-        (0, u128::try_from(x as i128 + y).unwrap())
+        (0, u128::try_from(x as i128 + y.as_i128()).unwrap())
     }
 
-    fn to_instruction_inputs(&self) -> (u64, i128) {
-        (self.register_state.rs1, 0)
+    fn to_instruction_inputs(&self) -> (u64, RightInputValue) {
+        (self.register_state.rs1, RightInputValue::Unsigned(0))
     }
 
     fn to_lookup_index(&self) -> u128 {

--- a/jolt-core/src/zkvm/instruction/xor.rs
+++ b/jolt-core/src/zkvm/instruction/xor.rs
@@ -2,7 +2,7 @@ use tracer::instruction::{xor::XOR, RISCVCycle};
 
 use crate::zkvm::lookup_table::{xor::XorTable, LookupTables};
 
-use super::{CircuitFlags, InstructionFlags, InstructionLookup, LookupQuery, NUM_CIRCUIT_FLAGS};
+use super::{CircuitFlags, InstructionFlags, InstructionLookup, LookupQuery, RightInputValue, NUM_CIRCUIT_FLAGS};
 
 impl<const XLEN: usize> InstructionLookup<XLEN> for XOR {
     fn lookup_table(&self) -> Option<LookupTables<XLEN>> {
@@ -26,18 +26,21 @@ impl InstructionFlags for XOR {
 }
 
 impl<const XLEN: usize> LookupQuery<XLEN> for RISCVCycle<XOR> {
-    fn to_instruction_inputs(&self) -> (u64, i128) {
+    fn to_instruction_inputs(&self) -> (u64, RightInputValue) {
         match XLEN {
             #[cfg(test)]
             8 => (
                 self.register_state.rs1 as u8 as u64,
-                self.register_state.rs2 as u8 as i128,
+                RightInputValue::Unsigned(self.register_state.rs2 as u8 as u64),
             ),
             32 => (
                 self.register_state.rs1 as u32 as u64,
-                self.register_state.rs2 as u32 as i128,
+                RightInputValue::Unsigned(self.register_state.rs2 as u32 as u64),
             ),
-            64 => (self.register_state.rs1, self.register_state.rs2 as i128),
+            64 => (
+                self.register_state.rs1,
+                RightInputValue::Unsigned(self.register_state.rs2),
+            ),
             _ => panic!("{XLEN}-bit word size is unsupported"),
         }
     }
@@ -46,9 +49,9 @@ impl<const XLEN: usize> LookupQuery<XLEN> for RISCVCycle<XOR> {
         let (x, y) = LookupQuery::<XLEN>::to_instruction_inputs(self);
         match XLEN {
             #[cfg(test)]
-            8 => (x as u8 ^ y as u8).into(),
-            32 => (x as u32 ^ y as u32).into(),
-            64 => x ^ y as u64,
+            8 => (x as u8 ^ y.as_u8()).into(),
+            32 => (x as u32 ^ y.as_u32()).into(),
+            64 => x ^ y.as_u64(),
             _ => panic!("{XLEN}-bit word size is unsupported"),
         }
     }

--- a/jolt-core/src/zkvm/instruction/xori.rs
+++ b/jolt-core/src/zkvm/instruction/xori.rs
@@ -2,7 +2,7 @@ use tracer::instruction::{xori::XORI, RISCVCycle};
 
 use crate::zkvm::lookup_table::{xor::XorTable, LookupTables};
 
-use super::{CircuitFlags, InstructionFlags, InstructionLookup, LookupQuery, NUM_CIRCUIT_FLAGS};
+use super::{CircuitFlags, InstructionFlags, InstructionLookup, LookupQuery, RightInputValue, NUM_CIRCUIT_FLAGS};
 
 impl<const XLEN: usize> InstructionLookup<XLEN> for XORI {
     fn lookup_table(&self) -> Option<LookupTables<XLEN>> {
@@ -26,20 +26,20 @@ impl InstructionFlags for XORI {
 }
 
 impl<const XLEN: usize> LookupQuery<XLEN> for RISCVCycle<XORI> {
-    fn to_instruction_inputs(&self) -> (u64, i128) {
+    fn to_instruction_inputs(&self) -> (u64, RightInputValue) {
         match XLEN {
             #[cfg(test)]
             8 => (
                 self.register_state.rs1 as u8 as u64,
-                self.instruction.operands.imm as u8 as i128,
+                RightInputValue::Unsigned(self.instruction.operands.imm as u8 as u64),
             ),
             32 => (
                 self.register_state.rs1 as u32 as u64,
-                self.instruction.operands.imm as u32 as i128,
+                RightInputValue::Unsigned(self.instruction.operands.imm as u32 as u64),
             ),
             64 => (
                 self.register_state.rs1,
-                self.instruction.operands.imm as i128,
+                RightInputValue::Unsigned(self.instruction.operands.imm as u64),
             ),
             _ => panic!("{XLEN}-bit word size is unsupported"),
         }
@@ -49,9 +49,9 @@ impl<const XLEN: usize> LookupQuery<XLEN> for RISCVCycle<XORI> {
         let (x, y) = LookupQuery::<XLEN>::to_instruction_inputs(self);
         match XLEN {
             #[cfg(test)]
-            8 => (x as u8 ^ y as u8).into(),
-            32 => (x as u32 ^ y as u32).into(),
-            64 => x ^ y as u64,
+            8 => (x as u8 ^ y.as_u8()).into(),
+            32 => (x as u32 ^ y.as_u32()).into(),
+            64 => x ^ y.as_u64(),
             _ => panic!("{XLEN}-bit word size is unsupported"),
         }
     }

--- a/jolt-inlines/bigint/src/multiplication/exec.rs
+++ b/jolt-inlines/bigint/src/multiplication/exec.rs
@@ -29,7 +29,7 @@ pub fn bigint_mul(lhs: [u64; INPUT_LIMBS], rhs: [u64; INPUT_LIMBS]) -> [u64; OUT
                 let (sum_with_hi, carry_hi) = result[result_position + 1].overflowing_add(high);
                 let (sum_with_carry, carry_carry) = sum_with_hi.overflowing_add(carry);
                 result[result_position + 1] = sum_with_carry;
-                carry = (carry_hi as u64) + (carry_carry as u64);
+                carry = (carry_hi as u64) + (carry_carry.as_u64());
 
                 // Continue propagating carry if needed
                 let mut carry_position = result_position + 2;


### PR DESCRIPTION
This PR tightens the semantics of right instruction input and product.

Before:
- `RightInstructionInput` is a `i128`, but it really is either an `u64` or `i64`
- `Product` is always the product of `LeftInstructionInput` with `RightInstructionInput`. Because the left one is always u64 and the right one is either u64 or i64, the result of product fits in neither u128 or i128 always. This meant previously one had to cast this up to field, instead of preserving its small-value semantics.

The fix:
- Define a new enum `RightInputValue` that is either `u64` or `i64`. This matches the semantics of `RightInstructionInput`. We switch `to_instruction_inputs()` to return a `RightInputValue` instead of a `i128`, and change all instructions accordingly.
- Define a new enum `ProductValue` that is either `u128` or `i128`. Propagate that change throughout
- Extend `CompactPolynomial` to take in these enums