### PR TITLE
feat/global-cse-opt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,6 +70,11 @@ transpiler/go/*_crossval_values.json
 transpiler/go/*_assertion_components.json
 transpiler/go/crossval/circuit.go
 
+# transpiler generated artifacts (Groth16 keys, circuit output per size class)
+transpiler/go/proving_key.bin
+transpiler/go/verifying_key.bin
+transpiler/go/class_*/
+
 # generated docs and scripts
 docs/
 scripts/ci-local.sh

--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,10 @@ jolt-sdk/tests/jolt_verifier_preprocessing_bytes.rs
 
 # transpiler test output
 transpiler/go/groth16_results.json
+transpiler/go/*_crossval_values.json
+transpiler/go/*_assertion_components.json
+transpiler/go/crossval/circuit.go
+
+# generated docs and scripts
+docs/
+scripts/ci-local.sh

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5467,6 +5467,7 @@ dependencies = [
  "light-poseidon",
  "num-bigint",
  "rand_core 0.6.4",
+ "serde",
  "serde_json",
  "zklean-extractor",
 ]

--- a/transpiler/Cargo.toml
+++ b/transpiler/Cargo.toml
@@ -35,3 +35,7 @@ path = "src/main.rs"
 [[bin]]
 name = "compute_r_inv"
 path = "src/bin/compute_r_inv.rs"
+
+[[bin]]
+name = "export_assertion_components"
+path = "src/bin/export_assertion_components.rs"

--- a/transpiler/Cargo.toml
+++ b/transpiler/Cargo.toml
@@ -36,4 +36,3 @@ path = "src/main.rs"
 [[bin]]
 name = "compute_r_inv"
 path = "src/bin/compute_r_inv.rs"
-

--- a/transpiler/Cargo.toml
+++ b/transpiler/Cargo.toml
@@ -9,6 +9,7 @@ ark-std.workspace = true
 ark-bn254.workspace = true
 ark-serialize.workspace = true
 ark-ff.workspace = true
+serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 clap = { version = "4.0", features = ["derive"] }
 

--- a/transpiler/Cargo.toml
+++ b/transpiler/Cargo.toml
@@ -36,6 +36,3 @@ path = "src/main.rs"
 name = "compute_r_inv"
 path = "src/bin/compute_r_inv.rs"
 
-[[bin]]
-name = "export_assertion_components"
-path = "src/bin/export_assertion_components.rs"

--- a/transpiler/go/crossval/crossval_test.go
+++ b/transpiler/go/crossval/crossval_test.go
@@ -1,0 +1,176 @@
+package crossval
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"math/big"
+	"os"
+	"path/filepath"
+	"reflect"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/consensys/gnark-crypto/ecc"
+	"github.com/consensys/gnark/test"
+)
+
+// loadAssignment loads witness data into the crossval circuit struct.
+func loadAssignment(witnessPath string) (*JoltStagesCircuit, error) {
+	data, err := os.ReadFile(witnessPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read witness file: %w", err)
+	}
+
+	var witnessMap map[string]string
+	if err := json.Unmarshal(data, &witnessMap); err != nil {
+		return nil, fmt.Errorf("failed to parse witness JSON: %w", err)
+	}
+
+	assignment := &JoltStagesCircuit{}
+	v := reflect.ValueOf(assignment).Elem()
+	t := v.Type()
+
+	loaded := 0
+	for i := 0; i < v.NumField(); i++ {
+		fieldName := t.Field(i).Name
+		field := v.Field(i)
+		if value, ok := witnessMap[fieldName]; ok {
+			if field.IsValid() && field.CanSet() {
+				val, ok := new(big.Int).SetString(value, 10)
+				if !ok {
+					return nil, fmt.Errorf("invalid value for %s: %s", fieldName, value)
+				}
+				field.Set(reflect.ValueOf(val))
+				loaded++
+			}
+		}
+	}
+
+	if loaded == 0 {
+		return nil, fmt.Errorf("no witness values loaded")
+	}
+	return assignment, nil
+}
+
+// AssertionValue holds LHS and RHS for one assertion.
+type AssertionValue struct {
+	Name string `json:"name"`
+	LHS  string `json:"lhs"`
+	RHS  string `json:"rhs"`
+}
+
+// TestCrossValidation runs the debug circuit and captures api.Println output.
+// The Println output goes through gnark's test engine and appears in test output.
+// We parse it from the (test.engine) lines and write to JSON.
+func TestCrossValidation(t *testing.T) {
+	// Redirect stdout to capture api.Println output from test engine
+	oldStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	// Load witness
+	_, currentFile, _, _ := runtime.Caller(0)
+	witnessPath := filepath.Join(filepath.Dir(currentFile), "..", "stages_witness.json")
+	assignment, err := loadAssignment(witnessPath)
+	if err != nil {
+		w.Close()
+		os.Stdout = oldStdout
+		t.Fatalf("Failed to load witness: %v", err)
+	}
+
+	// Solve circuit (triggers api.Println calls)
+	var circuit JoltStagesCircuit
+	err = test.IsSolved(&circuit, assignment, ecc.BN254.ScalarField())
+
+	// Restore stdout and read captured output
+	w.Close()
+	os.Stdout = oldStdout
+
+	capturedBytes, _ := io.ReadAll(r)
+	capturedOutput := string(capturedBytes)
+
+	if err != nil {
+		t.Fatalf("Circuit not satisfied: %v\nCaptured output:\n%s", err, capturedOutput)
+	}
+
+	// Parse api.Println output from captured stdout
+	// Format: (test.engine) circuit.go:NNNN KEY VALUE
+	values := make(map[string]string)
+	lines := strings.Split(capturedOutput, "\n")
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if !strings.Contains(line, "test.engine") {
+			continue
+		}
+		// Extract key-value pairs for assertion LHS/RHS
+		for i := 0; i < 20; i++ {
+			for _, suffix := range []string{"_lhs", "_rhs", "_total"} {
+				key := fmt.Sprintf("a%d%s", i, suffix)
+				idx := strings.Index(line, key)
+				if idx < 0 {
+					continue
+				}
+				rest := strings.TrimSpace(line[idx+len(key):])
+				parts := strings.Fields(rest)
+				if len(parts) > 0 {
+					values[key] = parts[0]
+				}
+			}
+		}
+	}
+
+	// Build assertion list
+	assertions := make([]AssertionValue, 20)
+	for i := 0; i < 20; i++ {
+		lhs := values[fmt.Sprintf("a%d_lhs", i)]
+		rhs := values[fmt.Sprintf("a%d_rhs", i)]
+
+		// a0 is special: sum_zero, LHS = total, RHS = 0
+		if i == 0 {
+			if total, ok := values["a0_total"]; ok {
+				lhs = total
+				rhs = "0"
+			}
+		}
+
+		assertions[i] = AssertionValue{
+			Name: fmt.Sprintf("a%d", i),
+			LHS:  lhs,
+			RHS:  rhs,
+		}
+		t.Logf("a%d: LHS=%s RHS=%s", i, truncate(lhs, 50), truncate(rhs, 50))
+	}
+
+	// Verify we got all values
+	missing := 0
+	for i, a := range assertions {
+		if a.LHS == "" {
+			t.Errorf("Missing LHS for a%d", i)
+			missing++
+		}
+		if a.RHS == "" && i != 0 {
+			t.Errorf("Missing RHS for a%d", i)
+			missing++
+		}
+	}
+
+	// Write to JSON
+	jsonBytes, err := json.MarshalIndent(assertions, "", "  ")
+	if err != nil {
+		t.Fatalf("Failed to marshal JSON: %v", err)
+	}
+	outPath := filepath.Join(filepath.Dir(currentFile), "..", "go_crossval_values.json")
+	if err := os.WriteFile(outPath, jsonBytes, 0644); err != nil {
+		t.Fatalf("Failed to write JSON: %v", err)
+	}
+	t.Logf("Wrote %d assertions to %s (missing: %d)", len(assertions), outPath, missing)
+}
+
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n-3] + "..."
+}

--- a/transpiler/go/crossval/crossval_test.go
+++ b/transpiler/go/crossval/crossval_test.go
@@ -8,7 +8,9 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"regexp"
 	"runtime"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -97,42 +99,43 @@ func TestCrossValidation(t *testing.T) {
 
 	// Parse api.Println output from captured stdout
 	// Format: (test.engine) circuit.go:NNNN KEY VALUE
+	// Keys match pattern: a<N>_(lhs|rhs|total) where N is the assertion index
 	values := make(map[string]string)
+	keyPattern := regexp.MustCompile(`\b(a\d+_(?:lhs|rhs|total))\s+(\S+)`)
 	lines := strings.Split(capturedOutput, "\n")
+	maxIdx := -1
 	for _, line := range lines {
 		line = strings.TrimSpace(line)
 		if !strings.Contains(line, "test.engine") {
 			continue
 		}
-		// Extract key-value pairs for assertion LHS/RHS
-		for i := 0; i < 20; i++ {
-			for _, suffix := range []string{"_lhs", "_rhs", "_total"} {
-				key := fmt.Sprintf("a%d%s", i, suffix)
-				idx := strings.Index(line, key)
-				if idx < 0 {
-					continue
-				}
-				rest := strings.TrimSpace(line[idx+len(key):])
-				parts := strings.Fields(rest)
-				if len(parts) > 0 {
-					values[key] = parts[0]
-				}
+		matches := keyPattern.FindAllStringSubmatch(line, -1)
+		for _, m := range matches {
+			values[m[1]] = m[2]
+			// Track the highest assertion index seen
+			idxStr := strings.TrimPrefix(m[1], "a")
+			idxStr = idxStr[:strings.Index(idxStr, "_")]
+			if idx, err := strconv.Atoi(idxStr); err == nil && idx > maxIdx {
+				maxIdx = idx
 			}
 		}
 	}
 
+	numAssertions := maxIdx + 1
+	if numAssertions == 0 {
+		t.Fatalf("No assertion values found in circuit output")
+	}
+
 	// Build assertion list
-	assertions := make([]AssertionValue, 20)
-	for i := 0; i < 20; i++ {
+	assertions := make([]AssertionValue, numAssertions)
+	for i := 0; i < numAssertions; i++ {
 		lhs := values[fmt.Sprintf("a%d_lhs", i)]
 		rhs := values[fmt.Sprintf("a%d_rhs", i)]
 
-		// a0 is special: sum_zero, LHS = total, RHS = 0
-		if i == 0 {
-			if total, ok := values["a0_total"]; ok {
-				lhs = total
-				rhs = "0"
-			}
+		// sum_zero assertions have _total instead of _lhs/_rhs
+		if total, ok := values[fmt.Sprintf("a%d_total", i)]; ok {
+			lhs = total
+			rhs = "0"
 		}
 
 		assertions[i] = AssertionValue{
@@ -150,7 +153,7 @@ func TestCrossValidation(t *testing.T) {
 			t.Errorf("Missing LHS for a%d", i)
 			missing++
 		}
-		if a.RHS == "" && i != 0 {
+		if a.RHS == "" {
 			t.Errorf("Missing RHS for a%d", i)
 			missing++
 		}

--- a/transpiler/src/ast_evaluator.rs
+++ b/transpiler/src/ast_evaluator.rs
@@ -29,7 +29,7 @@ fn eval_atom(atom: &Atom, witness: &HashMap<u16, Fr>) -> Fr {
         Atom::Scalar(limbs) => scalar_to_fr(limbs),
         Atom::Var(idx) => *witness
             .get(idx)
-            .unwrap_or_else(|| panic!("missing witness for Var({})", idx)),
+            .unwrap_or_else(|| panic!("missing witness for Var({idx})")),
         Atom::NamedVar(_) => panic!("NamedVar should not appear in serialized bundle"),
     }
 }
@@ -85,7 +85,9 @@ fn eval_node(
                     let data = eval_edge(data_edge, nodes, cache, witness);
                     let mut hasher =
                         Poseidon::<Fr>::new_circom(3).expect("failed to create Poseidon hasher");
-                    hasher.hash(&[state, rounds, data]).expect("Poseidon hash failed")
+                    hasher
+                        .hash(&[state, rounds, data])
+                        .expect("Poseidon hash failed")
                 }
                 _ => panic!("only Poseidon transcript is supported for evaluation"),
             }

--- a/transpiler/src/ast_evaluator.rs
+++ b/transpiler/src/ast_evaluator.rs
@@ -1,0 +1,232 @@
+//! Concrete evaluation of AST nodes using real field arithmetic.
+//!
+//! Walks the `AstBundle` node arena and evaluates each node to a concrete `Fr` value.
+//! Used for cross-validation: compare Rust AST evaluation against gnark circuit execution.
+
+use ark_bn254::Fr;
+use ark_ff::{Field, PrimeField};
+use light_poseidon::{Poseidon, PoseidonHasher};
+use std::collections::HashMap;
+use zklean_extractor::ast_bundle::Constraint;
+use zklean_extractor::mle_ast::{Atom, Edge, Node, NodeId, Scalar, TranscriptHashData};
+
+/// Evaluate an Edge to a concrete Fr value.
+fn eval_edge(
+    edge: &Edge,
+    nodes: &[Node],
+    cache: &mut HashMap<NodeId, Fr>,
+    witness: &HashMap<u16, Fr>,
+) -> Fr {
+    match edge {
+        Edge::Atom(atom) => eval_atom(atom, witness),
+        Edge::NodeRef(id) => eval_node(*id, nodes, cache, witness),
+    }
+}
+
+/// Evaluate an Atom to Fr.
+fn eval_atom(atom: &Atom, witness: &HashMap<u16, Fr>) -> Fr {
+    match atom {
+        Atom::Scalar(limbs) => scalar_to_fr(limbs),
+        Atom::Var(idx) => *witness
+            .get(idx)
+            .unwrap_or_else(|| panic!("missing witness for Var({})", idx)),
+        Atom::NamedVar(_) => panic!("NamedVar should not appear in serialized bundle"),
+    }
+}
+
+/// Convert a [u64; 4] scalar (raw, NOT Montgomery) to Fr.
+fn scalar_to_fr(limbs: &Scalar) -> Fr {
+    // Scalar is value-form (not Montgomery). Use from_le_bytes_mod_order.
+    let mut bytes = [0u8; 32];
+    for (i, limb) in limbs.iter().enumerate() {
+        bytes[i * 8..(i + 1) * 8].copy_from_slice(&limb.to_le_bytes());
+    }
+    Fr::from_le_bytes_mod_order(&bytes)
+}
+
+/// Evaluate a node, caching results.
+fn eval_node(
+    node_id: NodeId,
+    nodes: &[Node],
+    cache: &mut HashMap<NodeId, Fr>,
+    witness: &HashMap<u16, Fr>,
+) -> Fr {
+    if let Some(&val) = cache.get(&node_id) {
+        return val;
+    }
+
+    let result = match &nodes[node_id] {
+        Node::Atom(atom) => eval_atom(atom, witness),
+
+        Node::Add(a, b) => {
+            eval_edge(a, nodes, cache, witness) + eval_edge(b, nodes, cache, witness)
+        }
+        Node::Sub(a, b) => {
+            eval_edge(a, nodes, cache, witness) - eval_edge(b, nodes, cache, witness)
+        }
+        Node::Mul(a, b) => {
+            eval_edge(a, nodes, cache, witness) * eval_edge(b, nodes, cache, witness)
+        }
+        Node::Div(a, b) => {
+            let denom = eval_edge(b, nodes, cache, witness);
+            eval_edge(a, nodes, cache, witness) * denom.inverse().expect("div by zero")
+        }
+        Node::Neg(a) => -eval_edge(a, nodes, cache, witness),
+        Node::Inv(a) => eval_edge(a, nodes, cache, witness)
+            .inverse()
+            .expect("inv of zero"),
+
+        Node::TranscriptHash(hash_data, state_edge, rounds_edge) => {
+            let state = eval_edge(state_edge, nodes, cache, witness);
+            let rounds = eval_edge(rounds_edge, nodes, cache, witness);
+
+            match hash_data {
+                TranscriptHashData::Poseidon(data_edge) => {
+                    let data = eval_edge(data_edge, nodes, cache, witness);
+                    let mut hasher =
+                        Poseidon::<Fr>::new_circom(3).expect("failed to create Poseidon hasher");
+                    hasher.hash(&[state, rounds, data]).expect("Poseidon hash failed")
+                }
+                _ => panic!("only Poseidon transcript is supported for evaluation"),
+            }
+        }
+
+        Node::ByteReverse(e) => {
+            let val = eval_edge(e, nodes, cache, witness);
+            let bigint = val.into_bigint();
+            let mut bytes = [0u8; 32];
+            for (i, limb) in bigint.0.iter().enumerate() {
+                bytes[i * 8..(i + 1) * 8].copy_from_slice(&limb.to_le_bytes());
+            }
+            bytes.reverse();
+            Fr::from_le_bytes_mod_order(&bytes)
+        }
+
+        Node::Truncate128Reverse(e) => {
+            let val = eval_edge(e, nodes, cache, witness);
+            let bigint = val.into_bigint();
+            let mut le_bytes = [0u8; 32];
+            for (i, limb) in bigint.0.iter().enumerate() {
+                le_bytes[i * 8..(i + 1) * 8].copy_from_slice(&limb.to_le_bytes());
+            }
+            // Take low 16 bytes, reverse, interpret as field element, multiply by 2^128
+            let mut truncated = [0u8; 16];
+            truncated.copy_from_slice(&le_bytes[..16]);
+            truncated.reverse();
+            let base = Fr::from_le_bytes_mod_order(&truncated);
+            let shift = Fr::from(2u64).pow([128]);
+            base * shift
+        }
+
+        Node::Truncate128(e) => {
+            let val = eval_edge(e, nodes, cache, witness);
+            let bigint = val.into_bigint();
+            let mut le_bytes = [0u8; 32];
+            for (i, limb) in bigint.0.iter().enumerate() {
+                le_bytes[i * 8..(i + 1) * 8].copy_from_slice(&limb.to_le_bytes());
+            }
+            let mut truncated = [0u8; 16];
+            truncated.copy_from_slice(&le_bytes[..16]);
+            truncated.reverse();
+            Fr::from_le_bytes_mod_order(&truncated)
+        }
+
+        Node::AppendU64Transform(e) => {
+            let val = eval_edge(e, nodes, cache, witness);
+            // bswap64(x) * 2^192
+            let bigint = val.into_bigint();
+            let x = bigint.0[0]; // u64 value
+            let swapped = x.swap_bytes();
+            Fr::from(swapped) * Fr::from(2u64).pow([192])
+        }
+    };
+
+    cache.insert(node_id, result);
+    result
+}
+
+/// LHS and RHS of one assertion.
+pub struct AssertionValue {
+    pub name: String,
+    pub lhs: Fr,
+    pub rhs: Fr,
+}
+
+/// Evaluate all constraints in the bundle, returning LHS and RHS for each.
+///
+/// For constraints with `EqualZero` assertion:
+/// - If root is `Sub(lhs, rhs)`: returns the two sides separately
+/// - Otherwise (e.g., sum_zero): LHS = the expression, RHS = 0
+pub fn evaluate_assertions(
+    nodes: &[Node],
+    constraints: &[Constraint],
+    witness: &HashMap<u16, Fr>,
+) -> Vec<AssertionValue> {
+    let mut cache: HashMap<NodeId, Fr> = HashMap::new();
+    let mut results = Vec::new();
+
+    for constraint in constraints {
+        let root_node = &nodes[constraint.root];
+
+        let (lhs, rhs) = match root_node {
+            // Most assertions: Sub(lhs, rhs) == 0 means lhs == rhs
+            Node::Sub(lhs_edge, rhs_edge) => {
+                let l = eval_edge(lhs_edge, nodes, &mut cache, witness);
+                let r = eval_edge(rhs_edge, nodes, &mut cache, witness);
+                (l, r)
+            }
+            // sum_zero or other: the whole expression should be 0
+            _ => {
+                let val = eval_node(constraint.root, nodes, &mut cache, witness);
+                (val, Fr::from(0u64))
+            }
+        };
+
+        results.push(AssertionValue {
+            name: constraint.name.clone(),
+            lhs,
+            rhs,
+        });
+    }
+
+    results
+}
+
+/// Convert Fr to decimal string (matching gnark's output format).
+pub fn fr_to_decimal(f: &Fr) -> String {
+    f.into_bigint().to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_scalar_to_fr_zero() {
+        let zero = scalar_to_fr(&[0, 0, 0, 0]);
+        assert_eq!(zero, Fr::from(0u64));
+    }
+
+    #[test]
+    fn test_scalar_to_fr_one() {
+        let one = scalar_to_fr(&[1, 0, 0, 0]);
+        assert_eq!(one, Fr::from(1u64));
+    }
+
+    #[test]
+    fn test_scalar_to_fr_42() {
+        let val = scalar_to_fr(&[42, 0, 0, 0]);
+        assert_eq!(val, Fr::from(42u64));
+    }
+
+    #[test]
+    fn test_poseidon_hash_zeros() {
+        // Verify our Poseidon evaluation matches known test vectors
+        let mut hasher = Poseidon::<Fr>::new_circom(3).unwrap();
+        let result = hasher
+            .hash(&[Fr::from(0u64), Fr::from(0u64), Fr::from(0u64)])
+            .unwrap();
+        // This should match Go's poseidon.Hash(0, 0, 0)
+        assert_ne!(result, Fr::from(0u64)); // just verify it's non-trivial
+    }
+}

--- a/transpiler/src/gnark_codegen.rs
+++ b/transpiler/src/gnark_codegen.rs
@@ -171,6 +171,13 @@ enum ConstraintAssertion {
 /// its own expression tree with isolated CSE variables (`cse_N_*` for constraint N),
 /// making debugging easier: when a constraint fails, all `cse_N_*` variables
 /// belong to that constraint.
+/// Whether codegen is producing global CSE (gcse[i]) or per-constraint CSE (cse_K_i).
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum CseContext {
+    Global,
+    Constraint(usize),
+}
+
 pub(crate) struct GnarkCodeGen<'a> {
     /// Reference to the node arena (from AstBundle.nodes)
     nodes: &'a [Node],
@@ -184,8 +191,8 @@ pub(crate) struct GnarkCodeGen<'a> {
     pub(crate) cse_counter: usize,
     /// Maps variable index to input name (e.g., 0 -> "UniSkipCoeff0")
     var_names: &'a HashMap<u16, String>,
-    /// Constraint index for per-constraint CSE naming (e.g., constraint 3 uses cse_3_*)
-    constraint_idx: usize,
+    /// CSE context: global (gcse[i]) or per-constraint (cse_K_i)
+    cse_context: CseContext,
     /// Whether poseidon was used in this constraint
     uses_poseidon: bool,
 }
@@ -229,7 +236,7 @@ impl<'a> GnarkCodeGen<'a> {
             bindings: Vec::new(),
             cse_counter: 0,
             var_names,
-            constraint_idx,
+            cse_context: CseContext::Constraint(constraint_idx),
             uses_poseidon: false,
         }
     }
@@ -254,7 +261,7 @@ impl<'a> GnarkCodeGen<'a> {
             bindings: Vec::new(),
             cse_counter: 0,
             var_names,
-            constraint_idx: usize::MAX, // sentinel for global context
+            cse_context: CseContext::Global,
             uses_poseidon: false,
         }
     }
@@ -393,7 +400,7 @@ impl<'a> GnarkCodeGen<'a> {
             // extra gcse[] entries beyond the pre-allocated slice size.
             const MAX_INLINE_EXPR_LEN: usize = 1000;
             let ref_count = self.ref_counts.get(&node_id).copied().unwrap_or(1);
-            let is_global = self.constraint_idx == usize::MAX;
+            let is_global = self.cse_context == CseContext::Global;
             let should_hoist = if is_global {
                 ref_count > 1
             } else {
@@ -402,7 +409,7 @@ impl<'a> GnarkCodeGen<'a> {
             if should_hoist {
                 let var_name = self.make_cse_name();
                 self.cse_counter += 1;
-                if self.constraint_idx == usize::MAX {
+                if self.cse_context == CseContext::Global {
                     // Global CSE: slice assignment (gcse[N] = expr)
                     self.bindings.push(format!("\t{var_name} = {expr}\n"));
                 } else {
@@ -454,14 +461,15 @@ impl<'a> GnarkCodeGen<'a> {
 
     /// Generate a CSE variable name using the configured prefix
     fn make_cse_name(&self) -> String {
-        if self.constraint_idx == usize::MAX {
-            // Global CSE context
-            let cse_counter = self.cse_counter;
-            format!("gcse[{cse_counter}]")
-        } else {
-            let constraint_idx = self.constraint_idx;
-            let cse_counter = self.cse_counter;
-            format!("cse_{constraint_idx}_{cse_counter}")
+        match self.cse_context {
+            CseContext::Global => {
+                let cse_counter = self.cse_counter;
+                format!("gcse[{cse_counter}]")
+            }
+            CseContext::Constraint(idx) => {
+                let cse_counter = self.cse_counter;
+                format!("cse_{idx}_{cse_counter}")
+            }
         }
     }
 
@@ -474,10 +482,10 @@ impl<'a> GnarkCodeGen<'a> {
                 .get(&index)
                 .map(|name| format!("circuit.{}", sanitize_go_name(name)))
                 .unwrap_or_else(|| format!("circuit.X_{index}")),
-            Atom::NamedVar(index) => {
-                let constraint_idx = self.constraint_idx;
-                format!("cse_{constraint_idx}_{index}")
-            }
+            Atom::NamedVar(index) => match self.cse_context {
+                CseContext::Global => format!("gcse[{index}]"),
+                CseContext::Constraint(idx) => format!("cse_{idx}_{index}"),
+            },
         }
     }
 

--- a/transpiler/src/gnark_codegen.rs
+++ b/transpiler/src/gnark_codegen.rs
@@ -135,6 +135,10 @@ struct ProcessedConstraint {
     is_const: bool,
     /// Evaluated constant value (if is_const is true)
     const_val: Option<[u64; 4]>,
+    /// Crossval: LHS expression (only for Sub roots in crossval mode)
+    crossval_lhs: Option<String>,
+    /// Crossval: RHS expression (only for Sub roots in crossval mode)
+    crossval_rhs: Option<String>,
 }
 
 /// Assertion type for processed constraints (owned version of Assertion).
@@ -173,11 +177,11 @@ pub(crate) struct GnarkCodeGen<'a> {
     /// Reference counts for each NodeId (computed in first pass)
     ref_counts: HashMap<usize, usize>,
     /// Maps NodeId to CSE variable name (e.g., "cse_0" or "cse_3_0" for constraint 3)
-    generated: HashMap<usize, String>,
+    pub(crate) generated: HashMap<usize, String>,
     /// CSE variable definitions in order
     bindings: Vec<String>,
     /// Next CSE variable index
-    cse_counter: usize,
+    pub(crate) cse_counter: usize,
     /// Maps variable index to input name (e.g., 0 -> "UniSkipCoeff0")
     var_names: &'a HashMap<u16, String>,
     /// Constraint index for per-constraint CSE naming (e.g., constraint 3 uses cse_3_*)
@@ -385,9 +389,17 @@ impl<'a> GnarkCodeGen<'a> {
             // Hoist to CSE variable if referenced more than once OR expression is too large.
             // Large single-use expressions would create massive single-line Go code that
             // overwhelms the Go compiler (e.g., 48MB expression on one line).
+            // In global context, only hoist by ref_count — MAX_INLINE_EXPR_LEN could create
+            // extra gcse[] entries beyond the pre-allocated slice size.
             const MAX_INLINE_EXPR_LEN: usize = 1000;
             let ref_count = self.ref_counts.get(&node_id).copied().unwrap_or(1);
-            if ref_count > 1 || expr.len() > MAX_INLINE_EXPR_LEN {
+            let is_global = self.constraint_idx == usize::MAX;
+            let should_hoist = if is_global {
+                ref_count > 1
+            } else {
+                ref_count > 1 || expr.len() > MAX_INLINE_EXPR_LEN
+            };
+            if should_hoist {
                 let var_name = self.make_cse_name();
                 self.cse_counter += 1;
                 if self.constraint_idx == usize::MAX {
@@ -470,7 +482,7 @@ impl<'a> GnarkCodeGen<'a> {
     }
 
     /// Non-recursive edge_to_gnark that looks up already-generated expressions
-    fn edge_to_gnark_iterative(&mut self, edge: Edge) -> String {
+    pub(crate) fn edge_to_gnark_iterative(&mut self, edge: Edge) -> String {
         match edge {
             Edge::Atom(atom) => self.atom_to_gnark(atom),
             Edge::NodeRef(node_id) => {
@@ -529,7 +541,7 @@ pub fn generate_circuit_from_bundle(
         );
     }
 
-    let (code, stats) = generate_circuit_from_bundle_with_stats(bundle, circuit_name);
+    let (code, stats) = generate_circuit_from_bundle_with_stats(bundle, circuit_name, false);
 
     // Log statistics
     if stats.constant_skipped > 0 || stats.constant_failed > 0 {
@@ -573,6 +585,7 @@ pub fn generate_circuit_from_bundle(
 pub fn generate_circuit_from_bundle_with_stats(
     bundle: &zklean_extractor::mle_ast::AstBundle,
     circuit_name: &str,
+    crossval: bool,
 ) -> (String, ConstantAssertionStats) {
     use zklean_extractor::mle_ast::{Assertion, WitnessType};
 
@@ -620,8 +633,31 @@ pub fn generate_circuit_from_bundle_with_stats(
             &global_node_map,
         );
 
-        // Generate expression for this constraint
-        let expr = codegen.generate_expr(c.root);
+        // Generate expression for this constraint.
+        // In crossval mode, for Sub roots, generate lhs and rhs separately for api.Println hooks.
+        let (expr, crossval_lhs, crossval_rhs) = if crossval {
+            if let Node::Sub(lhs_edge, rhs_edge) = bundle.nodes[c.root].clone() {
+                // Generate subtrees for both edges first
+                if let Edge::NodeRef(id) = lhs_edge {
+                    codegen.generate_expr(id);
+                }
+                if let Edge::NodeRef(id) = rhs_edge {
+                    codegen.generate_expr(id);
+                }
+                // Now resolve edges (subtrees are in codegen.generated)
+                let lhs_expr = codegen.edge_to_gnark_iterative(lhs_edge);
+                let rhs_expr = codegen.edge_to_gnark_iterative(rhs_edge);
+                let full_expr = format!("api.Sub({}, {})", &lhs_expr, &rhs_expr);
+                codegen.generated.insert(c.root, full_expr.clone());
+                (full_expr, Some(lhs_expr), Some(rhs_expr))
+            } else {
+                let expr = codegen.generate_expr(c.root);
+                (expr, None, None)
+            }
+        } else {
+            let expr = codegen.generate_expr(c.root);
+            (expr, None, None)
+        };
 
         // Build the assertion (converting to owned form and generating other_expr if needed)
         let assertion = match &c.assertion {
@@ -665,6 +701,8 @@ pub fn generate_circuit_from_bundle_with_stats(
             assertion,
             is_const,
             const_val,
+            crossval_lhs,
+            crossval_rhs,
         });
     }
 
@@ -694,7 +732,11 @@ pub fn generate_circuit_from_bundle_with_stats(
     let mut output = String::new();
 
     // Package and imports
-    output.push_str("package jolt_verifier\n\n");
+    if crossval {
+        output.push_str("package crossval\n\n");
+    } else {
+        output.push_str("package jolt_verifier\n\n");
+    }
     output.push_str("import (\n");
     output.push_str("\t\"math/big\"\n");
     output.push('\n');
@@ -753,6 +795,12 @@ pub fn generate_circuit_from_bundle_with_stats(
         for &node_id in global_bindings {
             global_codegen.generate_expr(node_id);
         }
+
+        assert_eq!(
+            global_codegen.cse_counter, num_global,
+            "global CSE counter ({}) != global bindings count ({}): index mapping would be inconsistent",
+            global_codegen.cse_counter, num_global
+        );
 
         if global_codegen.uses_poseidon() {
             stats.uses_poseidon = true;
@@ -851,7 +899,9 @@ pub fn generate_circuit_from_bundle_with_stats(
                     pc.name
                 ));
                 stats.constant_skipped += 1;
-                continue;
+                if !crossval {
+                    continue;
+                }
             } else {
                 // Constant != 0 - static failure, emit warning comment but still generate constraint
                 output.push_str(&format!("// {} STATIC FAILURE: constant != 0\n", pc.name));
@@ -892,7 +942,7 @@ pub fn generate_circuit_from_bundle_with_stats(
                 for line in &binding_lines[start..end] {
                     // Rewrite "cse_K_N := expr" to "cse[N] = expr" and
                     // references to "cse_K_M" to "cse[M]" within the expression
-                    let rewritten = rewrite_cse_to_slice(line, idx);
+                    let rewritten = rewrite_cse_names_to_slice(line, idx, true);
                     output.push_str(&rewritten);
                     output.push('\n');
                 }
@@ -917,7 +967,7 @@ pub fn generate_circuit_from_bundle_with_stats(
             }
 
             // Rewrite the final expression to use cse[N] references
-            let rewritten_expr = rewrite_cse_refs_to_slice(&pc.expr, idx);
+            let rewritten_expr = rewrite_cse_names_to_slice(&pc.expr, idx, false);
             output.push_str(&format!("\t{var_name} := {rewritten_expr}\n"));
         } else {
             // Small constraint: emit as a single function with named CSE variables
@@ -933,6 +983,28 @@ pub fn generate_circuit_from_bundle_with_stats(
             output.push_str(&format!("\t{var_name} := {}\n", pc.expr));
         }
 
+        // Crossval: emit api.Println hooks for LHS/RHS before the assertion
+        if crossval {
+            if let (Some(lhs), Some(rhs)) = (&pc.crossval_lhs, &pc.crossval_rhs) {
+                let lhs_rewritten = if needs_splitting {
+                    rewrite_cse_names_to_slice(lhs, idx, false)
+                } else {
+                    lhs.clone()
+                };
+                let rhs_rewritten = if needs_splitting {
+                    rewrite_cse_names_to_slice(rhs, idx, false)
+                } else {
+                    rhs.clone()
+                };
+                output.push_str(&format!("\tcrossval_lhs_{idx} := {lhs_rewritten}\n"));
+                output.push_str(&format!("\tcrossval_rhs_{idx} := {rhs_rewritten}\n"));
+                output.push_str(&format!("\tapi.Println(\"a{idx}_lhs\", crossval_lhs_{idx})\n"));
+                output.push_str(&format!("\tapi.Println(\"a{idx}_rhs\", crossval_rhs_{idx})\n"));
+            } else {
+                output.push_str(&format!("\tapi.Println(\"a{idx}_total\", {var_name})\n"));
+            }
+        }
+
         // Emit assertion
         match &pc.assertion {
             ConstraintAssertion::EqualZero => {
@@ -946,7 +1018,7 @@ pub fn generate_circuit_from_bundle_with_stats(
             }
             ConstraintAssertion::EqualNode { other_expr } => {
                 let rewritten = if needs_splitting {
-                    rewrite_cse_refs_to_slice(other_expr, idx)
+                    rewrite_cse_names_to_slice(other_expr, idx, false)
                 } else {
                     other_expr.clone()
                 };
@@ -979,25 +1051,24 @@ pub fn generate_circuit_from_bundle_with_stats(
     (output, stats)
 }
 
-/// Rewrite a CSE binding line from named variables to slice indexing.
+/// Rewrite CSE named variables (`cse_K_N`) to slice indexing (`cse[N]`).
 ///
-/// Converts `\tcse_18_42 := api.Add(cse_18_3, circuit.X)` to
-/// `\tcse[42] = api.Add(cse[3], circuit.X)`.
-fn rewrite_cse_to_slice(line: &str, constraint_idx: usize) -> String {
+/// If `is_binding` is true, also converts the first `:=` to `=` (slice assignment).
+/// Used for both binding lines and expression references.
+fn rewrite_cse_names_to_slice(text: &str, constraint_idx: usize, is_binding: bool) -> String {
     let prefix = format!("cse_{constraint_idx}_");
-    let mut result = String::with_capacity(line.len());
+    let mut result = String::with_capacity(text.len());
     let mut i = 0;
-    let bytes = line.as_bytes();
+    let bytes = text.as_bytes();
 
     while i < bytes.len() {
-        if line[i..].starts_with(&prefix) {
-            // Found a cse reference, extract the number
+        if text[i..].starts_with(&prefix) {
             let num_start = i + prefix.len();
             let mut num_end = num_start;
             while num_end < bytes.len() && bytes[num_end].is_ascii_digit() {
                 num_end += 1;
             }
-            let num = &line[num_start..num_end];
+            let num = &text[num_start..num_end];
             result.push_str(&format!("cse[{num}]"));
             i = num_end;
         } else {
@@ -1006,36 +1077,11 @@ fn rewrite_cse_to_slice(line: &str, constraint_idx: usize) -> String {
         }
     }
 
-    // Replace first `:=` with `=` (slice assignment, not declaration)
-    result.replacen(":=", "=", 1)
-}
-
-/// Rewrite CSE references in an expression from named variables to slice indexing.
-///
-/// Converts `cse_18_42` to `cse[42]` in expression strings.
-fn rewrite_cse_refs_to_slice(expr: &str, constraint_idx: usize) -> String {
-    let prefix = format!("cse_{constraint_idx}_");
-    let mut result = String::with_capacity(expr.len());
-    let mut i = 0;
-    let bytes = expr.as_bytes();
-
-    while i < bytes.len() {
-        if expr[i..].starts_with(&prefix) {
-            let num_start = i + prefix.len();
-            let mut num_end = num_start;
-            while num_end < bytes.len() && bytes[num_end].is_ascii_digit() {
-                num_end += 1;
-            }
-            let num = &expr[num_start..num_end];
-            result.push_str(&format!("cse[{num}]"));
-            i = num_end;
-        } else {
-            result.push(bytes[i] as char);
-            i += 1;
-        }
+    if is_binding {
+        result.replacen(":=", "=", 1)
+    } else {
+        result
     }
-
-    result
 }
 
 /// Sanitize a name for use as a Go identifier (PascalCase with underscores).

--- a/transpiler/src/gnark_codegen.rs
+++ b/transpiler/src/gnark_codegen.rs
@@ -822,7 +822,9 @@ pub fn generate_circuit_from_bundle_with_stats(
         let needs_global_splitting = global_binding_lines.len() > MAX_GLOBAL_BINDING_LINES;
 
         if needs_global_splitting {
-            let num_parts = global_binding_lines.len().div_ceil(MAX_GLOBAL_BINDING_LINES);
+            let num_parts = global_binding_lines
+                .len()
+                .div_ceil(MAX_GLOBAL_BINDING_LINES);
             for part in 0..num_parts {
                 let start = part * MAX_GLOBAL_BINDING_LINES;
                 let end =
@@ -839,8 +841,7 @@ pub fn generate_circuit_from_bundle_with_stats(
             }
 
             output.push_str(&format!(
-                "// computeGlobalCse computes {} nodes shared across multiple constraints.\n",
-                num_global
+                "// computeGlobalCse computes {num_global} nodes shared across multiple constraints.\n"
             ));
             output.push_str(&format!(
                 "func (circuit *{circuit_name}) computeGlobalCse(api frontend.API) []frontend.Variable {{\n"
@@ -857,8 +858,7 @@ pub fn generate_circuit_from_bundle_with_stats(
             output.push_str("}\n\n");
         } else {
             output.push_str(&format!(
-                "// computeGlobalCse computes {} nodes shared across multiple constraints.\n",
-                num_global
+                "// computeGlobalCse computes {num_global} nodes shared across multiple constraints.\n"
             ));
             output.push_str(&format!(
                 "func (circuit *{circuit_name}) computeGlobalCse(api frontend.API) []frontend.Variable {{\n"
@@ -998,8 +998,12 @@ pub fn generate_circuit_from_bundle_with_stats(
                 };
                 output.push_str(&format!("\tcrossval_lhs_{idx} := {lhs_rewritten}\n"));
                 output.push_str(&format!("\tcrossval_rhs_{idx} := {rhs_rewritten}\n"));
-                output.push_str(&format!("\tapi.Println(\"a{idx}_lhs\", crossval_lhs_{idx})\n"));
-                output.push_str(&format!("\tapi.Println(\"a{idx}_rhs\", crossval_rhs_{idx})\n"));
+                output.push_str(&format!(
+                    "\tapi.Println(\"a{idx}_lhs\", crossval_lhs_{idx})\n"
+                ));
+                output.push_str(&format!(
+                    "\tapi.Println(\"a{idx}_rhs\", crossval_rhs_{idx})\n"
+                ));
             } else {
                 output.push_str(&format!("\tapi.Println(\"a{idx}_total\", {var_name})\n"));
             }

--- a/transpiler/src/gnark_codegen.rs
+++ b/transpiler/src/gnark_codegen.rs
@@ -201,6 +201,7 @@ impl<'a> GnarkCodeGen<'a> {
         var_names: &'a HashMap<u16, String>,
         constraint_idx: usize,
         cse_bindings: &[usize],
+        global_node_map: &HashMap<usize, usize>,
     ) -> Self {
         let mut ref_counts = HashMap::new();
 
@@ -211,6 +212,37 @@ impl<'a> GnarkCodeGen<'a> {
             ref_counts.insert(node_id, 2);
         }
 
+        // Pre-populate `generated` for global CSE nodes so they resolve to gcse[i]
+        let mut generated = HashMap::new();
+        for (&node_id, &gcse_idx) in global_node_map {
+            generated.insert(node_id, format!("gcse[{gcse_idx}]"));
+        }
+
+        Self {
+            nodes,
+            ref_counts,
+            generated,
+            bindings: Vec::new(),
+            cse_counter: 0,
+            var_names,
+            constraint_idx,
+            uses_poseidon: false,
+        }
+    }
+
+    /// Create a GnarkCodeGen for the global CSE block.
+    ///
+    /// Uses `gcse` naming: hoisted nodes become `gcse[i]`.
+    pub(crate) fn new_global(
+        nodes: &'a [Node],
+        var_names: &'a HashMap<u16, String>,
+        global_bindings: &[usize],
+    ) -> Self {
+        let mut ref_counts = HashMap::new();
+        for &node_id in global_bindings {
+            ref_counts.insert(node_id, 2);
+        }
+
         Self {
             nodes,
             ref_counts,
@@ -218,7 +250,7 @@ impl<'a> GnarkCodeGen<'a> {
             bindings: Vec::new(),
             cse_counter: 0,
             var_names,
-            constraint_idx,
+            constraint_idx: usize::MAX, // sentinel for global context
             uses_poseidon: false,
         }
     }
@@ -358,7 +390,13 @@ impl<'a> GnarkCodeGen<'a> {
             if ref_count > 1 || expr.len() > MAX_INLINE_EXPR_LEN {
                 let var_name = self.make_cse_name();
                 self.cse_counter += 1;
-                self.bindings.push(format!("\t{var_name} := {expr}\n"));
+                if self.constraint_idx == usize::MAX {
+                    // Global CSE: slice assignment (gcse[N] = expr)
+                    self.bindings.push(format!("\t{var_name} = {expr}\n"));
+                } else {
+                    // Per-constraint CSE: declaration (cse_K_N := expr)
+                    self.bindings.push(format!("\t{var_name} := {expr}\n"));
+                }
                 self.generated.insert(node_id, var_name);
             } else {
                 // Store the expression for single-use nodes too, so children can reference it
@@ -404,9 +442,15 @@ impl<'a> GnarkCodeGen<'a> {
 
     /// Generate a CSE variable name using the configured prefix
     fn make_cse_name(&self) -> String {
-        let constraint_idx = self.constraint_idx;
-        let cse_counter = self.cse_counter;
-        format!("cse_{constraint_idx}_{cse_counter}")
+        if self.constraint_idx == usize::MAX {
+            // Global CSE context
+            let cse_counter = self.cse_counter;
+            format!("gcse[{cse_counter}]")
+        } else {
+            let constraint_idx = self.constraint_idx;
+            let cse_counter = self.cse_counter;
+            format!("cse_{constraint_idx}_{cse_counter}")
+        }
     }
 
     /// Generate Gnark expression for an atom
@@ -555,11 +599,26 @@ pub fn generate_circuit_from_bundle_with_stats(
         );
     }
 
+    // Build global CSE node map: NodeId → index in gcse slice
+    let global_node_map: HashMap<usize, usize> = bundle
+        .global_cse
+        .bindings
+        .iter()
+        .enumerate()
+        .map(|(idx, &node_id)| (node_id, idx))
+        .collect();
+    let has_global_cse = !global_node_map.is_empty();
+
     for (constraint_idx, c) in bundle.constraints.iter().enumerate() {
         // Use pre-computed CSE bindings from AstBundle
         let cse_bindings = bundle.get_cse_bindings(constraint_idx).unwrap_or(&[]);
-        let mut codegen =
-            GnarkCodeGen::new(&bundle.nodes, &var_names, constraint_idx, cse_bindings);
+        let mut codegen = GnarkCodeGen::new(
+            &bundle.nodes,
+            &var_names,
+            constraint_idx,
+            cse_bindings,
+            &global_node_map,
+        );
 
         // Generate expression for this constraint
         let expr = codegen.generate_expr(c.root);
@@ -683,12 +742,103 @@ pub fn generate_circuit_from_bundle_with_stats(
     }
     output.push_str("}\n\n");
 
+    // Emit global CSE function if there are global bindings
+    if has_global_cse {
+        let global_bindings = &bundle.global_cse.bindings;
+        let num_global = global_bindings.len();
+        let mut global_codegen =
+            GnarkCodeGen::new_global(&bundle.nodes, &var_names, global_bindings);
+
+        // Generate expressions for all global nodes (in topological order)
+        for &node_id in global_bindings {
+            global_codegen.generate_expr(node_id);
+        }
+
+        if global_codegen.uses_poseidon() {
+            stats.uses_poseidon = true;
+        }
+
+        let global_bindings_code = global_codegen.bindings_code();
+
+        // Split into sub-functions if too large
+        let global_binding_lines: Vec<&str> = if global_bindings_code.is_empty() {
+            Vec::new()
+        } else {
+            global_bindings_code
+                .lines()
+                .filter(|l| !l.is_empty())
+                .collect()
+        };
+
+        const MAX_GLOBAL_BINDING_LINES: usize = 2000;
+        let needs_global_splitting = global_binding_lines.len() > MAX_GLOBAL_BINDING_LINES;
+
+        if needs_global_splitting {
+            let num_parts = global_binding_lines.len().div_ceil(MAX_GLOBAL_BINDING_LINES);
+            for part in 0..num_parts {
+                let start = part * MAX_GLOBAL_BINDING_LINES;
+                let end =
+                    std::cmp::min(start + MAX_GLOBAL_BINDING_LINES, global_binding_lines.len());
+
+                output.push_str(&format!(
+                    "func (circuit *{circuit_name}) computeGlobalCsePart{part}(api frontend.API, gcse []frontend.Variable) {{\n"
+                ));
+                for line in &global_binding_lines[start..end] {
+                    output.push_str(line);
+                    output.push('\n');
+                }
+                output.push_str("}\n\n");
+            }
+
+            output.push_str(&format!(
+                "// computeGlobalCse computes {} nodes shared across multiple constraints.\n",
+                num_global
+            ));
+            output.push_str(&format!(
+                "func (circuit *{circuit_name}) computeGlobalCse(api frontend.API) []frontend.Variable {{\n"
+            ));
+            output.push_str(&format!(
+                "\tgcse := make([]frontend.Variable, {num_global})\n"
+            ));
+            for part in 0..num_parts {
+                output.push_str(&format!(
+                    "\tcircuit.computeGlobalCsePart{part}(api, gcse)\n"
+                ));
+            }
+            output.push_str("\treturn gcse\n");
+            output.push_str("}\n\n");
+        } else {
+            output.push_str(&format!(
+                "// computeGlobalCse computes {} nodes shared across multiple constraints.\n",
+                num_global
+            ));
+            output.push_str(&format!(
+                "func (circuit *{circuit_name}) computeGlobalCse(api frontend.API) []frontend.Variable {{\n"
+            ));
+            output.push_str(&format!(
+                "\tgcse := make([]frontend.Variable, {num_global})\n"
+            ));
+            if !global_bindings_code.is_empty() {
+                output.push_str(&global_bindings_code);
+            }
+            output.push_str("\treturn gcse\n");
+            output.push_str("}\n\n");
+        }
+    }
+
     // Emit per-constraint helper methods.
     // Each constraint gets its own function to avoid arm64 "branch too far" compiler
     // errors when the entire circuit is in a single Define() method.
     // Large constraints are further split into sub-functions (max ~2000 binding lines each).
     const MAX_BINDING_LINES: usize = 2000;
     let mut constraint_func_names: Vec<String> = Vec::new();
+
+    // Extra parameter for global CSE passthrough
+    let gcse_param = if has_global_cse {
+        ", gcse []frontend.Variable"
+    } else {
+        ""
+    };
 
     for (idx, pc) in processed_constraints.iter().enumerate() {
         // Static verification for constant EqualZero assertions
@@ -736,7 +886,7 @@ pub fn generate_circuit_from_bundle_with_stats(
                 let end = std::cmp::min(start + MAX_BINDING_LINES, num_bindings);
 
                 output.push_str(&format!(
-                    "func (circuit *{circuit_name}) {func_name}Bindings{part}(api frontend.API, cse []frontend.Variable) {{\n"
+                    "func (circuit *{circuit_name}) {func_name}Bindings{part}(api frontend.API, cse []frontend.Variable{gcse_param}) {{\n"
                 ));
 
                 for line in &binding_lines[start..end] {
@@ -751,16 +901,19 @@ pub fn generate_circuit_from_bundle_with_stats(
             }
 
             // Emit the main constraint function that calls sub-functions
+            let gcse_arg = if has_global_cse { ", gcse" } else { "" };
             output.push_str(&format!("// {func_name} verifies: {}\n", pc.name));
             output.push_str(&format!(
-                "func (circuit *{circuit_name}) {func_name}(api frontend.API) {{\n"
+                "func (circuit *{circuit_name}) {func_name}(api frontend.API{gcse_param}) {{\n"
             ));
             output.push_str(&format!(
                 "\tcse := make([]frontend.Variable, {num_bindings})\n"
             ));
 
             for part in 0..num_parts {
-                output.push_str(&format!("\tcircuit.{func_name}Bindings{part}(api, cse)\n"));
+                output.push_str(&format!(
+                    "\tcircuit.{func_name}Bindings{part}(api, cse{gcse_arg})\n"
+                ));
             }
 
             // Rewrite the final expression to use cse[N] references
@@ -770,7 +923,7 @@ pub fn generate_circuit_from_bundle_with_stats(
             // Small constraint: emit as a single function with named CSE variables
             output.push_str(&format!("// {func_name} verifies: {}\n", pc.name));
             output.push_str(&format!(
-                "func (circuit *{circuit_name}) {func_name}(api frontend.API) {{\n"
+                "func (circuit *{circuit_name}) {func_name}(api frontend.API{gcse_param}) {{\n"
             ));
 
             if !pc.bindings.is_empty() {
@@ -809,8 +962,15 @@ pub fn generate_circuit_from_bundle_with_stats(
         "func (circuit *{circuit_name}) Define(api frontend.API) error {{\n"
     ));
 
-    for func_name in &constraint_func_names {
-        output.push_str(&format!("\tcircuit.{func_name}(api)\n"));
+    if has_global_cse {
+        output.push_str("\tgcse := circuit.computeGlobalCse(api)\n");
+        for func_name in &constraint_func_names {
+            output.push_str(&format!("\tcircuit.{func_name}(api, gcse)\n"));
+        }
+    } else {
+        for func_name in &constraint_func_names {
+            output.push_str(&format!("\tcircuit.{func_name}(api)\n"));
+        }
     }
 
     output.push_str("\treturn nil\n");

--- a/transpiler/src/lib.rs
+++ b/transpiler/src/lib.rs
@@ -76,6 +76,7 @@
 //! let circuit_code = gnark_codegen::generate_circuit_from_bundle(&bundle, "MyCircuit");
 //! ```
 
+pub mod ast_evaluator;
 pub mod gnark_codegen;
 pub mod symbolic_proof;
 pub mod symbolic_traits;

--- a/transpiler/src/main.rs
+++ b/transpiler/src/main.rs
@@ -98,6 +98,10 @@ struct Args {
     /// Output directory (defaults to target-specific directory, e.g., "go" for gnark)
     #[arg(long, short = 'o')]
     output_dir: Option<PathBuf>,
+
+    /// Also generate cross-validation circuit with api.Println hooks (crossval/circuit.go)
+    #[arg(long)]
+    crossval: bool,
 }
 
 fn main() {
@@ -390,6 +394,24 @@ fn main() {
                 .unwrap_or_else(|e| panic!("Failed to write circuit file {circuit_path:?}: {e}"));
             println!("  Circuit written to: {circuit_path:?}");
             println!("  Circuit size: {} bytes", circuit_code.len());
+
+            if args.crossval {
+                println!("\n=== Generating Crossval Circuit ===");
+                let (crossval_code, _) = gnark_codegen::generate_circuit_from_bundle_with_stats(
+                    &bundle,
+                    "JoltStagesCircuit",
+                    true,
+                );
+                let crossval_dir = output_dir.join("crossval");
+                std::fs::create_dir_all(&crossval_dir).unwrap_or_else(|e| {
+                    panic!("Failed to create crossval dir {crossval_dir:?}: {e}")
+                });
+                let crossval_path = crossval_dir.join("circuit.go");
+                std::fs::write(&crossval_path, &crossval_code).unwrap_or_else(|e| {
+                    panic!("Failed to write crossval circuit {crossval_path:?}: {e}")
+                });
+                println!("  Crossval circuit written to: {crossval_path:?}");
+            }
 
             // Get witness values captured during symbolization.
             // VarAllocator records both symbolic variables AND concrete values in a single pass,

--- a/transpiler/src/main.rs
+++ b/transpiler/src/main.rs
@@ -331,12 +331,21 @@ fn main() {
     }
     println!("  Constraints: {}", bundle.constraints.len());
 
-    // Run CSE (Common Subexpression Elimination) at the AST level.
+    // Run global CSE: identify nodes shared across multiple constraints
+    // (primarily TranscriptHash chains) and hoist them to a single computation block.
+    bundle.run_global_cse();
+    println!(
+        "  Global CSE: {} nodes hoisted across constraints",
+        bundle.global_cse.bindings.len()
+    );
+
+    // Run per-constraint CSE (Common Subexpression Elimination) at the AST level.
     // This pre-computes which nodes should be hoisted to named variables,
     // making codegen simpler (just reads pre-computed decisions).
+    // Nodes already in global CSE are excluded.
     bundle.run_cse();
     println!(
-        "  CSE bindings: {} total across {} constraints",
+        "  Per-constraint CSE bindings: {} total across {} constraints",
         bundle
             .constraint_cse
             .iter()

--- a/transpiler/tests/cross_validation.rs
+++ b/transpiler/tests/cross_validation.rs
@@ -1,0 +1,251 @@
+//! Cross-validation test: compare Rust AST evaluation against Go gnark circuit.
+//!
+//! Each system computes 20 assertions with LHS and RHS = 40 values per side.
+//! The test makes 40 comparisons: Rust_LHS==Go_LHS and Rust_RHS==Go_RHS for each assertion.
+//!
+//! Prerequisites:
+//! - Proof files in /tmp (from: cargo run -p fibonacci --features transcript-poseidon -- --save 50)
+//! - Generated circuit files (from: cargo run -p transpiler --bin transpiler --features transcript-poseidon)
+
+use ark_bn254::Fr;
+use std::collections::HashMap;
+use std::str::FromStr;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use transpiler::ast_evaluator::{evaluate_assertions, fr_to_decimal};
+use transpiler::gnark_codegen::sanitize_go_name;
+use zklean_extractor::AstBundle;
+
+fn go_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("go")
+}
+
+fn bundle_path() -> PathBuf {
+    go_dir().join("stages_bundle.json")
+}
+
+fn witness_path() -> PathBuf {
+    go_dir().join("stages_witness.json")
+}
+
+/// Load witness JSON and map to Var indices using the bundle's input descriptions.
+fn load_witness(bundle: &AstBundle, witness_path: &Path) -> HashMap<u16, Fr> {
+    let json_str = std::fs::read_to_string(witness_path).expect("failed to read witness JSON");
+    let witness_map: HashMap<String, String> =
+        serde_json::from_str(&json_str).expect("failed to parse witness JSON");
+
+    let mut result = HashMap::new();
+    for input in &bundle.inputs {
+        let go_name = sanitize_go_name(&input.name);
+        if let Some(value_str) = witness_map.get(&go_name) {
+            let fr = Fr::from_str(value_str).unwrap_or_else(|_| {
+                panic!(
+                    "failed to parse Fr for {} = {}",
+                    go_name,
+                    &value_str[..value_str.len().min(40)]
+                )
+            });
+            result.insert(input.index, fr);
+        } else {
+            panic!("witness missing value for input '{}' (go: '{}')", input.name, go_name);
+        }
+    }
+    result
+}
+
+/// Run the Go crossval test and return the assertion values from JSON.
+fn run_go_crossval() -> Vec<GoAssertionValue> {
+    let go_dir = go_dir();
+    let crossval_dir = go_dir.join("crossval");
+
+    // Run go test in crossval sub-package
+    let output = Command::new("go")
+        .args(["test", "-run", "TestCrossValidation", "-v", "-count=1", "-timeout", "10m"])
+        .current_dir(&crossval_dir)
+        .output()
+        .expect("failed to run go test");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    if !output.status.success() {
+        panic!(
+            "Go crossval test failed!\nstdout:\n{}\nstderr:\n{}",
+            stdout, stderr
+        );
+    }
+
+    // Read the JSON output
+    let json_path = go_dir.join("go_crossval_values.json");
+    let json_str = std::fs::read_to_string(&json_path).unwrap_or_else(|e| {
+        panic!(
+            "failed to read go_crossval_values.json: {}\nGo stdout:\n{}",
+            e, stdout
+        )
+    });
+
+    serde_json::from_str(&json_str).expect("failed to parse go_crossval_values.json")
+}
+
+#[derive(serde::Deserialize, Debug)]
+struct GoAssertionValue {
+    name: String,
+    lhs: String,
+    rhs: String,
+}
+
+#[test]
+fn test_cross_validation_80_values() {
+    // Skip if bundle doesn't exist (not generated yet)
+    if !bundle_path().exists() {
+        eprintln!("Skipping: {} not found. Run transpiler first.", bundle_path().display());
+        return;
+    }
+
+    println!("=== Loading AstBundle ===");
+    let bundle = AstBundle::read_json(&bundle_path()).expect("failed to load bundle");
+    println!(
+        "  {} nodes, {} constraints, {} inputs",
+        bundle.nodes.len(),
+        bundle.constraints.len(),
+        bundle.inputs.len()
+    );
+
+    println!("\n=== Loading Witness ===");
+    let witness = load_witness(&bundle, &witness_path());
+    println!("  {} witness values loaded", witness.len());
+
+    // === Rust side: evaluate AST ===
+    println!("\n=== Evaluating AST (Rust) ===");
+    let rust_values = evaluate_assertions(&bundle.nodes, &bundle.constraints, &witness);
+    println!("  {} assertions evaluated", rust_values.len());
+
+    // Build serializable Rust values and persist to JSON
+    let rust_json_values: Vec<serde_json::Value> = rust_values
+        .iter()
+        .map(|v| {
+            serde_json::json!({
+                "name": v.name,
+                "lhs": fr_to_decimal(&v.lhs),
+                "rhs": fr_to_decimal(&v.rhs),
+            })
+        })
+        .collect();
+    let rust_json_path = go_dir().join("rust_crossval_values.json");
+    let rust_json_bytes = serde_json::to_string_pretty(&rust_json_values).unwrap();
+    std::fs::write(&rust_json_path, &rust_json_bytes).expect("failed to write rust_crossval_values.json");
+    println!("  Wrote Rust values to {}", rust_json_path.display());
+
+    for v in &rust_values {
+        let lhs = fr_to_decimal(&v.lhs);
+        let rhs = fr_to_decimal(&v.rhs);
+        println!(
+            "  {}: LHS={} RHS={}",
+            v.name,
+            &lhs[..lhs.len().min(40)],
+            &rhs[..rhs.len().min(40)],
+        );
+    }
+
+    // === Go side: run crossval test ===
+    println!("\n=== Running Go Crossval Test ===");
+    let go_values = run_go_crossval();
+    println!("  {} assertions from Go", go_values.len());
+
+    // === Compare all 40 pairs (20 LHS + 20 RHS) ===
+    println!("\n=== Comparing 40 Value Pairs (20 LHS + 20 RHS) ===");
+    assert_eq!(
+        rust_values.len(),
+        go_values.len(),
+        "assertion count mismatch: Rust={} Go={}",
+        rust_values.len(),
+        go_values.len()
+    );
+
+    let mut pass_count = 0;
+    let mut fail_count = 0;
+    let total_comparisons = rust_values.len() * 2; // LHS + RHS per assertion
+
+    for (i, (rust_val, go_val)) in rust_values.iter().zip(go_values.iter()).enumerate() {
+        // Names differ in format (assertion_0 vs a0) but must refer to the same index
+        assert!(
+            go_val.name == format!("a{i}"),
+            "Go assertion order mismatch at index {i}: got {}",
+            go_val.name
+        );
+        let rust_lhs = fr_to_decimal(&rust_val.lhs);
+        let rust_rhs = fr_to_decimal(&rust_val.rhs);
+        let go_lhs = &go_val.lhs;
+        let go_rhs = &go_val.rhs;
+
+        let lhs_match = rust_lhs == *go_lhs;
+        let rhs_match = rust_rhs == *go_rhs;
+
+        if lhs_match && rhs_match {
+            println!("  {} LHS=MATCH RHS=MATCH", rust_val.name);
+            pass_count += 2;
+        } else {
+            if !lhs_match {
+                println!(
+                    "  {} LHS MISMATCH: Rust={} Go={}",
+                    rust_val.name,
+                    &rust_lhs[..rust_lhs.len().min(50)],
+                    &go_lhs[..go_lhs.len().min(50)]
+                );
+                fail_count += 1;
+            } else {
+                pass_count += 1;
+            }
+            if !rhs_match {
+                println!(
+                    "  {} RHS MISMATCH: Rust={} Go={}",
+                    rust_val.name,
+                    &rust_rhs[..rust_rhs.len().min(50)],
+                    &go_rhs[..go_rhs.len().min(50)]
+                );
+                fail_count += 1;
+            } else {
+                pass_count += 1;
+            }
+        }
+    }
+
+    println!("\n=== RESULTS ===");
+    println!("  {}/{} comparisons PASS", pass_count, total_comparisons);
+    if fail_count > 0 {
+        println!("  {}/{} comparisons FAIL", fail_count, total_comparisons);
+    }
+
+    assert_eq!(fail_count, 0, "{} of {} comparisons mismatched!", fail_count, total_comparisons);
+
+    // === Generate report ===
+    let report_path = go_dir().join("crossval_report.txt");
+    let mut report = String::new();
+    report.push_str("=== Cross-Validation Report ===\n\n");
+    report.push_str(&format!("Bundle: {} nodes, {} constraints, {} inputs\n",
+        bundle.nodes.len(), bundle.constraints.len(), bundle.inputs.len()));
+    report.push_str(&format!("Witness: {} values\n\n", witness.len()));
+
+    report.push_str(&format!("{:<6} {:<6} {:<80} {:<80}\n", "NAME", "SIDE", "RUST", "GO"));
+    report.push_str(&format!("{}\n", "-".repeat(174)));
+
+    for (rust_val, go_val) in rust_values.iter().zip(go_values.iter()) {
+        let rust_lhs = fr_to_decimal(&rust_val.lhs);
+        let rust_rhs = fr_to_decimal(&rust_val.rhs);
+        let go_lhs = &go_val.lhs;
+        let go_rhs = &go_val.rhs;
+
+        let lhs_ok = if rust_lhs == *go_lhs { "==" } else { "!=" };
+        let rhs_ok = if rust_rhs == *go_rhs { "==" } else { "!=" };
+
+        report.push_str(&format!("{:<6} LHS {} {:<80} {:<80}\n", rust_val.name, lhs_ok, rust_lhs, go_lhs));
+        report.push_str(&format!("{:<6} RHS {} {:<80} {:<80}\n", "", rhs_ok, rust_rhs, go_rhs));
+    }
+
+    report.push_str(&format!("\nResult: {}/{} PASS, {}/{} FAIL\n",
+        pass_count, total_comparisons, fail_count, total_comparisons));
+
+    std::fs::write(&report_path, &report).expect("failed to write report");
+    println!("\nReport written to {}", report_path.display());
+}

--- a/transpiler/tests/cross_validation.rs
+++ b/transpiler/tests/cross_validation.rs
@@ -9,9 +9,9 @@
 
 use ark_bn254::Fr;
 use std::collections::HashMap;
-use std::str::FromStr;
 use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::str::FromStr;
 
 use transpiler::ast_evaluator::{evaluate_assertions, fr_to_decimal};
 use transpiler::gnark_codegen::sanitize_go_name;
@@ -48,7 +48,10 @@ fn load_witness(bundle: &AstBundle, witness_path: &Path) -> HashMap<u16, Fr> {
             });
             result.insert(input.index, fr);
         } else {
-            panic!("witness missing value for input '{}' (go: '{}')", input.name, go_name);
+            panic!(
+                "witness missing value for input '{}' (go: '{}')",
+                input.name, go_name
+            );
         }
     }
     result
@@ -61,7 +64,15 @@ fn run_go_crossval() -> Vec<GoAssertionValue> {
 
     // Run go test in crossval sub-package
     let output = Command::new("go")
-        .args(["test", "-run", "TestCrossValidation", "-v", "-count=1", "-timeout", "10m"])
+        .args([
+            "test",
+            "-run",
+            "TestCrossValidation",
+            "-v",
+            "-count=1",
+            "-timeout",
+            "10m",
+        ])
         .current_dir(&crossval_dir)
         .output()
         .expect("failed to run go test");
@@ -99,7 +110,10 @@ struct GoAssertionValue {
 fn test_cross_validation_80_values() {
     // Skip if bundle doesn't exist (not generated yet)
     if !bundle_path().exists() {
-        eprintln!("Skipping: {} not found. Run transpiler first.", bundle_path().display());
+        eprintln!(
+            "Skipping: {} not found. Run transpiler first.",
+            bundle_path().display()
+        );
         return;
     }
 
@@ -134,7 +148,8 @@ fn test_cross_validation_80_values() {
         .collect();
     let rust_json_path = go_dir().join("rust_crossval_values.json");
     let rust_json_bytes = serde_json::to_string_pretty(&rust_json_values).unwrap();
-    std::fs::write(&rust_json_path, &rust_json_bytes).expect("failed to write rust_crossval_values.json");
+    std::fs::write(&rust_json_path, &rust_json_bytes)
+        .expect("failed to write rust_crossval_values.json");
     println!("  Wrote Rust values to {}", rust_json_path.display());
 
     for v in &rust_values {
@@ -217,17 +232,28 @@ fn test_cross_validation_80_values() {
         println!("  {}/{} comparisons FAIL", fail_count, total_comparisons);
     }
 
-    assert_eq!(fail_count, 0, "{} of {} comparisons mismatched!", fail_count, total_comparisons);
+    assert_eq!(
+        fail_count, 0,
+        "{} of {} comparisons mismatched!",
+        fail_count, total_comparisons
+    );
 
     // === Generate report ===
     let report_path = go_dir().join("crossval_report.txt");
     let mut report = String::new();
     report.push_str("=== Cross-Validation Report ===\n\n");
-    report.push_str(&format!("Bundle: {} nodes, {} constraints, {} inputs\n",
-        bundle.nodes.len(), bundle.constraints.len(), bundle.inputs.len()));
+    report.push_str(&format!(
+        "Bundle: {} nodes, {} constraints, {} inputs\n",
+        bundle.nodes.len(),
+        bundle.constraints.len(),
+        bundle.inputs.len()
+    ));
     report.push_str(&format!("Witness: {} values\n\n", witness.len()));
 
-    report.push_str(&format!("{:<6} {:<6} {:<80} {:<80}\n", "NAME", "SIDE", "RUST", "GO"));
+    report.push_str(&format!(
+        "{:<6} {:<6} {:<80} {:<80}\n",
+        "NAME", "SIDE", "RUST", "GO"
+    ));
     report.push_str(&format!("{}\n", "-".repeat(174)));
 
     for (rust_val, go_val) in rust_values.iter().zip(go_values.iter()) {
@@ -239,12 +265,20 @@ fn test_cross_validation_80_values() {
         let lhs_ok = if rust_lhs == *go_lhs { "==" } else { "!=" };
         let rhs_ok = if rust_rhs == *go_rhs { "==" } else { "!=" };
 
-        report.push_str(&format!("{:<6} LHS {} {:<80} {:<80}\n", rust_val.name, lhs_ok, rust_lhs, go_lhs));
-        report.push_str(&format!("{:<6} RHS {} {:<80} {:<80}\n", "", rhs_ok, rust_rhs, go_rhs));
+        report.push_str(&format!(
+            "{:<6} LHS {} {:<80} {:<80}\n",
+            rust_val.name, lhs_ok, rust_lhs, go_lhs
+        ));
+        report.push_str(&format!(
+            "{:<6} RHS {} {:<80} {:<80}\n",
+            "", rhs_ok, rust_rhs, go_rhs
+        ));
     }
 
-    report.push_str(&format!("\nResult: {}/{} PASS, {}/{} FAIL\n",
-        pass_count, total_comparisons, fail_count, total_comparisons));
+    report.push_str(&format!(
+        "\nResult: {}/{} PASS, {}/{} FAIL\n",
+        pass_count, total_comparisons, fail_count, total_comparisons
+    ));
 
     std::fs::write(&report_path, &report).expect("failed to write report");
     println!("\nReport written to {}", report_path.display());

--- a/zklean-extractor/src/ast_bundle.rs
+++ b/zklean-extractor/src/ast_bundle.rs
@@ -426,8 +426,7 @@ impl AstBundle {
     /// // Now generate code. CSE bindings are pre-computed
     /// ```
     pub fn run_cse(&mut self) {
-        let global_set: HashSet<NodeId> =
-            self.global_cse.bindings.iter().copied().collect();
+        let global_set: HashSet<NodeId> = self.global_cse.bindings.iter().copied().collect();
         self.constraint_cse = self
             .constraints
             .iter()

--- a/zklean-extractor/src/ast_bundle.rs
+++ b/zklean-extractor/src/ast_bundle.rs
@@ -138,6 +138,16 @@ pub struct ConstraintCse {
     pub bindings: Vec<NodeId>,
 }
 
+/// Global CSE bindings: nodes shared across ≥2 constraints, hoisted to a single
+/// computation block. Avoids re-computing expensive nodes (especially TranscriptHash
+/// chains) independently in each constraint function.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct GlobalCse {
+    /// NodeIds hoisted globally, in topological (post-order) order.
+    /// These become `gcse[i]` in generated code.
+    pub bindings: Vec<NodeId>,
+}
+
 /// Complete bundle of AST data for transpilation.
 ///
 /// This structure contains everything needed to:
@@ -162,6 +172,10 @@ pub struct ConstraintCse {
 pub struct AstBundle {
     /// The node arena - all nodes in the AST(s).
     pub nodes: Vec<Node>,
+    /// Global CSE bindings: nodes shared across ≥2 constraints.
+    /// Computed by `run_global_cse()` before `run_cse()`.
+    #[serde(default)]
+    pub global_cse: GlobalCse,
     /// Per-constraint CSE bindings, indexed by constraint index.
     /// Each constraint has its own isolated CSE context.
     #[serde(default)]
@@ -177,6 +191,7 @@ impl AstBundle {
     pub fn new() -> Self {
         Self {
             nodes: Vec::new(),
+            global_cse: GlobalCse::default(),
             constraint_cse: Vec::new(),
             constraints: Vec::new(),
             inputs: Vec::new(),
@@ -279,42 +294,163 @@ impl AstBundle {
         self.nodes = guard.clone();
     }
 
+    /// Run global CSE: identify nodes shared across ≥2 constraints and hoist them.
+    ///
+    /// This finds `TranscriptHash` nodes (and their dependencies) that appear in
+    /// multiple constraint subtrees. These are computed once in a global block
+    /// instead of being duplicated in each constraint function.
+    ///
+    /// Call this after `snapshot_arena()` and before `run_cse()`.
+    pub fn run_global_cse(&mut self) {
+        // Phase 1: For each constraint, collect the set of reachable NodeIds
+        let mut node_to_constraints: HashMap<NodeId, Vec<usize>> = HashMap::new();
+        for (idx, constraint) in self.constraints.iter().enumerate() {
+            let refs = self.count_refs(constraint.root);
+            for node_id in refs.keys() {
+                node_to_constraints.entry(*node_id).or_default().push(idx);
+            }
+            // Also include EqualNode targets
+            if let Assertion::EqualNode(other_id) = &constraint.assertion {
+                let other_refs = self.count_refs(*other_id);
+                for node_id in other_refs.keys() {
+                    node_to_constraints.entry(*node_id).or_default().push(idx);
+                }
+            }
+        }
+
+        // Phase 2: Find TranscriptHash nodes that appear in ≥2 distinct constraints
+        let mut global_nodes: HashSet<NodeId> = HashSet::new();
+        for (&node_id, constraints) in &node_to_constraints {
+            // Deduplicate constraint indices
+            let mut unique: Vec<usize> = constraints.clone();
+            unique.sort_unstable();
+            unique.dedup();
+            if unique.len() >= 2 && matches!(self.nodes[node_id], Node::TranscriptHash(..)) {
+                global_nodes.insert(node_id);
+            }
+        }
+
+        if global_nodes.is_empty() {
+            self.global_cse = GlobalCse::default();
+            return;
+        }
+
+        // Phase 3: Include dependencies of global nodes that are also multi-constraint.
+        // Walk children of each global node; if a child is in ≥2 constraints and is
+        // non-trivial (not an atom), include it too. This captures the full chain.
+        let mut expanded = global_nodes.clone();
+        let mut worklist: Vec<NodeId> = global_nodes.into_iter().collect();
+        while let Some(node_id) = worklist.pop() {
+            for child_id in self.node_children(node_id) {
+                if expanded.contains(&child_id) {
+                    continue;
+                }
+                if matches!(self.nodes[child_id], Node::Atom(_)) {
+                    continue;
+                }
+                // Check if child is in ≥2 distinct constraints
+                if let Some(constraints) = node_to_constraints.get(&child_id) {
+                    let mut unique: Vec<usize> = constraints.clone();
+                    unique.sort_unstable();
+                    unique.dedup();
+                    if unique.len() >= 2 {
+                        expanded.insert(child_id);
+                        worklist.push(child_id);
+                    }
+                }
+            }
+        }
+
+        // Phase 4: Topological sort (post-order) of the expanded set
+        // We need a post-order that respects dependencies within the global set.
+        // Use a multi-root post-order traversal restricted to the expanded set.
+        let bindings = self.topological_sort_subset(&expanded);
+
+        self.global_cse = GlobalCse { bindings };
+    }
+
+    /// Topological sort a subset of nodes in post-order (children before parents).
+    fn topological_sort_subset(&self, subset: &HashSet<NodeId>) -> Vec<NodeId> {
+        let mut result = Vec::new();
+        let mut visited: HashSet<NodeId> = HashSet::new();
+        let mut stack: Vec<(NodeId, bool)> = Vec::new();
+
+        // Start from all nodes in the subset
+        for &node_id in subset {
+            if visited.contains(&node_id) {
+                continue;
+            }
+            stack.push((node_id, false));
+
+            while let Some((nid, children_processed)) = stack.pop() {
+                if children_processed {
+                    if subset.contains(&nid) {
+                        result.push(nid);
+                    }
+                    continue;
+                }
+
+                if visited.contains(&nid) {
+                    continue;
+                }
+                visited.insert(nid);
+
+                stack.push((nid, true));
+
+                // Only traverse children that are in the subset
+                for child_id in self.node_children(nid).into_iter().rev() {
+                    if subset.contains(&child_id) && !visited.contains(&child_id) {
+                        stack.push((child_id, false));
+                    }
+                }
+            }
+        }
+
+        result
+    }
+
     /// Run CSE (Common Subexpression Elimination) on all constraints.
     ///
     /// This performs ref-counting CSE: any node referenced more than once
     /// within a constraint's expression tree is hoisted to a named variable.
     ///
-    /// Each constraint gets isolated CSE bindings (stored in `constraint_cse`).
-    /// This prevents aliasing bugs where structurally identical nodes from
-    /// different constraints would incorrectly share variables.
+    /// Nodes already in `global_cse` are excluded (they're computed globally).
     ///
-    /// Call this after `snapshot_arena()` and before code generation.
+    /// Call this after `run_global_cse()` and before code generation.
     ///
     /// # Example
     /// ```ignore
     /// bundle.snapshot_arena();
+    /// bundle.run_global_cse();
     /// bundle.run_cse();
     /// // Now generate code. CSE bindings are pre-computed
     /// ```
     pub fn run_cse(&mut self) {
+        let global_set: HashSet<NodeId> =
+            self.global_cse.bindings.iter().copied().collect();
         self.constraint_cse = self
             .constraints
             .iter()
-            .map(|constraint| self.compute_cse_for_constraint(constraint.root))
+            .map(|constraint| self.compute_cse_for_constraint(constraint.root, &global_set))
             .collect();
     }
 
     /// Compute CSE bindings for a single constraint.
     ///
     /// Uses ref-counting: nodes with ref_count > 1 are hoisted.
-    fn compute_cse_for_constraint(&self, root: NodeId) -> ConstraintCse {
+    /// Nodes in `global_set` are excluded (already hoisted globally).
+    fn compute_cse_for_constraint(
+        &self,
+        root: NodeId,
+        global_set: &HashSet<NodeId>,
+    ) -> ConstraintCse {
         // Phase 1: Count references to each node
         let ref_counts = self.count_refs(root);
 
         // Phase 2: Build post-order traversal and collect hoisted nodes
         let post_order = self.build_post_order(root);
 
-        // Phase 3: Collect nodes that should be hoisted (ref_count > 1, not atoms)
+        // Phase 3: Collect nodes that should be hoisted (ref_count > 1, not atoms, not global)
         let mut bindings = Vec::new();
 
         for node_id in post_order {
@@ -322,6 +458,11 @@ impl AstBundle {
 
             // Skip atoms, since they're always inlined
             if matches!(self.nodes[node_id], Node::Atom(_)) {
+                continue;
+            }
+
+            // Skip nodes already in global CSE
+            if global_set.contains(&node_id) {
                 continue;
             }
 


### PR DESCRIPTION
## Summary

Extends the transpiler's existing per-constraint CSE to global scope, detecting shared `TranscriptHash` chains across constraints and hoisting them into global variables. Previously each constraint had its own isolated CSE context, duplicating identical Poseidon hash computations. Also adds a Rust/Go cross-validation system for verifying codegen correctness. Builds on #1322 .

## Changes

- **Global CSE:** Detect shared `TranscriptHash` chains across constraints and hoist them into global variables, computed once and reused. Previously each constraint had isolated CSE, duplicating identical Poseidon hash computations.
- **Cross-validation system:** Compare intermediate assertion values (LHS/RHS) between a concrete AST evaluator in Rust and the generated gnark circuit in Go. Pass `--crossval` to auto-generate a cross-validation circuit and witness.
- **New files:** `ast_evaluator.rs` (concrete AST evaluation), `cross_validation.rs` (Rust test), `crossval_test.go` (Go test)
- **CseContext enum** instead of `usize::MAX` sentinel for CSE scope tracking
- **Dynamic assertion count** in `crossval_test.go`
- `.gitignore` for generated Groth16 artifacts
- Clippy and fmt fixes

## Testing

- [ ] cargo clippy and cargo fmt pass
- [ ] cargo test -p transpiler — cross-validation test
- [ ] cd transpiler/go && go test -v -run TestStagesCircuitProveVerify — Groth16 prove/verify
- [ ] cd transpiler/go && go test -v -run TestEndToEndPipeline -timeout 30m — full E2E pipeline

On the fibonacci test example, global CSE reduces constraints from ~2.7M to ~621K–677K. Proof size remains 164 bytes. Cross-validation Rust/Go passes on all intermediate values.

## Security Considerations

CSE is a pure optimization: it deduplicates constraint computation but does not change the constraint system's semantics. Each hoisted variable is assigned exactly once and referenced by the same constraints that previously computed it inline, so proof soundness is unaffected. The cross-validation system is test-only infrastructure and does not affect the proof pipeline.

## Breaking Changes

None
