### PR TITLE
optimistaion/better_parallels

### DIFF
--- a/jolt-core/src/poly/compact_polynomial.rs
+++ b/jolt-core/src/poly/compact_polynomial.rs
@@ -287,6 +287,7 @@ impl<T: SmallScalar, F: JoltField> PolynomialBinding<F> for CompactPolynomial<T,
                     let (left, right) = self.bound_coeffs.split_at_mut(n);
                     left.par_iter_mut()
                         .zip(right.par_iter())
+                        .with_min_len(4096)
                         .filter(|(a, b)| a != b)
                         .for_each(|(a, b)| {
                             *a += r * (*b - *a);

--- a/jolt-core/src/poly/dense_mlpoly.rs
+++ b/jolt-core/src/poly/dense_mlpoly.rs
@@ -127,6 +127,7 @@ impl<F: JoltField> DensePolynomial<F> {
 
         left.par_iter_mut()
             .zip(right.par_iter())
+            .with_min_len(4096)
             .filter(|(&mut a, &b)| a != b)
             .for_each(|(a, b)| {
                 *a += *r * (*b - *a);


### PR DESCRIPTION
- Nearly **2x** speedups on Multilinear parallel bind for compact and dense poly's -- with 2 lines of code changed (though it took a while to find this).
- There are few more of these optimisations; but I need to double check them as I pulled in all the new code changes.
I'll push a sequence of mini-PR's with speedups 

<img width="1212" height="519" alt="Screenshot 2025-10-30 at 04 04 40" src="https://github.com/user-attachments/assets/e814c1bf-5ebe-4d6e-b59a-f16f5375dfed" />
