### PR TITLE
feat: add an example for atomic operations 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,6 +75,8 @@ members = [
     "examples/malloc/guest",
     "examples/merkle-tree",
     "examples/merkle-tree/guest",
+    "examples/atomic",
+    "examples/atomic/guest",
 ]
 
 [features]

--- a/examples/atomic/Cargo.toml
+++ b/examples/atomic/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "atomic"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+jolt-sdk = { path = "../../jolt-sdk", features = ["host"] }
+tracing-subscriber = "0.3"
+tracing = "0.1"
+guest = { package = "atomic-guest", path = "./guest" }

--- a/examples/atomic/README.md
+++ b/examples/atomic/README.md
@@ -1,0 +1,49 @@
+# Atomic Operations Example
+
+This example demonstrates how Jolt properly processes atomic operations by converting them to regular instructions through the `passes=lower-atomic` compiler flag.
+
+## Purpose
+
+The demo tests that:
+1. Rust atomic operations (`AtomicU64`) compile successfully 
+2. Both `core::sync::atomic` and `portable-atomic` work identically
+3. **No actual atomic instructions** are generated in the final binary
+4. Atomic operations are lowered to regular load/store instructions that Jolt can trace
+
+## Verification
+
+After running the example, verify that no atomic instructions remain:
+
+```bash
+riscv64-unknown-elf-objdump -d /tmp/jolt-guest-targets/atomic-guest-atomic_test_u64/riscv64imac-unknown-none-elf/release/atomic-guest | grep -E "(amoadd|amoswap|amoor|amoand|amomin|amomax|amoxor|lr\.|sc\.)"
+```
+
+**Expected result**: No output (meaning no atomic instructions found).
+
+## What It Tests
+
+- `AtomicU64` operations (load, store, fetch_add) using `core::sync::atomic`
+- Same operations using `portable-atomic` for compatibility 
+- Both produce identical results when processed by `passes=lower-atomic`
+
+## Running the Example
+
+```bash
+cd examples/atomic
+cargo run --release
+```
+
+## Expected Output
+
+```
+Testing AtomicU64 compatibility (standard vs portable-atomic)...
+Standard atomic result: 44
+Portable-atomic result: 44
+Results match: true
+Proof valid: true
+✓ Both standard and portable-atomic operations work correctly!
+```
+
+## Key Point
+
+The success of this example proves that `passes=lower-atomic` correctly converts atomic operations into regular instructions that Jolt can trace and prove, eliminating the need for `portable-atomic` or `critical-section` dependencies in guest programs.

--- a/examples/atomic/guest/Cargo.toml
+++ b/examples/atomic/guest/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "atomic-guest"
+version = "0.1.0"
+edition = "2021"
+
+[features]
+guest = []
+
+[dependencies]
+jolt = { package = "jolt-sdk", path = "../../../jolt-sdk" }
+portable-atomic = { version = "1.0", default-features = false }

--- a/examples/atomic/guest/src/lib.rs
+++ b/examples/atomic/guest/src/lib.rs
@@ -1,0 +1,23 @@
+#![cfg_attr(feature = "guest", no_std)]
+use core::hint::black_box;
+use core::sync::atomic::{AtomicU64, Ordering};
+
+#[jolt::provable(memory_size = 10240, max_trace_length = 65536)]
+fn atomic_test_u64(input: u64) -> (u64, u64) {
+    // Test standard core::sync::atomic
+    let atomic_std = AtomicU64::new(input);
+    let loaded_std = atomic_std.load(Ordering::SeqCst);
+    atomic_std.store(loaded_std + 1, Ordering::SeqCst);
+    let incremented_std = atomic_std.fetch_add(1, Ordering::SeqCst);
+    let result_std = black_box(incremented_std + 1);
+
+    // Test portable-atomic (should work the same with passes=lower-atomic)
+    let atomic_portable = portable_atomic::AtomicU64::new(input);
+    let loaded_portable = atomic_portable.load(Ordering::SeqCst);
+    atomic_portable.store(loaded_portable + 1, Ordering::SeqCst);
+    let incremented_portable = atomic_portable.fetch_add(1, Ordering::SeqCst);
+    let result_portable = black_box(incremented_portable + 1);
+
+    // Return both results to verify they're identical
+    (result_std, result_portable)
+}

--- a/examples/atomic/guest/src/main.rs
+++ b/examples/atomic/guest/src/main.rs
@@ -1,0 +1,5 @@
+#![cfg_attr(feature = "guest", no_std)]
+#![no_main]
+
+#[allow(unused_imports)]
+use atomic_guest::*;

--- a/examples/atomic/src/main.rs
+++ b/examples/atomic/src/main.rs
@@ -1,0 +1,45 @@
+use std::time::Instant;
+use tracing::info;
+
+pub fn main() {
+    tracing_subscriber::fmt::init();
+
+    let target_dir = "/tmp/jolt-guest-targets";
+
+    // Test both standard atomics and portable-atomic compatibility
+    info!("Testing AtomicU64 compatibility (standard vs portable-atomic)...");
+    let mut program = guest::compile_atomic_test_u64(target_dir);
+
+    let prover_preprocessing = guest::preprocess_prover_atomic_test_u64(&mut program);
+    let verifier_preprocessing =
+        guest::verifier_preprocessing_from_prover_atomic_test_u64(&prover_preprocessing);
+
+    let prove = guest::build_prover_atomic_test_u64(program, prover_preprocessing);
+    let verify = guest::build_verifier_atomic_test_u64(verifier_preprocessing);
+
+    let now = Instant::now();
+    let (output, proof, program_io) = prove(42u64);
+    info!(
+        "AtomicU64 compatibility test prover runtime: {} s",
+        now.elapsed().as_secs_f64()
+    );
+
+    let is_valid = verify(42u64, output, program_io.panic, proof);
+
+    // Output is (std_result, portable_result)
+    info!("Standard atomic result: {}", output.0);
+    info!("Portable-atomic result: {}", output.1);
+    info!("Results match: {}", output.0 == output.1);
+    info!("Proof valid: {}", is_valid);
+
+    if is_valid && output.0 == output.1 {
+        info!("✓ Both standard and portable-atomic operations work correctly!");
+        info!("✓ This confirms compatibility between core::sync::atomic and portable-atomic");
+        info!("✓ Projects using portable-atomic can migrate to Jolt without code changes");
+        info!("✓ passes=lower-atomic handles both implementations correctly");
+    } else if is_valid {
+        info!("⚠ Proof valid but results differ - unexpected behavior");
+    } else {
+        info!("✗ Atomic operations test failed");
+    }
+}


### PR DESCRIPTION
This PR adds an example that uses atomic operations, and the user can verify that no atomic instructions are emitted in the ELF because Jolt has passed `-C passes=lower-atomic` to the compiler.