### PR TITLE
feat: add modexp example guest program and benchmark (#1067)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3304,6 +3304,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "modexp"
+version = "0.1.0"
+dependencies = [
+ "jolt-sdk",
+ "modexp-guest",
+ "num-bigint",
+ "rand 0.8.5",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "modexp-guest"
+version = "0.1.0"
+dependencies = [
+ "jolt-sdk",
+ "num-bigint",
+ "num-traits",
+]
+
+[[package]]
 name = "modinv"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3309,7 +3309,6 @@ version = "0.1.0"
 dependencies = [
  "jolt-sdk",
  "modexp-guest",
- "num-bigint",
  "rand 0.8.5",
  "tracing",
  "tracing-subscriber",
@@ -3321,7 +3320,6 @@ version = "0.1.0"
 dependencies = [
  "jolt-sdk",
  "num-bigint",
- "num-traits",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,6 +82,8 @@ members = [
     "examples/hash-bench/guest",
     "examples/modinv",
     "examples/modinv/guest",
+    "examples/modexp",
+    "examples/modexp/guest",
     "examples/advice-demo",
     "examples/advice-demo/guest",
     "examples/sig-recovery/host",

--- a/examples/modexp/Cargo.toml
+++ b/examples/modexp/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "modexp"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+jolt-sdk = { workspace = true, features = ["host"] }
+tracing-subscriber.workspace = true
+tracing.workspace = true
+num-bigint.workspace = true
+rand.workspace = true
+guest = { package = "modexp-guest", path = "./guest" }

--- a/examples/modexp/Cargo.toml
+++ b/examples/modexp/Cargo.toml
@@ -7,6 +7,5 @@ edition = "2021"
 jolt-sdk = { workspace = true, features = ["host"] }
 tracing-subscriber.workspace = true
 tracing.workspace = true
-num-bigint.workspace = true
 rand.workspace = true
 guest = { package = "modexp-guest", path = "./guest" }

--- a/examples/modexp/guest/Cargo.toml
+++ b/examples/modexp/guest/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "modexp-guest"
+version = "0.1.0"
+edition = "2021"
+
+[features]
+guest = []
+
+[dependencies]
+jolt = { package = "jolt-sdk", path = "../../../jolt-sdk", features = ["guest-std"] }
+num-bigint = { workspace = true, default-features = false }
+num-traits = { workspace = true, default-features = false }

--- a/examples/modexp/guest/Cargo.toml
+++ b/examples/modexp/guest/Cargo.toml
@@ -7,6 +7,5 @@ edition = "2021"
 guest = []
 
 [dependencies]
-jolt = { package = "jolt-sdk", path = "../../../jolt-sdk", features = ["guest-std"] }
+jolt = { package = "jolt-sdk", path = "../../../jolt-sdk", features = [] }
 num-bigint = { workspace = true, default-features = false }
-num-traits = { workspace = true, default-features = false }

--- a/examples/modexp/guest/src/lib.rs
+++ b/examples/modexp/guest/src/lib.rs
@@ -1,5 +1,7 @@
-#[jolt::provable(heap_size = 65536, max_trace_length = 4194304)]
-fn modexp(base: Vec<u8>, exp: Vec<u8>, modulus: Vec<u8>, num_iters: u32) -> Vec<u8> {
+#![cfg_attr(feature = "guest", no_std)]
+
+#[jolt::provable(heap_size = 65536, max_trace_length = 67108864)]
+fn modexp(base: [u8; 32], exp: [u8; 32], modulus: [u8; 32], num_iters: u32) -> [u8; 32] {
     use num_bigint::BigUint;
 
     let exp = BigUint::from_bytes_be(&exp);
@@ -10,5 +12,9 @@ fn modexp(base: Vec<u8>, exp: Vec<u8>, modulus: Vec<u8>, num_iters: u32) -> Vec<
         result = result.modpow(&exp, &modulus);
     }
 
-    result.to_bytes_be()
+    let bytes = result.to_bytes_be();
+    let mut out = [0u8; 32];
+    let start = 32 - bytes.len();
+    out[start..].copy_from_slice(&bytes);
+    out
 }

--- a/examples/modexp/guest/src/lib.rs
+++ b/examples/modexp/guest/src/lib.rs
@@ -1,0 +1,14 @@
+#[jolt::provable(heap_size = 65536, max_trace_length = 4194304)]
+fn modexp(base: Vec<u8>, exp: Vec<u8>, modulus: Vec<u8>, num_iters: u32) -> Vec<u8> {
+    use num_bigint::BigUint;
+
+    let exp = BigUint::from_bytes_be(&exp);
+    let modulus = BigUint::from_bytes_be(&modulus);
+    let mut result = BigUint::from_bytes_be(&base);
+
+    for _ in 0..num_iters {
+        result = result.modpow(&exp, &modulus);
+    }
+
+    result.to_bytes_be()
+}

--- a/examples/modexp/guest/src/main.rs
+++ b/examples/modexp/guest/src/main.rs
@@ -1,0 +1,4 @@
+#![no_main]
+
+#[allow(unused_imports)]
+use modexp_guest::*;

--- a/examples/modexp/guest/src/main.rs
+++ b/examples/modexp/guest/src/main.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(feature = "guest", no_std)]
 #![no_main]
 
 #[allow(unused_imports)]

--- a/examples/modexp/src/main.rs
+++ b/examples/modexp/src/main.rs
@@ -1,45 +1,27 @@
 use std::time::Instant;
 use tracing::info;
 
-const BIT_LENGTH: usize = 256;
 const NUM_ITERS: u32 = 10;
-
-fn random_biguint(bits: usize) -> num_bigint::BigUint {
-    use rand::Rng;
-    let bytes = bits.div_ceil(8);
-    let mut buf = vec![0u8; bytes];
-    rand::thread_rng().fill(&mut buf[..]);
-    // Ensure the top bit is set so we get a full-width number
-    buf[0] |= 0x80;
-    num_bigint::BigUint::from_bytes_be(&buf)
-}
 
 pub fn main() {
     tracing_subscriber::fmt::init();
 
     let target_dir = "/tmp/jolt-guest-targets";
 
-    let base = random_biguint(BIT_LENGTH);
-    let exp = random_biguint(BIT_LENGTH);
-    // Ensure modulus is odd (required for meaningful modexp)
-    let mut modulus = random_biguint(BIT_LENGTH);
-    modulus |= num_bigint::BigUint::from(1u8);
-
-    let base_bytes = base.to_bytes_be();
-    let exp_bytes = exp.to_bytes_be();
-    let modulus_bytes = modulus.to_bytes_be();
+    let mut base = [0u8; 32];
+    let mut exp = [0u8; 32];
+    let mut modulus = [0u8; 32];
+    rand::Rng::fill(&mut rand::thread_rng(), &mut base[..]);
+    rand::Rng::fill(&mut rand::thread_rng(), &mut exp[..]);
+    rand::Rng::fill(&mut rand::thread_rng(), &mut modulus[..]);
+    modulus[31] |= 0x01; // Ensure odd
 
     info!(
-        "Modular exponentiation: {}-bit base^exp mod modulus, {} iterations",
-        BIT_LENGTH, NUM_ITERS
+        "Modular exponentiation: 256-bit base^exp mod modulus, {} iterations",
+        NUM_ITERS
     );
 
-    let native_output = guest::modexp(
-        base_bytes.clone(),
-        exp_bytes.clone(),
-        modulus_bytes.clone(),
-        NUM_ITERS,
-    );
+    let native_output = guest::modexp(base, exp, modulus, NUM_ITERS);
 
     let mut program = guest::compile_modexp(target_dir);
     let shared_preprocessing = guest::preprocess_shared_modexp(&mut program);
@@ -51,26 +33,20 @@ pub fn main() {
     let verify_modexp = guest::build_verifier_modexp(verifier_preprocessing);
 
     let now = Instant::now();
-    let (output, proof, program_io) = prove_modexp(
-        base_bytes.clone(),
-        exp_bytes.clone(),
-        modulus_bytes.clone(),
-        NUM_ITERS,
-    );
+    let (output, proof, program_io) = prove_modexp(base, exp, modulus, NUM_ITERS);
     let prove_time = now.elapsed();
     info!("Prover runtime: {} s", prove_time.as_secs_f64());
 
     let is_valid = verify_modexp(
-        base_bytes,
-        exp_bytes,
-        modulus_bytes,
+        base,
+        exp,
+        modulus,
         NUM_ITERS,
-        output.clone(),
+        output,
         program_io.panic,
         proof,
     );
 
     assert_eq!(output, native_output, "output mismatch");
-    info!("Output: {} bytes", output.len());
     info!("Proof valid: {}", is_valid);
 }

--- a/examples/modexp/src/main.rs
+++ b/examples/modexp/src/main.rs
@@ -1,0 +1,76 @@
+use std::time::Instant;
+use tracing::info;
+
+const BIT_LENGTH: usize = 256;
+const NUM_ITERS: u32 = 10;
+
+fn random_biguint(bits: usize) -> num_bigint::BigUint {
+    use rand::Rng;
+    let bytes = bits.div_ceil(8);
+    let mut buf = vec![0u8; bytes];
+    rand::thread_rng().fill(&mut buf[..]);
+    // Ensure the top bit is set so we get a full-width number
+    buf[0] |= 0x80;
+    num_bigint::BigUint::from_bytes_be(&buf)
+}
+
+pub fn main() {
+    tracing_subscriber::fmt::init();
+
+    let target_dir = "/tmp/jolt-guest-targets";
+
+    let base = random_biguint(BIT_LENGTH);
+    let exp = random_biguint(BIT_LENGTH);
+    // Ensure modulus is odd (required for meaningful modexp)
+    let mut modulus = random_biguint(BIT_LENGTH);
+    modulus |= num_bigint::BigUint::from(1u8);
+
+    let base_bytes = base.to_bytes_be();
+    let exp_bytes = exp.to_bytes_be();
+    let modulus_bytes = modulus.to_bytes_be();
+
+    info!(
+        "Modular exponentiation: {}-bit base^exp mod modulus, {} iterations",
+        BIT_LENGTH, NUM_ITERS
+    );
+
+    let native_output = guest::modexp(
+        base_bytes.clone(),
+        exp_bytes.clone(),
+        modulus_bytes.clone(),
+        NUM_ITERS,
+    );
+
+    let mut program = guest::compile_modexp(target_dir);
+    let shared_preprocessing = guest::preprocess_shared_modexp(&mut program);
+    let prover_preprocessing = guest::preprocess_prover_modexp(shared_preprocessing.clone());
+    let verifier_setup = prover_preprocessing.generators.to_verifier_setup();
+    let verifier_preprocessing =
+        guest::preprocess_verifier_modexp(shared_preprocessing, verifier_setup);
+    let prove_modexp = guest::build_prover_modexp(program, prover_preprocessing);
+    let verify_modexp = guest::build_verifier_modexp(verifier_preprocessing);
+
+    let now = Instant::now();
+    let (output, proof, program_io) = prove_modexp(
+        base_bytes.clone(),
+        exp_bytes.clone(),
+        modulus_bytes.clone(),
+        NUM_ITERS,
+    );
+    let prove_time = now.elapsed();
+    info!("Prover runtime: {} s", prove_time.as_secs_f64());
+
+    let is_valid = verify_modexp(
+        base_bytes,
+        exp_bytes,
+        modulus_bytes,
+        NUM_ITERS,
+        output.clone(),
+        program_io.panic,
+        proof,
+    );
+
+    assert_eq!(output, native_output, "output mismatch");
+    info!("Output: {} bytes", output.len());
+    info!("Proof valid: {}", is_valid);
+}

--- a/jolt-core/benches/e2e_profiling.rs
+++ b/jolt-core/benches/e2e_profiling.rs
@@ -12,7 +12,7 @@ const CYCLES_PER_SHA256: f64 = 3396.0;
 const CYCLES_PER_SHA3: f64 = 4330.0;
 const CYCLES_PER_BTREEMAP_OP: f64 = 1550.0;
 const CYCLES_PER_FIBONACCI_UNIT: f64 = 12.0;
-const CYCLES_PER_MODEXP_256: f64 = 50000.0;
+const CYCLES_PER_MODEXP_256: f64 = 883_493.0;
 const SAFETY_MARGIN: f64 = 0.9; // Use 90% of max trace capacity
 
 /// Calculate number of operations to target a specific cycle count
@@ -81,16 +81,18 @@ fn sha2_chain() -> Vec<(tracing::Span, Box<dyn FnOnce()>)> {
 }
 
 fn modexp() -> Vec<(tracing::Span, Box<dyn FnOnce()>)> {
-    let mut inputs = vec![];
-    let base = vec![0xABu8; 32];
-    let exp = vec![0xCDu8; 32];
-    let mut modulus = vec![0xEFu8; 32];
-    modulus[31] |= 0x01; // Ensure odd
+    let base = [0xABu8; 32];
+    let exp = [0xCDu8; 32];
+    let mut modulus = [0xEFu8; 32];
+    modulus[31] |= 0x01;
     let iters = 10u32;
-    inputs.append(&mut postcard::to_stdvec(&base).unwrap());
-    inputs.append(&mut postcard::to_stdvec(&exp).unwrap());
-    inputs.append(&mut postcard::to_stdvec(&modulus).unwrap());
-    inputs.append(&mut postcard::to_stdvec(&iters).unwrap());
+    let inputs = [
+        postcard::to_stdvec(&base).unwrap(),
+        postcard::to_stdvec(&exp).unwrap(),
+        postcard::to_stdvec(&modulus).unwrap(),
+        postcard::to_stdvec(&iters).unwrap(),
+    ]
+    .concat();
     prove_example("modexp-guest", inputs)
 }
 
@@ -150,9 +152,9 @@ pub fn master_benchmark(
             }),
             BenchType::Modexp => ("modexp", |target| {
                 let iterations = scale_to_target_ops(target, CYCLES_PER_MODEXP_256);
-                let base = vec![0xABu8; 32];
-                let exp = vec![0xCDu8; 32];
-                let mut modulus = vec![0xEFu8; 32];
+                let base = [0xABu8; 32];
+                let exp = [0xCDu8; 32];
+                let mut modulus = [0xEFu8; 32];
                 modulus[31] |= 0x01;
                 [
                     postcard::to_stdvec(&base).unwrap(),

--- a/jolt-core/benches/e2e_profiling.rs
+++ b/jolt-core/benches/e2e_profiling.rs
@@ -12,6 +12,7 @@ const CYCLES_PER_SHA256: f64 = 3396.0;
 const CYCLES_PER_SHA3: f64 = 4330.0;
 const CYCLES_PER_BTREEMAP_OP: f64 = 1550.0;
 const CYCLES_PER_FIBONACCI_UNIT: f64 = 12.0;
+const CYCLES_PER_MODEXP_256: f64 = 50000.0;
 const SAFETY_MARGIN: f64 = 0.9; // Use 90% of max trace capacity
 
 /// Calculate number of operations to target a specific cycle count
@@ -31,6 +32,7 @@ pub enum BenchType {
     Sha2Chain,
     #[strum(serialize = "SHA3 Chain")]
     Sha3Chain,
+    Modexp,
 }
 
 pub fn benchmarks(bench_type: BenchType) -> Vec<(tracing::Span, Box<dyn FnOnce()>)> {
@@ -41,6 +43,7 @@ pub fn benchmarks(bench_type: BenchType) -> Vec<(tracing::Span, Box<dyn FnOnce()
         BenchType::Sha2Chain => sha2_chain(),
         BenchType::Sha3Chain => sha3_chain(),
         BenchType::Fibonacci => fibonacci(),
+        BenchType::Modexp => modexp(),
     }
 }
 
@@ -75,6 +78,20 @@ fn sha2_chain() -> Vec<(tracing::Span, Box<dyn FnOnce()>)> {
     );
     inputs.append(&mut postcard::to_stdvec(&iters).unwrap());
     prove_example("sha2-chain-guest", inputs)
+}
+
+fn modexp() -> Vec<(tracing::Span, Box<dyn FnOnce()>)> {
+    let mut inputs = vec![];
+    let base = vec![0xABu8; 32];
+    let exp = vec![0xCDu8; 32];
+    let mut modulus = vec![0xEFu8; 32];
+    modulus[31] |= 0x01; // Ensure odd
+    let iters = 10u32;
+    inputs.append(&mut postcard::to_stdvec(&base).unwrap());
+    inputs.append(&mut postcard::to_stdvec(&exp).unwrap());
+    inputs.append(&mut postcard::to_stdvec(&modulus).unwrap());
+    inputs.append(&mut postcard::to_stdvec(&iters).unwrap());
+    prove_example("modexp-guest", inputs)
 }
 
 fn sha3_chain() -> Vec<(tracing::Span, Box<dyn FnOnce()>)> {
@@ -130,6 +147,20 @@ pub fn master_benchmark(
             }),
             BenchType::BTreeMap => ("btreemap", |target| {
                 postcard::to_stdvec(&scale_to_target_ops(target, CYCLES_PER_BTREEMAP_OP)).unwrap()
+            }),
+            BenchType::Modexp => ("modexp", |target| {
+                let iterations = scale_to_target_ops(target, CYCLES_PER_MODEXP_256);
+                let base = vec![0xABu8; 32];
+                let exp = vec![0xCDu8; 32];
+                let mut modulus = vec![0xEFu8; 32];
+                modulus[31] |= 0x01;
+                [
+                    postcard::to_stdvec(&base).unwrap(),
+                    postcard::to_stdvec(&exp).unwrap(),
+                    postcard::to_stdvec(&modulus).unwrap(),
+                    postcard::to_stdvec(&iterations).unwrap(),
+                ]
+                .concat()
             }),
             BenchType::Sha2 => panic!("Use sha2-chain instead"),
             BenchType::Sha3 => panic!("Use sha3-chain instead"),


### PR DESCRIPTION
Add examples/modexp/ performing chained modular exponentiation (base^exp mod modulus) using num-bigint BigUint::modpow with configurable bit lengths and iteration count.

Add Modexp variant to e2e_profiling.rs benchmark.