### PR TITLE
Parallelize over lookup indices when initializing suffix polys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1990,6 +1990,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
 
 [[package]]
+name = "malloc-guest"
+version = "0.1.0"
+dependencies = [
+ "cc",
+ "jolt-sdk",
+]
+
+[[package]]
+name = "malloc-host"
+version = "0.1.0"
+dependencies = [
+ "jolt-sdk",
+ "malloc-guest",
+]
+
+[[package]]
 name = "maplit"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/jolt-core/src/poly/prefix_suffix.rs
+++ b/jolt-core/src/poly/prefix_suffix.rs
@@ -12,7 +12,7 @@ use crate::poly::dense_mlpoly::DensePolynomial;
 use crate::poly::multilinear_polynomial::{BindingOrder, PolynomialBinding, PolynomialEvaluation};
 use crate::utils::lookup_bits::LookupBits;
 use crate::utils::math::Math;
-use crate::utils::thread::{unsafe_allocate_zero_vec, unsafe_zero_slice};
+use crate::utils::thread::unsafe_allocate_zero_vec;
 
 #[repr(u8)]
 #[derive(Clone, Copy, EnumIterMacro, EnumCountMacro)]
@@ -238,14 +238,6 @@ impl<F: JoltField, const ORDER: usize> PrefixSuffixDecomposition<F, ORDER> {
             .collect::<Vec<_>>()
             .try_into()
             .unwrap()
-    }
-
-    pub fn reset_Q(&mut self) {
-        self.Q.iter_mut().for_each(|poly| {
-            poly.len = self.chunk_len.pow2();
-            poly.num_vars = self.chunk_len;
-            unsafe_zero_slice(&mut poly.Z);
-        });
     }
 
     #[tracing::instrument(skip_all, name = "PrefixSuffix::init_P")]

--- a/jolt-core/src/utils/thread.rs
+++ b/jolt-core/src/utils/thread.rs
@@ -36,22 +36,3 @@ pub fn unsafe_allocate_zero_vec<F: JoltField + Sized>(size: usize) -> Vec<F> {
     }
     result
 }
-
-#[tracing::instrument(skip_all)]
-pub fn unsafe_zero_slice<F: JoltField + Sized>(slice: &mut [F]) {
-    #[cfg(test)]
-    {
-        // Check for safety of 0 allocation
-        unsafe {
-            let value = &F::zero();
-            let ptr = value as *const F as *const u8;
-            let bytes = std::slice::from_raw_parts(ptr, std::mem::size_of::<F>());
-            assert!(bytes.iter().all(|&byte| byte == 0));
-        }
-    }
-
-    // Zero out existing slice memory
-    unsafe {
-        std::ptr::write_bytes(slice.as_mut_ptr(), 0, slice.len());
-    }
-}

--- a/jolt-core/src/utils/thread.rs
+++ b/jolt-core/src/utils/thread.rs
@@ -1,4 +1,3 @@
-use crate::field::JoltField;
 use num_traits::Zero;
 
 pub fn drop_in_background_thread<T>(data: T)

