### PR TITLE
Fix:  Keccak SDK

### DIFF
--- a/jolt-inlines/keccak256/src/sdk.rs
+++ b/jolt-inlines/keccak256/src/sdk.rs
@@ -166,7 +166,6 @@ impl Keccak256 {
         }
         self.buffer_len = 0;
     }
-
 }
 
 impl Default for Keccak256 {


### PR DESCRIPTION
Input to Keccak SDK update() function is not necessarily 8-byte aligned and this causes issue in Jolt tracer. This PR fixes this issue.