### PR TITLE
feat: backtrace support for tracer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,7 +8,23 @@ version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
 dependencies = [
- "gimli",
+ "gimli 0.31.1",
+]
+
+[[package]]
+name = "addr2line"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
+dependencies = [
+ "cpp_demangle",
+ "fallible-iterator",
+ "gimli 0.32.3",
+ "memmap2",
+ "object 0.37.3",
+ "rustc-demangle",
+ "smallvec",
+ "typed-arena",
 ]
 
 [[package]]
@@ -304,11 +320,11 @@ version = "0.3.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6806a6321ec58106fea15becdad98371e28d92ccbc7c8f1b3b6dd724fe8f1002"
 dependencies = [
- "addr2line",
+ "addr2line 0.24.2",
  "cfg-if",
  "libc",
  "miniz_oxide",
- "object",
+ "object 0.36.7",
  "rustc-demangle",
  "windows-targets 0.52.6",
 ]
@@ -652,6 +668,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "cpp_demangle"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96e58d342ad113c2b878f16d5d034c03be492ae460cdbc02b7f0f2284d310c7d"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -985,6 +1010,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1016,6 +1047,16 @@ name = "fixedbitset"
 version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
+
+[[package]]
+name = "flate2"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a3d7db9596fecd151c5f638c0ee5d5bd487b6e0ea232e5dc96d5250f6f94b1d"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "fnv"
@@ -1172,6 +1213,16 @@ name = "gimli"
 version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
+
+[[package]]
+name = "gimli"
+version = "0.32.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
+dependencies = [
+ "fallible-iterator",
+ "stable_deref_trait",
+]
 
 [[package]]
 name = "glob"
@@ -1956,6 +2007,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
 
 [[package]]
+name = "memmap2"
+version = "0.9.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "483758ad303d734cec05e5c12b41d7e93e6a6390c5e9dae6bdeb7c1259012d28"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "memory-ops"
 version = "0.1.0"
 dependencies = [
@@ -2200,6 +2260,17 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap",
  "memchr",
+]
+
+[[package]]
+name = "object"
+version = "0.37.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
+dependencies = [
+ "flate2",
+ "memchr",
+ "ruzstd",
 ]
 
 [[package]]
@@ -2823,6 +2894,15 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "ruzstd"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640bec8aad418d7d03c72ea2de10d5c646a598f9883c7babc160d91e3c1b26c"
+dependencies = [
+ "twox-hash",
+]
 
 [[package]]
 name = "ryu"
