### PR TITLE
Harden RNG: replace static mut with OnceLock<Mutex> and fix no_mangle signature

### DIFF
--- a/jolt-platform/src/random.rs
+++ b/jolt-platform/src/random.rs
@@ -2,10 +2,11 @@ use crate::jolt_println;
 use getrandom::Error;
 use rand::{rngs::StdRng, RngCore, SeedableRng};
 use std::slice;
+use std::sync::{Mutex, OnceLock};
 
 // JOLT in ASCII padded with 1s
 const SEED: u64 = 0x11114A4F4C541111;
-static mut RNG: Option<StdRng> = None;
+static RNG: OnceLock<Mutex<StdRng>> = OnceLock::new();
 
 // Warning: This is a deterministic PRNG implementation. We could allow the prover/verifier to agree on a seed in the future.
 // No atomics support so we're using a static mutable variable
@@ -13,27 +14,15 @@ static mut RNG: Option<StdRng> = None;
 #[no_mangle]
 pub unsafe fn sys_rand(dest: *mut u8, len: usize) {
     jolt_println!("Warning: sys_rand is a deterministic PRNG, not a cryptographically secure RNG. Use with caution.");
-
-    let rng_ptr: *mut Option<StdRng> = &raw mut RNG;
-
-    unsafe {
-        if (*rng_ptr).is_none() {
-            *rng_ptr = Some(StdRng::seed_from_u64(SEED));
-        }
-
-        let dest = slice::from_raw_parts_mut(dest, len);
-
-        // SAFETY: Direct field access, no shared reference created
-        match RNG {
-            Some(ref mut rng) => rng.fill_bytes(dest),
-            None => unreachable!(), // just in case
-        }
-    }
+    let dest = slice::from_raw_parts_mut(dest, len);
+    let rng_mutex = RNG.get_or_init(|| Mutex::new(StdRng::seed_from_u64(SEED)));
+    // lock poisoning here is unlikely; if it happens, propagate panic rather than UB
+    rng_mutex.lock().expect("RNG mutex poisoned").fill_bytes(dest);
 }
 
 #[allow(clippy::missing_safety_doc)]
-#[unsafe(no_mangle)]
-pub unsafe extern "Rust" fn __getrandom_custom(dest: *mut u8, len: usize) -> Result<(), Error> {
+#[no_mangle]
+pub unsafe extern "C" fn __getrandom_custom(dest: *mut u8, len: usize) -> Result<(), Error> {
     sys_rand(dest, len);
 
     Ok(())


### PR DESCRIPTION


### Description
- Replaced unsafe global `static mut RNG` with thread-safe `OnceLock<Mutex<StdRng>>`.
- Updated `sys_rand` to lock and fill bytes safely.
- Fixed export: `__getrandom_custom` now uses `#[no_mangle]` and `extern "C"`.

Why:
- Prevent data races and UB under parallel calls (rayon present).
- Correct ABI and attribute usage for the custom getrandom hook.

Impact:
- Same deterministic behavior; now thread-safe and predictable under concurrency.
- Minimal risk; mutex lock only around RNG access.

