### PR TITLE
spec: ecdsa inputs sanitation

### DIFF
--- a/jolt-inlines/p256/src/sdk.rs
+++ b/jolt-inlines/p256/src/sdk.rs
@@ -235,7 +235,7 @@ impl<C: P256FieldConfig> P256Field<C> {
     /// Creates a new element from a `[u64; 4]` array (unchecked).
     /// The array is assumed to contain a value in the range `[0, modulus)`.
     #[inline(always)]
-    pub fn from_u64_arr_unchecked(arr: &[u64; 4]) -> Self {
+    pub(crate) fn from_u64_arr_unchecked(arr: &[u64; 4]) -> Self {
         Self {
             e: *arr,
             _phantom: PhantomData,
@@ -817,16 +817,35 @@ fn shamir_4x128(scalars: [u128; 4], points: [P256Point; 4]) -> P256Point {
 ///
 /// This halves the doublings: 128 instead of 256, achieving ~1.7x speedup.
 ///
-/// Security: it is the responsibility of the caller to ensure
-/// 1. z, r, and s are well formed
-/// 2. q is a valid point on the curve
-///
-/// Note that these checks are automatically performed by the from_u64_arr constructors.
+/// All inputs are validated internally — no caller-side validation is required.
 #[inline(always)]
 pub fn ecdsa_verify(z: P256Fr, r: P256Fr, s: P256Fr, q: P256Point) -> Result<(), P256Error> {
+    // Validate scalar field ranges: z, r, s must be in [0, n)
+    if is_non_canonical(&z.e(), &P256_ORDER) {
+        return Err(P256Error::InvalidFrElement);
+    }
+    if is_non_canonical(&r.e(), &P256_ORDER) {
+        return Err(P256Error::InvalidFrElement);
+    }
+    if is_non_canonical(&s.e(), &P256_ORDER) {
+        return Err(P256Error::InvalidFrElement);
+    }
+    // Validate base field ranges: q.x, q.y must be in [0, p)
+    if is_non_canonical(&q.x().e(), &P256_MODULUS) {
+        return Err(P256Error::InvalidFqElement);
+    }
+    if is_non_canonical(&q.y().e(), &P256_MODULUS) {
+        return Err(P256Error::InvalidFqElement);
+    }
+    // Validate q is on the curve
+    if !q.is_on_curve() {
+        return Err(P256Error::NotOnCurve);
+    }
+    // Check that q is not infinity
     if q.is_infinity() {
         return Err(P256Error::QAtInfinity);
     }
+    // Check that r, s, and z are non-zero
     if r.is_zero() || s.is_zero() || z.is_zero() {
         return Err(P256Error::ROrSZero);
     }

--- a/jolt-inlines/p256/src/tests.rs
+++ b/jolt-inlines/p256/src/tests.rs
@@ -862,7 +862,7 @@ mod p256_tests {
     /// Negative ECDSA tests: invalid inputs should be rejected.
     #[test]
     fn test_ecdsa_verify_rejects_invalid() {
-        use crate::sdk::{ecdsa_verify, P256Error, P256Fr, P256Point};
+        use crate::sdk::{ecdsa_verify, P256Error, P256Fq, P256Fr, P256Point};
 
         let g = P256Point::generator();
         let z = P256Fr::from_u64_arr(&[1, 0, 0, 0]).unwrap();
@@ -881,6 +881,39 @@ mod p256_tests {
         // s = 0 → ROrSZero
         let result = ecdsa_verify(z.clone(), r.clone(), zero, g.clone());
         assert!(matches!(result, Err(P256Error::ROrSZero)));
+
+        // Non-canonical scalar (z >= n) → InvalidFrElement
+        let bad_z = P256Fr::from_u64_arr_unchecked(&[u64::MAX; 4]);
+        let result = ecdsa_verify(bad_z, r.clone(), s.clone(), g.clone());
+        assert!(matches!(result, Err(P256Error::InvalidFrElement)));
+
+        // Non-canonical scalar (r >= n) → InvalidFrElement
+        let bad_r = P256Fr::from_u64_arr_unchecked(&[u64::MAX; 4]);
+        let result = ecdsa_verify(z.clone(), bad_r, s.clone(), g.clone());
+        assert!(matches!(result, Err(P256Error::InvalidFrElement)));
+
+        // Non-canonical scalar (s >= n) → InvalidFrElement
+        let bad_s = P256Fr::from_u64_arr_unchecked(&[u64::MAX; 4]);
+        let result = ecdsa_verify(z.clone(), r.clone(), bad_s, g.clone());
+        assert!(matches!(result, Err(P256Error::InvalidFrElement)));
+
+        // Non-canonical coordinate (q.x >= p) → InvalidFqElement
+        let bad_x = P256Fq::from_u64_arr_unchecked(&[u64::MAX; 4]);
+        let bad_q = P256Point::new_unchecked(bad_x, g.y());
+        let result = ecdsa_verify(z.clone(), r.clone(), s.clone(), bad_q);
+        assert!(matches!(result, Err(P256Error::InvalidFqElement)));
+
+        // Non-canonical coordinate (q.y >= p) → InvalidFqElement
+        let bad_y = P256Fq::from_u64_arr_unchecked(&[u64::MAX; 4]);
+        let bad_q = P256Point::new_unchecked(g.x(), bad_y);
+        let result = ecdsa_verify(z.clone(), r.clone(), s.clone(), bad_q);
+        assert!(matches!(result, Err(P256Error::InvalidFqElement)));
+
+        // Off-curve point → NotOnCurve
+        let off_curve_y = P256Fq::from_u64_arr(&[1, 0, 0, 0]).unwrap();
+        let bad_q = P256Point::new_unchecked(g.x(), off_curve_y);
+        let result = ecdsa_verify(z.clone(), r.clone(), s.clone(), bad_q);
+        assert!(matches!(result, Err(P256Error::NotOnCurve)));
     }
 
     /// Verify a signature produced by the RustCrypto `p256` crate.

--- a/jolt-inlines/secp256k1/src/sdk.rs
+++ b/jolt-inlines/secp256k1/src/sdk.rs
@@ -94,7 +94,7 @@ impl Secp256k1Fq {
     /// creates a new Secp256k1Fq element from a [u64; 4] array (unchecked)
     /// the array is assumed to contain a value in the range [0, p)
     #[inline(always)]
-    pub fn from_u64_arr_unchecked(arr: &[u64; 4]) -> Self {
+    pub(crate) fn from_u64_arr_unchecked(arr: &[u64; 4]) -> Self {
         Secp256k1Fq { e: *arr }
     }
     /// get limbs
@@ -403,9 +403,10 @@ impl Secp256k1Fr {
         Ok(Secp256k1Fr { e: *arr })
     }
     /// creates a new Secp256k1Fr element from a [u64; 4] array (unchecked)
-    /// the array is assumed to contain a value in the range [0, p)
+    /// the array is assumed to contain a value in the range [0, n)
     #[inline(always)]
-    pub fn from_u64_arr_unchecked(arr: &[u64; 4]) -> Self {
+    #[allow(dead_code)]
+    pub(crate) fn from_u64_arr_unchecked(arr: &[u64; 4]) -> Self {
         Secp256k1Fr { e: *arr }
     }
     /// get limbs
@@ -851,17 +852,14 @@ fn conditional_negate(x: Secp256k1Point, cond: bool) -> Secp256k1Point {
     }
 }
 
-/// verify an ECDSA signature
-/// z is the hash of the message being signed
-/// r and s are the signature components
-/// q is the uncompressed public key point
-/// returns Ok(()) if the signature is valid
-/// returns Err(Secp256k1Error) if at any point, the verification fails
-/// Security: it is the responsibility of the caller to ensure
-/// 1. z, r, and s are well formed
-/// 2. q is a valid point on the curve
+/// Verify an ECDSA signature.
 ///
-/// Note that these checks are automatically performed by the from_u64_arr constructors.
+/// `z` is the hash of the message being signed, `r` and `s` are the signature
+/// components, and `q` is the uncompressed public key point.
+///
+/// Returns `Ok(())` if the signature is valid. Returns `Err(Secp256k1Error)` if
+/// any input is malformed or the verification fails. All inputs are validated
+/// internally — no caller-side validation is required.
 #[inline(always)]
 pub fn ecdsa_verify(
     z: Secp256k1Fr,
@@ -869,13 +867,34 @@ pub fn ecdsa_verify(
     s: Secp256k1Fr,
     q: Secp256k1Point,
 ) -> Result<(), Secp256k1Error> {
-    // step 0: check that q is not infinity
-    if q.is_infinity() {
-        return Result::Err(Secp256k1Error::QAtInfinity);
+    // Validate scalar field ranges: z, r, s must be in [0, n)
+    if is_fr_non_canonical(&z.e()) {
+        return Err(Secp256k1Error::InvalidFrElement);
     }
-    // step 1: check that r and s are in the correct range
+    if is_fr_non_canonical(&r.e()) {
+        return Err(Secp256k1Error::InvalidFrElement);
+    }
+    if is_fr_non_canonical(&s.e()) {
+        return Err(Secp256k1Error::InvalidFrElement);
+    }
+    // Validate base field ranges: q.x, q.y must be in [0, p)
+    if is_fq_non_canonical(&q.x().e()) {
+        return Err(Secp256k1Error::InvalidFqElement);
+    }
+    if is_fq_non_canonical(&q.y().e()) {
+        return Err(Secp256k1Error::InvalidFqElement);
+    }
+    // Validate q is on the curve
+    if !q.is_on_curve() {
+        return Err(Secp256k1Error::NotOnCurve);
+    }
+    // Check that q is not infinity
+    if q.is_infinity() {
+        return Err(Secp256k1Error::QAtInfinity);
+    }
+    // Check that r and s are non-zero
     if r.is_zero() || s.is_zero() {
-        return Result::Err(Secp256k1Error::ROrSZero);
+        return Err(Secp256k1Error::ROrSZero);
     }
     // step 2: compute u1 = z / s (mod r) and u2 = r / s (mod r)
     let u1 = z.div_assume_nonzero(&s);

--- a/jolt-inlines/secp256k1/src/tests.rs
+++ b/jolt-inlines/secp256k1/src/tests.rs
@@ -439,6 +439,63 @@ mod sequence_tests {
         assert!(crate::sdk::ecdsa_verify(z, r, s, q).is_ok());
     }
 
+    #[test]
+    fn test_ecdsa_verify_rejects_invalid() {
+        use crate::sdk::{ecdsa_verify, Secp256k1Error};
+
+        let g = Secp256k1Point::generator();
+        let z = Secp256k1Fr::from_u64_arr(&[1, 0, 0, 0]).unwrap();
+        let r = Secp256k1Fr::from_u64_arr(&[1, 0, 0, 0]).unwrap();
+        let s = Secp256k1Fr::from_u64_arr(&[1, 0, 0, 0]).unwrap();
+
+        // Q = infinity → QAtInfinity
+        let result = ecdsa_verify(z.clone(), r.clone(), s.clone(), Secp256k1Point::infinity());
+        assert!(matches!(result, Err(Secp256k1Error::QAtInfinity)));
+
+        // r = 0 → ROrSZero
+        let zero = Secp256k1Fr::from_u64_arr(&[0, 0, 0, 0]).unwrap();
+        let result = ecdsa_verify(z.clone(), zero.clone(), s.clone(), g.clone());
+        assert!(matches!(result, Err(Secp256k1Error::ROrSZero)));
+
+        // s = 0 → ROrSZero
+        let result = ecdsa_verify(z.clone(), r.clone(), zero, g.clone());
+        assert!(matches!(result, Err(Secp256k1Error::ROrSZero)));
+
+        // Non-canonical scalar (z >= n) → InvalidFrElement
+        let bad_z = Secp256k1Fr::from_u64_arr_unchecked(&[u64::MAX; 4]);
+        let result = ecdsa_verify(bad_z, r.clone(), s.clone(), g.clone());
+        assert!(matches!(result, Err(Secp256k1Error::InvalidFrElement)));
+
+        // Non-canonical scalar (r >= n) → InvalidFrElement
+        let bad_r = Secp256k1Fr::from_u64_arr_unchecked(&[u64::MAX; 4]);
+        let result = ecdsa_verify(z.clone(), bad_r, s.clone(), g.clone());
+        assert!(matches!(result, Err(Secp256k1Error::InvalidFrElement)));
+
+        // Non-canonical scalar (s >= n) → InvalidFrElement
+        let bad_s = Secp256k1Fr::from_u64_arr_unchecked(&[u64::MAX; 4]);
+        let result = ecdsa_verify(z.clone(), r.clone(), bad_s, g.clone());
+        assert!(matches!(result, Err(Secp256k1Error::InvalidFrElement)));
+
+        // Non-canonical coordinate (q.x >= p) → InvalidFqElement
+        let bad_x = Secp256k1Fq::from_u64_arr_unchecked(&[u64::MAX; 4]);
+        let bad_q = Secp256k1Point::new_unchecked(bad_x, g.y());
+        let result = ecdsa_verify(z.clone(), r.clone(), s.clone(), bad_q);
+        assert!(matches!(result, Err(Secp256k1Error::InvalidFqElement)));
+
+        // Non-canonical coordinate (q.y >= p) → InvalidFqElement
+        let bad_y = Secp256k1Fq::from_u64_arr_unchecked(&[u64::MAX; 4]);
+        let bad_q = Secp256k1Point::new_unchecked(g.x(), bad_y);
+        let result = ecdsa_verify(z.clone(), r.clone(), s.clone(), bad_q);
+        assert!(matches!(result, Err(Secp256k1Error::InvalidFqElement)));
+
+        // Off-curve point → NotOnCurve
+        // Take a valid x-coordinate and set y to a different valid value
+        let off_curve_y = Secp256k1Fq::from_u64_arr(&[1, 0, 0, 0]).unwrap();
+        let bad_q = Secp256k1Point::new_unchecked(g.x(), off_curve_y);
+        let result = ecdsa_verify(z.clone(), r.clone(), s.clone(), bad_q);
+        assert!(matches!(result, Err(Secp256k1Error::NotOnCurve)));
+    }
+
     /// Verify assumptions about Fq and Fr modulus limb structure used in
     /// `is_fq_non_canonical` and `is_fr_non_canonical`.
     #[test]

--- a/specs/1402-ecdsa-inputs-sanitation.md
+++ b/specs/1402-ecdsa-inputs-sanitation.md
@@ -4,7 +4,7 @@
 |-------------|--------------------------------|
 | Author(s)   | @0xAndoroid                    |
 | Created     | 2026-04-02                     |
-| Status      | proposed                       |
+| Status      | implemented                    |
 | PR          | #1402                          |
 
 ## Summary

--- a/specs/1402-ecdsa-inputs-sanitation.md
+++ b/specs/1402-ecdsa-inputs-sanitation.md
@@ -5,7 +5,7 @@
 | Author(s)   | @0xAndoroid                    |
 | Created     | 2026-04-02                     |
 | Status      | proposed                       |
-| PR          |                                |
+| PR          | #1402                          |
 
 ## Summary
 

--- a/specs/ecdsa-inputs-sanitation.md
+++ b/specs/ecdsa-inputs-sanitation.md
@@ -1,0 +1,98 @@
+# Spec: ECDSA Inputs Sanitation
+
+| Field       | Value                          |
+|-------------|--------------------------------|
+| Author(s)   | @0xAndoroid                    |
+| Created     | 2026-04-02                     |
+| Status      | proposed                       |
+| PR          |                                |
+
+## Summary
+
+`ecdsa_verify()` in both the secp256k1 and P-256 inline SDKs accepts typed inputs but performs no validation on them, trusting that callers used checked constructors. PR #1391 added documentation noting this caller responsibility, but this is a security footgun: callers can bypass validation via `_unchecked` constructors or direct struct construction and obtain proofs over incorrect ECDSA results. This spec moves input validation into `ecdsa_verify()` itself and restricts the `_unchecked` constructors to crate-internal use, eliminating the footgun.
+
+## Intent
+
+### Goal
+
+Make `ecdsa_verify()` self-contained and safe by validating all inputs internally — scalar field range, point field range, on-curve, and not-infinity checks — returning an error on malformed inputs, and restricting `_unchecked` constructors to `pub(crate)` visibility.
+
+### Invariants
+
+1. `ecdsa_verify()` returns `Err` if any scalar (z, r, s) has limbs outside `[0, n)` (scalar field modulus)
+2. `ecdsa_verify()` returns `Err` if any point coordinate (q.x, q.y) has limbs outside `[0, p)` (base field modulus)
+3. `ecdsa_verify()` returns `Err` if q is not on the curve (`y² != x³ + ax + b`)
+4. `ecdsa_verify()` returns `Err` if q is the point at infinity
+5. `ecdsa_verify()` returns `Err` if r or s is zero
+6. All checks are guest-side (part of the execution trace), not host-only assertions
+7. `from_u64_arr_unchecked()` is not accessible from outside the crate
+
+### Non-Goals
+
+1. Validating inputs for non-ECDSA operations (standalone field arithmetic, point addition)
+2. Signature malleability protection (enforcing low-s normalization)
+3. Supporting curves beyond secp256k1 and P-256
+
+## Evaluation
+
+### Acceptance Criteria
+
+- [ ] `ecdsa_verify` returns `Err` when q is not on-curve (both secp256k1 and P-256)
+- [ ] `ecdsa_verify` returns `Err` when q is point at infinity
+- [ ] `ecdsa_verify` returns `Err` when r or s is zero
+- [ ] `ecdsa_verify` returns `Err` when scalar/coordinate limbs are out of field range
+- [ ] `ecdsa_verify` returns `Ok(())` for valid signatures (existing inline tests pass)
+- [ ] Checks are proved (guest-side, part of the execution trace)
+- [ ] `from_u64_arr_unchecked` is `pub(crate)` or private — not accessible from external crates
+
+### Testing Strategy
+
+**Existing tests that must pass:**
+- `jolt-inlines/secp256k1/src/tests.rs` — all existing ECDSA and field op tests
+- `jolt-inlines/p256/src/tests.rs` — all existing ECDSA and field op tests
+- Example guest programs (`secp256k1-ecdsa-verify`, `p256-ecdsa-verify`)
+
+**New tests needed:**
+- Unit tests for each rejection case: out-of-range scalar, out-of-range coordinate, off-curve point, point at infinity, zero r, zero s
+- Tests for both secp256k1 and P-256
+
+**Feature coverage:** `--features host` only. No `zk` feature coverage needed.
+
+### Performance
+
+The on-curve check adds ~3 field operations (1 square, 1 square, 1 mul, 1 add, 1 compare) per `ecdsa_verify` call. This is negligible relative to the two GLV scalar multiplications in the verification itself. No benchmark target beyond "no regression beyond the expected ~3 field ops overhead."
+
+## Design
+
+### Architecture
+
+Changes are contained within the `jolt-inlines` workspace:
+
+**`jolt-inlines/secp256k1/src/sdk.rs`:**
+- Add validation at the top of `ecdsa_verify()`: scalar range checks via `is_fr_non_canonical()`, coordinate range checks via `is_fq_non_canonical()`, on-curve check via `is_on_curve()`, infinity check, r/s non-zero check
+- Change `from_u64_arr_unchecked()` visibility from `pub` to `pub(crate)` on `Secp256k1Fr`, `Secp256k1Fq`, and `Secp256k1Point`
+
+**`jolt-inlines/p256/src/sdk.rs`:**
+- Same changes for P-256 types and `ecdsa_verify()`
+
+**`jolt-inlines/sdk/src/ec.rs`:**
+- If `from_u64_arr_unchecked` exists on `AffinePoint`, restrict its visibility
+
+No new types, traits, or modules needed.
+
+### Alternatives Considered
+
+1. **Documentation-only (PR #1391 status quo):** Rejected — relying on callers to validate is a security footgun. Callers may not notice the requirement or implement checks sub-optimally.
+2. **Remove `_unchecked` constructors entirely:** Rejected — they are used internally for values already proven valid by the inline proof system. Removing them would add redundant re-validation on every intermediate field operation result.
+
+## Documentation
+
+No Jolt book changes needed. The `ecdsa_verify` API signature is unchanged; it simply becomes safer by validating internally. The book's existing usage examples remain correct.
+
+## Execution
+
+The implementer should derive the approach from the intent and evaluation sections above.
+
+## References
+
+- [PR #1391](https://github.com/a16z/jolt/pull/1391) — Added documentation noting caller responsibility for input validation


### PR DESCRIPTION
## Summary
- Add spec for moving ECDSA input validation into `ecdsa_verify()` for both secp256k1 and P-256
- Restrict `_unchecked` constructors to `pub(crate)` visibility
- Addresses the security footgun documented in #1391

## Test plan
- [ ] Review spec for completeness
- [ ] Run `@claude analyze` on the PR for second-opinion analysis