### PR TITLE
fix: harden Claude CI workflows against prompt injection and unauthorized access

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,0 @@
-# Protect CI/CD workflow definitions — changes require maintainer review
-.github/workflows/ @a16z/jolt-maintainers

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Protect CI/CD workflow definitions — changes require maintainer review
+.github/workflows/ @a16z/jolt-maintainers

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Download PR metadata
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: pr-metadata
           run-id: ${{ github.event.workflow_run.id }}
@@ -56,12 +56,12 @@ jobs:
           echo "Validated PR #$PR_NUMBER (SHA: $WORKFLOW_HEAD_SHA)"
 
       - name: Checkout base branch
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 1
 
       - name: Run Claude Code Review
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@26ec041249acb0a944c0a47b6c0c13f05dbc5b44 # v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -88,12 +88,12 @@ jobs:
 
     steps:
       - name: Checkout base branch
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 1
 
       - name: Run Claude Code Review
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@26ec041249acb0a944c0a47b6c0c13f05dbc5b44 # v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,11 +1,85 @@
 name: Claude Code Review
 
 on:
-  pull_request_target:
-    types: [opened, synchronize, ready_for_review, reopened]
+  workflow_run:
+    workflows: ["Prepare Claude Review"]
+    types: [completed]
+  issue_comment:
+    types: [created]
 
 jobs:
-  claude-review:
+  # PATH A: Auto-trigger via workflow_run (trusted authors, or label-approved fork PRs)
+  claude-review-auto:
+    if: |
+      github.event_name == 'workflow_run' &&
+      github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+      actions: read
+
+    steps:
+      - name: Download PR metadata
+        uses: actions/download-artifact@v4
+        with:
+          name: pr-metadata
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Validate PR metadata
+        id: pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          WORKFLOW_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          REPO: ${{ github.repository }}
+        run: |
+          PR_NUMBER=$(cat pr_number.txt)
+
+          # Validate PR number is a positive integer (defense against artifact tampering)
+          if ! [[ "$PR_NUMBER" =~ ^[0-9]+$ ]]; then
+            echo "::error::Invalid PR number in artifact: not an integer"
+            exit 1
+          fi
+
+          # Cross-reference: verify the PR's head SHA matches the workflow_run's head SHA
+          # github.event.workflow_run.head_sha is set by GitHub and cannot be modified by forks
+          ACTUAL_SHA=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json headRefOid -q '.headRefOid')
+          if [ "$ACTUAL_SHA" != "$WORKFLOW_HEAD_SHA" ]; then
+            echo "::error::SHA mismatch -- artifact PR ($ACTUAL_SHA) != workflow trigger ($WORKFLOW_HEAD_SHA)"
+            echo "::error::This may indicate artifact tampering. Aborting."
+            exit 1
+          fi
+
+          echo "number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
+          echo "Validated PR #$PR_NUMBER (SHA: $WORKFLOW_HEAD_SHA)"
+
+      - name: Checkout base branch
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code Review
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          plugin_marketplaces: "https://github.com/anthropics/claude-code.git"
+          plugins: "code-review@claude-code-plugins"
+          prompt: "/code-review:code-review ${{ github.repository }}/pull/${{ steps.pr.outputs.number }}"
+
+  # PATH B: Manual trigger via CODEOWNER thumbs-up comment on a PR
+  claude-review-manual:
+    if: |
+      github.event_name == 'issue_comment' &&
+      github.event.issue.pull_request &&
+      (
+        github.event.comment.author_association == 'MEMBER' ||
+        github.event.comment.author_association == 'COLLABORATOR' ||
+        github.event.comment.author_association == 'OWNER'
+      ) &&
+      contains(github.event.comment.body, '👍')
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -13,18 +87,16 @@ jobs:
       issues: write
 
     steps:
-      - name: Checkout repository
+      - name: Checkout base branch
         uses: actions/checkout@v6
         with:
           fetch-depth: 1
-          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Run Claude Code Review
-        id: claude-review
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           plugin_marketplaces: "https://github.com/anthropics/claude-code.git"
           plugins: "code-review@claude-code-plugins"
-          prompt: "/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}"
+          prompt: "/code-review:code-review ${{ github.repository }}/pull/${{ github.event.issue.number }}"

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -69,7 +69,7 @@ jobs:
           plugins: "code-review@claude-code-plugins"
           prompt: "/code-review:code-review ${{ github.repository }}/pull/${{ steps.pr.outputs.number }}"
 
