### PR TITLE
feat: Add custom getrandom backend for RISC-V bare-metal targets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1817,6 +1817,7 @@ dependencies = [
  "ark-ec",
  "common",
  "getrandom 0.2.16",
+ "getrandom 0.3.3",
  "hex-literal",
  "jolt-core",
  "jolt-platform",

--- a/jolt-core/src/host/program.rs
+++ b/jolt-core/src/host/program.rs
@@ -90,6 +90,8 @@ impl Program {
                 "strip=symbols",
                 "-C",
                 "opt-level=z",
+                "--cfg",
+                "getrandom_backend=\"custom\"",
             ];
 
             let target_triple = if self.std {

--- a/jolt-sdk/Cargo.toml
+++ b/jolt-sdk/Cargo.toml
@@ -46,7 +46,8 @@ jolt-sdk-macros = { path = "./macros" }
 common = { path = "../common", optional = true }
 jolt-core = { path = "../jolt-core", default-features = false, optional = true }
 tracer = { path = "../tracer", optional = true }
-getrandom = { version = "0.2.16", features = ["custom"], optional = true }
+getrandom_v02 = { version = "0.2.16", default-features = false, features = ["custom"], package = "getrandom" }
+getrandom_v03 = { version = "0.3.3" , default-features = false, package = "getrandom" }
 rand = { version = "0.8.5", optional = true }
 
 [dev-dependencies]

--- a/jolt-sdk/src/getrandom.rs
+++ b/jolt-sdk/src/getrandom.rs
@@ -1,0 +1,32 @@
+mod syscalls {
+    static mut SEED: u64 = 0x123456789ABCDEF0;
+    #[no_mangle]
+    pub unsafe fn sys_rand(dest: *mut u8, len: usize) {
+        for i in 0..len {
+            SEED = SEED.wrapping_mul(1103515245).wrapping_add(12345);
+            *dest.add(i) = (SEED >> 24) as u8;
+        }
+    }
+}
+
+pub fn _getrandom_v02(s: &mut [u8]) -> Result<(), getrandom_v02::Error> {
+    unsafe {
+        syscalls::sys_rand(s.as_mut_ptr(), s.len());
+    }
+
+    Ok(())
+}
+
+getrandom_v02::register_custom_getrandom!(_getrandom_v02);
+
+#[no_mangle]
+unsafe extern "Rust" fn __getrandom_v03_custom(
+    dest: *mut u8,
+    len: usize,
+) -> Result<(), getrandom_v03::Error> {
+    unsafe {
+        syscalls::sys_rand(dest, len);
+    }
+
+    Ok(())
+}

--- a/jolt-sdk/src/lib.rs
+++ b/jolt-sdk/src/lib.rs
@@ -7,6 +7,9 @@ pub mod host_utils;
 #[cfg(any(feature = "host", feature = "guest-verifier"))]
 pub use host_utils::*;
 
+#[cfg(not(feature = "host"))]
+mod getrandom;
+
 pub use jolt_platform::*;
 pub use jolt_sdk_macros::provable;
 pub use postcard;


### PR DESCRIPTION
This PR introduces a custom implementation of the `getrandom` backend tailored for RISC-V bare-metal environments, where standard OS-level randomness sources (e.g. `/dev/urandom`, system calls) are unavailable.

#### Why this is needed:
- The `getrandom` crate expects platform-specific entropy sources, which do not exist in bare-metal targets.
- Without a custom backend, any crate relying on `getrandom` (e.g. `rand`, `secp256k1`, cryptographic protocols) will fail to compile or panic at runtime.
- RISC-V guest environments require deterministic or syscall-based entropy generation.

#### What this PR adds:
- A simple linear congruential generator (LCG) seeded with a fixed value, exposed via a `sys_rand` syscall.
- Implementations for both `getrandom_v02` and `getrandom_v03` interfaces.
- Integration via `getrandom_v02::register_custom_getrandom!` and a `#[no_mangle]` hook for v0.3.

This enables cryptographic crates to function correctly in guest-mode RISC-V environments, while maintaining compatibility with the `getrandom` ecosystem.