--- a/jolt-core/src/zkvm/instruction_lookups/read_raf_checking.rs
+++ b/jolt-core/src/zkvm/instruction_lookups/read_raf_checking.rs
@@ -658,8 +658,8 @@ impl<F: JoltField> ReadRafProverState<F> {
             .for_each(|(old, new)| {
                 old.iter_mut()
                     .zip(new.into_iter())
-                    .for_each(|(src, mut dest)| {
-                        *src = DensePolynomial::new(std::mem::take(&mut dest));
+                    .for_each(|(poly, mut coeffs)| {
+                        *poly = DensePolynomial::new(std::mem::take(&mut coeffs));
                     });
             });
     }

--- a/jolt-core/src/zkvm/instruction_lookups/read_raf_checking.rs
+++ b/jolt-core/src/zkvm/instruction_lookups/read_raf_checking.rs
@@ -28,10 +28,8 @@ use crate::{
     subprotocols::sumcheck::SumcheckInstance,
     transcripts::Transcript,
     utils::{
-        expanding_table::ExpandingTable,
-        lookup_bits::LookupBits,
-        math::Math,
-        thread::{unsafe_allocate_zero_vec, unsafe_zero_slice},
+        expanding_table::ExpandingTable, lookup_bits::LookupBits, math::Math,
+        thread::unsafe_allocate_zero_vec,
     },
     zkvm::{
         dag::state_manager::StateManager,
@@ -270,7 +268,7 @@ impl<'a, F: JoltField> ReadRafProverState<F> {
                 table
                     .suffixes()
                     .par_iter()
-                    .map(|_| DensePolynomial::new(unsafe_allocate_zero_vec(M)))
+                    .map(|_| DensePolynomial::default()) // Will be properly initialized in `init_phase`
                     .collect()
             })
             .collect();
@@ -600,43 +598,72 @@ impl<F: JoltField> ReadRafProverState<F> {
                 self.identity_ps
                     .init_Q(&self.u_evals, &self.lookup_indices_identity)
             });
-            s.spawn(|_| {
-                LookupTables::<XLEN>::iter()
-                    .collect::<Vec<_>>()
-                    .par_iter()
-                    .zip(self.suffix_polys.par_iter_mut())
-                    .zip(self.lookup_indices_by_table.par_iter())
-                    .for_each(|((table, polys), lookup_indices)| {
-                        table
-                            .suffixes()
-                            .par_iter()
-                            .zip(polys.par_iter_mut())
-                            .for_each(|(suffix, poly)| {
-                                if phase != 0 {
-                                    // Reset polynomial
-                                    poly.len = M;
-                                    poly.num_vars = poly.len.log_2();
-                                    unsafe_zero_slice(&mut poly.Z);
-                                }
-
-                                for (j, k) in lookup_indices.iter() {
-                                    let (prefix_bits, suffix_bits) =
-                                        k.split((PHASES - 1 - phase) * LOG_M);
-                                    let t = suffix.suffix_mle::<XLEN>(suffix_bits);
-                                    if t != 0 {
-                                        let u = self.u_evals[*j];
-                                        poly.Z[prefix_bits % M] += u.mul_u64(t);
-                                    }
-                                }
-                            });
-                    });
-            });
         });
+
+        self.init_suffix_polys(phase);
+
         self.identity_ps.init_P(&mut self.prefix_registry);
         self.right_operand_ps.init_P(&mut self.prefix_registry);
         self.left_operand_ps.init_P(&mut self.prefix_registry);
 
         self.v.reset(F::one());
+    }
+
+    #[tracing::instrument(skip_all, name = "InstructionReadRafProverState::init_suffix_polys")]
+    fn init_suffix_polys(&mut self, phase: usize) {
+        let num_chunks = rayon::current_num_threads().next_power_of_two();
+        let chunk_size = (self.lookup_indices.len() / num_chunks).max(1);
+
+        let new_suffix_polys: Vec<_> = LookupTables::<XLEN>::iter()
+            .collect::<Vec<_>>()
+            .par_iter()
+            .zip(self.lookup_indices_by_table.par_iter())
+            .map(|(table, lookup_indices)| {
+                let suffixes = table.suffixes();
+                lookup_indices
+                    .par_chunks(chunk_size)
+                    .map(|chunk| {
+                        let mut chunk_result: Vec<Vec<F>> =
+                            vec![unsafe_allocate_zero_vec(M); suffixes.len()];
+
+                        for (j, k) in chunk {
+                            let (prefix_bits, suffix_bits) = k.split((PHASES - 1 - phase) * LOG_M);
+                            for (suffix, result) in suffixes.iter().zip(chunk_result.iter_mut()) {
+                                let t = suffix.suffix_mle::<XLEN>(suffix_bits);
+                                if t != 0 {
+                                    let u = self.u_evals[*j];
+                                    result[prefix_bits % M] += u.mul_u64(t);
+                                }
+                            }
+                        }
+
+                        chunk_result
+                    })
+                    .reduce(
+                        || vec![unsafe_allocate_zero_vec(M); suffixes.len()],
+                        |mut acc, new| {
+                            for (acc_i, new_i) in acc.iter_mut().zip(new.iter()) {
+                                for (acc_coeff, new_coeff) in acc_i.iter_mut().zip(new_i.iter()) {
+                                    *acc_coeff += *new_coeff;
+                                }
+                            }
+                            acc
+                        },
+                    )
+            })
+            .collect();
+
+        // Replace existing suffix polynomials
+        self.suffix_polys
+            .iter_mut()
+            .zip(new_suffix_polys.into_iter())
+            .for_each(|(old, new)| {
+                old.iter_mut()
+                    .zip(new.into_iter())
+                    .for_each(|(src, mut dest)| {
+                        *src = DensePolynomial::new(std::mem::take(&mut dest));
+                    });
+            });
     }
 
     /// To be called at the end of each phase, after binding is done


### PR DESCRIPTION
Similar to https://github.com/a16z/jolt/pull/933 but for initializing the suffix polys at the start of each phase, i.e. we now parallelize over chunks of lookup indices. No noticeable performance difference on my Macbook, but should result in better performance on machines with many cores (e.g. Threadripper)