-  # PATH B: Manual trigger via CODEOWNER thumbs-up comment on a PR
+  # PATH B: Manual trigger via /claude-review comment on a PR
   claude-review-manual:
     if: |
       github.event_name == 'issue_comment' &&
@@ -79,7 +79,7 @@ jobs:
         github.event.comment.author_association == 'COLLABORATOR' ||
         github.event.comment.author_association == 'OWNER'
       ) &&
-      contains(github.event.comment.body, '👍')
+      contains(github.event.comment.body, '/claude-review')
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,43 +1,30 @@
 name: Claude Code Review
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, ready_for_review, reopened]
-    # Optional: Only run on specific file changes
-    # paths:
-    #   - "src/**/*.ts"
-    #   - "src/**/*.tsx"
-    #   - "src/**/*.js"
-    #   - "src/**/*.jsx"
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
-
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
-      issues: read
-      id-token: write
+      pull-requests: write
+      issues: write
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
           fetch-depth: 1
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Run Claude Code Review
         id: claude-review
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           plugin_marketplaces: "https://github.com/anthropics/claude-code.git"
           plugins: "code-review@claude-code-plugins"
           prompt: "/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}"
-          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
-          # or https://code.claude.com/docs/en/cli-reference for available options

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -20,10 +20,9 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
-      issues: read
-      id-token: write
-      actions: read # Required for Claude to read CI results on PRs
+      pull-requests: write
+      issues: write
+      actions: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -35,15 +34,4 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-
-          # This is an optional setting that allows Claude to read CI results on PRs
-          additional_permissions: |
-            actions: read
-
-          # Optional: Give a custom prompt to Claude. If this is not specified, Claude will perform the instructions specified in the comment that tagged it.
-          # prompt: 'Update the pull request description to include a summary of changes.'
-
-          # Optional: Add claude_args to customize behavior and configuration
-          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
-          # or https://code.claude.com/docs/en/cli-reference for available options
-          # claude_args: '--allowed-tools Bash(gh pr:*)'
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -12,11 +12,45 @@ on:
 
 jobs:
   claude:
+    # Only trusted authors (MEMBER/COLLABORATOR/OWNER) can invoke @claude.
+    # External users are rejected to prevent prompt injection → code execution.
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      (
+        github.event_name == 'issue_comment' &&
+        contains(github.event.comment.body, '@claude') &&
+        (
+          github.event.comment.author_association == 'MEMBER' ||
+          github.event.comment.author_association == 'COLLABORATOR' ||
+          github.event.comment.author_association == 'OWNER'
+        )
+      ) ||
+      (
+        github.event_name == 'pull_request_review_comment' &&
+        contains(github.event.comment.body, '@claude') &&
+        (
+          github.event.comment.author_association == 'MEMBER' ||
+          github.event.comment.author_association == 'COLLABORATOR' ||
+          github.event.comment.author_association == 'OWNER'
+        )
+      ) ||
+      (
+        github.event_name == 'pull_request_review' &&
+        contains(github.event.review.body, '@claude') &&
+        (
+          github.event.review.author_association == 'MEMBER' ||
+          github.event.review.author_association == 'COLLABORATOR' ||
+          github.event.review.author_association == 'OWNER'
+        )
+      ) ||
+      (
+        github.event_name == 'issues' &&
+        (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')) &&
+        (
+          github.event.issue.author_association == 'MEMBER' ||
+          github.event.issue.author_association == 'COLLABORATOR' ||
+          github.event.issue.author_association == 'OWNER'
+        )
+      )
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -25,13 +59,14 @@ jobs:
       actions: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 1
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@26ec041249acb0a944c0a47b6c0c13f05dbc5b44 # v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          claude_args: '--allowed-tools "Bash(gh pr:*)" "Bash(gh issue:*)" "Bash(cargo:*)" Read Edit Write Glob Grep Agent'

--- a/.github/workflows/prepare-claude-review.yml
+++ b/.github/workflows/prepare-claude-review.yml
@@ -1,0 +1,32 @@
+name: Prepare Claude Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review, reopened, labeled]
+
+permissions:
+  contents: read
+
+jobs:
+  prepare:
+    # Trusted authors: auto-trigger on any PR event
+    # External/first-time contributors: require 'claude-review-approved' label from a CODEOWNER
+    if: |
+      github.event.pull_request.author_association == 'MEMBER' ||
+      github.event.pull_request.author_association == 'COLLABORATOR' ||
+      github.event.pull_request.author_association == 'OWNER' ||
+      contains(github.event.pull_request.labels.*.name, 'claude-review-approved')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Save PR metadata
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          echo "$PR_NUMBER" > pr_number.txt
+
+      - name: Upload PR metadata
+        uses: actions/upload-artifact@v4
+        with:
+          name: pr-metadata
+          path: pr_number.txt
+          retention-days: 1

