### PR TITLE
fix: collect all BSS subsections in linker script

### DIFF
--- a/jolt-core/src/host/mod.rs
+++ b/jolt-core/src/host/mod.rs
@@ -46,13 +46,18 @@ SECTIONS {
   } > program
 
   .bss (NOLOAD) : {
-    *(.bss)
+    __bss_start = .;
+    *(.bss .bss.*)
+    *(COMMON)
+    . = ALIGN(8);
+    __bss_end = .;
   } > program
 
   . = ALIGN(8);
   _STACK_END = .;
   . = . + {STACK_CANARY};
   . = . + {STACK_SIZE};
+  . = ALIGN(8);
   _STACK_PTR = .;
 
   . = ALIGN(8);


### PR DESCRIPTION
The linker script didn't collect all BSS subsections, which meant we would place the stack in the wrong spot and sometimes cause stack corruption. Because our rust elf builds are not stable, this was working fine for the most part but on some systems, sometimes, we'd end up with failures in examples. 