### PR TITLE
[JOLT-208] docs: add comprehensive inline_sequence documentation for RISC-V inst…

### DIFF
--- a/tracer/src/instruction/addiw.rs
+++ b/tracer/src/instruction/addiw.rs
@@ -25,11 +25,6 @@ declare_riscv_instr!(
 
 impl ADDIW {
     fn exec(&self, cpu: &mut Cpu, _: &mut <ADDIW as RISCVInstruction>::RAMAccess) {
-        // ADDIW is an RV64I instruction that adds the sign-extended 12-bit immediate to register
-        // rs1 and produces the proper sign extension of a 32-bit result in rd. Overflows are
-        // ignored and the result is the low 32 bits of the result sign-extended to 64 bits. Note,
-        // ADDIW rd, rs1, 0 writes the sign extension of the lower 32 bits of register rs1 into
-        // register rd (assembler pseudoinstruction SEXT.W).
         cpu.x[self.operands.rd as usize] = cpu.x[self.operands.rs1 as usize]
             .wrapping_add(normalize_imm(self.operands.imm, &cpu.xlen))
             as i32 as i64;
@@ -41,12 +36,10 @@ impl RISCVTrace for ADDIW {
         let inline_sequence = self.inline_sequence(&cpu.vr_allocator, cpu.xlen);
         let mut trace = trace;
         for instr in inline_sequence {
-            // In each iteration, create a new Option containing a re-borrowed reference
             instr.trace(cpu, trace.as_deref_mut());
         }
     }
 
-    /// 32-bit add immediate with sign extension on 64-bit systems.
     fn inline_sequence(
         &self,
         allocator: &VirtualRegisterAllocator,

--- a/tracer/src/instruction/addiw.rs
+++ b/tracer/src/instruction/addiw.rs
@@ -46,6 +46,7 @@ impl RISCVTrace for ADDIW {
         }
     }
 
+    /// 32-bit add immediate with sign extension on 64-bit systems.
     fn inline_sequence(
         &self,
         allocator: &VirtualRegisterAllocator,

--- a/tracer/src/instruction/addw.rs
+++ b/tracer/src/instruction/addw.rs
@@ -42,6 +42,8 @@ impl RISCVTrace for ADDW {
         }
     }
 
+    /// Generates inline sequence for 32-bit addition on 64-bit systems.
+    /// Performs 64-bit addition then sign-extends the lower 32 bits.
     fn inline_sequence(
         &self,
         allocator: &VirtualRegisterAllocator,

--- a/tracer/src/instruction/addw.rs
+++ b/tracer/src/instruction/addw.rs
@@ -22,10 +22,6 @@ declare_riscv_instr!(
 
 impl ADDW {
     fn exec(&self, cpu: &mut Cpu, _: &mut <ADDW as RISCVInstruction>::RAMAccess) {
-        // ADDW and SUBW are RV64I-only instructions that are defined analogously to ADD and SUB
-        // but operate on 32-bit values and produce signed 32-bit results. Overflows are ignored,
-        // and the low 32-bits of the result is sign-extended to 64-bits and written to the
-        // destination register.
         cpu.x[self.operands.rd as usize] = cpu.x[self.operands.rs1 as usize]
             .wrapping_add(cpu.x[self.operands.rs2 as usize])
             as i32 as i64;
@@ -37,13 +33,10 @@ impl RISCVTrace for ADDW {
         let inline_sequence = self.inline_sequence(&cpu.vr_allocator, cpu.xlen);
         let mut trace = trace;
         for instr in inline_sequence {
-            // In each iteration, create a new Option containing a re-borrowed reference
             instr.trace(cpu, trace.as_deref_mut());
         }
     }
 
-    /// Generates inline sequence for 32-bit addition on 64-bit systems.
-    /// Performs 64-bit addition then sign-extends the lower 32 bits.
     fn inline_sequence(
         &self,
         allocator: &VirtualRegisterAllocator,

--- a/tracer/src/instruction/amoaddd.rs
+++ b/tracer/src/instruction/amoaddd.rs
@@ -51,46 +51,24 @@ impl RISCVTrace for AMOADDD {
         let inline_sequence = self.inline_sequence(&cpu.vr_allocator, cpu.xlen);
         let mut trace = trace;
         for instr in inline_sequence {
-            // In each iteration, create a new Option containing a re-borrowed reference
             instr.trace(cpu, trace.as_deref_mut());
         }
     }
 
-    /// Generates inline sequence for atomic memory operation add (64-bit).
-    ///
-    /// AMOADD.D atomically loads a 64-bit value from memory, adds rs2 to it,
-    /// stores the result back to memory, and returns the original value in rd.
-    ///
-    /// The implementation sequence:
-    /// 1. Load the current value from memory address in rs1
-    /// 2. Add rs2 to the loaded value
-    /// 3. Store the result back to the same memory address
-    /// 4. Move the original value to rd
-    ///
-    /// Note: In zkVM, atomicity is guaranteed by the execution model rather than
-    /// hardware synchronization, as there's only one execution thread.
+    /// AMOADD.D atomically adds rs2 to a memory location and returns the original value.
     fn inline_sequence(
         &self,
         allocator: &VirtualRegisterAllocator,
         xlen: Xlen,
     ) -> Vec<Instruction> {
-        let v_rs2 = allocator.allocate(); // holds the sum result
-        let v_rd = allocator.allocate(); // holds the original memory value
+        let v_rs2 = allocator.allocate();
+        let v_rd = allocator.allocate();
 
         let mut asm = InstrAssembler::new(self.address, self.is_compressed, xlen, allocator);
-
-        // Step 1: Load the current 64-bit value from memory
         asm.emit_ld::<LD>(*v_rd, self.operands.rs1, 0);
-
-        // Step 2: Add rs2 to the loaded value
         asm.emit_r::<ADD>(*v_rs2, *v_rd, self.operands.rs2);
-
-        // Step 3: Store the sum back to memory
         asm.emit_s::<SD>(self.operands.rs1, *v_rs2, 0);
-
-        // Step 4: Move original value to destination register
         asm.emit_i::<VirtualMove>(self.operands.rd, *v_rd, 0);
-
         asm.finalize()
     }
 }

--- a/tracer/src/instruction/amoaddw.rs
+++ b/tracer/src/instruction/amoaddw.rs
@@ -53,6 +53,25 @@ impl RISCVTrace for AMOADDW {
         }
     }
 
+    /// Generates inline sequence for atomic memory add operation (32-bit).
+    ///
+    /// AMOADD.W atomically loads a 32-bit word from memory, adds the lower 32 bits
+    /// of rs2 to it, stores the result back to memory, and returns the original
+    /// value sign-extended in rd.
+    ///
+    /// The implementation differs between RV32 and RV64:
+    /// - On RV32: Direct word operations with amo_pre32/post32 helpers
+    /// - On RV64: Complex handling for 32-bit operations in 64-bit system
+    ///
+    /// For RV64, the sequence must:
+    /// 1. Align address to 64-bit boundaries
+    /// 2. Extract the 32-bit word from the aligned 64-bit load
+    /// 3. Perform 32-bit addition with proper overflow wrapping
+    /// 4. Merge the result back into the 64-bit word for storage
+    /// 5. Sign-extend the original 32-bit value to 64 bits for rd
+    ///
+    /// The amo_pre/post helpers handle the memory alignment complexity,
+    /// ensuring atomic semantics even though zkVM execution is single-threaded.
     fn inline_sequence(
         &self,
         allocator: &VirtualRegisterAllocator,

--- a/tracer/src/instruction/amoaddw.rs
+++ b/tracer/src/instruction/amoaddw.rs
@@ -48,7 +48,6 @@ impl RISCVTrace for AMOADDW {
         let inline_sequence = self.inline_sequence(&cpu.vr_allocator, cpu.xlen);
         let mut trace = trace;
         for instr in inline_sequence {
-            // In each iteration, create a new Option containing a re-borrowed reference
             instr.trace(cpu, trace.as_deref_mut());
         }
     }

--- a/tracer/src/instruction/amoandd.rs
+++ b/tracer/src/instruction/amoandd.rs
@@ -54,19 +54,41 @@ impl RISCVTrace for AMOANDD {
         }
     }
 
+    /// Generates inline sequence for atomic memory operation AND (64-bit).
+    ///
+    /// AMOAND.D atomically loads a 64-bit value from memory, performs bitwise AND
+    /// with rs2, stores the result back to memory, and returns the original value in rd.
+    ///
+    /// The implementation sequence:
+    /// 1. Load the current value from memory address in rs1
+    /// 2. Perform bitwise AND with rs2
+    /// 3. Store the result back to the same memory address
+    /// 4. Move the original value to rd
+    ///
+    /// This is useful for atomically clearing bits in shared memory locations.
+    /// In zkVM, atomicity is guaranteed by the single-threaded execution model.
     fn inline_sequence(
         &self,
         allocator: &VirtualRegisterAllocator,
         xlen: Xlen,
     ) -> Vec<Instruction> {
-        let v_rs2 = allocator.allocate();
-        let v_rd = allocator.allocate();
+        let v_rs2 = allocator.allocate(); // holds the AND result
+        let v_rd = allocator.allocate(); // holds the original memory value
 
         let mut asm = InstrAssembler::new(self.address, self.is_compressed, xlen, allocator);
+
+        // Step 1: Load the current 64-bit value from memory
         asm.emit_ld::<LD>(*v_rd, self.operands.rs1, 0);
+
+        // Step 2: Perform bitwise AND with rs2
         asm.emit_r::<AND>(*v_rs2, *v_rd, self.operands.rs2);
+
+        // Step 3: Store the AND result back to memory
         asm.emit_s::<SD>(self.operands.rs1, *v_rs2, 0);
+
+        // Step 4: Move original value to destination register
         asm.emit_i::<VirtualMove>(self.operands.rd, *v_rd, 0);
+
         asm.finalize()
     }
 }

--- a/tracer/src/instruction/amoandd.rs
+++ b/tracer/src/instruction/amoandd.rs
@@ -53,7 +53,22 @@ impl RISCVTrace for AMOANDD {
         }
     }
 
-    /// AMOAND.D atomically ANDs a memory location with rs2.
+    /// AMOAND.D atomically performs bitwise AND on a 64-bit memory location with rs2.
+    ///
+    /// This atomic memory operation (AMO) instruction atomically loads a doubleword from
+    /// the memory address in rs1, performs a bitwise AND with the value in rs2, stores
+    /// the result back to memory, and returns the original memory value in rd.
+    ///
+    /// In the zkVM context:
+    /// - Atomicity is guaranteed by the single-threaded execution model
+    /// - No explicit memory barriers needed since no concurrent access
+    /// - Direct 64-bit operations on naturally aligned addresses
+    ///
+    /// Implementation sequence:
+    /// 1. Load original value from memory[rs1]
+    /// 2. Compute new_value = original & rs2
+    /// 3. Store new_value back to memory[rs1]
+    /// 4. Return original value in rd
     fn inline_sequence(
         &self,
         allocator: &VirtualRegisterAllocator,

--- a/tracer/src/instruction/amoandw.rs
+++ b/tracer/src/instruction/amoandw.rs
@@ -48,58 +48,35 @@ impl RISCVTrace for AMOANDW {
         let inline_sequence = self.inline_sequence(&cpu.vr_allocator, cpu.xlen);
         let mut trace = trace;
         for instr in inline_sequence {
-            // In each iteration, create a new Option containing a re-borrowed reference
             instr.trace(cpu, trace.as_deref_mut());
         }
     }
 
-    /// Generates inline sequence for atomic memory operation AND (32-bit).
-    ///
-    /// AMOAND.W atomically loads a 32-bit word from memory, performs bitwise AND
-    /// with the lower 32 bits of rs2, stores the result back to memory, and
-    /// returns the original value sign-extended in rd.
-    ///
-    /// The implementation differs between 32-bit and 64-bit systems:
-    /// - On RV32: Direct word operations using amo_pre32/post32 helpers
-    /// - On RV64: More complex due to potential misalignment within 64-bit words
-    ///
-    /// For RV64, the sequence handles:
-    /// 1. Address alignment to 64-bit boundaries
-    /// 2. Extracting the 32-bit word from the aligned 64-bit load
-    /// 3. Performing the AND operation on the 32-bit value
-    /// 4. Merging the result back into the 64-bit word for storage
-    ///
-    /// The amo_pre/post helpers encapsulate the complexity of:
-    /// - Memory alignment and word extraction
-    /// - Sign extension of the result
-    /// - Proper masking and shifting for sub-word operations
+    /// AMOAND.W atomically ANDs a 32-bit word in memory with rs2.
+    /// On RV64, uses amo_pre64/post64 helpers to handle 32-bit operations within 64-bit memory.
     fn inline_sequence(
         &self,
         allocator: &VirtualRegisterAllocator,
         xlen: Xlen,
     ) -> Vec<Instruction> {
-        let v_rd = allocator.allocate(); // holds original 32-bit value
-        let v_rs2 = allocator.allocate(); // holds AND result
+        let v_rd = allocator.allocate();
+        let v_rs2 = allocator.allocate();
 
         let mut asm = InstrAssembler::new(self.address, self.is_compressed, xlen, allocator);
 
         match xlen {
             Xlen::Bit32 => {
-                // Simple case: direct 32-bit word operations
-                amo_pre32(&mut asm, self.operands.rs1, *v_rd); // Load word from memory
-                asm.emit_r::<AND>(*v_rs2, *v_rd, self.operands.rs2); // AND with rs2
+                amo_pre32(&mut asm, self.operands.rs1, *v_rd);
+                asm.emit_r::<AND>(*v_rs2, *v_rd, self.operands.rs2);
                 amo_post32(&mut asm, *v_rs2, self.operands.rs1, self.operands.rd, *v_rd);
-                // Store and return
             }
             Xlen::Bit64 => {
-                // Complex case: handle 32-bit operations within 64-bit system
-                let v_mask = allocator.allocate(); // mask for word extraction
-                let v_dword_address = allocator.allocate(); // aligned 64-bit address
-                let v_dword = allocator.allocate(); // 64-bit loaded value
-                let v_word = allocator.allocate(); // extracted 32-bit word
-                let v_shift = allocator.allocate(); // shift amount for alignment
+                let v_mask = allocator.allocate();
+                let v_dword_address = allocator.allocate();
+                let v_dword = allocator.allocate();
+                let v_word = allocator.allocate();
+                let v_shift = allocator.allocate();
 
-                // Pre-operation: load and extract 32-bit word from 64-bit memory
                 amo_pre64(
                     &mut asm,
                     self.operands.rs1,
@@ -108,11 +85,7 @@ impl RISCVTrace for AMOANDW {
                     *v_dword,
                     *v_shift,
                 );
-
-                // Perform AND on the 32-bit value
                 asm.emit_r::<AND>(*v_rs2, *v_rd, self.operands.rs2);
-
-                // Post-operation: merge result back and store to memory
                 amo_post64(
                     &mut asm,
                     *v_rs2,

--- a/tracer/src/instruction/amomaxd.rs
+++ b/tracer/src/instruction/amomaxd.rs
@@ -57,7 +57,6 @@ impl RISCVTrace for AMOMAXD {
         let inline_sequence = self.inline_sequence(&cpu.vr_allocator, cpu.xlen);
         let mut trace = trace;
         for instr in inline_sequence {
-            // In each iteration, create a new Option containing a re-borrowed reference
             instr.trace(cpu, trace.as_deref_mut());
         }
     }

--- a/tracer/src/instruction/amomaxud.rs
+++ b/tracer/src/instruction/amomaxud.rs
@@ -57,7 +57,6 @@ impl RISCVTrace for AMOMAXUD {
         let inline_sequence = self.inline_sequence(&cpu.vr_allocator, cpu.xlen);
         let mut trace = trace;
         for instr in inline_sequence {
-            // In each iteration, create a new Option containing a re-borrowed reference
             instr.trace(cpu, trace.as_deref_mut());
         }
     }

--- a/tracer/src/instruction/amomaxud.rs
+++ b/tracer/src/instruction/amomaxud.rs
@@ -62,6 +62,19 @@ impl RISCVTrace for AMOMAXUD {
         }
     }
 
+    /// Generates inline sequence for atomic maximum operation (unsigned 64-bit).
+    ///
+    /// AMOMAXU.D atomically loads a 64-bit value from memory, computes the maximum
+    /// of that value and rs2 (treating both as unsigned), stores the maximum back
+    /// to memory, and returns the original value in rd.
+    ///
+    /// Uses the same branchless approach as AMOMAX.D but with unsigned comparison:
+    /// 1. Load current value from memory
+    /// 2. Use SLTU for unsigned comparison (current < rs2)
+    /// 3. Compute selector bits and use multiplication to select maximum
+    /// 4. Store result and return original value
+    ///
+    /// The branchless multiplication technique ensures zkVM compatibility.
     fn inline_sequence(
         &self,
         allocator: &VirtualRegisterAllocator,

--- a/tracer/src/instruction/amomaxuw.rs
+++ b/tracer/src/instruction/amomaxuw.rs
@@ -62,6 +62,23 @@ impl RISCVTrace for AMOMAXUW {
         }
     }
 
+    /// Generates inline sequence for atomic maximum operation (unsigned 32-bit).
+    ///
+    /// AMOMAXU.W atomically loads a 32-bit word from memory, computes the maximum
+    /// of that value and the lower 32 bits of rs2 (treating both as unsigned),
+    /// stores the maximum back to memory, and returns the original value
+    /// sign-extended in rd.
+    ///
+    /// The implementation uses a branchless maximum selection:
+    /// 1. Load and prepare operands with proper zero-extension for comparison
+    /// 2. Use SLTU to compare unsigned values
+    /// 3. Use multiplication with selector bits to choose maximum
+    /// 4. Store result and return original value sign-extended
+    ///
+    /// On RV64, additional complexity arises from:
+    /// - Need to zero-extend both operands for correct unsigned comparison
+    /// - Use amo_pre64/post64 helpers for word alignment within doublewords
+    /// - Proper sign extension of the original value for rd
     fn inline_sequence(
         &self,
         allocator: &VirtualRegisterAllocator,

--- a/tracer/src/instruction/amomaxuw.rs
+++ b/tracer/src/instruction/amomaxuw.rs
@@ -57,7 +57,6 @@ impl RISCVTrace for AMOMAXUW {
         let inline_sequence = self.inline_sequence(&cpu.vr_allocator, cpu.xlen);
         let mut trace = trace;
         for instr in inline_sequence {
-            // In each iteration, create a new Option containing a re-borrowed reference
             instr.trace(cpu, trace.as_deref_mut());
         }
     }

--- a/tracer/src/instruction/amomaxw.rs
+++ b/tracer/src/instruction/amomaxw.rs
@@ -62,6 +62,21 @@ impl RISCVTrace for AMOMAXW {
         }
     }
 
+    /// Generates inline sequence for atomic maximum operation (signed 32-bit).
+    ///
+    /// AMOMAX.W atomically loads a 32-bit word from memory, computes the maximum
+    /// of that value and the lower 32 bits of rs2 (treating both as signed),
+    /// stores the maximum back to memory, and returns the original value
+    /// sign-extended in rd.
+    ///
+    /// Uses branchless maximum computation with signed comparison:
+    /// 1. Load word and prepare operands with sign extension
+    /// 2. Use SLT for signed comparison to generate selector bits
+    /// 3. Multiply each value by its selector bit and add for branchless max
+    /// 4. Store result and return original value sign-extended
+    ///
+    /// On RV64, requires sign-extending both operands to 64 bits before
+    /// comparison to ensure correct signed comparison semantics.
     fn inline_sequence(
         &self,
         allocator: &VirtualRegisterAllocator,

--- a/tracer/src/instruction/amomaxw.rs
+++ b/tracer/src/instruction/amomaxw.rs
@@ -57,7 +57,6 @@ impl RISCVTrace for AMOMAXW {
         let inline_sequence = self.inline_sequence(&cpu.vr_allocator, cpu.xlen);
         let mut trace = trace;
         for instr in inline_sequence {
-            // In each iteration, create a new Option containing a re-borrowed reference
             instr.trace(cpu, trace.as_deref_mut());
         }
     }

--- a/tracer/src/instruction/amomind.rs
+++ b/tracer/src/instruction/amomind.rs
@@ -62,6 +62,21 @@ impl RISCVTrace for AMOMIND {
         }
     }
 
+    /// Generates inline sequence for atomic minimum operation (signed 64-bit).
+    ///
+    /// AMOMIN.D atomically loads a 64-bit value from memory, computes the minimum
+    /// of that value and rs2 (treating both as signed), stores the minimum back
+    /// to memory, and returns the original value in rd.
+    ///
+    /// Uses branchless minimum computation:
+    /// 1. Load current value from memory
+    /// 2. Compare rs2 < current to get selector bit (1 if rs2 is smaller)
+    /// 3. Invert to get selector for current (1 if current is smaller/equal)
+    /// 4. Multiply and add to select minimum without branches
+    /// 5. Store result and return original value
+    ///
+    /// Note the comparison order: SLT(rs2, current) not SLT(current, rs2),
+    /// ensuring correct minimum selection semantics.
     fn inline_sequence(
         &self,
         allocator: &VirtualRegisterAllocator,

--- a/tracer/src/instruction/amomind.rs
+++ b/tracer/src/instruction/amomind.rs
@@ -57,7 +57,6 @@ impl RISCVTrace for AMOMIND {
         let inline_sequence = self.inline_sequence(&cpu.vr_allocator, cpu.xlen);
         let mut trace = trace;
         for instr in inline_sequence {
-            // In each iteration, create a new Option containing a re-borrowed reference
             instr.trace(cpu, trace.as_deref_mut());
         }
     }

--- a/tracer/src/instruction/amominud.rs
+++ b/tracer/src/instruction/amominud.rs
@@ -62,6 +62,15 @@ impl RISCVTrace for AMOMINUD {
         }
     }
 
+    /// Generates inline sequence for atomic minimum operation (unsigned 64-bit).
+    ///
+    /// AMOMINU.D atomically loads a 64-bit value from memory, computes the minimum
+    /// of that value and rs2 (treating both as unsigned), stores the minimum back
+    /// to memory, and returns the original value in rd.
+    ///
+    /// Uses same branchless approach as AMOMIN.D but with unsigned comparison:
+    /// - SLTU instead of SLT for unsigned comparison
+    /// - Otherwise identical multiplication-based selection logic
     fn inline_sequence(
         &self,
         allocator: &VirtualRegisterAllocator,

--- a/tracer/src/instruction/amominud.rs
+++ b/tracer/src/instruction/amominud.rs
@@ -57,7 +57,6 @@ impl RISCVTrace for AMOMINUD {
         let inline_sequence = self.inline_sequence(&cpu.vr_allocator, cpu.xlen);
         let mut trace = trace;
         for instr in inline_sequence {
-            // In each iteration, create a new Option containing a re-borrowed reference
             instr.trace(cpu, trace.as_deref_mut());
         }
     }

--- a/tracer/src/instruction/amominuw.rs
+++ b/tracer/src/instruction/amominuw.rs
@@ -57,7 +57,6 @@ impl RISCVTrace for AMOMINUW {
         let inline_sequence = self.inline_sequence(&cpu.vr_allocator, cpu.xlen);
         let mut trace = trace;
         for instr in inline_sequence {
-            // In each iteration, create a new Option containing a re-borrowed reference
             instr.trace(cpu, trace.as_deref_mut());
         }
     }

--- a/tracer/src/instruction/amominuw.rs
+++ b/tracer/src/instruction/amominuw.rs
@@ -62,6 +62,17 @@ impl RISCVTrace for AMOMINUW {
         }
     }
 
+    /// Generates inline sequence for atomic minimum operation (unsigned 32-bit).
+    ///
+    /// AMOMINU.W atomically loads a 32-bit word from memory, computes the minimum
+    /// of that value and the lower 32 bits of rs2 (treating both as unsigned),
+    /// stores the minimum back to memory, and returns the original value
+    /// sign-extended in rd.
+    ///
+    /// Uses branchless minimum selection with unsigned comparison:
+    /// - SLTU for unsigned comparison instead of SLT
+    /// - Zero-extension on RV64 for correct unsigned semantics
+    /// - Otherwise identical multiplication-based selection
     fn inline_sequence(
         &self,
         allocator: &VirtualRegisterAllocator,

--- a/tracer/src/instruction/amominw.rs
+++ b/tracer/src/instruction/amominw.rs
@@ -57,7 +57,6 @@ impl RISCVTrace for AMOMINW {
         let inline_sequence = self.inline_sequence(&cpu.vr_allocator, cpu.xlen);
         let mut trace = trace;
         for instr in inline_sequence {
-            // In each iteration, create a new Option containing a re-borrowed reference
             instr.trace(cpu, trace.as_deref_mut());
         }
     }

--- a/tracer/src/instruction/amominw.rs
+++ b/tracer/src/instruction/amominw.rs
@@ -62,6 +62,20 @@ impl RISCVTrace for AMOMINW {
         }
     }
 
+    /// Generates inline sequence for atomic minimum operation (signed 32-bit).
+    ///
+    /// AMOMIN.W atomically loads a 32-bit word from memory, computes the minimum
+    /// of that value and the lower 32 bits of rs2 (treating both as signed),
+    /// stores the minimum back to memory, and returns the original value
+    /// sign-extended in rd.
+    ///
+    /// Uses branchless minimum selection with signed comparison:
+    /// 1. Load word and prepare operands with sign extension (on RV64)
+    /// 2. Use SLT with rs2 < current to determine which is smaller
+    /// 3. Use multiplication to select minimum without branches
+    /// 4. Store result and return original value sign-extended
+    ///
+    /// On RV64, requires sign-extending both operands for correct comparison.
     fn inline_sequence(
         &self,
         allocator: &VirtualRegisterAllocator,

--- a/tracer/src/instruction/amoord.rs
+++ b/tracer/src/instruction/amoord.rs
@@ -54,6 +54,16 @@ impl RISCVTrace for AMOORD {
         }
     }
 
+    /// Generates inline sequence for atomic OR operation (64-bit).
+    ///
+    /// AMOOR.D atomically loads a 64-bit value from memory, performs bitwise OR
+    /// with rs2, stores the result back to memory, and returns the original value in rd.
+    ///
+    /// Simple load-modify-store sequence:
+    /// 1. Load current 64-bit value from memory
+    /// 2. OR with rs2
+    /// 3. Store result back to memory
+    /// 4. Return original value in rd
     fn inline_sequence(
         &self,
         allocator: &VirtualRegisterAllocator,

--- a/tracer/src/instruction/amoord.rs
+++ b/tracer/src/instruction/amoord.rs
@@ -53,16 +53,32 @@ impl RISCVTrace for AMOORD {
         }
     }
 
-    /// Generates inline sequence for atomic OR operation (64-bit).
+    /// AMOOR.D atomically performs bitwise OR on a 64-bit memory location with rs2.
     ///
-    /// AMOOR.D atomically loads a 64-bit value from memory, performs bitwise OR
-    /// with rs2, stores the result back to memory, and returns the original value in rd.
+    /// This atomic memory operation (AMO) instruction atomically loads a doubleword from
+    /// the memory address in rs1, performs a bitwise OR with the value in rs2, stores
+    /// the result back to memory, and returns the original memory value in rd.
     ///
-    /// Simple load-modify-store sequence:
-    /// 1. Load current 64-bit value from memory
-    /// 2. OR with rs2
-    /// 3. Store result back to memory
+    /// In the zkVM context:
+    /// - Atomicity is guaranteed by the single-threaded execution model
+    /// - No explicit memory barriers or locks needed
+    /// - Direct 64-bit operations on naturally aligned addresses
+    ///
+    /// The bitwise OR operation is commonly used for:
+    /// - Setting specific bits in shared flags or status words
+    /// - Non-destructive bit accumulation in concurrent algorithms
+    /// - Lock-free set operations on bitmasks
+    /// - Atomic enabling of features or permissions
+    ///
+    /// Implementation sequence:
+    /// 1. Load original value from memory[rs1]
+    /// 2. Compute new_value = original | rs2
+    /// 3. Store new_value back to memory[rs1]
     /// 4. Return original value in rd
+    ///
+    /// Memory ordering: Provides acquire-release semantics in multi-threaded contexts,
+    /// ensuring all prior memory operations are visible before the OR and all subsequent
+    /// operations see the OR's result, though this is implicit in zkVM's execution model.
     fn inline_sequence(
         &self,
         allocator: &VirtualRegisterAllocator,

--- a/tracer/src/instruction/amoord.rs
+++ b/tracer/src/instruction/amoord.rs
@@ -49,7 +49,6 @@ impl RISCVTrace for AMOORD {
         let inline_sequence = self.inline_sequence(&cpu.vr_allocator, cpu.xlen);
         let mut trace = trace;
         for instr in inline_sequence {
-            // In each iteration, create a new Option containing a re-borrowed reference
             instr.trace(cpu, trace.as_deref_mut());
         }
     }

--- a/tracer/src/instruction/amoorw.rs
+++ b/tracer/src/instruction/amoorw.rs
@@ -53,6 +53,13 @@ impl RISCVTrace for AMOORW {
         }
     }
 
+    /// Generates inline sequence for atomic OR operation (32-bit).
+    ///
+    /// AMOOR.W atomically loads a 32-bit word from memory, performs bitwise OR
+    /// with the lower 32 bits of rs2, stores the result back to memory, and
+    /// returns the original value sign-extended in rd.
+    ///
+    /// Uses amo_pre/post helpers to handle word alignment on both RV32 and RV64.
     fn inline_sequence(
         &self,
         allocator: &VirtualRegisterAllocator,

--- a/tracer/src/instruction/amoorw.rs
+++ b/tracer/src/instruction/amoorw.rs
@@ -48,7 +48,6 @@ impl RISCVTrace for AMOORW {
         let inline_sequence = self.inline_sequence(&cpu.vr_allocator, cpu.xlen);
         let mut trace = trace;
         for instr in inline_sequence {
-            // In each iteration, create a new Option containing a re-borrowed reference
             instr.trace(cpu, trace.as_deref_mut());
         }
     }

--- a/tracer/src/instruction/amoswapd.rs
+++ b/tracer/src/instruction/amoswapd.rs
@@ -49,7 +49,6 @@ impl RISCVTrace for AMOSWAPD {
         let inline_sequence = self.inline_sequence(&cpu.vr_allocator, cpu.xlen);
         let mut trace = trace;
         for instr in inline_sequence {
-            // In each iteration, create a new Option containing a re-borrowed reference
             instr.trace(cpu, trace.as_deref_mut());
         }
     }

--- a/tracer/src/instruction/amoswapd.rs
+++ b/tracer/src/instruction/amoswapd.rs
@@ -53,15 +53,32 @@ impl RISCVTrace for AMOSWAPD {
         }
     }
 
-    /// Generates inline sequence for atomic swap operation (64-bit).
+    /// AMOSWAP.D atomically swaps a 64-bit memory location with rs2.
     ///
-    /// AMOSWAP.D atomically loads a 64-bit value from memory, stores rs2 to that
-    /// location, and returns the original value in rd.
+    /// This atomic memory operation (AMO) instruction atomically loads a doubleword from
+    /// the memory address in rs1, stores the value from rs2 to that location, and returns
+    /// the original memory value in rd. This is an unconditional atomic exchange.
     ///
-    /// Simplest AMO operation - unconditional exchange:
-    /// 1. Load current value from memory
-    /// 2. Store rs2 to the same location
+    /// In the zkVM context:
+    /// - Atomicity is guaranteed by the single-threaded execution model
+    /// - No compare-and-swap semantics needed (unlike LR/SC sequences)
+    /// - Direct 64-bit operations on naturally aligned addresses
+    ///
+    /// AMOSWAP is commonly used for:
+    /// - Implementing mutex acquisition (swap in lock value, check old)
+    /// - Atomic pointer swapping in lock-free data structures
+    /// - Message passing between threads (though zkVM is single-threaded)
+    /// - Implementing semaphores and other synchronization primitives
+    /// - Atomic queue operations (head/tail pointer updates)
+    ///
+    /// Implementation sequence:
+    /// 1. Load original value from memory[rs1]
+    /// 2. Store rs2 value to memory[rs1]
     /// 3. Return original value in rd
+    ///
+    /// This is the simplest AMO operation as it requires no computation,
+    /// just an atomic exchange. The returned value can be examined to
+    /// determine the previous state (e.g., was a lock already held).
     fn inline_sequence(
         &self,
         allocator: &VirtualRegisterAllocator,

--- a/tracer/src/instruction/amoswapd.rs
+++ b/tracer/src/instruction/amoswapd.rs
@@ -54,6 +54,15 @@ impl RISCVTrace for AMOSWAPD {
         }
     }
 
+    /// Generates inline sequence for atomic swap operation (64-bit).
+    ///
+    /// AMOSWAP.D atomically loads a 64-bit value from memory, stores rs2 to that
+    /// location, and returns the original value in rd.
+    ///
+    /// Simplest AMO operation - unconditional exchange:
+    /// 1. Load current value from memory
+    /// 2. Store rs2 to the same location
+    /// 3. Return original value in rd
     fn inline_sequence(
         &self,
         allocator: &VirtualRegisterAllocator,

--- a/tracer/src/instruction/amoswapw.rs
+++ b/tracer/src/instruction/amoswapw.rs
@@ -45,7 +45,6 @@ impl RISCVTrace for AMOSWAPW {
         let inline_sequence = self.inline_sequence(&cpu.vr_allocator, cpu.xlen);
         let mut trace = trace;
         for instr in inline_sequence {
-            // In each iteration, create a new Option containing a re-borrowed reference
             instr.trace(cpu, trace.as_deref_mut());
         }
     }

--- a/tracer/src/instruction/amoswapw.rs
+++ b/tracer/src/instruction/amoswapw.rs
@@ -50,6 +50,16 @@ impl RISCVTrace for AMOSWAPW {
         }
     }
 
+    /// Generates inline sequence for atomic swap operation (32-bit).
+    ///
+    /// AMOSWAP.W atomically loads a 32-bit word from memory, stores the lower
+    /// 32 bits of rs2 to that location, and returns the original value
+    /// sign-extended in rd.
+    ///
+    /// Implementation differs between RV32 and RV64:
+    /// - RV32: Simple word-aligned load/store swap
+    /// - RV64: Complex manipulation to handle 32-bit word within 64-bit doubleword,
+    ///   including alignment, masking, and sign extension
     fn inline_sequence(
         &self,
         allocator: &VirtualRegisterAllocator,

--- a/tracer/src/instruction/amoxord.rs
+++ b/tracer/src/instruction/amoxord.rs
@@ -50,7 +50,6 @@ impl RISCVTrace for AMOXORD {
         let inline_sequence = self.inline_sequence(&cpu.vr_allocator, cpu.xlen);
         let mut trace = trace;
         for instr in inline_sequence {
-            // In each iteration, create a new Option containing a re-borrowed reference
             instr.trace(cpu, trace.as_deref_mut());
         }
     }

--- a/tracer/src/instruction/amoxord.rs
+++ b/tracer/src/instruction/amoxord.rs
@@ -55,6 +55,12 @@ impl RISCVTrace for AMOXORD {
         }
     }
 
+    /// Generates inline sequence for atomic XOR operation (64-bit).
+    ///
+    /// AMOXOR.D atomically loads a 64-bit value from memory, performs bitwise XOR
+    /// with rs2, stores the result back to memory, and returns the original value in rd.
+    ///
+    /// Useful for toggling bits atomically in shared memory locations.
     fn inline_sequence(
         &self,
         allocator: &VirtualRegisterAllocator,

--- a/tracer/src/instruction/amoxorw.rs
+++ b/tracer/src/instruction/amoxorw.rs
@@ -50,7 +50,6 @@ impl RISCVTrace for AMOXORW {
         let inline_sequence = self.inline_sequence(&cpu.vr_allocator, cpu.xlen);
         let mut trace = trace;
         for instr in inline_sequence {
-            // In each iteration, create a new Option containing a re-borrowed reference
             instr.trace(cpu, trace.as_deref_mut());
         }
     }

--- a/tracer/src/instruction/amoxorw.rs
+++ b/tracer/src/instruction/amoxorw.rs
@@ -55,6 +55,14 @@ impl RISCVTrace for AMOXORW {
         }
     }
 
+    /// Generates inline sequence for atomic XOR operation (32-bit).
+    ///
+    /// AMOXOR.W atomically loads a 32-bit word from memory, performs bitwise XOR
+    /// with the lower 32 bits of rs2, stores the result back to memory, and
+    /// returns the original value sign-extended in rd.
+    ///
+    /// Simple implementation using LW/SW directly since this appears to be RV32 only
+    /// (uses LW instead of amo_pre/post helpers).
     fn inline_sequence(
         &self,
         allocator: &VirtualRegisterAllocator,

--- a/tracer/src/instruction/div.rs
+++ b/tracer/src/instruction/div.rs
@@ -86,33 +86,21 @@ impl RISCVTrace for DIV {
 
         let mut trace = trace;
         for instr in inline_sequence {
-            // In each iteration, create a new Option containing a re-borrowed reference
             instr.trace(cpu, trace.as_deref_mut());
         }
     }
 
-    /// Generates an inline sequence to verify signed division operation.
-    ///
-    /// This function implements a verifiable signed division by decomposing it into simpler
-    /// operations that can be proven correct. The approach:
-    /// 1. Receives untrusted quotient and remainder advice from an oracle
-    /// 2. Verifies the mathematical relationship: dividend = quotient × divisor + remainder
-    /// 3. Ensures |remainder| < |divisor| (division property)
-    /// 4. Handles special cases per RISC-V spec (division by zero, overflow)
-    ///
-    /// The verification avoids directly computing division (which would be circular) and instead
-    /// proves the correctness of the provided quotient through multiplication and range checks.
     fn inline_sequence(
         &self,
         allocator: &VirtualRegisterAllocator,
         xlen: Xlen,
     ) -> Vec<Instruction> {
-        let a0 = self.operands.rs1; // dividend (input)
-        let a1 = self.operands.rs2; // divisor (input)
-        let a2 = allocator.allocate(); // quotient from oracle (untrusted)
-        let a3 = allocator.allocate(); // unsigned remainder from oracle (untrusted)
-        let t0 = allocator.allocate(); // adjusted divisor (handles special cases)
-        let t1 = allocator.allocate(); // temporary for high multiplication result
+        let a0 = self.operands.rs1;
+        let a1 = self.operands.rs2;
+        let a2 = allocator.allocate();
+        let a3 = allocator.allocate();
+        let t0 = allocator.allocate();
+        let t1 = allocator.allocate();
 
         let shmat = match xlen {
             Xlen::Bit32 => 31,
@@ -121,54 +109,27 @@ impl RISCVTrace for DIV {
 
         let mut asm = InstrAssembler::new(self.address, self.is_compressed, xlen, allocator);
 
-        // Step 1: Get untrusted advice values from oracle
-        // These will be verified for correctness below
-        asm.emit_j::<VirtualAdvice>(*a2, 0); // get quotient advice
-        asm.emit_j::<VirtualAdvice>(*a3, 0); // get |remainder| advice
+        asm.emit_j::<VirtualAdvice>(*a2, 0);
+        asm.emit_j::<VirtualAdvice>(*a3, 0);
+        asm.emit_b::<VirtualAssertValidDiv0>(a1, *a2, 0);
+        asm.emit_r::<VirtualChangeDivisor>(*t0, a0, a1);
+        asm.emit_r::<MULH>(*t1, *a2, *t0);
 
-        // Step 2: Handle special cases per RISC-V spec
-        // - Division by zero: returns -1 as quotient
-        // - Overflow (most_negative / -1): returns dividend as quotient
-        asm.emit_b::<VirtualAssertValidDiv0>(a1, *a2, 0); // validates quotient for div-by-zero case
-        asm.emit_r::<VirtualChangeDivisor>(*t0, a0, a1); // adjusts divisor for overflow case
-
-        // Step 3: Check for multiplication overflow
-        // For valid division, quotient × divisor must fit in register width
-        // MULH computes high bits of signed multiplication
-        asm.emit_r::<MULH>(*t1, *a2, *t0); // t1 = high_bits(quotient × adjusted_divisor)
-
-        // Allocate new registers after MULH completes (register pressure optimization)
         let t2 = allocator.allocate();
         let t3 = allocator.allocate();
 
-        // Compute low bits of multiplication
-        asm.emit_r::<MUL>(*t2, *a2, *t0); // t2 = quotient × adjusted_divisor (low bits)
-
-        // Sign-extend the low bits to compare with high bits
-        // If no overflow, high bits should match sign extension of low bits
-        asm.emit_i::<SRAI>(*t3, *t2, shmat); // t3 = sign_extend(t2)
-        asm.emit_b::<VirtualAssertEQ>(*t1, *t3, 0); // assert no overflow occurred
-
-        // Step 4: Construct signed remainder from unsigned advice
-        // The oracle provides |remainder|, we apply the dividend's sign per RISC-V spec
-        asm.emit_i::<SRAI>(*t1, a0, shmat); // t1 = sign_bit(dividend) extended
-        asm.emit_r::<XOR>(*t3, *a3, *t1); // t3 = |remainder| ^ sign_mask
-        asm.emit_r::<SUB>(*t3, *t3, *t1); // t3 = signed_remainder (two's complement if negative)
-
-        // Step 5: Verify fundamental division property
-        // dividend = quotient × divisor + remainder (all operations mod 2^n)
-        asm.emit_r::<ADD>(*t2, *t2, *t3); // t2 = (quotient × divisor) + signed_remainder
-        asm.emit_b::<VirtualAssertEQ>(*t2, a0, 0); // assert t2 == dividend
-
-        // Step 6: Verify remainder magnitude constraint
-        // |remainder| < |divisor| is required for valid division
-        // First compute |adjusted_divisor|
-        asm.emit_i::<SRAI>(*t1, *t0, shmat); // t1 = sign_bit(adjusted_divisor) extended
-        asm.emit_r::<XOR>(*t3, *t0, *t1); // t3 = adjusted_divisor ^ sign_mask
-        asm.emit_r::<SUB>(*t3, *t3, *t1); // t3 = |adjusted_divisor|
-        asm.emit_b::<VirtualAssertValidUnsignedRemainder>(*a3, *t3, 0); // assert |remainder| < |divisor|
-
-        // Step 7: Move verified quotient to destination register
+        asm.emit_r::<MUL>(*t2, *a2, *t0);
+        asm.emit_i::<SRAI>(*t3, *t2, shmat);
+        asm.emit_b::<VirtualAssertEQ>(*t1, *t3, 0);
+        asm.emit_i::<SRAI>(*t1, a0, shmat);
+        asm.emit_r::<XOR>(*t3, *a3, *t1);
+        asm.emit_r::<SUB>(*t3, *t3, *t1);
+        asm.emit_r::<ADD>(*t2, *t2, *t3);
+        asm.emit_b::<VirtualAssertEQ>(*t2, a0, 0);
+        asm.emit_i::<SRAI>(*t1, *t0, shmat);
+        asm.emit_r::<XOR>(*t3, *t0, *t1);
+        asm.emit_r::<SUB>(*t3, *t3, *t1);
+        asm.emit_b::<VirtualAssertValidUnsignedRemainder>(*a3, *t3, 0);
         asm.emit_i::<VirtualMove>(self.operands.rd, *a2, 0);
         asm.finalize()
     }

--- a/tracer/src/instruction/div.rs
+++ b/tracer/src/instruction/div.rs
@@ -91,17 +91,28 @@ impl RISCVTrace for DIV {
         }
     }
 
+    /// Generates an inline sequence to verify signed division operation.
+    ///
+    /// This function implements a verifiable signed division by decomposing it into simpler
+    /// operations that can be proven correct. The approach:
+    /// 1. Receives untrusted quotient and remainder advice from an oracle
+    /// 2. Verifies the mathematical relationship: dividend = quotient × divisor + remainder
+    /// 3. Ensures |remainder| < |divisor| (division property)
+    /// 4. Handles special cases per RISC-V spec (division by zero, overflow)
+    ///
+    /// The verification avoids directly computing division (which would be circular) and instead
+    /// proves the correctness of the provided quotient through multiplication and range checks.
     fn inline_sequence(
         &self,
         allocator: &VirtualRegisterAllocator,
         xlen: Xlen,
     ) -> Vec<Instruction> {
-        let a0 = self.operands.rs1;
-        let a1 = self.operands.rs2;
-        let a2 = allocator.allocate();
-        let a3 = allocator.allocate();
-        let t0 = allocator.allocate();
-        let t1 = allocator.allocate();
+        let a0 = self.operands.rs1; // dividend (input)
+        let a1 = self.operands.rs2; // divisor (input)
+        let a2 = allocator.allocate(); // quotient from oracle (untrusted)
+        let a3 = allocator.allocate(); // unsigned remainder from oracle (untrusted)
+        let t0 = allocator.allocate(); // adjusted divisor (handles special cases)
+        let t1 = allocator.allocate(); // temporary for high multiplication result
 
         let shmat = match xlen {
             Xlen::Bit32 => 31,
@@ -109,33 +120,55 @@ impl RISCVTrace for DIV {
         };
 
         let mut asm = InstrAssembler::new(self.address, self.is_compressed, xlen, allocator);
-        // get advice
-        asm.emit_j::<VirtualAdvice>(*a2, 0);
-        asm.emit_j::<VirtualAdvice>(*a3, 0);
-        // handle special cases
-        asm.emit_b::<VirtualAssertValidDiv0>(a1, *a2, 0);
-        asm.emit_r::<VirtualChangeDivisor>(*t0, a0, a1);
-        // check that quotient * divisor don't overflow
-        asm.emit_r::<MULH>(*t1, *a2, *t0);
-        // When MULH is done, its allocated virtual registers are freed, then we can allocate registers for the next instructions.
+
+        // Step 1: Get untrusted advice values from oracle
+        // These will be verified for correctness below
+        asm.emit_j::<VirtualAdvice>(*a2, 0); // get quotient advice
+        asm.emit_j::<VirtualAdvice>(*a3, 0); // get |remainder| advice
+
+        // Step 2: Handle special cases per RISC-V spec
+        // - Division by zero: returns -1 as quotient
+        // - Overflow (most_negative / -1): returns dividend as quotient
+        asm.emit_b::<VirtualAssertValidDiv0>(a1, *a2, 0); // validates quotient for div-by-zero case
+        asm.emit_r::<VirtualChangeDivisor>(*t0, a0, a1); // adjusts divisor for overflow case
+
+        // Step 3: Check for multiplication overflow
+        // For valid division, quotient × divisor must fit in register width
+        // MULH computes high bits of signed multiplication
+        asm.emit_r::<MULH>(*t1, *a2, *t0); // t1 = high_bits(quotient × adjusted_divisor)
+
+        // Allocate new registers after MULH completes (register pressure optimization)
         let t2 = allocator.allocate();
         let t3 = allocator.allocate();
-        asm.emit_r::<MUL>(*t2, *a2, *t0);
-        asm.emit_i::<SRAI>(*t3, *t2, shmat);
-        asm.emit_b::<VirtualAssertEQ>(*t1, *t3, 0);
-        // construct signed reminder (apply dividend's sign to reminder)
-        asm.emit_i::<SRAI>(*t1, a0, shmat);
-        asm.emit_r::<XOR>(*t3, *a3, *t1);
-        asm.emit_r::<SUB>(*t3, *t3, *t1);
-        // verify quotient * divisor + reminder == dividend
-        asm.emit_r::<ADD>(*t2, *t2, *t3);
-        asm.emit_b::<VirtualAssertEQ>(*t2, a0, 0);
-        // check |remainder| < |divisor|
-        asm.emit_i::<SRAI>(*t1, *t0, shmat);
-        asm.emit_r::<XOR>(*t3, *t0, *t1);
-        asm.emit_r::<SUB>(*t3, *t3, *t1);
-        asm.emit_b::<VirtualAssertValidUnsignedRemainder>(*a3, *t3, 0);
-        // move result
+
+        // Compute low bits of multiplication
+        asm.emit_r::<MUL>(*t2, *a2, *t0); // t2 = quotient × adjusted_divisor (low bits)
+
+        // Sign-extend the low bits to compare with high bits
+        // If no overflow, high bits should match sign extension of low bits
+        asm.emit_i::<SRAI>(*t3, *t2, shmat); // t3 = sign_extend(t2)
+        asm.emit_b::<VirtualAssertEQ>(*t1, *t3, 0); // assert no overflow occurred
+
+        // Step 4: Construct signed remainder from unsigned advice
+        // The oracle provides |remainder|, we apply the dividend's sign per RISC-V spec
+        asm.emit_i::<SRAI>(*t1, a0, shmat); // t1 = sign_bit(dividend) extended
+        asm.emit_r::<XOR>(*t3, *a3, *t1); // t3 = |remainder| ^ sign_mask
+        asm.emit_r::<SUB>(*t3, *t3, *t1); // t3 = signed_remainder (two's complement if negative)
+
+        // Step 5: Verify fundamental division property
+        // dividend = quotient × divisor + remainder (all operations mod 2^n)
+        asm.emit_r::<ADD>(*t2, *t2, *t3); // t2 = (quotient × divisor) + signed_remainder
+        asm.emit_b::<VirtualAssertEQ>(*t2, a0, 0); // assert t2 == dividend
+
+        // Step 6: Verify remainder magnitude constraint
+        // |remainder| < |divisor| is required for valid division
+        // First compute |adjusted_divisor|
+        asm.emit_i::<SRAI>(*t1, *t0, shmat); // t1 = sign_bit(adjusted_divisor) extended
+        asm.emit_r::<XOR>(*t3, *t0, *t1); // t3 = adjusted_divisor ^ sign_mask
+        asm.emit_r::<SUB>(*t3, *t3, *t1); // t3 = |adjusted_divisor|
+        asm.emit_b::<VirtualAssertValidUnsignedRemainder>(*a3, *t3, 0); // assert |remainder| < |divisor|
+
+        // Step 7: Move verified quotient to destination register
         asm.emit_i::<VirtualMove>(self.operands.rd, *a2, 0);
         asm.finalize()
     }

--- a/tracer/src/instruction/div.rs
+++ b/tracer/src/instruction/div.rs
@@ -90,17 +90,28 @@ impl RISCVTrace for DIV {
         }
     }
 
+    /// DIV performs signed division using untrusted oracle advice.
+    ///
+    /// The zkVM cannot directly compute division, so we receive the quotient and remainder
+    /// as advice from an untrusted oracle, then verify the correctness using constraints:
+    /// 1. dividend = quotient × divisor + remainder
+    /// 2. |remainder| < |divisor|
+    /// 3. sign(remainder) = sign(dividend) when remainder ≠ 0
+    ///
+    /// Special cases per RISC-V spec:
+    /// - Division by zero: returns -1
+    /// - Overflow (most_negative / -1): returns most_negative
     fn inline_sequence(
         &self,
         allocator: &VirtualRegisterAllocator,
         xlen: Xlen,
     ) -> Vec<Instruction> {
-        let a0 = self.operands.rs1;
-        let a1 = self.operands.rs2;
-        let a2 = allocator.allocate();
-        let a3 = allocator.allocate();
-        let t0 = allocator.allocate();
-        let t1 = allocator.allocate();
+        let a0 = self.operands.rs1; // dividend
+        let a1 = self.operands.rs2; // divisor
+        let a2 = allocator.allocate(); // quotient (from oracle)
+        let a3 = allocator.allocate(); // |remainder| (from oracle)
+        let t0 = allocator.allocate(); // adjusted divisor
+        let t1 = allocator.allocate(); // temporary
 
         let shmat = match xlen {
             Xlen::Bit32 => 31,
@@ -109,27 +120,40 @@ impl RISCVTrace for DIV {
 
         let mut asm = InstrAssembler::new(self.address, self.is_compressed, xlen, allocator);
 
-        asm.emit_j::<VirtualAdvice>(*a2, 0);
-        asm.emit_j::<VirtualAdvice>(*a3, 0);
-        asm.emit_b::<VirtualAssertValidDiv0>(a1, *a2, 0);
-        asm.emit_r::<VirtualChangeDivisor>(*t0, a0, a1);
-        asm.emit_r::<MULH>(*t1, *a2, *t0);
+        // Get untrusted advice from oracle
+        asm.emit_j::<VirtualAdvice>(*a2, 0); // quotient
+        asm.emit_j::<VirtualAdvice>(*a3, 0); // |remainder|
+
+        // Handle special cases: div-by-zero and overflow
+        asm.emit_b::<VirtualAssertValidDiv0>(a1, *a2, 0); // Check div-by-zero
+        asm.emit_r::<VirtualChangeDivisor>(*t0, a0, a1); // Adjust divisor for overflow case
+
+        // Verify no overflow: quotient × divisor must not overflow
+        asm.emit_r::<MULH>(*t1, *a2, *t0); // High bits of multiplication
 
         let t2 = allocator.allocate();
         let t3 = allocator.allocate();
 
-        asm.emit_r::<MUL>(*t2, *a2, *t0);
-        asm.emit_i::<SRAI>(*t3, *t2, shmat);
-        asm.emit_b::<VirtualAssertEQ>(*t1, *t3, 0);
-        asm.emit_i::<SRAI>(*t1, a0, shmat);
-        asm.emit_r::<XOR>(*t3, *a3, *t1);
-        asm.emit_r::<SUB>(*t3, *t3, *t1);
-        asm.emit_r::<ADD>(*t2, *t2, *t3);
-        asm.emit_b::<VirtualAssertEQ>(*t2, a0, 0);
-        asm.emit_i::<SRAI>(*t1, *t0, shmat);
-        asm.emit_r::<XOR>(*t3, *t0, *t1);
-        asm.emit_r::<SUB>(*t3, *t3, *t1);
+        asm.emit_r::<MUL>(*t2, *a2, *t0); // quotient × adjusted_divisor
+        asm.emit_i::<SRAI>(*t3, *t2, shmat); // Sign-extend low bits
+        asm.emit_b::<VirtualAssertEQ>(*t1, *t3, 0); // Assert no overflow
+
+        // Apply sign of dividend to remainder
+        asm.emit_i::<SRAI>(*t1, a0, shmat); // Sign bit of dividend
+        asm.emit_r::<XOR>(*t3, *a3, *t1); // XOR with |remainder|
+        asm.emit_r::<SUB>(*t3, *t3, *t1); // Two's complement if negative
+
+        // Verify: dividend = quotient × divisor + remainder
+        asm.emit_r::<ADD>(*t2, *t2, *t3); // Add signed remainder
+        asm.emit_b::<VirtualAssertEQ>(*t2, a0, 0); // Assert equals dividend
+
+        // Verify: |remainder| < |divisor|
+        asm.emit_i::<SRAI>(*t1, *t0, shmat); // Sign bit of adjusted divisor
+        asm.emit_r::<XOR>(*t3, *t0, *t1); // XOR to get magnitude
+        asm.emit_r::<SUB>(*t3, *t3, *t1); // |adjusted_divisor|
         asm.emit_b::<VirtualAssertValidUnsignedRemainder>(*a3, *t3, 0);
+
+        // Move quotient to destination register
         asm.emit_i::<VirtualMove>(self.operands.rd, *a2, 0);
         asm.finalize()
     }

--- a/tracer/src/instruction/divu.rs
+++ b/tracer/src/instruction/divu.rs
@@ -73,26 +73,49 @@ impl RISCVTrace for DIVU {
         }
     }
 
+    /// DIVU performs unsigned division using untrusted oracle advice.
+    ///
+    /// The zkVM cannot directly compute division, so we receive the quotient and remainder
+    /// as advice from an untrusted oracle, then verify the correctness using constraints:
+    /// 1. dividend = quotient × divisor + remainder
+    /// 2. remainder < divisor (unsigned comparison)
+    /// 3. quotient × divisor does not overflow
+    ///
+    /// Special case per RISC-V spec:
+    /// - Division by zero: returns all 1s (u32::MAX or u64::MAX)
     fn inline_sequence(
         &self,
         allocator: &VirtualRegisterAllocator,
         xlen: Xlen,
     ) -> Vec<Instruction> {
-        let a0 = self.operands.rs1;
-        let a1 = self.operands.rs2;
-        let a2 = allocator.allocate();
-        let a3 = allocator.allocate();
-        let t0 = allocator.allocate();
+        let a0 = self.operands.rs1; // dividend
+        let a1 = self.operands.rs2; // divisor
+        let a2 = allocator.allocate(); // quotient (from oracle)
+        let a3 = allocator.allocate(); // remainder (from oracle)
+        let t0 = allocator.allocate(); // temporary for multiplication
         let mut asm = InstrAssembler::new(self.address, self.is_compressed, xlen, allocator);
 
-        asm.emit_j::<VirtualAdvice>(*a2, 0);
-        asm.emit_j::<VirtualAdvice>(*a3, 0);
+        // Get untrusted advice from oracle
+        asm.emit_j::<VirtualAdvice>(*a2, 0); // quotient
+        asm.emit_j::<VirtualAdvice>(*a3, 0); // remainder
+
+        // Handle special case: division by zero
         asm.emit_b::<VirtualAssertValidDiv0>(a1, *a2, 0);
+
+        // Verify no overflow: quotient × divisor must not overflow
         asm.emit_b::<VirtualAssertMulUNoOverflow>(*a2, a1, 0);
+
+        // Compute quotient × divisor
         asm.emit_r::<MUL>(*t0, *a2, a1);
+
+        // Verify: dividend = quotient × divisor + remainder
         asm.emit_r::<ADD>(*t0, *t0, *a3);
         asm.emit_b::<VirtualAssertEQ>(*t0, a0, 0);
+
+        // Verify: remainder < divisor (unsigned)
         asm.emit_b::<VirtualAssertValidUnsignedRemainder>(*a3, a1, 0);
+
+        // Move quotient to destination register
         asm.emit_i::<VirtualMove>(self.operands.rd, *a2, 0);
         asm.finalize()
     }

--- a/tracer/src/instruction/divu.rs
+++ b/tracer/src/instruction/divu.rs
@@ -69,64 +69,30 @@ impl RISCVTrace for DIVU {
 
         let mut trace = trace;
         for instr in inline_sequence {
-            // In each iteration, create a new Option containing a re-borrowed reference
             instr.trace(cpu, trace.as_deref_mut());
         }
     }
 
-    /// Generates an inline sequence to verify unsigned division operation.
-    ///
-    /// This function implements a verifiable unsigned division by decomposing it into simpler
-    /// operations that can be proven correct. Unlike signed division, unsigned division is
-    /// simpler as it doesn't need to handle negative numbers or sign extensions.
-    ///
-    /// The approach:
-    /// 1. Receives untrusted quotient and remainder advice from an oracle
-    /// 2. Verifies quotient × divisor doesn't overflow (must fit in register width)
-    /// 3. Verifies the mathematical relationship: dividend = quotient × divisor + remainder
-    /// 4. Ensures remainder < divisor (division property for unsigned)
-    /// 5. Handles division by zero per RISC-V spec (returns all 1s)
-    ///
-    /// The verification ensures correctness without directly computing division.
     fn inline_sequence(
         &self,
         allocator: &VirtualRegisterAllocator,
         xlen: Xlen,
     ) -> Vec<Instruction> {
-        let a0 = self.operands.rs1; // dividend (unsigned input)
-        let a1 = self.operands.rs2; // divisor (unsigned input)
-        let a2 = allocator.allocate(); // quotient from oracle (untrusted)
-        let a3 = allocator.allocate(); // remainder from oracle (untrusted)
-        let t0 = allocator.allocate(); // temporary for multiplication result
+        let a0 = self.operands.rs1;
+        let a1 = self.operands.rs2;
+        let a2 = allocator.allocate();
+        let a3 = allocator.allocate();
+        let t0 = allocator.allocate();
         let mut asm = InstrAssembler::new(self.address, self.is_compressed, xlen, allocator);
 
-        // Step 1: Get untrusted advice values from oracle
-        // Both quotient and remainder are unsigned values
-        asm.emit_j::<VirtualAdvice>(*a2, 0); // get quotient advice
-        asm.emit_j::<VirtualAdvice>(*a3, 0); // get remainder advice
-
-        // Step 2: Handle division by zero special case
-        // Per RISC-V spec: if divisor == 0, quotient = all 1s (maximum unsigned value)
+        asm.emit_j::<VirtualAdvice>(*a2, 0);
+        asm.emit_j::<VirtualAdvice>(*a3, 0);
         asm.emit_b::<VirtualAssertValidDiv0>(a1, *a2, 0);
-
-        // Step 3: Check for multiplication overflow
-        // For valid unsigned division, quotient × divisor must not overflow
-        // This ensures the quotient is in valid range
         asm.emit_b::<VirtualAssertMulUNoOverflow>(*a2, a1, 0);
-
-        // Step 4: Verify fundamental division property
-        // dividend = quotient × divisor + remainder
-        // All operations are unsigned and modulo 2^n
-        asm.emit_r::<MUL>(*t0, *a2, a1); // t0 = quotient × divisor
-        asm.emit_r::<ADD>(*t0, *t0, *a3); // t0 = (quotient × divisor) + remainder
-        asm.emit_b::<VirtualAssertEQ>(*t0, a0, 0); // assert t0 == dividend
-
-        // Step 5: Verify remainder constraint
-        // For valid unsigned division, remainder < divisor
-        // This is simpler than signed case as both values are unsigned
+        asm.emit_r::<MUL>(*t0, *a2, a1);
+        asm.emit_r::<ADD>(*t0, *t0, *a3);
+        asm.emit_b::<VirtualAssertEQ>(*t0, a0, 0);
         asm.emit_b::<VirtualAssertValidUnsignedRemainder>(*a3, a1, 0);
-
-        // Step 6: Move verified quotient to destination register
         asm.emit_i::<VirtualMove>(self.operands.rd, *a2, 0);
         asm.finalize()
     }

--- a/tracer/src/instruction/divuw.rs
+++ b/tracer/src/instruction/divuw.rs
@@ -74,79 +74,41 @@ impl RISCVTrace for DIVUW {
 
         let mut trace = trace;
         for instr in inline_sequence {
-            // In each iteration, create a new Option containing a re-borrowed reference
             instr.trace(cpu, trace.as_deref_mut());
         }
     }
 
-    /// Generates an inline sequence to verify 32-bit unsigned division on 64-bit systems.
-    ///
-    /// DIVUW is an RV64 instruction that performs unsigned division on the lower 32 bits
-    /// of the operands, treating them as unsigned 32-bit integers. The 32-bit quotient
-    /// is then sign-extended to 64 bits (despite being unsigned division, the result
-    /// is sign-extended per RISC-V spec).
-    ///
-    /// The approach:
-    /// 1. Zero-extend inputs to get proper 32-bit unsigned values
-    /// 2. Receive untrusted quotient and remainder advice from oracle
-    /// 3. Handle division by zero (returns u32::MAX = 0xFFFFFFFF)
-    /// 4. Verify quotient × divisor doesn't overflow in 32-bit unsigned space
-    /// 5. Verify division property: dividend = quotient × divisor + remainder
-    /// 6. Ensure remainder < divisor (unsigned comparison)
-    /// 7. Sign-extend the 32-bit result to 64 bits
+    /// DIVUW performs unsigned 32-bit division on RV64, sign-extending the result to 64 bits.
+    /// Verifies division via untrusted oracle advice: dividend = quotient × divisor + remainder.
     fn inline_sequence(
         &self,
         allocator: &VirtualRegisterAllocator,
         xlen: Xlen,
     ) -> Vec<Instruction> {
-        let a0 = self.operands.rs1; // dividend register (64-bit, contains 32-bit value)
-        let a1 = self.operands.rs2; // divisor register (64-bit, contains 32-bit value)
-        let a2 = allocator.allocate(); // quotient from oracle (untrusted)
-        let a3 = allocator.allocate(); // remainder from oracle (untrusted)
-        let t0 = allocator.allocate(); // temporary for multiplication result
-        let t1 = allocator.allocate(); // temporary for high bits check
-        let t2 = allocator.allocate(); // zero-extended quotient
-        let t3 = allocator.allocate(); // zero-extended dividend
-        let t4 = allocator.allocate(); // zero-extended divisor
-        let zero = 0; // x0 register (always contains 0)
+        let a0 = self.operands.rs1;
+        let a1 = self.operands.rs2;
+        let a2 = allocator.allocate();
+        let a3 = allocator.allocate();
+        let t0 = allocator.allocate();
+        let t1 = allocator.allocate();
+        let t2 = allocator.allocate();
+        let t3 = allocator.allocate();
+        let t4 = allocator.allocate();
+        let zero = 0;
         let mut asm = InstrAssembler::new(self.address, self.is_compressed, xlen, allocator);
 
-        // Step 1: Get untrusted advice values from oracle
-        asm.emit_j::<VirtualAdvice>(*a2, 0); // get quotient advice
-        asm.emit_j::<VirtualAdvice>(*a3, 0); // get remainder advice
-
-        // Step 2: Zero-extend inputs to proper 32-bit unsigned values
-        // This ensures we work with correct 32-bit unsigned interpretations
-        asm.emit_i::<VirtualZeroExtendWord>(*t3, a0, 0); // t3 = zero_extend_32(dividend)
-        asm.emit_i::<VirtualZeroExtendWord>(*t4, a1, 0); // t4 = zero_extend_32(divisor)
-
-        // Step 3: Handle division by zero special case
-        // Check raw quotient before zero-extension
-        // If divisor is 0, quotient must be u64::MAX (all 1s)
+        asm.emit_j::<VirtualAdvice>(*a2, 0);
+        asm.emit_j::<VirtualAdvice>(*a3, 0);
+        asm.emit_i::<VirtualZeroExtendWord>(*t3, a0, 0);
+        asm.emit_i::<VirtualZeroExtendWord>(*t4, a1, 0);
         asm.emit_b::<VirtualAssertValidDiv0>(*t4, *a2, 0);
-
-        // Step 4: Zero-extend quotient for calculations
-        // After verifying special cases, prepare quotient for arithmetic
-        asm.emit_i::<VirtualZeroExtendWord>(*t2, *a2, 0); // t2 = zero_extend_32(quotient)
-
-        // Step 5: Check 32-bit unsigned multiplication doesn't overflow
-        // Valid 32-bit unsigned division means quotient × divisor fits in 32 bits
-        asm.emit_r::<MUL>(*t0, *t2, *t4); // t0 = quotient × divisor (lower 64 bits)
-        asm.emit_r::<MULHU>(*t1, *t2, *t4); // t1 = high bits of unsigned multiply
-        asm.emit_b::<VirtualAssertEQ>(*t1, zero, 0); // assert high bits are 0 (no overflow)
-
-        // Step 6: Verify fundamental division property
-        // dividend = quotient × divisor + remainder (all unsigned 32-bit values)
-        asm.emit_r::<ADD>(*t0, *t0, *a3); // t0 = (quotient × divisor) + remainder
-        asm.emit_b::<VirtualAssertEQ>(*t0, *t3, 0); // assert t0 == zero_extended_dividend
-
-        // Step 7: Verify remainder constraint
-        // For valid unsigned division: remainder < divisor
+        asm.emit_i::<VirtualZeroExtendWord>(*t2, *a2, 0);
+        asm.emit_r::<MUL>(*t0, *t2, *t4);
+        asm.emit_r::<MULHU>(*t1, *t2, *t4);
+        asm.emit_b::<VirtualAssertEQ>(*t1, zero, 0);
+        asm.emit_r::<ADD>(*t0, *t0, *a3);
+        asm.emit_b::<VirtualAssertEQ>(*t0, *t3, 0);
         asm.emit_b::<VirtualAssertValidUnsignedRemainder>(*a3, *t4, 0);
-
-        // Step 8: Sign-extend result to 64 bits
-        // Despite being unsigned division, RISC-V spec requires sign-extension
-        // This means if bit 31 is set, bits 32-63 will be set to 1
         asm.emit_i::<VirtualSignExtendWord>(self.operands.rd, *a2, 0);
         asm.finalize()
     }

--- a/tracer/src/instruction/divuw.rs
+++ b/tracer/src/instruction/divuw.rs
@@ -79,50 +79,74 @@ impl RISCVTrace for DIVUW {
         }
     }
 
+    /// Generates an inline sequence to verify 32-bit unsigned division on 64-bit systems.
+    ///
+    /// DIVUW is an RV64 instruction that performs unsigned division on the lower 32 bits
+    /// of the operands, treating them as unsigned 32-bit integers. The 32-bit quotient
+    /// is then sign-extended to 64 bits (despite being unsigned division, the result
+    /// is sign-extended per RISC-V spec).
+    ///
+    /// The approach:
+    /// 1. Zero-extend inputs to get proper 32-bit unsigned values
+    /// 2. Receive untrusted quotient and remainder advice from oracle
+    /// 3. Handle division by zero (returns u32::MAX = 0xFFFFFFFF)
+    /// 4. Verify quotient × divisor doesn't overflow in 32-bit unsigned space
+    /// 5. Verify division property: dividend = quotient × divisor + remainder
+    /// 6. Ensure remainder < divisor (unsigned comparison)
+    /// 7. Sign-extend the 32-bit result to 64 bits
     fn inline_sequence(
         &self,
         allocator: &VirtualRegisterAllocator,
         xlen: Xlen,
     ) -> Vec<Instruction> {
-        let a0 = self.operands.rs1; // dividend
-        let a1 = self.operands.rs2; // divisor
-        let a2 = allocator.allocate(); // quotient from oracle
-        let a3 = allocator.allocate(); // remainder from oracle
-        let t0 = allocator.allocate();
-        let t1 = allocator.allocate();
-        let t2 = allocator.allocate();
-        let t3 = allocator.allocate();
-        let t4 = allocator.allocate();
-        let zero = 0; // x0 register
+        let a0 = self.operands.rs1; // dividend register (64-bit, contains 32-bit value)
+        let a1 = self.operands.rs2; // divisor register (64-bit, contains 32-bit value)
+        let a2 = allocator.allocate(); // quotient from oracle (untrusted)
+        let a3 = allocator.allocate(); // remainder from oracle (untrusted)
+        let t0 = allocator.allocate(); // temporary for multiplication result
+        let t1 = allocator.allocate(); // temporary for high bits check
+        let t2 = allocator.allocate(); // zero-extended quotient
+        let t3 = allocator.allocate(); // zero-extended dividend
+        let t4 = allocator.allocate(); // zero-extended divisor
+        let zero = 0; // x0 register (always contains 0)
         let mut asm = InstrAssembler::new(self.address, self.is_compressed, xlen, allocator);
 
-        // get advice
-        asm.emit_j::<VirtualAdvice>(*a2, 0);
-        asm.emit_j::<VirtualAdvice>(*a3, 0);
+        // Step 1: Get untrusted advice values from oracle
+        asm.emit_j::<VirtualAdvice>(*a2, 0); // get quotient advice
+        asm.emit_j::<VirtualAdvice>(*a3, 0); // get remainder advice
 
-        // zero-extend inputs to 32-bit values
-        asm.emit_i::<VirtualZeroExtendWord>(*t3, a0, 0); // zero-extended dividend
-        asm.emit_i::<VirtualZeroExtendWord>(*t4, a1, 0); // zero-extended divisor
+        // Step 2: Zero-extend inputs to proper 32-bit unsigned values
+        // This ensures we work with correct 32-bit unsigned interpretations
+        asm.emit_i::<VirtualZeroExtendWord>(*t3, a0, 0); // t3 = zero_extend_32(dividend)
+        asm.emit_i::<VirtualZeroExtendWord>(*t4, a1, 0); // t4 = zero_extend_32(divisor)
 
-        // handle special case: check raw quotient before zero-extension
-        asm.emit_b::<VirtualAssertValidDiv0>(*t4, *a2, 0); // checks if t4==0 then a2==u64::MAX
+        // Step 3: Handle division by zero special case
+        // Check raw quotient before zero-extension
+        // If divisor is 0, quotient must be u64::MAX (all 1s)
+        asm.emit_b::<VirtualAssertValidDiv0>(*t4, *a2, 0);
 
-        // zero-extend quotient for calculations
-        asm.emit_i::<VirtualZeroExtendWord>(*t2, *a2, 0); // zero-extended quotient
+        // Step 4: Zero-extend quotient for calculations
+        // After verifying special cases, prepare quotient for arithmetic
+        asm.emit_i::<VirtualZeroExtendWord>(*t2, *a2, 0); // t2 = zero_extend_32(quotient)
 
-        // check 32-bit unsigned multiplication doesn't overflow
-        asm.emit_r::<MUL>(*t0, *t2, *t4); // multiply zero-extended values
-        asm.emit_r::<MULHU>(*t1, *t2, *t4); // upper bits must be 0
-        asm.emit_b::<VirtualAssertEQ>(*t1, zero, 0);
+        // Step 5: Check 32-bit unsigned multiplication doesn't overflow
+        // Valid 32-bit unsigned division means quotient × divisor fits in 32 bits
+        asm.emit_r::<MUL>(*t0, *t2, *t4); // t0 = quotient × divisor (lower 64 bits)
+        asm.emit_r::<MULHU>(*t1, *t2, *t4); // t1 = high bits of unsigned multiply
+        asm.emit_b::<VirtualAssertEQ>(*t1, zero, 0); // assert high bits are 0 (no overflow)
 
-        // verify quotient * divisor + remainder == dividend
-        asm.emit_r::<ADD>(*t0, *t0, *a3);
-        asm.emit_b::<VirtualAssertEQ>(*t0, *t3, 0);
+        // Step 6: Verify fundamental division property
+        // dividend = quotient × divisor + remainder (all unsigned 32-bit values)
+        asm.emit_r::<ADD>(*t0, *t0, *a3); // t0 = (quotient × divisor) + remainder
+        asm.emit_b::<VirtualAssertEQ>(*t0, *t3, 0); // assert t0 == zero_extended_dividend
 
-        // check remainder < divisor (unsigned)
+        // Step 7: Verify remainder constraint
+        // For valid unsigned division: remainder < divisor
         asm.emit_b::<VirtualAssertValidUnsignedRemainder>(*a3, *t4, 0);
 
-        // sign-extend result (per RISC-V spec)
+        // Step 8: Sign-extend result to 64 bits
+        // Despite being unsigned division, RISC-V spec requires sign-extension
+        // This means if bit 31 is set, bits 32-63 will be set to 1
         asm.emit_i::<VirtualSignExtendWord>(self.operands.rd, *a2, 0);
         asm.finalize()
     }

--- a/tracer/src/instruction/divw.rs
+++ b/tracer/src/instruction/divw.rs
@@ -90,41 +90,71 @@ impl RISCVTrace for DIVW {
     }
 
     /// DIVW performs signed 32-bit division on RV64, sign-extending the result to 64 bits.
-    /// Verifies division via untrusted oracle advice, handling overflow and division by zero.
+    ///
+    /// This RV64 instruction divides the lower 32 bits of rs1 by the lower 32 bits of rs2,
+    /// treating them as signed 32-bit integers. The result is sign-extended to 64 bits.
+    ///
+    /// Verification strategy:
+    /// 1. Sign-extend inputs to proper 32-bit signed values
+    /// 2. Receive untrusted quotient and |remainder| from oracle
+    /// 3. Handle special cases (div-by-zero returns -1, overflow returns i32::MIN)
+    /// 4. Verify quotient × divisor doesn't overflow 32 bits (MULW vs MUL comparison)
+    /// 5. Apply sign of dividend to remainder (per RISC-V spec)
+    /// 6. Verify: dividend = quotient × divisor + remainder (in 32-bit space)
+    /// 7. Verify: |remainder| < |divisor|
+    ///
+    /// Special cases:
+    /// - Division by zero: returns -1
+    /// - Overflow (i32::MIN / -1): returns i32::MIN, handled by VirtualChangeDivisorW
     fn inline_sequence(
         &self,
         allocator: &VirtualRegisterAllocator,
         xlen: Xlen,
     ) -> Vec<Instruction> {
-        let a0 = self.operands.rs1;
-        let a1 = self.operands.rs2;
-        let a2 = allocator.allocate();
-        let a3 = allocator.allocate();
-        let t0 = allocator.allocate();
-        let t1 = allocator.allocate();
-        let t2 = allocator.allocate();
-        let t3 = allocator.allocate();
-        let t4 = allocator.allocate();
+        let a0 = self.operands.rs1; // dividend
+        let a1 = self.operands.rs2; // divisor
+        let a2 = allocator.allocate(); // quotient from oracle
+        let a3 = allocator.allocate(); // |remainder| from oracle
+        let t0 = allocator.allocate(); // adjusted divisor
+        let t1 = allocator.allocate(); // temporary
+        let t2 = allocator.allocate(); // temporary
+        let t3 = allocator.allocate(); // temporary
+        let t4 = allocator.allocate(); // sign-extended dividend
         let mut asm = InstrAssembler::new(self.address, self.is_compressed, xlen, allocator);
 
-        asm.emit_j::<VirtualAdvice>(*a2, 0);
-        asm.emit_j::<VirtualAdvice>(*a3, 0);
-        asm.emit_i::<VirtualSignExtendWord>(*t4, a0, 0);
-        asm.emit_i::<VirtualSignExtendWord>(*t3, a1, 0);
-        asm.emit_b::<VirtualAssertValidDiv0>(*t3, *a2, 0);
-        asm.emit_r::<VirtualChangeDivisorW>(*t0, *t4, *t3);
-        asm.emit_r::<MULW>(*t1, *a2, *t0);
-        asm.emit_r::<MUL>(*t2, *a2, *t0);
-        asm.emit_b::<VirtualAssertEQ>(*t1, *t2, 0);
-        asm.emit_i::<SRAI>(*t2, *t4, 31);
-        asm.emit_r::<XOR>(*t3, *a3, *t2);
-        asm.emit_r::<SUB>(*t3, *t3, *t2);
-        asm.emit_r::<ADDW>(*t1, *t1, *t3);
+        // Get untrusted advice from oracle
+        asm.emit_j::<VirtualAdvice>(*a2, 0); // quotient
+        asm.emit_j::<VirtualAdvice>(*a3, 0); // |remainder|
+
+        // Sign-extend inputs to proper 32-bit values
+        asm.emit_i::<VirtualSignExtendWord>(*t4, a0, 0); // dividend
+        asm.emit_i::<VirtualSignExtendWord>(*t3, a1, 0); // divisor
+
+        // Handle special cases: div-by-zero and overflow
+        asm.emit_b::<VirtualAssertValidDiv0>(*t3, *a2, 0); // Check div-by-zero
+        asm.emit_r::<VirtualChangeDivisorW>(*t0, *t4, *t3); // Adjust for overflow
+
+        // Verify no 32-bit overflow: MULW and MUL must match
+        asm.emit_r::<MULW>(*t1, *a2, *t0); // 32-bit multiply, sign-extended
+        asm.emit_r::<MUL>(*t2, *a2, *t0); // Full 64-bit multiply
+        asm.emit_b::<VirtualAssertEQ>(*t1, *t2, 0); // Assert no overflow
+
+        // Apply sign of dividend to remainder
+        asm.emit_i::<SRAI>(*t2, *t4, 31); // Sign bit of dividend
+        asm.emit_r::<XOR>(*t3, *a3, *t2); // XOR with |remainder|
+        asm.emit_r::<SUB>(*t3, *t3, *t2); // Two's complement if negative
+
+        // Verify: dividend = quotient × divisor + remainder (32-bit)
+        asm.emit_r::<ADDW>(*t1, *t1, *t3); // 32-bit add
         asm.emit_b::<VirtualAssertEQ>(*t1, *t4, 0);
-        asm.emit_i::<SRAI>(*t2, *t0, 31);
-        asm.emit_r::<XOR>(*t1, *t0, *t2);
-        asm.emit_r::<SUB>(*t1, *t1, *t2);
+
+        // Verify: |remainder| < |divisor|
+        asm.emit_i::<SRAI>(*t2, *t0, 31); // Sign bit of adjusted divisor
+        asm.emit_r::<XOR>(*t1, *t0, *t2); // Get magnitude
+        asm.emit_r::<SUB>(*t1, *t1, *t2); // |adjusted_divisor|
         asm.emit_b::<VirtualAssertValidUnsignedRemainder>(*a3, *t1, 0);
+
+        // Sign-extend result to 64 bits
         asm.emit_i::<VirtualSignExtendWord>(self.operands.rd, *a2, 0);
         asm.finalize()
     }

--- a/tracer/src/instruction/divw.rs
+++ b/tracer/src/instruction/divw.rs
@@ -90,55 +90,78 @@ impl RISCVTrace for DIVW {
         }
     }
 
+    /// Generates an inline sequence to verify 32-bit signed division on 64-bit systems.
+    ///
+    /// DIVW is an RV64 instruction that performs signed division on the lower 32 bits of
+    /// the operands, treating them as signed 32-bit integers, and sign-extends the
+    /// 32-bit quotient to 64 bits. This is similar to DIV but operates on 32-bit values
+    /// within 64-bit registers.
+    ///
+    /// The approach:
+    /// 1. Sign-extend inputs to proper 32-bit signed values
+    /// 2. Receive untrusted quotient and |remainder| advice from oracle
+    /// 3. Handle special cases (division by zero, i32::MIN / -1 overflow)
+    /// 4. Verify quotient × divisor doesn't overflow in 32-bit space
+    /// 5. Verify division property: dividend = quotient × divisor + remainder (mod 2^32)
+    /// 6. Ensure |remainder| < |divisor|
+    /// 7. Sign-extend the 32-bit result to 64 bits
     fn inline_sequence(
         &self,
         allocator: &VirtualRegisterAllocator,
         xlen: Xlen,
     ) -> Vec<Instruction> {
-        let a0 = self.operands.rs1; // dividend
-        let a1 = self.operands.rs2; // divisor
-        let a2 = allocator.allocate(); // quotient from oracle
-        let a3 = allocator.allocate(); // |remainder| from oracle (unsigned)
-        let t0 = allocator.allocate();
-        let t1 = allocator.allocate();
-        let t2 = allocator.allocate();
-        let t3 = allocator.allocate();
-        let t4 = allocator.allocate();
+        let a0 = self.operands.rs1; // dividend register (64-bit, contains 32-bit value)
+        let a1 = self.operands.rs2; // divisor register (64-bit, contains 32-bit value)
+        let a2 = allocator.allocate(); // quotient from oracle (untrusted)
+        let a3 = allocator.allocate(); // |remainder| from oracle (unsigned, untrusted)
+        let t0 = allocator.allocate(); // adjusted 32-bit divisor (handles special cases)
+        let t1 = allocator.allocate(); // temporary for 32-bit multiplication result
+        let t2 = allocator.allocate(); // temporary for 64-bit multiplication / sign operations
+        let t3 = allocator.allocate(); // temporary for signed remainder construction
+        let t4 = allocator.allocate(); // sign-extended 32-bit dividend
         let mut asm = InstrAssembler::new(self.address, self.is_compressed, xlen, allocator);
 
-        // get advice
-        asm.emit_j::<VirtualAdvice>(*a2, 0);
-        asm.emit_j::<VirtualAdvice>(*a3, 0);
+        // Step 1: Get untrusted advice values from oracle
+        asm.emit_j::<VirtualAdvice>(*a2, 0); // get quotient advice
+        asm.emit_j::<VirtualAdvice>(*a3, 0); // get |remainder| advice
 
-        // sign-extend inputs to 32-bit values
-        asm.emit_i::<VirtualSignExtendWord>(*t4, a0, 0); // sign-extended dividend
-        asm.emit_i::<VirtualSignExtendWord>(*t3, a1, 0); // sign-extended divisor
+        // Step 2: Sign-extend inputs to proper 32-bit values
+        // This ensures we work with correct 32-bit signed interpretations
+        asm.emit_i::<VirtualSignExtendWord>(*t4, a0, 0); // t4 = sign_extend_32(dividend)
+        asm.emit_i::<VirtualSignExtendWord>(*t3, a1, 0); // t3 = sign_extend_32(divisor)
 
-        // handle special cases
-        asm.emit_b::<VirtualAssertValidDiv0>(*t3, *a2, 0);
-        asm.emit_r::<VirtualChangeDivisorW>(*t0, *t4, *t3); // handles MIN_INT32/-1
+        // Step 3: Handle special cases per RISC-V spec
+        // - Division by zero: quotient = -1
+        // - Overflow (i32::MIN / -1): quotient = i32::MIN
+        asm.emit_b::<VirtualAssertValidDiv0>(*t3, *a2, 0); // validates quotient for div-by-zero
+        asm.emit_r::<VirtualChangeDivisorW>(*t0, *t4, *t3); // t0 = adjusted divisor for overflow
 
-        // check 32-bit multiplication doesn't overflow
-        asm.emit_r::<MULW>(*t1, *a2, *t0); // 32-bit multiply, sign-extended
-        asm.emit_r::<MUL>(*t2, *a2, *t0); // full 64-bit multiply
-        asm.emit_b::<VirtualAssertEQ>(*t1, *t2, 0); // if equal, no 32-bit overflow
+        // Step 4: Check 32-bit multiplication doesn't overflow
+        // We verify this by comparing 32-bit multiply with full 64-bit multiply
+        asm.emit_r::<MULW>(*t1, *a2, *t0); // t1 = 32-bit multiply, sign-extended to 64 bits
+        asm.emit_r::<MUL>(*t2, *a2, *t0); // t2 = full 64-bit multiply
+        asm.emit_b::<VirtualAssertEQ>(*t1, *t2, 0); // assert they match (no 32-bit overflow)
 
-        // construct signed remainder (apply dividend's sign to |remainder|)
-        asm.emit_i::<SRAI>(*t2, *t4, 31); // sign of 32-bit dividend
-        asm.emit_r::<XOR>(*t3, *a3, *t2);
-        asm.emit_r::<SUB>(*t3, *t3, *t2);
+        // Step 5: Construct signed remainder from unsigned advice
+        // Apply dividend's sign to |remainder| per RISC-V spec
+        asm.emit_i::<SRAI>(*t2, *t4, 31); // t2 = sign_bit(32-bit dividend) extended
+        asm.emit_r::<XOR>(*t3, *a3, *t2); // t3 = |remainder| ^ sign_mask
+        asm.emit_r::<SUB>(*t3, *t3, *t2); // t3 = signed_remainder (two's complement if negative)
 
-        // verify quotient * divisor + remainder == dividend (in 32-bit space)
-        asm.emit_r::<ADDW>(*t1, *t1, *t3); // 32-bit add
-        asm.emit_b::<VirtualAssertEQ>(*t1, *t4, 0);
+        // Step 6: Verify division property in 32-bit space
+        // dividend = quotient × divisor + remainder (all operations in 32-bit space)
+        asm.emit_r::<ADDW>(*t1, *t1, *t3); // t1 = (quotient × divisor) + remainder (32-bit add)
+        asm.emit_b::<VirtualAssertEQ>(*t1, *t4, 0); // assert t1 == sign_extended_dividend
 
-        // check |remainder| < |divisor|
-        asm.emit_i::<SRAI>(*t2, *t0, 31);
-        asm.emit_r::<XOR>(*t1, *t0, *t2);
-        asm.emit_r::<SUB>(*t1, *t1, *t2);
-        asm.emit_b::<VirtualAssertValidUnsignedRemainder>(*a3, *t1, 0);
+        // Step 7: Verify remainder magnitude constraint
+        // |remainder| < |divisor| is required for valid division
+        asm.emit_i::<SRAI>(*t2, *t0, 31); // t2 = sign_bit(adjusted_divisor) extended
+        asm.emit_r::<XOR>(*t1, *t0, *t2); // t1 = adjusted_divisor ^ sign_mask
+        asm.emit_r::<SUB>(*t1, *t1, *t2); // t1 = |adjusted_divisor|
+        asm.emit_b::<VirtualAssertValidUnsignedRemainder>(*a3, *t1, 0); // assert |remainder| < |divisor|
 
-        // sign-extend and move result
+        // Step 8: Sign-extend 32-bit quotient to 64 bits and move to destination
+        // This ensures the result is properly sign-extended as per DIVW specification
         asm.emit_i::<VirtualSignExtendWord>(self.operands.rd, *a2, 0);
         asm.finalize()
     }

--- a/tracer/src/instruction/lb.rs
+++ b/tracer/src/instruction/lb.rs
@@ -51,6 +51,14 @@ impl RISCVTrace for LB {
         }
     }
 
+    /// Generates an inline sequence to load a sign-extended byte from memory.
+    ///
+    /// LB (Load Byte) loads an 8-bit value from memory and sign-extends it to XLEN bits.
+    /// The implementation loads a naturally-aligned word/dword containing the byte,
+    /// then extracts and sign-extends the specific byte.
+    ///
+    /// This approach is used because the zkVM works with word-aligned memory accesses,
+    /// so byte loads must be emulated using word loads and bit manipulation.
     fn inline_sequence(
         &self,
         allocator: &VirtualRegisterAllocator,
@@ -64,37 +72,85 @@ impl RISCVTrace for LB {
 }
 
 impl LB {
+    /// 32-bit implementation of byte load with sign extension.
+    ///
+    /// Algorithm:
+    /// 1. Calculate effective address (base + offset)
+    /// 2. Align address to 4-byte boundary to get word address
+    /// 3. Load the aligned 32-bit word containing the target byte
+    /// 4. Calculate shift amount based on byte position within word
+    /// 5. Shift byte to MSB position and sign-extend by arithmetic right shift
+    ///
+    /// The byte position within the word is determined by the lower 2 bits of the address.
+    /// For little-endian systems, XOR with 3 reverses the byte order for shifting.
     fn inline_sequence_32(&self, allocator: &VirtualRegisterAllocator) -> Vec<Instruction> {
-        let v_address = allocator.allocate();
-        let v_word_address = allocator.allocate();
-        let v_word = allocator.allocate();
-        let v_shift = allocator.allocate();
+        let v_address = allocator.allocate(); // effective address
+        let v_word_address = allocator.allocate(); // aligned word address
+        let v_word = allocator.allocate(); // loaded word
+        let v_shift = allocator.allocate(); // shift amount
 
         let mut asm = InstrAssembler::new(self.address, self.is_compressed, Xlen::Bit32, allocator);
+
+        // Step 1: Calculate effective address = base + immediate
         asm.emit_i::<ADDI>(*v_address, self.operands.rs1, self.operands.imm as u64);
+
+        // Step 2: Align to 4-byte boundary (clear lower 2 bits)
         asm.emit_i::<ANDI>(*v_word_address, *v_address, -4i64 as u64);
+
+        // Step 3: Load the aligned 32-bit word
         asm.emit_i::<VirtualLW>(*v_word, *v_word_address, 0);
-        asm.emit_i::<XORI>(*v_shift, *v_address, 3);
-        asm.emit_i::<SLLI>(*v_shift, *v_shift, 3);
-        asm.emit_r::<SLL>(self.operands.rd, *v_word, *v_shift);
-        asm.emit_i::<SRAI>(self.operands.rd, self.operands.rd, 24);
+
+        // Step 4: Calculate shift amount to position byte at MSB
+        // XOR with 3 handles little-endian byte ordering
+        // Multiply by 8 converts byte offset to bit offset
+        asm.emit_i::<XORI>(*v_shift, *v_address, 3); // reverse byte position
+        asm.emit_i::<SLLI>(*v_shift, *v_shift, 3); // multiply by 8 (bits per byte)
+
+        // Step 5: Shift byte to MSB and sign-extend
+        asm.emit_r::<SLL>(self.operands.rd, *v_word, *v_shift); // shift byte to top
+        asm.emit_i::<SRAI>(self.operands.rd, self.operands.rd, 24); // sign-extend from bit 7
+
         asm.finalize()
     }
 
+    /// 64-bit implementation of byte load with sign extension.
+    ///
+    /// Algorithm:
+    /// 1. Calculate effective address (base + offset)
+    /// 2. Align address to 8-byte boundary to get dword address
+    /// 3. Load the aligned 64-bit dword containing the target byte
+    /// 4. Calculate shift amount based on byte position within dword
+    /// 5. Shift byte to MSB position and sign-extend by arithmetic right shift
+    ///
+    /// The byte position within the dword is determined by the lower 3 bits of the address.
+    /// For little-endian systems, XOR with 7 reverses the byte order for shifting.
     fn inline_sequence_64(&self, allocator: &VirtualRegisterAllocator) -> Vec<Instruction> {
-        let v_address = allocator.allocate();
-        let v_dword_address = allocator.allocate();
-        let v_dword = allocator.allocate();
-        let v_shift = allocator.allocate();
+        let v_address = allocator.allocate(); // effective address
+        let v_dword_address = allocator.allocate(); // aligned dword address
+        let v_dword = allocator.allocate(); // loaded dword
+        let v_shift = allocator.allocate(); // shift amount
 
         let mut asm = InstrAssembler::new(self.address, self.is_compressed, Xlen::Bit64, allocator);
+
+        // Step 1: Calculate effective address = base + immediate
         asm.emit_i::<ADDI>(*v_address, self.operands.rs1, self.operands.imm as u64);
+
+        // Step 2: Align to 8-byte boundary (clear lower 3 bits)
         asm.emit_i::<ANDI>(*v_dword_address, *v_address, -8i64 as u64);
+
+        // Step 3: Load the aligned 64-bit dword
         asm.emit_ld::<LD>(*v_dword, *v_dword_address, 0);
-        asm.emit_i::<XORI>(*v_shift, *v_address, 7);
-        asm.emit_i::<SLLI>(*v_shift, *v_shift, 3);
-        asm.emit_r::<SLL>(self.operands.rd, *v_dword, *v_shift);
-        asm.emit_i::<SRAI>(self.operands.rd, self.operands.rd, 56);
+
+        // Step 4: Calculate shift amount to position byte at MSB
+        // XOR with 7 handles little-endian byte ordering
+        // Multiply by 8 converts byte offset to bit offset
+        asm.emit_i::<XORI>(*v_shift, *v_address, 7); // reverse byte position
+        asm.emit_i::<SLLI>(*v_shift, *v_shift, 3); // multiply by 8 (bits per byte)
+
+        // Step 5: Shift byte to MSB and sign-extend
+        asm.emit_r::<SLL>(self.operands.rd, *v_dword, *v_shift); // shift byte to top
+        asm.emit_i::<SRAI>(self.operands.rd, self.operands.rd, 56); // sign-extend from bit 7
+
         asm.finalize()
     }
 }

--- a/tracer/src/instruction/lb.rs
+++ b/tracer/src/instruction/lb.rs
@@ -51,14 +51,6 @@ impl RISCVTrace for LB {
         }
     }
 
-    /// Generates an inline sequence to load a sign-extended byte from memory.
-    ///
-    /// LB (Load Byte) loads an 8-bit value from memory and sign-extends it to XLEN bits.
-    /// The implementation loads a naturally-aligned word/dword containing the byte,
-    /// then extracts and sign-extends the specific byte.
-    ///
-    /// This approach is used because the zkVM works with word-aligned memory accesses,
-    /// so byte loads must be emulated using word loads and bit manipulation.
     fn inline_sequence(
         &self,
         allocator: &VirtualRegisterAllocator,
@@ -72,84 +64,40 @@ impl RISCVTrace for LB {
 }
 
 impl LB {
-    /// 32-bit implementation of byte load with sign extension.
-    ///
-    /// Algorithm:
-    /// 1. Calculate effective address (base + offset)
-    /// 2. Align address to 4-byte boundary to get word address
-    /// 3. Load the aligned 32-bit word containing the target byte
-    /// 4. Calculate shift amount based on byte position within word
-    /// 5. Shift byte to MSB position and sign-extend by arithmetic right shift
-    ///
-    /// The byte position within the word is determined by the lower 2 bits of the address.
-    /// For little-endian systems, XOR with 3 reverses the byte order for shifting.
     fn inline_sequence_32(&self, allocator: &VirtualRegisterAllocator) -> Vec<Instruction> {
-        let v_address = allocator.allocate(); // effective address
-        let v_word_address = allocator.allocate(); // aligned word address
-        let v_word = allocator.allocate(); // loaded word
-        let v_shift = allocator.allocate(); // shift amount
+        let v_address = allocator.allocate();
+        let v_word_address = allocator.allocate();
+        let v_word = allocator.allocate();
+        let v_shift = allocator.allocate();
 
         let mut asm = InstrAssembler::new(self.address, self.is_compressed, Xlen::Bit32, allocator);
 
-        // Step 1: Calculate effective address = base + immediate
         asm.emit_i::<ADDI>(*v_address, self.operands.rs1, self.operands.imm as u64);
-
-        // Step 2: Align to 4-byte boundary (clear lower 2 bits)
         asm.emit_i::<ANDI>(*v_word_address, *v_address, -4i64 as u64);
-
-        // Step 3: Load the aligned 32-bit word
         asm.emit_i::<VirtualLW>(*v_word, *v_word_address, 0);
-
-        // Step 4: Calculate shift amount to position byte at MSB
-        // XOR with 3 handles little-endian byte ordering
-        // Multiply by 8 converts byte offset to bit offset
-        asm.emit_i::<XORI>(*v_shift, *v_address, 3); // reverse byte position
-        asm.emit_i::<SLLI>(*v_shift, *v_shift, 3); // multiply by 8 (bits per byte)
-
-        // Step 5: Shift byte to MSB and sign-extend
-        asm.emit_r::<SLL>(self.operands.rd, *v_word, *v_shift); // shift byte to top
-        asm.emit_i::<SRAI>(self.operands.rd, self.operands.rd, 24); // sign-extend from bit 7
+        asm.emit_i::<XORI>(*v_shift, *v_address, 3);
+        asm.emit_i::<SLLI>(*v_shift, *v_shift, 3);
+        asm.emit_r::<SLL>(self.operands.rd, *v_word, *v_shift);
+        asm.emit_i::<SRAI>(self.operands.rd, self.operands.rd, 24);
 
         asm.finalize()
     }
 
-    /// 64-bit implementation of byte load with sign extension.
-    ///
-    /// Algorithm:
-    /// 1. Calculate effective address (base + offset)
-    /// 2. Align address to 8-byte boundary to get dword address
-    /// 3. Load the aligned 64-bit dword containing the target byte
-    /// 4. Calculate shift amount based on byte position within dword
-    /// 5. Shift byte to MSB position and sign-extend by arithmetic right shift
-    ///
-    /// The byte position within the dword is determined by the lower 3 bits of the address.
-    /// For little-endian systems, XOR with 7 reverses the byte order for shifting.
     fn inline_sequence_64(&self, allocator: &VirtualRegisterAllocator) -> Vec<Instruction> {
-        let v_address = allocator.allocate(); // effective address
-        let v_dword_address = allocator.allocate(); // aligned dword address
-        let v_dword = allocator.allocate(); // loaded dword
-        let v_shift = allocator.allocate(); // shift amount
+        let v_address = allocator.allocate();
+        let v_dword_address = allocator.allocate();
+        let v_dword = allocator.allocate();
+        let v_shift = allocator.allocate();
 
         let mut asm = InstrAssembler::new(self.address, self.is_compressed, Xlen::Bit64, allocator);
 
-        // Step 1: Calculate effective address = base + immediate
         asm.emit_i::<ADDI>(*v_address, self.operands.rs1, self.operands.imm as u64);
-
-        // Step 2: Align to 8-byte boundary (clear lower 3 bits)
         asm.emit_i::<ANDI>(*v_dword_address, *v_address, -8i64 as u64);
-
-        // Step 3: Load the aligned 64-bit dword
         asm.emit_ld::<LD>(*v_dword, *v_dword_address, 0);
-
-        // Step 4: Calculate shift amount to position byte at MSB
-        // XOR with 7 handles little-endian byte ordering
-        // Multiply by 8 converts byte offset to bit offset
-        asm.emit_i::<XORI>(*v_shift, *v_address, 7); // reverse byte position
-        asm.emit_i::<SLLI>(*v_shift, *v_shift, 3); // multiply by 8 (bits per byte)
-
-        // Step 5: Shift byte to MSB and sign-extend
-        asm.emit_r::<SLL>(self.operands.rd, *v_dword, *v_shift); // shift byte to top
-        asm.emit_i::<SRAI>(self.operands.rd, self.operands.rd, 56); // sign-extend from bit 7
+        asm.emit_i::<XORI>(*v_shift, *v_address, 7);
+        asm.emit_i::<SLLI>(*v_shift, *v_shift, 3);
+        asm.emit_r::<SLL>(self.operands.rd, *v_dword, *v_shift);
+        asm.emit_i::<SRAI>(self.operands.rd, self.operands.rd, 56);
 
         asm.finalize()
     }

--- a/tracer/src/instruction/lh.rs
+++ b/tracer/src/instruction/lh.rs
@@ -49,7 +49,6 @@ impl RISCVTrace for LH {
         let inline_sequence = self.inline_sequence(&cpu.vr_allocator, cpu.xlen);
         let mut trace = trace;
         for instr in inline_sequence {
-            // In each iteration, create a new Option containing a re-borrowed reference
             instr.trace(cpu, trace.as_deref_mut());
         }
     }

--- a/tracer/src/instruction/lhu.rs
+++ b/tracer/src/instruction/lhu.rs
@@ -47,7 +47,6 @@ impl RISCVTrace for LHU {
         let inline_sequence = self.inline_sequence(&cpu.vr_allocator, cpu.xlen);
         let mut trace = trace;
         for instr in inline_sequence {
-            // In each iteration, create a new Option containing a re-borrowed reference
             instr.trace(cpu, trace.as_deref_mut());
         }
     }

--- a/tracer/src/instruction/lw.rs
+++ b/tracer/src/instruction/lw.rs
@@ -48,7 +48,6 @@ impl RISCVTrace for LW {
         let inline_sequence = self.inline_sequence(&cpu.vr_allocator, cpu.xlen);
         let mut trace = trace;
         for instr in inline_sequence {
-            // In each iteration, create a new Option containing a re-borrowed reference
             instr.trace(cpu, trace.as_deref_mut());
         }
     }

--- a/tracer/src/instruction/lw.rs
+++ b/tracer/src/instruction/lw.rs
@@ -53,6 +53,7 @@ impl RISCVTrace for LW {
         }
     }
 
+    /// Load word (32-bit) from aligned memory.    
     fn inline_sequence(
         &self,
         allocator: &VirtualRegisterAllocator,

--- a/tracer/src/instruction/lwu.rs
+++ b/tracer/src/instruction/lwu.rs
@@ -52,6 +52,7 @@ impl RISCVTrace for LWU {
         }
     }
 
+    /// Load unsigned word (32-bit) with zero extension to 64-bit.    
     fn inline_sequence(
         &self,
         allocator: &VirtualRegisterAllocator,

--- a/tracer/src/instruction/lwu.rs
+++ b/tracer/src/instruction/lwu.rs
@@ -47,7 +47,6 @@ impl RISCVTrace for LWU {
         let inline_sequence = self.inline_sequence(&cpu.vr_allocator, cpu.xlen);
         let mut trace = trace;
         for instr in inline_sequence {
-            // In each iteration, create a new Option containing a re-borrowed reference
             instr.trace(cpu, trace.as_deref_mut());
         }
     }

--- a/tracer/src/instruction/mulh.rs
+++ b/tracer/src/instruction/mulh.rs
@@ -40,58 +40,30 @@ impl RISCVTrace for MULH {
         let inline_sequence = self.inline_sequence(&cpu.vr_allocator, cpu.xlen);
         let mut trace = trace;
         for instr in inline_sequence {
-            // In each iteration, create a new Option containing a re-borrowed reference
             instr.trace(cpu, trace.as_deref_mut());
         }
     }
 
-    /// Generates an inline sequence to compute the high bits of signed multiplication.
-    ///
-    /// MULH returns the upper XLEN bits of the 2×XLEN-bit product of signed multiplication.
-    /// This is useful for checking multiplication overflow and extended precision arithmetic.
-    ///
-    /// The implementation uses the algebraic identity:
-    /// MULH(x, y) = MULHU(x, y) + sign_adjust_x + sign_adjust_y
-    ///
-    /// Where:
-    /// - MULHU(x, y) computes unsigned high bits
-    /// - sign_adjust_x = sign(x) × y (adjusts for x being negative)
-    /// - sign_adjust_y = sign(y) × x (adjusts for y being negative)
-    ///
-    /// This works because signed multiplication can be expressed as:
-    /// x × y = |x| × |y| × sign(x×y) + corrections for negative operands
-    ///
-    /// The corrections account for two's complement representation where
-    /// a negative number -n is represented as 2^XLEN - n.
+    /// MULH computes the high 64 bits of signed multiplication using identity:
+    /// (x × y)_high = (x × y)_high_unsigned + sign(x) × y + sign(y) × x
     fn inline_sequence(
         &self,
         allocator: &VirtualRegisterAllocator,
         xlen: Xlen,
     ) -> Vec<Instruction> {
-        let v_sx = allocator.allocate(); // sign adjustment for rs1
-        let v_sy = allocator.allocate(); // sign adjustment for rs2
-        let v_0 = allocator.allocate(); // accumulator for result
+        let v_sx = allocator.allocate();
+        let v_sy = allocator.allocate();
+        let v_0 = allocator.allocate();
 
         let mut asm = InstrAssembler::new(self.address, self.is_compressed, xlen, allocator);
 
-        // Step 1: Extract sign bits as adjustment factors
-        // VirtualMovsign returns -1 if input is negative, 0 otherwise
-        asm.emit_i::<VirtualMovsign>(*v_sx, self.operands.rs1, 0); // v_sx = sign(rs1)
-        asm.emit_i::<VirtualMovsign>(*v_sy, self.operands.rs2, 0); // v_sy = sign(rs2)
-
-        // Step 2: Compute unsigned high multiplication
-        // This gives us the base high bits treating inputs as unsigned
-        asm.emit_r::<MULHU>(*v_0, self.operands.rs1, self.operands.rs2); // v_0 = MULHU(rs1, rs2)
-
-        // Step 3: Apply sign corrections
-        // If rs1 is negative, subtract rs2 from high bits (accounts for two's complement)
-        asm.emit_r::<MUL>(*v_sx, *v_sx, self.operands.rs2); // v_sx = sign(rs1) × rs2
-                                                            // If rs2 is negative, subtract rs1 from high bits (accounts for two's complement)
-        asm.emit_r::<MUL>(*v_sy, *v_sy, self.operands.rs1); // v_sy = sign(rs2) × rs1
-
-        // Step 4: Combine all components
-        asm.emit_r::<ADD>(*v_0, *v_0, *v_sx); // v_0 += sign_adjust_x
-        asm.emit_r::<ADD>(self.operands.rd, *v_0, *v_sy); // rd = v_0 + sign_adjust_y
+        asm.emit_i::<VirtualMovsign>(*v_sx, self.operands.rs1, 0);
+        asm.emit_i::<VirtualMovsign>(*v_sy, self.operands.rs2, 0);
+        asm.emit_r::<MULHU>(*v_0, self.operands.rs1, self.operands.rs2);
+        asm.emit_r::<MUL>(*v_sx, *v_sx, self.operands.rs2);
+        asm.emit_r::<MUL>(*v_sy, *v_sy, self.operands.rs1);
+        asm.emit_r::<ADD>(*v_0, *v_0, *v_sx);
+        asm.emit_r::<ADD>(self.operands.rd, *v_0, *v_sy);
 
         asm.finalize()
     }

--- a/tracer/src/instruction/mulhsu.rs
+++ b/tracer/src/instruction/mulhsu.rs
@@ -47,6 +47,22 @@ impl RISCVTrace for MULHSU {
         }
     }
 
+    /// Generates an inline sequence to compute high bits of signed×unsigned multiplication.
+    ///
+    /// MULHSU multiplies rs1 (signed) by rs2 (unsigned) and returns the upper XLEN bits
+    /// of the 2×XLEN-bit product. This is useful for mixed signed/unsigned arithmetic.
+    ///
+    /// The implementation converts the signed operand to unsigned, performs unsigned
+    /// multiplication, then adjusts the result to account for the sign.
+    ///
+    /// Algorithm overview:
+    /// 1. Convert signed rs1 to unsigned absolute value
+    /// 2. Perform unsigned multiplication to get full product
+    /// 3. If rs1 was negative, negate the entire product
+    /// 4. Extract the high bits with proper carry propagation
+    ///
+    /// The negation of a product is done by XOR with sign mask and adding 1,
+    /// which implements two's complement negation across the full 2×XLEN bits.
     fn inline_sequence(
         &self,
         allocator: &VirtualRegisterAllocator,
@@ -55,37 +71,52 @@ impl RISCVTrace for MULHSU {
         // MULHSU implements signed-unsigned multiplication: rs1 (signed) × rs2 (unsigned)
         //
         // For negative rs1, two's complement encoding means:
-        // rs1_unsigned = rs1 + 2^32 (when rs1 < 0)
+        // rs1_unsigned = rs1 + 2^XLEN (when rs1 < 0)
         //
         // Therefore:
-        // MULHU(rs1_unsigned, rs2) = upper_bits((rs1 + 2^32) × rs2)
-        //                          = upper_bits(rs1 × rs2 + 2^32 × rs2)
+        // MULHU(rs1_unsigned, rs2) = upper_bits((rs1 + 2^XLEN) × rs2)
+        //                          = upper_bits(rs1 × rs2 + 2^XLEN × rs2)
         //                          = upper_bits(rs1 × rs2) + rs2
         //                          = MULHSU(rs1, rs2) + rs2
         //
         // So: MULHSU(rs1, rs2) = MULHU(rs1_unsigned, rs2) - rs2
 
-        // Virtual registers used in sequence
-        let v_sx = allocator.allocate();
-        let v_sx_0 = allocator.allocate();
-        let v_rs1 = allocator.allocate();
-        let v_hi = allocator.allocate();
-        let v_lo = allocator.allocate();
-        let v_tmp = allocator.allocate();
-        let v_carry = allocator.allocate();
+        let v_sx = allocator.allocate(); // sign mask for rs1 (all 1s if negative)
+        let v_sx_0 = allocator.allocate(); // LSB of sign mask (1 if negative, 0 otherwise)
+        let v_rs1 = allocator.allocate(); // absolute value of rs1
+        let v_hi = allocator.allocate(); // high bits of unsigned multiplication
+        let v_lo = allocator.allocate(); // low bits of unsigned multiplication
+        let v_tmp = allocator.allocate(); // temporary for carry calculation
+        let v_carry = allocator.allocate(); // carry bit from low to high
 
         let mut asm = InstrAssembler::new(self.address, self.is_compressed, xlen, allocator);
+
+        // Step 1: Extract sign information from rs1
+        // v_sx = all 1s if rs1 < 0, all 0s otherwise
         asm.emit_i::<VirtualMovsign>(*v_sx, self.operands.rs1, 0);
+        // v_sx_0 = 1 if rs1 < 0, 0 otherwise (for two's complement addition)
         asm.emit_i::<ANDI>(*v_sx_0, *v_sx, 1);
-        asm.emit_r::<XOR>(*v_rs1, self.operands.rs1, *v_sx);
-        asm.emit_r::<ADD>(*v_rs1, *v_rs1, *v_sx_0);
-        asm.emit_r::<MULHU>(*v_hi, *v_rs1, self.operands.rs2);
-        asm.emit_r::<MUL>(*v_lo, *v_rs1, self.operands.rs2);
-        asm.emit_r::<XOR>(*v_hi, *v_hi, *v_sx);
-        asm.emit_r::<XOR>(*v_lo, *v_lo, *v_sx);
-        asm.emit_r::<ADD>(*v_tmp, *v_lo, *v_sx_0);
-        asm.emit_r::<SLTU>(*v_carry, *v_tmp, *v_lo);
-        asm.emit_r::<ADD>(self.operands.rd, *v_hi, *v_carry);
+
+        // Step 2: Convert rs1 to absolute value (unsigned)
+        // If negative: XOR flips bits, ADD 1 completes two's complement
+        asm.emit_r::<XOR>(*v_rs1, self.operands.rs1, *v_sx); // flip bits if negative
+        asm.emit_r::<ADD>(*v_rs1, *v_rs1, *v_sx_0); // add 1 if negative
+
+        // Step 3: Perform unsigned multiplication
+        // Get full 2×XLEN-bit product of |rs1| × rs2
+        asm.emit_r::<MULHU>(*v_hi, *v_rs1, self.operands.rs2); // high bits
+        asm.emit_r::<MUL>(*v_lo, *v_rs1, self.operands.rs2); // low bits
+
+        // Step 4: Apply sign correction if rs1 was negative
+        // Negate the entire 2×XLEN-bit product using two's complement
+        asm.emit_r::<XOR>(*v_hi, *v_hi, *v_sx); // flip high bits if negative
+        asm.emit_r::<XOR>(*v_lo, *v_lo, *v_sx); // flip low bits if negative
+
+        // Step 5: Complete two's complement by adding 1 (with carry propagation)
+        asm.emit_r::<ADD>(*v_tmp, *v_lo, *v_sx_0); // add 1 to low bits if negative
+        asm.emit_r::<SLTU>(*v_carry, *v_tmp, *v_lo); // check for carry (overflow from low)
+        asm.emit_r::<ADD>(self.operands.rd, *v_hi, *v_carry); // add carry to high bits
+
         asm.finalize()
     }
 }

--- a/tracer/src/instruction/mulhsu.rs
+++ b/tracer/src/instruction/mulhsu.rs
@@ -42,80 +42,36 @@ impl RISCVTrace for MULHSU {
         let inline_sequence = self.inline_sequence(&cpu.vr_allocator, cpu.xlen);
         let mut trace = trace;
         for instr in inline_sequence {
-            // In each iteration, create a new Option containing a re-borrowed reference
             instr.trace(cpu, trace.as_deref_mut());
         }
     }
 
-    /// Generates an inline sequence to compute high bits of signed×unsigned multiplication.
-    ///
-    /// MULHSU multiplies rs1 (signed) by rs2 (unsigned) and returns the upper XLEN bits
-    /// of the 2×XLEN-bit product. This is useful for mixed signed/unsigned arithmetic.
-    ///
-    /// The implementation converts the signed operand to unsigned, performs unsigned
-    /// multiplication, then adjusts the result to account for the sign.
-    ///
-    /// Algorithm overview:
-    /// 1. Convert signed rs1 to unsigned absolute value
-    /// 2. Perform unsigned multiplication to get full product
-    /// 3. If rs1 was negative, negate the entire product
-    /// 4. Extract the high bits with proper carry propagation
-    ///
-    /// The negation of a product is done by XOR with sign mask and adding 1,
-    /// which implements two's complement negation across the full 2×XLEN bits.
     fn inline_sequence(
         &self,
         allocator: &VirtualRegisterAllocator,
         xlen: Xlen,
     ) -> Vec<Instruction> {
-        // MULHSU implements signed-unsigned multiplication: rs1 (signed) × rs2 (unsigned)
-        //
-        // For negative rs1, two's complement encoding means:
-        // rs1_unsigned = rs1 + 2^XLEN (when rs1 < 0)
-        //
-        // Therefore:
-        // MULHU(rs1_unsigned, rs2) = upper_bits((rs1 + 2^XLEN) × rs2)
-        //                          = upper_bits(rs1 × rs2 + 2^XLEN × rs2)
-        //                          = upper_bits(rs1 × rs2) + rs2
-        //                          = MULHSU(rs1, rs2) + rs2
-        //
-        // So: MULHSU(rs1, rs2) = MULHU(rs1_unsigned, rs2) - rs2
-
-        let v_sx = allocator.allocate(); // sign mask for rs1 (all 1s if negative)
-        let v_sx_0 = allocator.allocate(); // LSB of sign mask (1 if negative, 0 otherwise)
-        let v_rs1 = allocator.allocate(); // absolute value of rs1
-        let v_hi = allocator.allocate(); // high bits of unsigned multiplication
-        let v_lo = allocator.allocate(); // low bits of unsigned multiplication
-        let v_tmp = allocator.allocate(); // temporary for carry calculation
-        let v_carry = allocator.allocate(); // carry bit from low to high
+        let v_sx = allocator.allocate();
+        let v_sx_0 = allocator.allocate();
+        let v_rs1 = allocator.allocate();
+        let v_hi = allocator.allocate();
+        let v_lo = allocator.allocate();
+        let v_tmp = allocator.allocate();
+        let v_carry = allocator.allocate();
 
         let mut asm = InstrAssembler::new(self.address, self.is_compressed, xlen, allocator);
 
-        // Step 1: Extract sign information from rs1
-        // v_sx = all 1s if rs1 < 0, all 0s otherwise
         asm.emit_i::<VirtualMovsign>(*v_sx, self.operands.rs1, 0);
-        // v_sx_0 = 1 if rs1 < 0, 0 otherwise (for two's complement addition)
         asm.emit_i::<ANDI>(*v_sx_0, *v_sx, 1);
-
-        // Step 2: Convert rs1 to absolute value (unsigned)
-        // If negative: XOR flips bits, ADD 1 completes two's complement
-        asm.emit_r::<XOR>(*v_rs1, self.operands.rs1, *v_sx); // flip bits if negative
-        asm.emit_r::<ADD>(*v_rs1, *v_rs1, *v_sx_0); // add 1 if negative
-
-        // Step 3: Perform unsigned multiplication
-        // Get full 2×XLEN-bit product of |rs1| × rs2
-        asm.emit_r::<MULHU>(*v_hi, *v_rs1, self.operands.rs2); // high bits
-        asm.emit_r::<MUL>(*v_lo, *v_rs1, self.operands.rs2); // low bits
-
-        // Step 4: Apply sign correction if rs1 was negative
-        // Negate the entire 2×XLEN-bit product using two's complement
-        asm.emit_r::<XOR>(*v_hi, *v_hi, *v_sx); // flip high bits if negative
-        asm.emit_r::<XOR>(*v_lo, *v_lo, *v_sx); // flip low bits if negative
-
-        // Step 5: Complete two's complement by adding 1 (with carry propagation)
-        asm.emit_r::<ADD>(*v_tmp, *v_lo, *v_sx_0); // add 1 to low bits if negative
-        asm.emit_r::<SLTU>(*v_carry, *v_tmp, *v_lo); // check for carry (overflow from low)
-        asm.emit_r::<ADD>(self.operands.rd, *v_hi, *v_carry); // add carry to high bits
+        asm.emit_r::<XOR>(*v_rs1, self.operands.rs1, *v_sx);
+        asm.emit_r::<ADD>(*v_rs1, *v_rs1, *v_sx_0);
+        asm.emit_r::<MULHU>(*v_hi, *v_rs1, self.operands.rs2);
+        asm.emit_r::<MUL>(*v_lo, *v_rs1, self.operands.rs2);
+        asm.emit_r::<XOR>(*v_hi, *v_hi, *v_sx);
+        asm.emit_r::<XOR>(*v_lo, *v_lo, *v_sx);
+        asm.emit_r::<ADD>(*v_tmp, *v_lo, *v_sx_0);
+        asm.emit_r::<SLTU>(*v_carry, *v_tmp, *v_lo);
+        asm.emit_r::<ADD>(self.operands.rd, *v_hi, *v_carry);
 
         asm.finalize()
     }

--- a/tracer/src/instruction/mulw.rs
+++ b/tracer/src/instruction/mulw.rs
@@ -42,14 +42,33 @@ impl RISCVTrace for MULW {
         }
     }
 
+    /// Generates an inline sequence for 32-bit multiplication on 64-bit systems.
+    ///
+    /// MULW is an RV64 instruction that multiplies the lower 32 bits of rs1 and rs2,
+    /// treating them as 32-bit signed integers, and sign-extends the lower 32 bits
+    /// of the result to 64 bits.
+    ///
+    /// The implementation:
+    /// 1. Performs full 64-bit multiplication (which includes the 32-bit result)
+    /// 2. Sign-extends the lower 32 bits to get the final 64-bit result
+    ///
+    /// This works because the lower 32 bits of a 64-bit multiplication are identical
+    /// to a 32-bit multiplication, regardless of the upper bits of the operands.
     fn inline_sequence(
         &self,
         allocator: &VirtualRegisterAllocator,
         xlen: Xlen,
     ) -> Vec<Instruction> {
         let mut asm = InstrAssembler::new(self.address, self.is_compressed, xlen, allocator);
+
+        // Step 1: Perform full 64-bit multiplication
+        // The lower 32 bits contain the 32-bit multiplication result
         asm.emit_r::<MUL>(self.operands.rd, self.operands.rs1, self.operands.rs2);
+
+        // Step 2: Sign-extend the 32-bit result to 64 bits
+        // This ensures bits 32-63 match bit 31 (sign bit of 32-bit result)
         asm.emit_i::<VirtualSignExtendWord>(self.operands.rd, self.operands.rd, 0);
+
         asm.finalize()
     }
 }

--- a/tracer/src/instruction/mulw.rs
+++ b/tracer/src/instruction/mulw.rs
@@ -37,23 +37,10 @@ impl RISCVTrace for MULW {
 
         let mut trace = trace;
         for instr in inline_sequence {
-            // In each iteration, create a new Option containing a re-borrowed reference
             instr.trace(cpu, trace.as_deref_mut());
         }
     }
 
-    /// Generates an inline sequence for 32-bit multiplication on 64-bit systems.
-    ///
-    /// MULW is an RV64 instruction that multiplies the lower 32 bits of rs1 and rs2,
-    /// treating them as 32-bit signed integers, and sign-extends the lower 32 bits
-    /// of the result to 64 bits.
-    ///
-    /// The implementation:
-    /// 1. Performs full 64-bit multiplication (which includes the 32-bit result)
-    /// 2. Sign-extends the lower 32 bits to get the final 64-bit result
-    ///
-    /// This works because the lower 32 bits of a 64-bit multiplication are identical
-    /// to a 32-bit multiplication, regardless of the upper bits of the operands.
     fn inline_sequence(
         &self,
         allocator: &VirtualRegisterAllocator,
@@ -61,12 +48,7 @@ impl RISCVTrace for MULW {
     ) -> Vec<Instruction> {
         let mut asm = InstrAssembler::new(self.address, self.is_compressed, xlen, allocator);
 
-        // Step 1: Perform full 64-bit multiplication
-        // The lower 32 bits contain the 32-bit multiplication result
         asm.emit_r::<MUL>(self.operands.rd, self.operands.rs1, self.operands.rs2);
-
-        // Step 2: Sign-extend the 32-bit result to 64 bits
-        // This ensures bits 32-63 match bit 31 (sign bit of 32-bit result)
         asm.emit_i::<VirtualSignExtendWord>(self.operands.rd, self.operands.rd, 0);
 
         asm.finalize()

--- a/tracer/src/instruction/rem.rs
+++ b/tracer/src/instruction/rem.rs
@@ -93,52 +93,79 @@ impl RISCVTrace for REM {
         }
     }
 
+    /// Generates an inline sequence to verify signed remainder operation.
+    ///
+    /// This function implements a verifiable signed remainder (modulo) operation by decomposing
+    /// it into simpler operations that can be proven correct. Per RISC-V spec, the sign of a
+    /// nonzero remainder equals the sign of the dividend.
+    ///
+    /// The approach:
+    /// 1. Receives untrusted quotient and |remainder| advice from an oracle
+    /// 2. Verifies the fundamental division property: dividend = quotient × divisor + remainder
+    /// 3. Ensures |remainder| < |divisor| (modulo property)
+    /// 4. Handles special cases per RISC-V spec (division by zero, overflow)
+    ///
+    /// Unlike DIV, REM doesn't need overflow checking for quotient × divisor since we only
+    /// care about the remainder, and the multiplication is performed modulo 2^n.
     fn inline_sequence(
         &self,
         allocator: &VirtualRegisterAllocator,
         xlen: Xlen,
     ) -> Vec<Instruction> {
-        let a0 = self.operands.rs1; // dividend
-        let a1 = self.operands.rs2; // divisor
+        let a0 = self.operands.rs1; // dividend (input)
+        let a1 = self.operands.rs2; // divisor (input)
         let a2 = allocator.allocate(); // quotient from oracle (untrusted)
-        let a3 = allocator.allocate(); // |remainder| from oracle (unsigned)
-        let t0 = allocator.allocate();
-        let t1 = allocator.allocate();
-        let t2 = allocator.allocate();
-        let t3 = allocator.allocate();
+        let a3 = allocator.allocate(); // |remainder| from oracle (unsigned, untrusted)
+        let t0 = allocator.allocate(); // adjusted divisor (handles special cases)
+        let t1 = allocator.allocate(); // temporary for multiplication result
+        let t2 = allocator.allocate(); // temporary for sign operations
+        let t3 = allocator.allocate(); // temporary for signed remainder construction
+
         let shmat = match xlen {
             Xlen::Bit32 => 31,
             Xlen::Bit64 => 63,
         };
         let mut asm = InstrAssembler::new(self.address, self.is_compressed, xlen, allocator);
 
-        // get advice
-        asm.emit_j::<VirtualAdvice>(*a2, 0);
-        asm.emit_j::<VirtualAdvice>(*a3, 0);
+        // Step 1: Get untrusted advice values from oracle
+        // The oracle provides quotient and absolute value of remainder
+        asm.emit_j::<VirtualAdvice>(*a2, 0); // get quotient advice
+        asm.emit_j::<VirtualAdvice>(*a3, 0); // get |remainder| advice
 
-        // handle special cases
-        asm.emit_b::<VirtualAssertValidDiv0>(a1, *a2, 0);
-        asm.emit_r::<VirtualChangeDivisor>(*t0, a0, a1);
+        // Step 2: Handle special cases per RISC-V spec
+        // - Division by zero: remainder = dividend
+        // - Overflow (most_negative / -1): remainder = 0
+        asm.emit_b::<VirtualAssertValidDiv0>(a1, *a2, 0); // validates quotient for div-by-zero case
+        asm.emit_r::<VirtualChangeDivisor>(*t0, a0, a1); // adjusts divisor for overflow case
 
-        // compute quotient * divisor (no overflow check needed!)
-        asm.emit_r::<MUL>(*t1, *a2, *t0);
+        // Step 3: Compute quotient × divisor (modulo 2^n)
+        // No overflow check needed since we work modulo 2^n for remainder
+        // This is different from DIV where we need to ensure no overflow
+        asm.emit_r::<MUL>(*t1, *a2, *t0); // t1 = quotient × adjusted_divisor (mod 2^n)
 
-        // construct signed remainder (apply dividend's sign to |remainder|)
-        asm.emit_i::<SRAI>(*t2, a0, shmat);
-        asm.emit_r::<XOR>(*t3, *a3, *t2);
-        asm.emit_r::<SUB>(*t3, *t3, *t2);
+        // Step 4: Construct signed remainder from unsigned advice
+        // RISC-V spec: sign(remainder) = sign(dividend) when remainder ≠ 0
+        // We apply two's complement conversion if dividend is negative
+        asm.emit_i::<SRAI>(*t2, a0, shmat); // t2 = sign_bit(dividend) extended (all 1s if negative)
+        asm.emit_r::<XOR>(*t3, *a3, *t2); // t3 = |remainder| ^ sign_mask (flip bits if negative)
+        asm.emit_r::<SUB>(*t3, *t3, *t2); // t3 = signed_remainder (add 1 if negative via subtraction)
 
-        // verify quotient * divisor + remainder == dividend (mod 2^n)
-        asm.emit_r::<ADD>(*t1, *t1, *t3);
-        asm.emit_b::<VirtualAssertEQ>(*t1, a0, 0);
+        // Step 5: Verify fundamental division property
+        // dividend = quotient × divisor + remainder (all operations mod 2^n)
+        // This ensures our remainder is mathematically correct
+        asm.emit_r::<ADD>(*t1, *t1, *t3); // t1 = (quotient × divisor) + signed_remainder
+        asm.emit_b::<VirtualAssertEQ>(*t1, a0, 0); // assert t1 == dividend
 
-        // check |remainder| < |divisor|
-        asm.emit_i::<SRAI>(*t2, *t0, shmat);
-        asm.emit_r::<XOR>(*t1, *t0, *t2);
-        asm.emit_r::<SUB>(*t1, *t1, *t2);
-        asm.emit_b::<VirtualAssertValidUnsignedRemainder>(*a3, *t1, 0);
+        // Step 6: Verify remainder magnitude constraint
+        // |remainder| < |divisor| is required for valid modulo operation
+        // First compute |adjusted_divisor| using two's complement if negative
+        asm.emit_i::<SRAI>(*t2, *t0, shmat); // t2 = sign_bit(adjusted_divisor) extended
+        asm.emit_r::<XOR>(*t1, *t0, *t2); // t1 = adjusted_divisor ^ sign_mask
+        asm.emit_r::<SUB>(*t1, *t1, *t2); // t1 = |adjusted_divisor|
+        asm.emit_b::<VirtualAssertValidUnsignedRemainder>(*a3, *t1, 0); // assert |remainder| < |divisor|
 
-        // move signed remainder to result
+        // Step 7: Move verified signed remainder to destination register
+        // The signed remainder (with correct sign) is the final result
         asm.emit_i::<VirtualMove>(self.operands.rd, *t3, 0);
         asm.finalize()
     }

--- a/tracer/src/instruction/remu.rs
+++ b/tracer/src/instruction/remu.rs
@@ -69,29 +69,57 @@ impl RISCVTrace for REMU {
         }
     }
 
+    /// Generates an inline sequence to verify unsigned remainder operation.
+    ///
+    /// This function implements a verifiable unsigned remainder (modulo) operation by
+    /// decomposing it into simpler operations that can be proven correct. Unlike signed
+    /// remainder, unsigned remainder is simpler as all values are non-negative.
+    ///
+    /// The approach:
+    /// 1. Receives untrusted quotient and remainder advice from an oracle
+    /// 2. Verifies the fundamental division property: dividend = quotient × divisor + remainder
+    /// 3. Ensures remainder < divisor (modulo property for unsigned)
+    /// 4. Handles division by zero per RISC-V spec (returns dividend)
+    ///
+    /// Note: When divisor is 0, the quotient advice is ignored (can be any value) since
+    /// multiplication by 0 yields 0, and the check becomes: 0 + remainder = dividend.
+    /// The VirtualAssertValidUnsignedRemainder handles the special case where divisor is 0.
     fn inline_sequence(
         &self,
         allocator: &VirtualRegisterAllocator,
         xlen: Xlen,
     ) -> Vec<Instruction> {
-        let a0 = self.operands.rs1; // dividend
-        let a1 = self.operands.rs2; // divisor
+        let a0 = self.operands.rs1; // dividend (unsigned input)
+        let a1 = self.operands.rs2; // divisor (unsigned input)
         let a2 = allocator.allocate(); // quotient from oracle (ignored when divisor==0)
-        let a3 = allocator.allocate(); // remainder from oracle
-        let t0 = allocator.allocate();
+        let a3 = allocator.allocate(); // remainder from oracle (untrusted)
+        let t0 = allocator.allocate(); // temporary for multiplication result
         let mut asm = InstrAssembler::new(self.address, self.is_compressed, xlen, allocator);
 
-        // get advice
-        asm.emit_j::<VirtualAdvice>(*a2, 0);
-        asm.emit_j::<VirtualAdvice>(*a3, 0);
-        // compute quotient * divisor
-        asm.emit_r::<MUL>(*t0, *a2, a1);
-        // verify quotient * divisor + remainder == dividend (mod 2^n)
-        asm.emit_r::<ADD>(*t0, *t0, *a3);
-        asm.emit_b::<VirtualAssertEQ>(*t0, a0, 0);
-        // check remainder < divisor (unsigned)
+        // Step 1: Get untrusted advice values from oracle
+        // Both quotient and remainder are unsigned values
+        asm.emit_j::<VirtualAdvice>(*a2, 0); // get quotient advice
+        asm.emit_j::<VirtualAdvice>(*a3, 0); // get remainder advice
+
+        // Step 2: Compute quotient × divisor
+        // When divisor is 0, this multiplication yields 0, which is correct
+        // for the special case handling (remainder should equal dividend)
+        asm.emit_r::<MUL>(*t0, *a2, a1); // t0 = quotient × divisor
+
+        // Step 3: Verify fundamental division property
+        // dividend = quotient × divisor + remainder (all operations mod 2^n)
+        // When divisor is 0: dividend = 0 + remainder, so remainder must equal dividend
+        asm.emit_r::<ADD>(*t0, *t0, *a3); // t0 = (quotient × divisor) + remainder
+        asm.emit_b::<VirtualAssertEQ>(*t0, a0, 0); // assert t0 == dividend
+
+        // Step 4: Verify remainder constraint
+        // For valid unsigned division: remainder < divisor
+        // Special case: when divisor is 0, this check ensures remainder == dividend
+        // (the assertion handles this by checking remainder < MAX when divisor is 0)
         asm.emit_b::<VirtualAssertValidUnsignedRemainder>(*a3, a1, 0);
-        // move remainder to result
+
+        // Step 5: Move verified remainder to destination register
+        // The remainder is the final result for REMU instruction
         asm.emit_i::<VirtualMove>(self.operands.rd, *a3, 0);
         asm.finalize()
     }

--- a/tracer/src/instruction/remuw.rs
+++ b/tracer/src/instruction/remuw.rs
@@ -75,74 +75,36 @@ impl RISCVTrace for REMUW {
 
         let mut trace = trace;
         for instr in inline_sequence {
-            // In each iteration, create a new Option containing a re-borrowed reference
             instr.trace(cpu, trace.as_deref_mut());
         }
     }
 
-    /// Generates an inline sequence to verify 32-bit unsigned remainder on 64-bit systems.
-    ///
-    /// REMUW is an RV64 instruction that computes the unsigned remainder of dividing the
-    /// lower 32 bits of rs1 by the lower 32 bits of rs2, treating them as unsigned 32-bit
-    /// integers. The 32-bit remainder is then sign-extended to 64 bits (despite being
-    /// unsigned remainder, the result is sign-extended per RISC-V spec).
-    ///
-    /// The approach:
-    /// 1. Zero-extend inputs to get proper 32-bit unsigned values
-    /// 2. Receive untrusted quotient and remainder advice from oracle
-    /// 3. Verify division property: dividend = quotient × divisor + remainder (mod 2^32)
-    /// 4. Ensure remainder < divisor (unsigned comparison)
-    /// 5. Sign-extend the 32-bit remainder to 64 bits
-    ///
-    /// Special case: When divisor is 0, remainder = dividend (per RISC-V spec).
-    /// No overflow check is needed since we work modulo 2^32 for remainder.
+    /// REMUW computes unsigned 32-bit remainder on RV64, sign-extending the result to 64 bits.
+    /// Verifies division property via untrusted oracle: dividend = quotient × divisor + remainder.
     fn inline_sequence(
         &self,
         allocator: &VirtualRegisterAllocator,
         xlen: Xlen,
     ) -> Vec<Instruction> {
-        let a0 = self.operands.rs1; // dividend register (64-bit, contains 32-bit value)
-        let a1 = self.operands.rs2; // divisor register (64-bit, contains 32-bit value)
-        let a2 = allocator.allocate(); // quotient from oracle (untrusted)
-        let a3 = allocator.allocate(); // remainder from oracle (untrusted)
-        let t0 = allocator.allocate(); // temporary for multiplication result
-        let t1 = allocator.allocate(); // zero-extended dividend
-        let t2 = allocator.allocate(); // zero-extended divisor
-        let t3 = allocator.allocate(); // zero-extended quotient
+        let a0 = self.operands.rs1;
+        let a1 = self.operands.rs2;
+        let a2 = allocator.allocate();
+        let a3 = allocator.allocate();
+        let t0 = allocator.allocate();
+        let t1 = allocator.allocate();
+        let t2 = allocator.allocate();
+        let t3 = allocator.allocate();
         let mut asm = InstrAssembler::new(self.address, self.is_compressed, xlen, allocator);
 
-        // Step 1: Get untrusted advice values from oracle
-        asm.emit_j::<VirtualAdvice>(*a2, 0); // get quotient advice
-        asm.emit_j::<VirtualAdvice>(*a3, 0); // get remainder advice
-
-        // Step 2: Zero-extend inputs to proper 32-bit unsigned values
-        // This ensures we work with correct 32-bit unsigned interpretations
-        asm.emit_i::<VirtualZeroExtendWord>(*t1, a0, 0); // t1 = zero_extend_32(dividend)
-        asm.emit_i::<VirtualZeroExtendWord>(*t2, a1, 0); // t2 = zero_extend_32(divisor)
-
-        // Step 3: Zero-extend quotient for unsigned multiplication
-        // Prepare quotient for arithmetic operations
-        asm.emit_i::<VirtualZeroExtendWord>(*t3, *a2, 0); // t3 = zero_extend_32(quotient)
-
-        // Step 4: Compute quotient × divisor
-        // No overflow check needed since remainder only cares about value mod 2^32
-        // When divisor is 0, this multiplication yields 0, making the check: 0 + remainder = dividend
-        asm.emit_r::<MUL>(*t0, *t3, *t2); // t0 = quotient × divisor (multiply zero-extended values)
-
-        // Step 5: Verify fundamental division property
-        // dividend = quotient × divisor + remainder (all operations mod 2^32)
-        // This works correctly even when divisor is 0 (remainder must equal dividend)
-        asm.emit_r::<ADD>(*t0, *t0, *a3); // t0 = (quotient × divisor) + remainder
-        asm.emit_b::<VirtualAssertEQ>(*t0, *t1, 0); // assert t0 == zero_extended_dividend
-
-        // Step 6: Verify remainder constraint
-        // For valid unsigned division: remainder < divisor
-        // When divisor is 0, this check ensures remainder fits in 32 bits
+        asm.emit_j::<VirtualAdvice>(*a2, 0);
+        asm.emit_j::<VirtualAdvice>(*a3, 0);
+        asm.emit_i::<VirtualZeroExtendWord>(*t1, a0, 0);
+        asm.emit_i::<VirtualZeroExtendWord>(*t2, a1, 0);
+        asm.emit_i::<VirtualZeroExtendWord>(*t3, *a2, 0);
+        asm.emit_r::<MUL>(*t0, *t3, *t2);
+        asm.emit_r::<ADD>(*t0, *t0, *a3);
+        asm.emit_b::<VirtualAssertEQ>(*t0, *t1, 0);
         asm.emit_b::<VirtualAssertValidUnsignedRemainder>(*a3, *t2, 0);
-
-        // Step 7: Sign-extend result to 64 bits
-        // Despite being unsigned remainder, RISC-V spec requires sign-extension
-        // This means if bit 31 is set, bits 32-63 will be set to 1
         asm.emit_i::<VirtualSignExtendWord>(self.operands.rd, *a3, 0);
         asm.finalize()
     }

--- a/tracer/src/instruction/remuw.rs
+++ b/tracer/src/instruction/remuw.rs
@@ -80,31 +80,55 @@ impl RISCVTrace for REMUW {
     }
 
     /// REMUW computes unsigned 32-bit remainder on RV64, sign-extending the result to 64 bits.
-    /// Verifies division property via untrusted oracle: dividend = quotient × divisor + remainder.
+    ///
+    /// This RV64 instruction computes the remainder of dividing the lower 32 bits of rs1
+    /// by the lower 32 bits of rs2, treating them as unsigned integers. The result is
+    /// sign-extended to 64 bits despite being unsigned remainder (per RISC-V spec).
+    ///
+    /// Verification strategy:
+    /// 1. Zero-extend inputs to get proper 32-bit unsigned values
+    /// 2. Receive untrusted quotient and remainder from oracle
+    /// 3. Verify: dividend = quotient × divisor + remainder (all 32-bit unsigned)
+    /// 4. Verify: remainder < divisor
+    ///
+    /// Special case: Division by zero returns dividend (handled by VirtualAssertValidUnsignedRemainder)
+    ///
+    /// Note: No overflow check needed since remainder operations work modulo 2^32.
     fn inline_sequence(
         &self,
         allocator: &VirtualRegisterAllocator,
         xlen: Xlen,
     ) -> Vec<Instruction> {
-        let a0 = self.operands.rs1;
-        let a1 = self.operands.rs2;
-        let a2 = allocator.allocate();
-        let a3 = allocator.allocate();
-        let t0 = allocator.allocate();
-        let t1 = allocator.allocate();
-        let t2 = allocator.allocate();
-        let t3 = allocator.allocate();
+        let a0 = self.operands.rs1; // dividend (contains 32-bit value)
+        let a1 = self.operands.rs2; // divisor (contains 32-bit value)
+        let a2 = allocator.allocate(); // quotient from oracle
+        let a3 = allocator.allocate(); // remainder from oracle
+        let t0 = allocator.allocate(); // multiplication result
+        let t1 = allocator.allocate(); // zero-extended dividend
+        let t2 = allocator.allocate(); // zero-extended divisor
+        let t3 = allocator.allocate(); // zero-extended quotient
         let mut asm = InstrAssembler::new(self.address, self.is_compressed, xlen, allocator);
 
-        asm.emit_j::<VirtualAdvice>(*a2, 0);
-        asm.emit_j::<VirtualAdvice>(*a3, 0);
-        asm.emit_i::<VirtualZeroExtendWord>(*t1, a0, 0);
-        asm.emit_i::<VirtualZeroExtendWord>(*t2, a1, 0);
-        asm.emit_i::<VirtualZeroExtendWord>(*t3, *a2, 0);
+        // Get untrusted advice from oracle
+        asm.emit_j::<VirtualAdvice>(*a2, 0); // quotient
+        asm.emit_j::<VirtualAdvice>(*a3, 0); // remainder
+
+        // Zero-extend inputs to proper 32-bit unsigned values
+        asm.emit_i::<VirtualZeroExtendWord>(*t1, a0, 0); // dividend
+        asm.emit_i::<VirtualZeroExtendWord>(*t2, a1, 0); // divisor
+        asm.emit_i::<VirtualZeroExtendWord>(*t3, *a2, 0); // quotient
+
+        // Compute quotient × divisor (32-bit unsigned values)
         asm.emit_r::<MUL>(*t0, *t3, *t2);
+
+        // Verify: dividend = quotient × divisor + remainder
         asm.emit_r::<ADD>(*t0, *t0, *a3);
         asm.emit_b::<VirtualAssertEQ>(*t0, *t1, 0);
+
+        // Verify: remainder < divisor (or remainder == dividend when divisor == 0)
         asm.emit_b::<VirtualAssertValidUnsignedRemainder>(*a3, *t2, 0);
+
+        // Sign-extend 32-bit remainder to 64 bits
         asm.emit_i::<VirtualSignExtendWord>(self.operands.rd, *a3, 0);
         asm.finalize()
     }

--- a/tracer/src/instruction/remw.rs
+++ b/tracer/src/instruction/remw.rs
@@ -82,82 +82,44 @@ impl RISCVTrace for REMW {
 
         let mut trace = trace;
         for instr in inline_sequence {
-            // In each iteration, create a new Option containing a re-borrowed reference
             instr.trace(cpu, trace.as_deref_mut());
         }
     }
 
-    /// Generates an inline sequence to verify 32-bit signed remainder on 64-bit systems.
-    ///
-    /// REMW is an RV64 instruction that computes the signed remainder of dividing the
-    /// lower 32 bits of rs1 by the lower 32 bits of rs2, treating them as signed 32-bit
-    /// integers. The 32-bit remainder is sign-extended to 64 bits. Per RISC-V spec,
-    /// the sign of a nonzero remainder equals the sign of the dividend.
-    ///
-    /// The approach:
-    /// 1. Sign-extend inputs to proper 32-bit signed values
-    /// 2. Receive untrusted quotient and |remainder| advice from oracle
-    /// 3. Handle special cases (division by zero returns dividend, i32::MIN % -1 returns 0)
-    /// 4. Verify division property: dividend = quotient × divisor + remainder (mod 2^32)
-    /// 5. Ensure |remainder| < |divisor|
-    /// 6. Sign-extend the 32-bit remainder to 64 bits
-    ///
-    /// Unlike DIVW, no overflow check is needed for quotient × divisor since we work mod 2^32.
+    /// REMW computes signed 32-bit remainder on RV64, sign-extending the result to 64 bits.
+    /// Verifies division property via untrusted oracle, handling special cases.
     fn inline_sequence(
         &self,
         allocator: &VirtualRegisterAllocator,
         xlen: Xlen,
     ) -> Vec<Instruction> {
-        let a0 = self.operands.rs1; // dividend register (64-bit, contains 32-bit value)
-        let a1 = self.operands.rs2; // divisor register (64-bit, contains 32-bit value)
-        let a2 = allocator.allocate(); // quotient from oracle (untrusted)
-        let a3 = allocator.allocate(); // |remainder| from oracle (unsigned, untrusted)
-        let t0 = allocator.allocate(); // adjusted 32-bit divisor (handles special cases)
-        let t1 = allocator.allocate(); // temporary for multiplication/computation
-        let t2 = allocator.allocate(); // temporary for sign operations
-        let t3 = allocator.allocate(); // temporary for signed remainder
-        let t4 = allocator.allocate(); // sign-extended 32-bit dividend
+        let a0 = self.operands.rs1;
+        let a1 = self.operands.rs2;
+        let a2 = allocator.allocate();
+        let a3 = allocator.allocate();
+        let t0 = allocator.allocate();
+        let t1 = allocator.allocate();
+        let t2 = allocator.allocate();
+        let t3 = allocator.allocate();
+        let t4 = allocator.allocate();
         let mut asm = InstrAssembler::new(self.address, self.is_compressed, xlen, allocator);
 
-        // Step 1: Get untrusted advice values from oracle
-        asm.emit_j::<VirtualAdvice>(*a2, 0); // get quotient advice
-        asm.emit_j::<VirtualAdvice>(*a3, 0); // get |remainder| advice
-
-        // Step 2: Sign-extend inputs to proper 32-bit values
-        // This ensures we work with correct 32-bit signed interpretations
-        asm.emit_i::<VirtualSignExtendWord>(*t4, a0, 0); // t4 = sign_extend_32(dividend)
-        asm.emit_i::<VirtualSignExtendWord>(*t3, a1, 0); // t3 = sign_extend_32(divisor)
-
-        // Step 3: Handle special cases per RISC-V spec
-        // - Division by zero: remainder = dividend
-        // - Overflow (i32::MIN % -1): remainder = 0
-        asm.emit_b::<VirtualAssertValidDiv0>(*t3, *a2, 0); // validates quotient for div-by-zero
-        asm.emit_r::<VirtualChangeDivisorW>(*t0, *t4, *t3); // t0 = adjusted divisor for overflow
-
-        // Step 4: Compute quotient × divisor in 32-bit space
-        // No overflow check needed since remainder only cares about value mod 2^32
-        asm.emit_r::<MULW>(*t1, *a2, *t0); // t1 = quotient × adjusted_divisor (32-bit multiply)
-
-        // Step 5: Construct signed remainder from unsigned advice
-        // Apply dividend's sign to |remainder| per RISC-V spec
-        asm.emit_i::<SRAI>(*t2, *t4, 31); // t2 = sign_bit(32-bit dividend) extended
-        asm.emit_r::<XOR>(*t3, *a3, *t2); // t3 = |remainder| ^ sign_mask
-        asm.emit_r::<SUB>(*t3, *t3, *t2); // t3 = signed_remainder (two's complement if negative)
-
-        // Step 6: Verify division property in 32-bit space
-        // dividend = quotient × divisor + remainder (all operations in 32-bit space)
-        asm.emit_r::<ADDW>(*t1, *t1, *t3); // t1 = (quotient × divisor) + remainder (32-bit add)
-        asm.emit_b::<VirtualAssertEQ>(*t1, *t4, 0); // assert t1 == sign_extended_dividend
-
-        // Step 7: Verify remainder magnitude constraint
-        // |remainder| < |divisor| is required for valid modulo operation
-        asm.emit_i::<SRAI>(*t2, *t0, 31); // t2 = sign_bit(adjusted_divisor) extended
-        asm.emit_r::<XOR>(*t1, *t0, *t2); // t1 = adjusted_divisor ^ sign_mask
-        asm.emit_r::<SUB>(*t1, *t1, *t2); // t1 = |adjusted_divisor|
-        asm.emit_b::<VirtualAssertValidUnsignedRemainder>(*a3, *t1, 0); // assert |remainder| < |divisor|
-
-        // Step 8: Sign-extend 32-bit remainder to 64 bits and move to destination
-        // This ensures the result is properly sign-extended as per REMW specification
+        asm.emit_j::<VirtualAdvice>(*a2, 0);
+        asm.emit_j::<VirtualAdvice>(*a3, 0);
+        asm.emit_i::<VirtualSignExtendWord>(*t4, a0, 0);
+        asm.emit_i::<VirtualSignExtendWord>(*t3, a1, 0);
+        asm.emit_b::<VirtualAssertValidDiv0>(*t3, *a2, 0);
+        asm.emit_r::<VirtualChangeDivisorW>(*t0, *t4, *t3);
+        asm.emit_r::<MULW>(*t1, *a2, *t0);
+        asm.emit_i::<SRAI>(*t2, *t4, 31);
+        asm.emit_r::<XOR>(*t3, *a3, *t2);
+        asm.emit_r::<SUB>(*t3, *t3, *t2);
+        asm.emit_r::<ADDW>(*t1, *t1, *t3);
+        asm.emit_b::<VirtualAssertEQ>(*t1, *t4, 0);
+        asm.emit_i::<SRAI>(*t2, *t0, 31);
+        asm.emit_r::<XOR>(*t1, *t0, *t2);
+        asm.emit_r::<SUB>(*t1, *t1, *t2);
+        asm.emit_b::<VirtualAssertValidUnsignedRemainder>(*a3, *t1, 0);
         asm.emit_i::<VirtualSignExtendWord>(self.operands.rd, *t3, 0);
         asm.finalize()
     }

--- a/tracer/src/instruction/remw.rs
+++ b/tracer/src/instruction/remw.rs
@@ -87,39 +87,72 @@ impl RISCVTrace for REMW {
     }
 
     /// REMW computes signed 32-bit remainder on RV64, sign-extending the result to 64 bits.
-    /// Verifies division property via untrusted oracle, handling special cases.
+    ///
+    /// This RV64 instruction computes the remainder of dividing the lower 32 bits of rs1
+    /// by the lower 32 bits of rs2, treating them as signed 32-bit integers. The result
+    /// is sign-extended to 64 bits. Per RISC-V spec, the sign of a nonzero remainder
+    /// equals the sign of the dividend.
+    ///
+    /// Verification strategy:
+    /// 1. Sign-extend inputs to proper 32-bit signed values
+    /// 2. Receive untrusted quotient and |remainder| from oracle
+    /// 3. Handle special cases (div-by-zero returns dividend, overflow returns 0)
+    /// 4. Apply sign of dividend to remainder
+    /// 5. Verify: dividend = quotient × divisor + remainder (in 32-bit space)
+    /// 6. Verify: |remainder| < |divisor|
+    ///
+    /// Special cases:
+    /// - Division by zero: remainder = dividend
+    /// - Overflow (i32::MIN % -1): remainder = 0 (handled by VirtualChangeDivisorW)
+    ///
+    /// Note: No overflow check needed for multiplication since we work modulo 2^32.
     fn inline_sequence(
         &self,
         allocator: &VirtualRegisterAllocator,
         xlen: Xlen,
     ) -> Vec<Instruction> {
-        let a0 = self.operands.rs1;
-        let a1 = self.operands.rs2;
-        let a2 = allocator.allocate();
-        let a3 = allocator.allocate();
-        let t0 = allocator.allocate();
-        let t1 = allocator.allocate();
-        let t2 = allocator.allocate();
-        let t3 = allocator.allocate();
-        let t4 = allocator.allocate();
+        let a0 = self.operands.rs1; // dividend
+        let a1 = self.operands.rs2; // divisor
+        let a2 = allocator.allocate(); // quotient from oracle
+        let a3 = allocator.allocate(); // |remainder| from oracle
+        let t0 = allocator.allocate(); // adjusted divisor
+        let t1 = allocator.allocate(); // temporary
+        let t2 = allocator.allocate(); // temporary
+        let t3 = allocator.allocate(); // signed remainder
+        let t4 = allocator.allocate(); // sign-extended dividend
         let mut asm = InstrAssembler::new(self.address, self.is_compressed, xlen, allocator);
 
-        asm.emit_j::<VirtualAdvice>(*a2, 0);
-        asm.emit_j::<VirtualAdvice>(*a3, 0);
-        asm.emit_i::<VirtualSignExtendWord>(*t4, a0, 0);
-        asm.emit_i::<VirtualSignExtendWord>(*t3, a1, 0);
-        asm.emit_b::<VirtualAssertValidDiv0>(*t3, *a2, 0);
-        asm.emit_r::<VirtualChangeDivisorW>(*t0, *t4, *t3);
-        asm.emit_r::<MULW>(*t1, *a2, *t0);
-        asm.emit_i::<SRAI>(*t2, *t4, 31);
-        asm.emit_r::<XOR>(*t3, *a3, *t2);
-        asm.emit_r::<SUB>(*t3, *t3, *t2);
-        asm.emit_r::<ADDW>(*t1, *t1, *t3);
+        // Get untrusted advice from oracle
+        asm.emit_j::<VirtualAdvice>(*a2, 0); // quotient
+        asm.emit_j::<VirtualAdvice>(*a3, 0); // |remainder|
+
+        // Sign-extend inputs to proper 32-bit values
+        asm.emit_i::<VirtualSignExtendWord>(*t4, a0, 0); // dividend
+        asm.emit_i::<VirtualSignExtendWord>(*t3, a1, 0); // divisor
+
+        // Handle special cases: div-by-zero and overflow
+        asm.emit_b::<VirtualAssertValidDiv0>(*t3, *a2, 0); // Check div-by-zero
+        asm.emit_r::<VirtualChangeDivisorW>(*t0, *t4, *t3); // Adjust for overflow
+
+        // Compute quotient × divisor in 32-bit space (no overflow check needed)
+        asm.emit_r::<MULW>(*t1, *a2, *t0); // 32-bit multiply
+
+        // Apply sign of dividend to remainder (RISC-V: sign(remainder) = sign(dividend))
+        asm.emit_i::<SRAI>(*t2, *t4, 31); // Sign bit of 32-bit dividend
+        asm.emit_r::<XOR>(*t3, *a3, *t2); // XOR with |remainder|
+        asm.emit_r::<SUB>(*t3, *t3, *t2); // Two's complement if negative
+
+        // Verify: dividend = quotient × divisor + remainder (32-bit)
+        asm.emit_r::<ADDW>(*t1, *t1, *t3); // 32-bit add
         asm.emit_b::<VirtualAssertEQ>(*t1, *t4, 0);
-        asm.emit_i::<SRAI>(*t2, *t0, 31);
-        asm.emit_r::<XOR>(*t1, *t0, *t2);
-        asm.emit_r::<SUB>(*t1, *t1, *t2);
+
+        // Verify: |remainder| < |divisor|
+        asm.emit_i::<SRAI>(*t2, *t0, 31); // Sign bit of adjusted divisor
+        asm.emit_r::<XOR>(*t1, *t0, *t2); // Get magnitude
+        asm.emit_r::<SUB>(*t1, *t1, *t2); // |adjusted_divisor|
         asm.emit_b::<VirtualAssertValidUnsignedRemainder>(*a3, *t1, 0);
+
+        // Sign-extend signed remainder to 64 bits
         asm.emit_i::<VirtualSignExtendWord>(self.operands.rd, *t3, 0);
         asm.finalize()
     }

--- a/tracer/src/instruction/remw.rs
+++ b/tracer/src/instruction/remw.rs
@@ -87,53 +87,77 @@ impl RISCVTrace for REMW {
         }
     }
 
+    /// Generates an inline sequence to verify 32-bit signed remainder on 64-bit systems.
+    ///
+    /// REMW is an RV64 instruction that computes the signed remainder of dividing the
+    /// lower 32 bits of rs1 by the lower 32 bits of rs2, treating them as signed 32-bit
+    /// integers. The 32-bit remainder is sign-extended to 64 bits. Per RISC-V spec,
+    /// the sign of a nonzero remainder equals the sign of the dividend.
+    ///
+    /// The approach:
+    /// 1. Sign-extend inputs to proper 32-bit signed values
+    /// 2. Receive untrusted quotient and |remainder| advice from oracle
+    /// 3. Handle special cases (division by zero returns dividend, i32::MIN % -1 returns 0)
+    /// 4. Verify division property: dividend = quotient × divisor + remainder (mod 2^32)
+    /// 5. Ensure |remainder| < |divisor|
+    /// 6. Sign-extend the 32-bit remainder to 64 bits
+    ///
+    /// Unlike DIVW, no overflow check is needed for quotient × divisor since we work mod 2^32.
     fn inline_sequence(
         &self,
         allocator: &VirtualRegisterAllocator,
         xlen: Xlen,
     ) -> Vec<Instruction> {
-        let a0 = self.operands.rs1; // dividend
-        let a1 = self.operands.rs2; // divisor
+        let a0 = self.operands.rs1; // dividend register (64-bit, contains 32-bit value)
+        let a1 = self.operands.rs2; // divisor register (64-bit, contains 32-bit value)
         let a2 = allocator.allocate(); // quotient from oracle (untrusted)
-        let a3 = allocator.allocate(); // |remainder| from oracle (unsigned)
-        let t0 = allocator.allocate();
-        let t1 = allocator.allocate();
-        let t2 = allocator.allocate();
-        let t3 = allocator.allocate();
-        let t4 = allocator.allocate();
+        let a3 = allocator.allocate(); // |remainder| from oracle (unsigned, untrusted)
+        let t0 = allocator.allocate(); // adjusted 32-bit divisor (handles special cases)
+        let t1 = allocator.allocate(); // temporary for multiplication/computation
+        let t2 = allocator.allocate(); // temporary for sign operations
+        let t3 = allocator.allocate(); // temporary for signed remainder
+        let t4 = allocator.allocate(); // sign-extended 32-bit dividend
         let mut asm = InstrAssembler::new(self.address, self.is_compressed, xlen, allocator);
 
-        // get advice
-        asm.emit_j::<VirtualAdvice>(*a2, 0);
-        asm.emit_j::<VirtualAdvice>(*a3, 0);
+        // Step 1: Get untrusted advice values from oracle
+        asm.emit_j::<VirtualAdvice>(*a2, 0); // get quotient advice
+        asm.emit_j::<VirtualAdvice>(*a3, 0); // get |remainder| advice
 
-        // sign-extend inputs to 32-bit values
-        asm.emit_i::<VirtualSignExtendWord>(*t4, a0, 0); // sign-extended dividend
-        asm.emit_i::<VirtualSignExtendWord>(*t3, a1, 0); // sign-extended divisor
+        // Step 2: Sign-extend inputs to proper 32-bit values
+        // This ensures we work with correct 32-bit signed interpretations
+        asm.emit_i::<VirtualSignExtendWord>(*t4, a0, 0); // t4 = sign_extend_32(dividend)
+        asm.emit_i::<VirtualSignExtendWord>(*t3, a1, 0); // t3 = sign_extend_32(divisor)
 
-        // handle special cases
-        asm.emit_b::<VirtualAssertValidDiv0>(*t3, *a2, 0);
-        asm.emit_r::<VirtualChangeDivisorW>(*t0, *t4, *t3); // handles MIN_INT32/-1
+        // Step 3: Handle special cases per RISC-V spec
+        // - Division by zero: remainder = dividend
+        // - Overflow (i32::MIN % -1): remainder = 0
+        asm.emit_b::<VirtualAssertValidDiv0>(*t3, *a2, 0); // validates quotient for div-by-zero
+        asm.emit_r::<VirtualChangeDivisorW>(*t0, *t4, *t3); // t0 = adjusted divisor for overflow
 
-        // compute quotient * divisor (no overflow check needed for remainder!)
-        asm.emit_r::<MULW>(*t1, *a2, *t0); // 32-bit multiply
+        // Step 4: Compute quotient × divisor in 32-bit space
+        // No overflow check needed since remainder only cares about value mod 2^32
+        asm.emit_r::<MULW>(*t1, *a2, *t0); // t1 = quotient × adjusted_divisor (32-bit multiply)
 
-        // construct signed remainder (apply dividend's sign to |remainder|)
-        asm.emit_i::<SRAI>(*t2, *t4, 31); // sign of 32-bit dividend
-        asm.emit_r::<XOR>(*t3, *a3, *t2);
-        asm.emit_r::<SUB>(*t3, *t3, *t2);
+        // Step 5: Construct signed remainder from unsigned advice
+        // Apply dividend's sign to |remainder| per RISC-V spec
+        asm.emit_i::<SRAI>(*t2, *t4, 31); // t2 = sign_bit(32-bit dividend) extended
+        asm.emit_r::<XOR>(*t3, *a3, *t2); // t3 = |remainder| ^ sign_mask
+        asm.emit_r::<SUB>(*t3, *t3, *t2); // t3 = signed_remainder (two's complement if negative)
 
-        // verify quotient * divisor + remainder == dividend (in 32-bit space)
-        asm.emit_r::<ADDW>(*t1, *t1, *t3);
-        asm.emit_b::<VirtualAssertEQ>(*t1, *t4, 0);
+        // Step 6: Verify division property in 32-bit space
+        // dividend = quotient × divisor + remainder (all operations in 32-bit space)
+        asm.emit_r::<ADDW>(*t1, *t1, *t3); // t1 = (quotient × divisor) + remainder (32-bit add)
+        asm.emit_b::<VirtualAssertEQ>(*t1, *t4, 0); // assert t1 == sign_extended_dividend
 
-        // check |remainder| < |divisor|
-        asm.emit_i::<SRAI>(*t2, *t0, 31);
-        asm.emit_r::<XOR>(*t1, *t0, *t2);
-        asm.emit_r::<SUB>(*t1, *t1, *t2);
-        asm.emit_b::<VirtualAssertValidUnsignedRemainder>(*a3, *t1, 0);
+        // Step 7: Verify remainder magnitude constraint
+        // |remainder| < |divisor| is required for valid modulo operation
+        asm.emit_i::<SRAI>(*t2, *t0, 31); // t2 = sign_bit(adjusted_divisor) extended
+        asm.emit_r::<XOR>(*t1, *t0, *t2); // t1 = adjusted_divisor ^ sign_mask
+        asm.emit_r::<SUB>(*t1, *t1, *t2); // t1 = |adjusted_divisor|
+        asm.emit_b::<VirtualAssertValidUnsignedRemainder>(*a3, *t1, 0); // assert |remainder| < |divisor|
 
-        // sign-extend remainder result
+        // Step 8: Sign-extend 32-bit remainder to 64 bits and move to destination
+        // This ensures the result is properly sign-extended as per REMW specification
         asm.emit_i::<VirtualSignExtendWord>(self.operands.rd, *t3, 0);
         asm.finalize()
     }

--- a/tracer/src/instruction/sb.rs
+++ b/tracer/src/instruction/sb.rs
@@ -53,6 +53,13 @@ impl RISCVTrace for SB {
         }
     }
 
+    /// Store byte to memory using word-aligned access.
+    ///
+    /// SB stores the lower 8 bits of rs2 to memory at address rs1+imm.
+    /// Since zkVM uses word-aligned memory, this requires:
+    /// 1. Loading the aligned word containing the target byte
+    /// 2. Masking and replacing the specific byte
+    /// 3. Storing the modified word back to memory
     fn inline_sequence(
         &self,
         allocator: &VirtualRegisterAllocator,
@@ -66,6 +73,18 @@ impl RISCVTrace for SB {
 }
 
 impl SB {
+    /// 32-bit implementation of store byte.
+    ///
+    /// Algorithm:
+    /// 1. Calculate target address and align to 4-byte boundary
+    /// 2. Load the aligned word containing the target byte
+    /// 3. Create a mask for the specific byte position (0xFF shifted to position)
+    /// 4. Shift the byte value to the correct position
+    /// 5. Use XOR operations to replace only the target byte
+    /// 6. Store the modified word back to memory
+    ///
+    /// The XOR technique: (word ^ byte) & mask ^ word
+    /// This clears the original byte and sets the new byte value.
     fn inline_sequence_32(&self, allocator: &VirtualRegisterAllocator) -> Vec<Instruction> {
         let v_address = allocator.allocate();
         let v_word_address = allocator.allocate();
@@ -89,6 +108,11 @@ impl SB {
         asm.finalize()
     }
 
+    /// 64-bit implementation of store byte.
+    ///
+    /// Similar to 32-bit version but operates on 64-bit doublewords.
+    /// The byte position is determined by the lower 3 bits of the address,
+    /// and the shift amount is multiplied by 8 to convert to bit positions.
     fn inline_sequence_64(&self, allocator: &VirtualRegisterAllocator) -> Vec<Instruction> {
         let v_address = allocator.allocate();
         let v_dword_address = allocator.allocate();

--- a/tracer/src/instruction/sb.rs
+++ b/tracer/src/instruction/sb.rs
@@ -48,7 +48,6 @@ impl RISCVTrace for SB {
         let inline_sequence = self.inline_sequence(&cpu.vr_allocator, cpu.xlen);
         let mut trace = trace;
         for instr in inline_sequence {
-            // In each iteration, create a new Option containing a re-borrowed reference
             instr.trace(cpu, trace.as_deref_mut());
         }
     }

--- a/tracer/src/instruction/sh.rs
+++ b/tracer/src/instruction/sh.rs
@@ -50,7 +50,6 @@ impl RISCVTrace for SH {
         let inline_sequence = self.inline_sequence(&cpu.vr_allocator, cpu.xlen);
         let mut trace = trace;
         for instr in inline_sequence {
-            // In each iteration, create a new Option containing a re-borrowed reference
             instr.trace(cpu, trace.as_deref_mut());
         }
     }

--- a/tracer/src/instruction/sll.rs
+++ b/tracer/src/instruction/sll.rs
@@ -42,16 +42,33 @@ impl RISCVTrace for SLL {
         }
     }
 
+    /// Generates an inline sequence for logical left shift operation.
+    ///
+    /// SLL (Shift Left Logical) shifts rs1 left by the shift amount in the lower
+    /// 5 bits (RV32) or 6 bits (RV64) of rs2, filling the vacated bits with zeros.
+    ///
+    /// The implementation uses the mathematical equivalence:
+    /// x << n = x × 2^n
+    ///
+    /// This allows the shift to be verified using multiplication, which is
+    /// more amenable to proof systems that work with field arithmetic.
     fn inline_sequence(
         &self,
         allocator: &VirtualRegisterAllocator,
         xlen: Xlen,
     ) -> Vec<Instruction> {
-        let v_pow2 = allocator.allocate();
+        let v_pow2 = allocator.allocate(); // holds 2^shift_amount
 
         let mut asm = InstrAssembler::new(self.address, self.is_compressed, xlen, allocator);
+
+        // Step 1: Compute 2^shift_amount
+        // VirtualPow2 computes 2^(rs2 & mask) where mask is 0x1f (RV32) or 0x3f (RV64)
         asm.emit_i::<VirtualPow2>(*v_pow2, self.operands.rs2, 0);
+
+        // Step 2: Multiply rs1 by 2^shift_amount
+        // This achieves the left shift: rs1 << shift_amount = rs1 × 2^shift_amount
         asm.emit_r::<MUL>(self.operands.rd, self.operands.rs1, *v_pow2);
+
         asm.finalize()
     }
 }

--- a/tracer/src/instruction/slli.rs
+++ b/tracer/src/instruction/slli.rs
@@ -40,6 +40,17 @@ impl RISCVTrace for SLLI {
         }
     }
 
+    /// Generates inline sequence for shift left logical immediate.
+    ///
+    /// SLLI (Shift Left Logical Immediate) shifts rs1 left by a constant amount.
+    /// The implementation uses multiplication by 2^shift_amount, leveraging the
+    /// mathematical equivalence: x << n = x * 2^n
+    ///
+    /// This approach is zkVM-friendly as multiplication is a native operation
+    /// that can be efficiently verified in the constraint system.
+    ///
+    /// The shift amount is masked to 5 bits on RV32 (0-31) or 6 bits on RV64 (0-63),
+    /// ensuring the shift stays within valid bounds for the architecture.
     fn inline_sequence(
         &self,
         allocator: &VirtualRegisterAllocator,

--- a/tracer/src/instruction/slli.rs
+++ b/tracer/src/instruction/slli.rs
@@ -35,7 +35,6 @@ impl RISCVTrace for SLLI {
         let inline_sequence = self.inline_sequence(&cpu.vr_allocator, cpu.xlen);
         let mut trace = trace;
         for instr in inline_sequence {
-            // In each iteration, create a new Option containing a re-borrowed reference
             instr.trace(cpu, trace.as_deref_mut());
         }
     }

--- a/tracer/src/instruction/slliw.rs
+++ b/tracer/src/instruction/slliw.rs
@@ -39,6 +39,16 @@ impl RISCVTrace for SLLIW {
         }
     }
 
+    /// Shift left logical immediate for 32-bit words with sign extension.
+    ///
+    /// SLLIW is an RV64I-only instruction that shifts the lower 32 bits of rs1
+    /// left by a constant amount, then sign-extends the 32-bit result to 64 bits.
+    ///
+    /// Implementation:
+    /// 1. Multiply by 2^shift_amount (equivalent to left shift)
+    /// 2. Sign-extend the lower 32 bits to 64 bits
+    ///
+    /// The shift amount is restricted to 5 bits (0-31) for 32-bit operations.
     fn inline_sequence(
         &self,
         allocator: &VirtualRegisterAllocator,

--- a/tracer/src/instruction/slliw.rs
+++ b/tracer/src/instruction/slliw.rs
@@ -34,7 +34,6 @@ impl RISCVTrace for SLLIW {
         let inline_sequence = self.inline_sequence(&cpu.vr_allocator, cpu.xlen);
         let mut trace = trace;
         for instr in inline_sequence {
-            // In each iteration, create a new Option containing a re-borrowed reference
             instr.trace(cpu, trace.as_deref_mut());
         }
     }

--- a/tracer/src/instruction/sllw.rs
+++ b/tracer/src/instruction/sllw.rs
@@ -37,7 +37,6 @@ impl RISCVTrace for SLLW {
         let inline_sequence = self.inline_sequence(&cpu.vr_allocator, cpu.xlen);
         let mut trace = trace;
         for instr in inline_sequence {
-            // In each iteration, create a new Option containing a re-borrowed reference
             instr.trace(cpu, trace.as_deref_mut());
         }
     }

--- a/tracer/src/instruction/sllw.rs
+++ b/tracer/src/instruction/sllw.rs
@@ -42,6 +42,18 @@ impl RISCVTrace for SLLW {
         }
     }
 
+    /// Shift left logical for 32-bit words with sign extension.
+    ///
+    /// SLLW is an RV64I-only instruction that shifts the lower 32 bits of rs1
+    /// left by the amount in the lower 5 bits of rs2, then sign-extends the
+    /// 32-bit result to 64 bits.
+    ///
+    /// Implementation:
+    /// 1. Compute 2^(rs2[4:0]) using VirtualPow2W
+    /// 2. Multiply rs1 by this power of 2 (equivalent to left shift)
+    /// 3. Sign-extend the lower 32 bits of the result
+    ///
+    /// The multiplication approach allows zkVM-friendly verification.
     fn inline_sequence(
         &self,
         allocator: &VirtualRegisterAllocator,

--- a/tracer/src/instruction/sra.rs
+++ b/tracer/src/instruction/sra.rs
@@ -43,16 +43,34 @@ impl RISCVTrace for SRA {
         }
     }
 
+    /// Generates an inline sequence for arithmetic right shift operation.
+    ///
+    /// SRA (Shift Right Arithmetic) shifts rs1 right by the shift amount in rs2,
+    /// filling the vacated bits with copies of the sign bit (bit XLEN-1).
+    ///
+    /// The implementation uses a bitmask approach where:
+    /// 1. A bitmask is computed based on the shift amount
+    /// 2. Virtual SRA instruction applies the shift using the bitmask
+    ///
+    /// This approach allows the shift to be verified in a way that's compatible
+    /// with zkVM's constraint system.
     fn inline_sequence(
         &self,
         allocator: &VirtualRegisterAllocator,
         xlen: Xlen,
     ) -> Vec<Instruction> {
-        let v_bitmask = allocator.allocate();
+        let v_bitmask = allocator.allocate(); // holds the shift bitmask
 
         let mut asm = InstrAssembler::new(self.address, self.is_compressed, xlen, allocator);
+
+        // Step 1: Generate bitmask for right shift
+        // Creates a mask that represents which bits to keep/shift
         asm.emit_i::<VirtualShiftRightBitmask>(*v_bitmask, self.operands.rs2, 0);
+
+        // Step 2: Apply arithmetic right shift using the bitmask
+        // Preserves sign bit during the shift operation
         asm.emit_vshift_r::<VirtualSRA>(self.operands.rd, self.operands.rs1, *v_bitmask);
+
         asm.finalize()
     }
 }

--- a/tracer/src/instruction/srai.rs
+++ b/tracer/src/instruction/srai.rs
@@ -35,7 +35,6 @@ impl RISCVTrace for SRAI {
         let inline_sequence = self.inline_sequence(&cpu.vr_allocator, cpu.xlen);
         let mut trace = trace;
         for instr in inline_sequence {
-            // In each iteration, create a new Option containing a re-borrowed reference
             instr.trace(cpu, trace.as_deref_mut());
         }
     }

--- a/tracer/src/instruction/srai.rs
+++ b/tracer/src/instruction/srai.rs
@@ -40,6 +40,17 @@ impl RISCVTrace for SRAI {
         }
     }
 
+    /// Arithmetic right shift immediate using bitmask approach.
+    ///
+    /// SRAI (Shift Right Arithmetic Immediate) shifts rs1 right by a constant amount,
+    /// filling the vacated bits with copies of the sign bit.
+    ///
+    /// Implementation:
+    /// 1. Calculate a bitmask for the shift amount
+    /// 2. Apply arithmetic shift using VirtualSRAI with the bitmask
+    ///
+    /// The arithmetic shift preserves the sign bit, extending it into the
+    /// high-order bits, which is essential for signed integer division by powers of 2.
     fn inline_sequence(
         &self,
         allocator: &VirtualRegisterAllocator,

--- a/tracer/src/instruction/sraiw.rs
+++ b/tracer/src/instruction/sraiw.rs
@@ -35,7 +35,6 @@ impl RISCVTrace for SRAIW {
         let inline_sequence = self.inline_sequence(&cpu.vr_allocator, cpu.xlen);
         let mut trace = trace;
         for instr in inline_sequence {
-            // In each iteration, create a new Option containing a re-borrowed reference
             instr.trace(cpu, trace.as_deref_mut());
         }
     }

--- a/tracer/src/instruction/sraiw.rs
+++ b/tracer/src/instruction/sraiw.rs
@@ -40,6 +40,18 @@ impl RISCVTrace for SRAIW {
         }
     }
 
+    /// Arithmetic right shift immediate for 32-bit words with sign extension.
+    ///
+    /// SRAIW is an RV64I-only instruction that arithmetically shifts the lower 32 bits
+    /// of rs1 right by a constant amount (preserving sign), then sign-extends the
+    /// 32-bit result to 64 bits.
+    ///
+    /// Implementation:
+    /// 1. Sign-extend rs1 from 32 to 64 bits
+    /// 2. Apply 64-bit arithmetic right shift
+    /// 3. Sign-extend the result again to ensure proper 32-bit semantics
+    ///
+    /// The double sign-extension ensures correct handling of negative 32-bit values.
     fn inline_sequence(
         &self,
         allocator: &VirtualRegisterAllocator,

--- a/tracer/src/instruction/sraw.rs
+++ b/tracer/src/instruction/sraw.rs
@@ -37,7 +37,6 @@ impl RISCVTrace for SRAW {
         let inline_sequence = self.inline_sequence(&cpu.vr_allocator, cpu.xlen);
         let mut trace = trace;
         for instr in inline_sequence {
-            // In each iteration, create a new Option containing a re-borrowed reference
             instr.trace(cpu, trace.as_deref_mut());
         }
     }

--- a/tracer/src/instruction/sraw.rs
+++ b/tracer/src/instruction/sraw.rs
@@ -42,6 +42,20 @@ impl RISCVTrace for SRAW {
         }
     }
 
+    /// Arithmetic right shift for 32-bit words with sign extension.
+    ///
+    /// SRAW is an RV64I-only instruction that arithmetically shifts the lower 32 bits
+    /// of rs1 right by the amount in the lower 5 bits of rs2, preserving the sign bit,
+    /// then sign-extends the 32-bit result to 64 bits.
+    ///
+    /// Implementation:
+    /// 1. Sign-extend rs1 from 32 to 64 bits to prepare for arithmetic shift
+    /// 2. Mask rs2 to get only the lower 5 bits (shift amount 0-31)
+    /// 3. Generate bitmask for the shift amount
+    /// 4. Apply arithmetic right shift (preserves sign bit)
+    /// 5. Sign-extend the result to ensure proper 32-bit semantics
+    ///
+    /// The double sign-extension ensures correct handling of negative 32-bit values.
     fn inline_sequence(
         &self,
         allocator: &VirtualRegisterAllocator,

--- a/tracer/src/instruction/srl.rs
+++ b/tracer/src/instruction/srl.rs
@@ -43,16 +43,34 @@ impl RISCVTrace for SRL {
         }
     }
 
+    /// Generates an inline sequence for logical right shift operation.
+    ///
+    /// SRL (Shift Right Logical) shifts rs1 right by the shift amount in rs2,
+    /// filling the vacated bits with zeros (unlike SRA which fills with sign bit).
+    ///
+    /// The implementation uses a bitmask approach where:
+    /// 1. A bitmask is computed based on the shift amount
+    /// 2. Virtual SRL instruction applies the shift using the bitmask
+    ///
+    /// This approach allows the shift to be verified in a way that's compatible
+    /// with zkVM's constraint system, avoiding direct bit manipulation.
     fn inline_sequence(
         &self,
         allocator: &VirtualRegisterAllocator,
         xlen: Xlen,
     ) -> Vec<Instruction> {
-        let v_bitmask = allocator.allocate();
+        let v_bitmask = allocator.allocate(); // holds the shift bitmask
 
         let mut asm = InstrAssembler::new(self.address, self.is_compressed, xlen, allocator);
+
+        // Step 1: Generate bitmask for right shift
+        // Creates a mask that represents which bits to keep after shifting
         asm.emit_i::<VirtualShiftRightBitmask>(*v_bitmask, self.operands.rs2, 0);
+
+        // Step 2: Apply logical right shift using the bitmask
+        // Fills high bits with zeros during the shift operation
         asm.emit_vshift_r::<VirtualSRL>(self.operands.rd, self.operands.rs1, *v_bitmask);
+
         asm.finalize()
     }
 }

--- a/tracer/src/instruction/srli.rs
+++ b/tracer/src/instruction/srli.rs
@@ -41,6 +41,17 @@ impl RISCVTrace for SRLI {
         }
     }
 
+    /// Logical right shift immediate using bitmask approach.
+    ///
+    /// SRLI (Shift Right Logical Immediate) shifts rs1 right by a constant amount,
+    /// filling the vacated bits with zeros.
+    ///
+    /// Implementation:
+    /// 1. Calculate a bitmask representing which bits remain after the shift
+    /// 2. Apply the shift using VirtualSRLI with the precomputed bitmask
+    ///
+    /// The bitmask has 1s in positions that will contain data after the shift,
+    /// allowing efficient verification in the zkVM constraint system.
     fn inline_sequence(
         &self,
         allocator: &VirtualRegisterAllocator,

--- a/tracer/src/instruction/srli.rs
+++ b/tracer/src/instruction/srli.rs
@@ -36,7 +36,6 @@ impl RISCVTrace for SRLI {
         let inline_sequence = self.inline_sequence(&cpu.vr_allocator, cpu.xlen);
         let mut trace = trace;
         for instr in inline_sequence {
-            // In each iteration, create a new Option containing a re-borrowed reference
             instr.trace(cpu, trace.as_deref_mut());
         }
     }

--- a/tracer/src/instruction/srliw.rs
+++ b/tracer/src/instruction/srliw.rs
@@ -36,7 +36,6 @@ impl RISCVTrace for SRLIW {
         let inline_sequence = self.inline_sequence(&cpu.vr_allocator, cpu.xlen);
         let mut trace = trace;
         for instr in inline_sequence {
-            // In each iteration, create a new Option containing a re-borrowed reference
             instr.trace(cpu, trace.as_deref_mut());
         }
     }

--- a/tracer/src/instruction/srliw.rs
+++ b/tracer/src/instruction/srliw.rs
@@ -41,6 +41,17 @@ impl RISCVTrace for SRLIW {
         }
     }
 
+    /// Logical right shift immediate for 32-bit words with sign extension.
+    ///
+    /// SRLIW is an RV64I-only instruction that logically shifts the lower 32 bits
+    /// of rs1 right by a constant amount, then sign-extends the 32-bit result to 64 bits.
+    ///
+    /// Implementation:
+    /// 1. Shift rs1 left by 32 to position the lower 32 bits in the upper half
+    /// 2. Apply a 64-bit logical right shift by (shift_amount + 32)
+    /// 3. Sign-extend the resulting 32-bit value
+    ///
+    /// This technique ensures proper 32-bit logical shift semantics on 64-bit system.
     fn inline_sequence(
         &self,
         allocator: &VirtualRegisterAllocator,

--- a/tracer/src/instruction/srlw.rs
+++ b/tracer/src/instruction/srlw.rs
@@ -39,7 +39,6 @@ impl RISCVTrace for SRLW {
         let inline_sequence = self.inline_sequence(&cpu.vr_allocator, cpu.xlen);
         let mut trace = trace;
         for instr in inline_sequence {
-            // In each iteration, create a new Option containing a re-borrowed reference
             instr.trace(cpu, trace.as_deref_mut());
         }
     }

--- a/tracer/src/instruction/srlw.rs
+++ b/tracer/src/instruction/srlw.rs
@@ -44,6 +44,20 @@ impl RISCVTrace for SRLW {
         }
     }
 
+    /// Logical right shift for 32-bit words with sign extension.
+    ///
+    /// SRLW is an RV64I-only instruction that logically shifts the lower 32 bits
+    /// of rs1 right by the amount in the lower 5 bits of rs2, then sign-extends
+    /// the 32-bit result to 64 bits.
+    ///
+    /// Implementation:
+    /// 1. Shift rs1 left by 32 to position the lower 32 bits in the upper half
+    /// 2. OR rs2 with 32 to create a shift amount for 64-bit logical right shift
+    /// 3. Generate bitmask for the adjusted shift amount
+    /// 4. Apply logical right shift (which now operates on the upper 32 bits)
+    /// 5. Sign-extend the resulting 32-bit value
+    ///
+    /// This approach ensures proper 32-bit logical shift semantics on 64-bit system.
     fn inline_sequence(
         &self,
         allocator: &VirtualRegisterAllocator,

--- a/tracer/src/instruction/subw.rs
+++ b/tracer/src/instruction/subw.rs
@@ -42,6 +42,7 @@ impl RISCVTrace for SUBW {
         }
     }
 
+    /// 32-bit subtraction with sign extension on 64-bit systems.    
     fn inline_sequence(
         &self,
         allocator: &VirtualRegisterAllocator,

--- a/tracer/src/instruction/subw.rs
+++ b/tracer/src/instruction/subw.rs
@@ -37,7 +37,6 @@ impl RISCVTrace for SUBW {
         let inline_sequence = self.inline_sequence(&cpu.vr_allocator, cpu.xlen);
         let mut trace = trace;
         for instr in inline_sequence {
-            // In each iteration, create a new Option containing a re-borrowed reference
             instr.trace(cpu, trace.as_deref_mut());
         }
     }

--- a/tracer/src/instruction/sw.rs
+++ b/tracer/src/instruction/sw.rs
@@ -49,7 +49,6 @@ impl RISCVTrace for SW {
         let inline_sequence = self.inline_sequence(&cpu.vr_allocator, cpu.xlen);
         let mut trace = trace;
         for instr in inline_sequence {
-            // In each iteration, create a new Option containing a re-borrowed reference
             instr.trace(cpu, trace.as_deref_mut());
         }
     }

--- a/tracer/src/instruction/sw.rs
+++ b/tracer/src/instruction/sw.rs
@@ -54,6 +54,7 @@ impl RISCVTrace for SW {
         }
     }
 
+    /// Store word (32-bit) to aligned memory.    
     fn inline_sequence(
         &self,
         allocator: &VirtualRegisterAllocator,


### PR DESCRIPTION
…ructions

Document all inline_sequence implementations in the tracer with detailed explanations of:
- Division/remainder instructions using untrusted oracle advice pattern
- Multiplication instructions with overflow handling and algebraic identities
- Load/store byte/halfword operations with word-aligned memory access
- Shift instructions using mathematical equivalences and bitmask approaches
- Atomic memory operations (AMO) with branchless implementations

Each documentation includes:
- Function-level descriptions of instruction behavior
- Implementation details for zkVM constraint compatibility
- Step-by-step algorithm explanations
- Differences between 32-bit and 64-bit implementations
- Mathematical techniques used for verification

This documentation helps developers understand how RISC-V instructions are decomposed into verifiable inline sequences within the Jolt zkVM.