--- a/.github/workflows/prepare-claude-review.yml
+++ b/.github/workflows/prepare-claude-review.yml
@@ -9,13 +9,22 @@ permissions:
 
 jobs:
   prepare:
-    # Trusted authors: auto-trigger on any PR event
-    # External/first-time contributors: require 'claude-review-approved' label from a CODEOWNER
+    # Non-label events: trusted authors auto-trigger
+    # Label events: only fire when 'claude-review-approved' is the label being added
+    # This prevents unrelated label changes from triggering expensive scans
     if: |
-      github.event.pull_request.author_association == 'MEMBER' ||
-      github.event.pull_request.author_association == 'COLLABORATOR' ||
-      github.event.pull_request.author_association == 'OWNER' ||
-      contains(github.event.pull_request.labels.*.name, 'claude-review-approved')
+      (
+        github.event.action != 'labeled' &&
+        (
+          github.event.pull_request.author_association == 'MEMBER' ||
+          github.event.pull_request.author_association == 'COLLABORATOR' ||
+          github.event.pull_request.author_association == 'OWNER' ||
+          contains(github.event.pull_request.labels.*.name, 'claude-review-approved')
+        )
+      ) || (
+        github.event.action == 'labeled' &&
+        github.event.label.name == 'claude-review-approved'
+      )
     runs-on: ubuntu-latest
     steps:
       - name: Save PR metadata

--- a/.github/workflows/prepare-claude-review.yml
+++ b/.github/workflows/prepare-claude-review.yml
@@ -25,7 +25,7 @@ jobs:
           echo "$PR_NUMBER" > pr_number.txt
 
       - name: Upload PR metadata
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: pr-metadata
           path: pr_number.txt

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -56,4 +56,4 @@ Cargo.toml @moodlezoup @markosg04 @0xAndoroid
 Cargo.lock @moodlezoup @markosg04 @0xAndoroid
 
 # CI/CD workflows
-.github/workflows/ @a16z/jolt-maintainers
+.github/workflows/ @moodlezoup @0xAndoroid @markosg04 @sagar-a16z

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,59 @@
+# Default owner for everything
+* @moodlezoup
+
+# Core proving system
+jolt-core/ @moodlezoup @0xAndoroid @markosg04
+
+# Dory commitment scheme
+jolt-core/src/poly/commitment/dory/ @markosg04
+
+# BlindFold zero-knowledge protocol
+jolt-core/src/subprotocols/blindfold/ @0xAndoroid
+
+# Host (ELF compilation, program analysis)
+jolt-core/src/host/ @moodlezoup @sagar-a16z
+
+# Tracer (RISC-V emulator)
+tracer/ @moodlezoup @sagar-a16z
+tracer/src/instruction/ @moodlezoup
+
+# SDK
+jolt-sdk/ @moodlezoup @sagar-a16z
+
+# Inlines (optimized cryptographic primitives)
+jolt-inlines/ @0xAndoroid
+
+# Common types and constants
+common/ @moodlezoup @sagar-a16z
+
+# Documentation
+book/ @moodlezoup
+README.md @moodlezoup @markosg04 @0xAndoroid
+
+# Examples and integration tests
+examples/ @sagar-a16z @0xAndoroid @moodlezoup
+
+# Formal verification
+z3-verifier/ @moodlezoup
+zklean-extractor/ @moodlezoup
+
+# Platform support
+jolt-platform/ @sagar-a16z @0xAndoroid
+
+# Scripts and tooling
+scripts/ @0xAndoroid
+
+# AI
+.claude/ @moodlezoup @markosg04 @0xAndoroid
+agent-skills/ @moodlezoup @markosg04 @0xAndoroid
+CLAUDE.md @moodlezoup @markosg04 @0xAndoroid
+
+# Binary
+src/ @sagar-a16z
+
+# Cargo
+Cargo.toml @moodlezoup @markosg04 @0xAndoroid
+Cargo.lock @moodlezoup @markosg04 @0xAndoroid
+
+# CI/CD workflows
+.github/workflows/ @a16z/jolt-maintainers


### PR DESCRIPTION
## Summary