@@ -3489,6 +3569,7 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 name = "tracer"
 version = "0.2.0"
 dependencies = [
+ "addr2line 0.25.1",
  "ark-serialize",
  "clap",
  "common",
@@ -3497,7 +3578,7 @@ dependencies = [
  "itertools 0.10.5",
  "jolt-platform",
  "lazy_static",
- "object",
+ "object 0.36.7",
  "paste",
  "postcard",
  "rand 0.8.5",
@@ -3586,6 +3667,18 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "twox-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
+
+[[package]]
+name = "typed-arena"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6af6ae20167a9ece4bcb41af5b80f8a1f1df981f6391189ce00fd257af04126a"
 
 [[package]]
 name = "typenum"

--- a/README.md
+++ b/README.md
@@ -111,6 +111,23 @@ Where, as above, `--name` can be `sha2`, `sha3`, `sha2-chain`, `fibonacci`, or `
 
 The above command will log memory usage info to the command line and output multiple SVG files, e.g. `stage3_start_flamechart.svg`, which can be viewed in a web browser of your choosing.
 
+### Debugging
+
+Tracer, Jolt's emulator, doesn't currently support attaching a debugger. 
+
+However, it supports backtraces for panics that happen in guest programs. 
+By default, DWARF symbols are stripped from the guest elf and backtraces won't have much information. 
+
+To enable symbolized backtraces, set the `JOLT_BACKTRACE` environment variable to `1` or `full`:
+```
+JOLT_BACKTRACE=1 cargo run --release -p example
+```
+When `JOLT_BACKTRACE=full` is set, the backtraces include cycle counts and non-zero values of registers at each frame.
+
+To further assist in debugging, Jolt also supports prints via `jolt_print!` and `jolt_println!` macros, which can be used in guest programs.
+
+When debugging issues with guest programs, it's recommended to use the corresponding `trace_analyze` for your `#[jolt::provable]` functions. This skips instantiating the prover and allows for faster iteration.
+
 ## CI Benchmarking
 
 We have enabled [benchmarking during CI](https://a16z.github.io/jolt/dev/bench/) to track performance changes over time in terms of prover runtime and peak memory usage.

--- a/common/src/jolt_device.rs
+++ b/common/src/jolt_device.rs
@@ -65,7 +65,6 @@ impl JoltDevice {
 
     pub fn store(&mut self, address: u64, value: u8) {
         if address == self.memory_layout.panic {
-            println!("GUEST PANIC");
             self.panic = true;
             return;
         } else if self.is_panic(address) || self.is_termination(address) {

--- a/jolt-core/src/zkvm/mod.rs
+++ b/jolt-core/src/zkvm/mod.rs
@@ -209,7 +209,7 @@ where
         };
 
         let (mut trace, final_memory_state, mut program_io) =
-            guest::program::trace(elf_contents, inputs, &memory_config);
+            guest::program::trace(elf_contents, None, inputs, &memory_config);
         let num_riscv_cycles: usize = trace
             .par_iter()
             .map(|cycle| {

--- a/tracer/Cargo.toml
+++ b/tracer/Cargo.toml
@@ -55,6 +55,7 @@ clap = { version = "4.4", features = ["derive"] }
 common = { path = "../common", default-features = false }
 postcard = { version = "1.0.8", default-features = false }
 lazy_static = "1.4"
+addr2line = "0.25.1"
 
 [dev-dependencies]
 rand = { version = "0.8.5" }

--- a/tracer/src/emulator/mod.rs
+++ b/tracer/src/emulator/mod.rs
@@ -33,6 +33,7 @@ use self::terminal::Terminal;
 
 use common::constants::{EMULATOR_MEMORY_CAPACITY, RAM_START_ADDRESS};
 use std::io::Write;
+use std::path::Path;
 
 /// RISC-V emulator. It emulates RISC-V CPU and peripheral devices.
 ///
@@ -49,6 +50,9 @@ use std::io::Write;
 /// ```
 #[derive(Clone)]
 pub struct Emulator {
+    /// addr2line instance for symbol lookups
+    pub elf_path: Option<std::path::PathBuf>,
+
     cpu: Cpu,
 
     /// Stores mapping from symbol to virtual address
@@ -92,6 +96,7 @@ impl Emulator {
             cpu: Cpu::new(terminal),
 
             symbol_map: FnvHashMap::default(),
+            elf_path: None,
 
             // These can be updated in setup_program()
             is_test: false,
@@ -151,6 +156,13 @@ impl Emulator {
     /// Runs CPU one cycle
     pub fn tick(&mut self, trace: Option<&mut Vec<Cycle>>) {
         self.cpu.tick(trace)
+    }
+
+    /// This enables usage of addr2line to find debug info embedded in the binary
+    pub fn set_elf_path(&mut self, elf_path: &Path) {
+        if elf_path.exists() {
+            self.elf_path = Some(elf_path.to_path_buf());
+        }
     }
 
     /// Sets up program run by the program. This method analyzes the passed content

--- a/tracer/src/instruction/format/mod.rs
+++ b/tracer/src/instruction/format/mod.rs
@@ -14,7 +14,7 @@ pub mod format_u;
 pub mod format_virtual_right_shift_i;
 pub mod format_virtual_right_shift_r;
 
-#[derive(Default)]
+#[derive(Default, Debug, Clone, Copy, PartialEq)]
 pub struct NormalizedOperands {
     pub rs1: u8,
     pub rs2: u8,

--- a/tracer/src/instruction/jalr.rs
+++ b/tracer/src/instruction/jalr.rs
@@ -1,8 +1,8 @@
 use serde::{Deserialize, Serialize};
 
-use crate::{declare_riscv_instr, emulator::cpu::Cpu};
-
 use super::{format::format_i::FormatI, RISCVInstruction, RISCVTrace};
+use crate::instruction::format::NormalizedOperands;
+use crate::{declare_riscv_instr, emulator::cpu::Cpu};
 
 declare_riscv_instr!(
     name   = JALR,
@@ -19,6 +19,10 @@ impl JALR {
             .wrapping_add(self.operands.imm as i32 as u64))
             & !1;
         if self.operands.rd != 0 {
+            // Skip returns (rd=0) and non-standard link registers
+            if self.operands.rd == 1 {
+                cpu.track_call(self.address, NormalizedOperands::from(self.operands));
+            }
             cpu.x[self.operands.rd as usize] = tmp;
         }
     }

--- a/tracer/src/utils/mod.rs
+++ b/tracer/src/utils/mod.rs
@@ -3,5 +3,6 @@ pub mod inline_sequence_writer;
 #[cfg(any(feature = "test-utils", test))]
 pub mod inline_test_harness;
 pub mod instruction_macros;
+pub(crate) mod panic;
 pub mod trace_writer;
 pub mod virtual_registers;

--- a/tracer/src/utils/panic.rs
+++ b/tracer/src/utils/panic.rs
@@ -1,0 +1,215 @@
+use crate::emulator::cpu::get_register_name;
+use crate::emulator::EmulatorState;
+use crate::instruction::format::NormalizedOperands;
+use common::constants::{REGISTER_COUNT, RISCV_REGISTER_COUNT};
+
+/// Represents a single function call for stack trace
+#[derive(Clone, Copy, Debug)]
+pub struct CallFrame {
+    pub call_site: u64,
+    /// register snapshot
+    pub x: [i64; REGISTER_COUNT as usize],
+    pub operands: NormalizedOperands,
+    /// cycle count at the time of call
+    pub cycle_count: usize,
+}
+
+#[derive(Debug)]
+pub struct ResolvedFrame {
+    pub function_name: String,
+    pub location: Option<SourceLocation>,
+    pub inlined_frames: Vec<(String, Option<SourceLocation>)>,
+}
+
+#[derive(Debug, Clone)]
+pub struct SourceLocation {
+    pub file: String,
+    pub line: Option<u32>,
+    pub column: Option<u32>,
+}
+
+impl SourceLocation {
+    pub fn fmt_short(&self) -> String {
+        match (self.line, self.column) {
+            (Some(line), Some(col)) => format!("{}:{}:{}", self.file, line, col),
+            (Some(line), None) => format!("{}:{}", self.file, line),
+            _ => self.file.clone(),
+        }
+    }
+}
+
+pub fn resolve_frame(loader: &addr2line::Loader, frame: &CallFrame) -> Option<ResolvedFrame> {
+    let addr = frame.call_site;
+
+    if let Ok(mut frames) = loader.find_frames(addr) {
+        let mut primary_frame = None;
+        let mut inlined = vec![];
+
+        while let Ok(Some(frame)) = frames.next() {
+            let name = frame
+                .function
+                .and_then(|f| f.demangle().ok().map(|s| s.to_string()))
+                .unwrap_or_else(|| "<unknown>".to_string());
+
+            let location = frame.location.map(|loc| SourceLocation {
+                file: shorten_path(loc.file.unwrap_or("??")),
+                line: loc.line,
+                column: loc.column,
+            });
+
+            if primary_frame.is_none() {
+                primary_frame = Some((name, location));
+            } else {
+                inlined.push((name, location));
+            }
+        }
+
+        if let Some((name, location)) = primary_frame {
+            return Some(ResolvedFrame {
+                function_name: name,
+                location,
+                inlined_frames: inlined,
+            });
+        }
+    }
+
+    // Fallback to just symbol name
+    if let Some(sym_name) = loader.find_symbol(addr) {
+        let demangled = addr2line::demangle_auto(std::borrow::Cow::Borrowed(sym_name), None);
+        return Some(ResolvedFrame {
+            function_name: demangled.to_string(),
+            location: None,
+            inlined_frames: vec![],
+        });
+    }
+
+    None
+}
+
+fn shorten_path(path: &str) -> String {
+    const MAX_LENGTH: usize = 50; // Adjust as needed
+
+    if path.len() <= MAX_LENGTH {
+        return path.to_string();
+    }
+
+    let components: Vec<&str> = path.split('/').collect();
+
+    let filename = components.last().unwrap_or(&"");
+
+    let mut result_components = vec![*filename];
+    let mut total_len = filename.len();
+
+    for component in components.iter().rev().skip(1) {
+        let new_len = total_len + component.len() + 1; // +1 for '/'
+        if new_len > MAX_LENGTH - 4 {
+            // -4 for ".../""
+            break;
+        }
+        result_components.insert(0, *component);
+        total_len = new_len;
+    }
+
+    // Add ellipsis if we truncated
+    if result_components.len() < components.len() {
+        format!(".../{}", result_components.join("/"))
+    } else {
+        result_components.join("/")
+    }
+}
+
+pub fn display_panic_backtrace(emulator_state: &EmulatorState) {
+    let cpu = emulator_state.get_cpu();
+    let call_stack = cpu.get_call_stack();
+
+    if call_stack.is_empty() || emulator_state.elf_path.is_none() {
+        println!("  <no backtrace available>");
+        return;
+    }
+
+    let loader = match emulator_state
+        .elf_path
+        .as_ref()
+        .and_then(|path| addr2line::Loader::new(path).ok())
+    {
+        Some(loader) => loader,
+        None => {
+            println!("  <failed to load symbols>");
+            return;
+        }
+    };
+
+    // Get panic location from most recent frame
+    let panic_info = if !call_stack.is_empty() && emulator_state.elf_path.is_some() {
+        if let Ok(loader) = addr2line::Loader::new(emulator_state.elf_path.as_ref().unwrap()) {
+            let last_frame = call_stack.back().unwrap();
+            resolve_frame(&loader, last_frame)
+                .map(|resolved| (resolved.function_name, resolved.location))
+        } else {
+            None
+        }
+    } else {
+        None
+    };
+
+    if let Some((func, Some(loc))) = panic_info {
+        println!(
+            "Guest Program panicked in \"{}\" at \"{}\"",
+            func,
+            loc.fmt_short()
+        );
+    }
+
+    println!("stack backtrace:");
+
+    let full_backtrace = std::env::var("JOLT_BACKTRACE")
+        .map(|v| v.eq_ignore_ascii_case("full"))
+        .unwrap_or(false);
+
+    for (frame_num, frame) in call_stack.iter().rev().enumerate() {
+        print!("{:4}: {:#08x} - ", frame_num, frame.call_site);
+
+        if let Some(resolved) = resolve_frame(&loader, frame) {
+            print_resolved_frame(&resolved);
+        } else {
+            println!("<unknown>");
+        }
+
+        if full_backtrace {
+            print_extended_frame_info(frame);
+        }
+    }
+}
+
+fn print_resolved_frame(resolved: &ResolvedFrame) {
+    print!("{}", resolved.function_name);
+    if let Some(loc) = &resolved.location {
+        println!();
+        println!("                               at {}", loc.fmt_short());
+    } else {
+        println!();
+    }
+
+    for (name, location) in &resolved.inlined_frames {
+        println!("                   {name}");
+        if let Some(loc) = location {
+            println!("                               at {}", loc.fmt_short());
+        }
+    }
+}
+
+fn print_extended_frame_info(frame: &CallFrame) {
+    let mut regs = vec![];
+    for i in 0..RISCV_REGISTER_COUNT {
+        let i = i as usize;
+        if frame.x[i] != 0 || i == 2 {
+            // Always show sp
+            regs.push(format!("{}={:#x}", get_register_name(i), frame.x[i]));
+        }
+    }
+    if !regs.is_empty() {
+        println!("                   registers: {}", regs.join(", "));
+    }
+    println!("                   cycle: {}", frame.cycle_count);
+    println!();
+}


### PR DESCRIPTION
Backtraces with JOLT_BACKTRACE=1/true/full

`JOLT_BACKTRACE=1`:
```
Guest Program panicked in "fibonacci_guest::example_crash" at ".../Work/jolt/examples/fibonacci/guest/src/lib.rs:32:5"
stack backtrace:
   0: 0x8000003a - fibonacci_guest::example_crash
                               at .../Work/jolt/examples/fibonacci/guest/src/lib.rs:32:5
                   fibonacci_guest::call_crash
                               at .../Work/jolt/examples/fibonacci/guest/src/lib.rs:28:5
   1: 0x800000d6 - fibonacci_guest::main::{{closure}}
                               at .../Work/jolt/examples/fibonacci/guest/src/lib.rs:19:13
                   main
                               at .../Work/jolt/examples/fibonacci/guest/src/lib.rs:4:1
   2: 0x8000000c - <unknown>

```

`JOLT_BACKTRACE=full`:
```
Guest Program panicked in "fibonacci_guest::example_crash" at ".../Work/jolt/examples/fibonacci/guest/src/lib.rs:32:5"
stack backtrace:
   0: 0x8000003a - fibonacci_guest::example_crash
                               at .../Work/jolt/examples/fibonacci/guest/src/lib.rs:32:5
                   fibonacci_guest::call_crash
                               at .../Work/jolt/examples/fibonacci/guest/src/lib.rs:28:5
                   registers: ra=0x80000036, sp=0x800013a8, t1=0x6, a0=0x8, a3=0xa, a5=0x5, a6=0x5
                   cycle: 126

   1: 0x800000d6 - fibonacci_guest::main::{{closure}}
                               at .../Work/jolt/examples/fibonacci/guest/src/lib.rs:19:13
                   main
                               at .../Work/jolt/examples/fibonacci/guest/src/lib.rs:4:1
                   registers: ra=0x800000d2, sp=0x800013a8, t1=0x6, a0=0x8, a3=0xa, a5=0x5, a6=0x5
                   cycle: 124

   2: 0x8000000c - <unknown>
                   registers: ra=0x80000008, sp=0x800013c8
                   cycle: 3
```