- Replace insecure single-stage `pull_request_target` with a two-stage workflow that never places fork code on disk alongside secrets
- **Stage 1** (`prepare-claude-review.yml`): Runs on `pull_request` (no secrets), gates on author association or `claude-review-approved` label, uploads PR number as artifact
- **Stage 2** (`claude-code-review.yml`): Two independent jobs:
  - **Path A (auto)**: `workflow_run` trigger consumes stage 1 artifact, validates PR number + SHA cross-reference, checks out base branch only, runs Claude review
  - **Path B (manual)**: `issue_comment` trigger fires when a CODEOWNER comments `/claude-review` on a fork PR — no artifact needed, inherently safe
- Add `author_association` gating to `claude.yml` so only MEMBER/COLLABORATOR/OWNER can invoke `@claude`
- Add `--allowed-tools` restriction to `claude.yml` limiting Bash to `gh` and `cargo` commands
- Pin all GitHub Actions to immutable commit SHAs (defense against tag rewriting)
- Remove `id-token: write` from both workflows (eliminates OIDC token minting risk)
- Add explicit `github_token` to both review workflows, bypassing OIDC token exchange
- Consolidate `CODEOWNERS` rules in root file, protecting `.github/workflows/` from unauthorized modification

## Context

PR #1323 switched from OAuth to API key auth but the `setupGitHubToken()` path still relied on OIDC token exchange, which GitHub Actions never provides for fork PR runs. This caused failures on fork PRs like #1310.

The initial fix (commit `a253a3db`) used `pull_request_target` to run in base repo context. While functional, this places untrusted fork code on disk in a workflow that holds secrets and a write-capable `GITHUB_TOKEN`. A fork-modified `CLAUDE.md` could attempt prompt injection against the LLM reviewer.

Additionally, `claude.yml` allowed any GitHub user to comment `@claude` on issues/PRs to invoke the agent with unrestricted tool access — effectively giving any external user command execution in the CI runner.

The two-stage architecture resolves the code-review tension, while author-association gating and tool restrictions close the `claude.yml` attack surface.

## Security

**Two-stage isolation (code-review):**
- Fork code is **never** on disk in the secret-bearing stage
- `CLAUDE.md` always comes from the trusted base branch — prompt injection via modified project instructions is eliminated
- `workflow_run` trigger always uses base branch workflow YAML — forks cannot modify stage 2

**Author-association gating (claude.yml):**
- Only MEMBER, COLLABORATOR, or OWNER can invoke `@claude` — external users are rejected at the workflow `if:` condition level
- Gating uses GitHub's `author_association` field which is set by GitHub infrastructure and cannot be forged by the commenter

**Tool restrictions (claude.yml):**
- `--allowed-tools` limits Bash to `gh pr:*`, `gh issue:*`, and `cargo:*` patterns
- Agent retains ability to interact with GitHub and build/test code, but cannot run arbitrary shell commands
- Defense-in-depth: even if a trusted user's comment is somehow weaponized, the agent cannot exfiltrate secrets via arbitrary commands

**Artifact tampering defense (code-review Path A):**
- Artifact contains only a PR number (integer) — minimal attack surface
- Stage 2 validates the PR number is a positive integer
- Cross-references PR's `headRefOid` against `github.event.workflow_run.head_sha` (set by GitHub, unforgeable)
- SHA mismatch causes hard failure

**Supply chain hardening:**
- All GitHub Actions pinned to immutable commit SHAs — tag rewriting attacks are eliminated
- `CODEOWNERS` requires maintainer review for workflow file changes

**Expression injection prevention:**
- All `${{ }}` expressions touching user-controlled data use `env:` indirection, never direct interpolation in `run:` blocks

## Test plan

- [ ] Verify stage 1 (`Prepare Claude Review`) triggers on PRs from MEMBER authors
- [ ] Verify stage 2 (`Claude Code Review` / `claude-review-auto`) triggers via `workflow_run` and posts review
- [ ] Verify SHA validation passes (artifact PR number matches workflow_run head SHA)
- [ ] Test Path B: CODEOWNER comments `/claude-review` on a fork PR — verify `claude-review-manual` triggers
- [ ] Test negative: fork author comments `/claude-review` on own PR — verify no trigger (author_association rejected)
- [ ] Test label gate: open PR from fork without label — verify stage 1 skips; apply `claude-review-approved` label — verify stage 1 triggers
- [ ] Test `@claude` from non-member: comment `@claude hello` from external account — verify `claude.yml` does NOT trigger
- [ ] Test `@claude` from member: comment `@claude hello` from org member — verify workflow runs normally
- [ ] Test tool restrictions: verify Claude cannot run arbitrary Bash commands in `claude.yml`
- [ ] Verify all action SHA pins resolve to expected versions
- [ ] Re-test on a fork PR (e.g. #1310) to validate end-to-end fork PR review