### PR TITLE
fix(blindfold): soundness fixes for uni-skip and aliased OpeningIds (J-30–J-36)

### DIFF
--- a/jolt-core/src/subprotocols/blindfold/folding.rs
+++ b/jolt-core/src/subprotocols/blindfold/folding.rs
@@ -116,7 +116,8 @@ pub fn sample_random_satisfying_pair<F: JoltField, C: JoltCurve<F = F>, R: Crypt
                 ..
             } => {
                 for id in &constraint.required_openings {
-                    if seen_openings.insert(*id) && !oc_opening_ids.contains(id) {
+                    let resolved = r1cs.resolve_alias(*id);
+                    if seen_openings.insert(resolved) && !oc_opening_ids.contains(&resolved) {
                         W[noncoeff_idx] = F::random(rng);
                         noncoeff_idx += 1;
                     }
@@ -161,7 +162,8 @@ pub fn sample_random_satisfying_pair<F: JoltField, C: JoltCurve<F = F>, R: Crypt
                 ..
             } => {
                 for id in &constraint.required_openings {
-                    if seen_openings.insert(*id) && !oc_opening_ids.contains(id) {
+                    let resolved = r1cs.resolve_alias(*id);
+                    if seen_openings.insert(resolved) && !oc_opening_ids.contains(&resolved) {
                         W[noncoeff_idx] = F::random(rng);
                         noncoeff_idx += 1;
                     }

--- a/jolt-core/src/subprotocols/blindfold/mod.rs
+++ b/jolt-core/src/subprotocols/blindfold/mod.rs
@@ -82,6 +82,8 @@ pub struct UniSkipStageData<F: JoltField, C: JoltCurve<F = F>> {
     pub commitment: C::G1,
     pub input_constraint: InputClaimConstraint,
     pub input_constraint_challenge_values: Vec<F>,
+    pub output_constraint: Option<OutputClaimConstraint>,
+    pub output_constraint_challenge_values: Vec<F>,
     pub output_claims: Vec<(OpeningId, F)>,
     pub output_claims_blindings: Vec<F>,
     pub output_claims_commitments: Vec<C::G1>,
@@ -488,7 +490,7 @@ impl StageConfig {
         self.initial_input
             .as_ref()
             .and_then(|ii| ii.constraint.as_ref())
-            .is_some()
+            .is_some_and(|c| !c.terms.is_empty())
     }
 }
 

--- a/jolt-core/src/subprotocols/blindfold/r1cs.rs
+++ b/jolt-core/src/subprotocols/blindfold/r1cs.rs
@@ -5,7 +5,7 @@ use super::{
 };
 use crate::field::JoltField;
 use crate::poly::opening_proof::OpeningId;
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 
 enum ResolvedValue<F> {
     Constant(F),
@@ -296,9 +296,18 @@ pub struct VerifierR1CS<F: JoltField> {
     /// Opening IDs placed in the output claims region, in layout-traversal order.
     /// Empty when output claims binding is disabled.
     pub output_claims_opening_ids: Vec<OpeningId>,
+    /// Alias map: aliased OpeningId → canonical OpeningId.
+    pub opening_aliases: BTreeMap<OpeningId, OpeningId>,
 }
 
 impl<F: JoltField> VerifierR1CS<F> {
+    pub fn resolve_alias(&self, mut key: OpeningId) -> OpeningId {
+        while let Some(next) = self.opening_aliases.get(&key) {
+            key = *next;
+        }
+        key
+    }
+
     /// Check satisfaction and return the first failing constraint index if any
     pub fn check_satisfaction(&self, z: &[F]) -> Result<(), usize> {
         assert_eq!(z.len(), self.num_vars);
@@ -331,6 +340,9 @@ pub struct VerifierR1CSBuilder<F: JoltField> {
     /// `ceil(len/C)` complete Hyrax rows. The per-stage Pedersen commitments
     /// map 1:1 to these rows.
     oc_blocks: Vec<Vec<OpeningId>>,
+    /// Alias map from the opening accumulator: aliased OpeningId → canonical OpeningId.
+    /// Used to ensure aliased IDs reuse the same R1CS variable as their canonical target.
+    opening_aliases: BTreeMap<OpeningId, OpeningId>,
 }
 
 struct RoundVariables {
@@ -341,7 +353,7 @@ struct RoundVariables {
 impl<F: JoltField> VerifierR1CSBuilder<F> {
     #[cfg(test)]
     pub fn new(stage_configs: &[StageConfig], baked: &BakedPublicInputs<F>) -> Self {
-        Self::new_with_extra(stage_configs, &[], baked, Vec::new())
+        Self::new_with_extra(stage_configs, &[], baked, Vec::new(), BTreeMap::new())
     }
 
     pub fn new_with_extra(
@@ -349,6 +361,7 @@ impl<F: JoltField> VerifierR1CSBuilder<F> {
         extra_constraints: &[OutputClaimConstraint],
         baked: &BakedPublicInputs<F>,
         oc_blocks: Vec<Vec<OpeningId>>,
+        opening_aliases: BTreeMap<OpeningId, OpeningId>,
     ) -> Self {
         Self {
             constraints: Vec::new(),
@@ -359,7 +372,15 @@ impl<F: JoltField> VerifierR1CSBuilder<F> {
             extra_blinding_vars: Vec::new(),
             baked: baked.clone(),
             oc_blocks,
+            opening_aliases,
         }
+    }
+
+    fn resolve_alias(&self, mut key: OpeningId) -> OpeningId {
+        while let Some(next) = self.opening_aliases.get(&key) {
+            key = *next;
+        }
+        key
     }
 
     /// Add a constraint: a * b = c
@@ -507,10 +528,16 @@ impl<F: JoltField> VerifierR1CSBuilder<F> {
                     constraint, kind, ..
                 } => {
                     for opening_id in &constraint.required_openings {
-                        if !global_opening_vars.contains_key(opening_id) {
+                        let resolved = self.resolve_alias(*opening_id);
+                        if let Some(&var) = global_opening_vars.get(&resolved) {
+                            global_opening_vars.insert(*opening_id, var);
+                        } else {
                             let var = Variable::new(self.next_var);
                             self.next_var += 1;
                             global_opening_vars.insert(*opening_id, var);
+                            if resolved != *opening_id {
+                                global_opening_vars.insert(resolved, var);
+                            }
                         }
                     }
 
@@ -594,10 +621,16 @@ impl<F: JoltField> VerifierR1CSBuilder<F> {
                 }
                 LayoutStep::ExtraConstraintVars { constraint, .. } => {
                     for opening_id in &constraint.required_openings {
-                        if !global_opening_vars.contains_key(opening_id) {
+                        let resolved = self.resolve_alias(*opening_id);
+                        if let Some(&var) = global_opening_vars.get(&resolved) {
+                            global_opening_vars.insert(*opening_id, var);
+                        } else {
                             let var = Variable::new(self.next_var);
                             self.next_var += 1;
                             global_opening_vars.insert(*opening_id, var);
+                            if resolved != *opening_id {
+                                global_opening_vars.insert(resolved, var);
+                            }
                         }
                     }
 
@@ -660,6 +693,7 @@ impl<F: JoltField> VerifierR1CSBuilder<F> {
             extra_blinding_vars: self.extra_blinding_vars,
             hyrax,
             output_claims_opening_ids,
+            opening_aliases: self.opening_aliases,
         }
     }
 

--- a/jolt-core/src/subprotocols/blindfold/witness.rs
+++ b/jolt-core/src/subprotocols/blindfold/witness.rs
@@ -297,7 +297,8 @@ impl<F: JoltField> BlindFoldWitness<F> {
                         for (opening_id, val) in
                             constraint.required_openings.iter().zip(opening_values)
                         {
-                            if assigned_openings.insert(*opening_id) {
+                            let resolved = r1cs.resolve_alias(*opening_id);
+                            if assigned_openings.insert(resolved) {
                                 z[noncoeff_idx] = *val;
                                 noncoeff_idx += 1;
                             }
@@ -370,7 +371,8 @@ impl<F: JoltField> BlindFoldWitness<F> {
                             .iter()
                             .zip(&witness.opening_values)
                         {
-                            if assigned_openings.insert(*opening_id) {
+                            let resolved = r1cs.resolve_alias(*opening_id);
+                            if assigned_openings.insert(resolved) {
                                 z[noncoeff_idx] = *val;
                                 noncoeff_idx += 1;
                             }

--- a/jolt-core/src/subprotocols/univariate_skip.rs
+++ b/jolt-core/src/subprotocols/univariate_skip.rs
@@ -194,6 +194,10 @@ pub fn prove_uniskip_round_zk<
     let input_constraint_challenge_values = instance
         .get_params()
         .input_constraint_challenge_values(opening_accumulator);
+    let output_constraint = instance.get_params().output_claim_constraint();
+    let output_constraint_challenge_values = instance
+        .get_params()
+        .output_constraint_challenge_values(&[r0]);
 
     blindfold_accumulator.push_uniskip_data(UniSkipStageData {
         input_claim,
@@ -204,6 +208,8 @@ pub fn prove_uniskip_round_zk<
         commitment,
         input_constraint,
         input_constraint_challenge_values,
+        output_constraint,
+        output_constraint_challenge_values,
         output_claims,
         output_claims_blindings,
         output_claims_commitments: output_claims_commitments.clone(),

--- a/jolt-core/src/zkvm/prover.rs
+++ b/jolt-core/src/zkvm/prover.rs
@@ -1459,22 +1459,38 @@ impl<
                     FinalOutputWitness::general(input_challenge_values, input_opening_values);
 
                 // Uni-skip config with its input constraint
-                let config = if stage_idx == 0 {
+                let mut config = if stage_idx == 0 {
                     StageConfig::new_uniskip(poly_degree, power_sums)
                         .with_input_constraint(input_constraint)
                 } else {
                     StageConfig::new_uniskip_chain(poly_degree, power_sums)
                         .with_input_constraint(input_constraint)
                 };
+
+                // Attach output constraint to link NextClaim to OC region
+                let final_output = if let Some(oc) = uniskip.output_constraint.clone() {
+                    let opening_values: Vec<F> = oc
+                        .required_openings
+                        .iter()
+                        .map(|id| self.opening_accumulator.get_opening(*id))
+                        .collect();
+                    let fout = FinalOutputWitness::general(
+                        uniskip.output_constraint_challenge_values.clone(),
+                        opening_values,
+                    );
+                    config = config.with_constraint(oc);
+                    Some(fout)
+                } else {
+                    None
+                };
+
                 stage_configs.push(config);
-                stage_witnesses.push(StageWitness::with_initial_input(
-                    vec![RoundWitness::with_claimed_sum(
-                        coeffs.clone(),
-                        challenge,
-                        claimed_sum,
-                    )],
-                    initial_input,
-                ));
+                let round = RoundWitness::with_claimed_sum(coeffs.clone(), challenge, claimed_sum);
+                let stage_witness = match final_output {
+                    Some(fout) => StageWitness::with_both(vec![round], initial_input, fout),
+                    None => StageWitness::with_initial_input(vec![round], initial_input),
+                };
+                stage_witnesses.push(stage_witness);
             } else {
                 // Stages 2-6: no uni-skip, push initial claim for regular rounds
                 initial_claims.push(zk_data.initial_claim);
@@ -1611,6 +1627,11 @@ impl<
                 // Uni-skip input constraint challenges
                 baked_input_challenges
                     .extend(uniskip.input_constraint_challenge_values.iter().cloned());
+                // Uni-skip output constraint challenges
+                if uniskip.output_constraint.is_some() {
+                    baked_output_challenges
+                        .extend(uniskip.output_constraint_challenge_values.iter().cloned());
+                }
                 // Uni-skip round challenge
                 baked_challenges.push(uniskip.challenge.into());
             }
@@ -1649,7 +1670,7 @@ impl<
 
         let baked = BakedPublicInputs {
             challenges: baked_challenges,
-            initial_claims: Vec::new(),
+            initial_claims: initial_claims.clone(),
             batching_coefficients: Vec::new(),
             output_constraint_challenges: baked_output_challenges,
             input_constraint_challenges: baked_input_challenges,

--- a/jolt-core/src/zkvm/prover.rs
+++ b/jolt-core/src/zkvm/prover.rs
@@ -1698,6 +1698,7 @@ impl<
             &extra_constraints,
             &baked,
             oc_blocks.clone(),
+            self.opening_accumulator.aliases.clone(),
         );
         let r1cs = builder.build();
 

--- a/jolt-core/src/zkvm/verifier.rs
+++ b/jolt-core/src/zkvm/verifier.rs
@@ -1363,6 +1363,7 @@ impl<
             &extra_constraints,
             &baked,
             oc_blocks,
+            self.opening_accumulator.aliases.clone(),
         );
         let r1cs = builder.build();
 

--- a/jolt-core/src/zkvm/verifier.rs
+++ b/jolt-core/src/zkvm/verifier.rs
@@ -101,6 +101,8 @@ struct StageVerifyResult<F: JoltField> {
     input_constraint_challenge_values: Vec<F>,
     uniskip_input_constraint: Option<InputClaimConstraint>,
     uniskip_input_constraint_challenge_values: Vec<F>,
+    uniskip_output_constraint: Option<OutputClaimConstraint>,
+    uniskip_output_constraint_challenge_values: Vec<F>,
     oc_block_ids: Vec<Vec<OpeningId>>,
 }
 
@@ -128,6 +130,8 @@ impl<F: JoltField> StageVerifyResult<F> {
             input_constraint_challenge_values,
             uniskip_input_constraint: None,
             uniskip_input_constraint_challenge_values: Vec::new(),
+            uniskip_output_constraint: None,
+            uniskip_output_constraint_challenge_values: Vec::new(),
             oc_block_ids,
         }
     }
@@ -141,6 +145,8 @@ impl<F: JoltField> StageVerifyResult<F> {
         input_constraint_challenge_values: Vec<F>,
         uniskip_input_constraint: InputClaimConstraint,
         uniskip_input_constraint_challenge_values: Vec<F>,
+        uniskip_output_constraint: Option<OutputClaimConstraint>,
+        uniskip_output_constraint_challenge_values: Vec<F>,
         oc_block_ids: Vec<Vec<OpeningId>>,
     ) -> Self {
         Self {
@@ -151,6 +157,8 @@ impl<F: JoltField> StageVerifyResult<F> {
             input_constraint_challenge_values,
             uniskip_input_constraint: Some(uniskip_input_constraint),
             uniskip_input_constraint_challenge_values,
+            uniskip_output_constraint,
+            uniskip_output_constraint_challenge_values,
             oc_block_ids,
         }
     }
@@ -513,6 +521,19 @@ impl<
                 oc_blocks.extend(stage6_result.oc_block_ids);
                 oc_blocks.extend(stage7_result.oc_block_ids);
 
+                let uniskip_output_constraints = [
+                    stage1_result.uniskip_output_constraint.clone(),
+                    stage2_result.uniskip_output_constraint.clone(),
+                ];
+                let uniskip_output_challenge_values = [
+                    stage1_result
+                        .uniskip_output_constraint_challenge_values
+                        .clone(),
+                    stage2_result
+                        .uniskip_output_constraint_challenge_values
+                        .clone(),
+                ];
+
                 self.verify_blindfold(
                     &sumcheck_challenges,
                     uniskip_challenges,
@@ -524,6 +545,8 @@ impl<
                     &stage2_result.batched_input_constraint,
                     &stage1_result.input_constraint_challenge_values,
                     &stage2_result.input_constraint_challenge_values,
+                    &uniskip_output_constraints,
+                    &uniskip_output_challenge_values,
                     &stage8_data,
                     oc_blocks,
                 )?;
@@ -605,6 +628,9 @@ impl<
             let uniskip_input_constraint = uni_skip_params.input_claim_constraint();
             let uniskip_input_constraint_challenge_values =
                 uni_skip_params.input_constraint_challenge_values(&self.opening_accumulator);
+            let uniskip_output_constraint = uni_skip_params.output_claim_constraint();
+            let uniskip_output_constraint_challenge_values =
+                uni_skip_params.output_constraint_challenge_values(&[uni_skip_challenge]);
 
             let stage_result = StageVerifyResult::with_uniskip(
                 r_stage1,
@@ -614,6 +640,8 @@ impl<
                 input_constraint_challenge_values,
                 uniskip_input_constraint,
                 uniskip_input_constraint_challenge_values,
+                uniskip_output_constraint,
+                uniskip_output_constraint_challenge_values,
                 vec![uniskip_oc_ids, regular_oc_ids],
             );
 
@@ -722,6 +750,9 @@ impl<
             let uniskip_input_constraint = uni_skip_params.input_claim_constraint();
             let uniskip_input_constraint_challenge_values =
                 uni_skip_params.input_constraint_challenge_values(&self.opening_accumulator);
+            let uniskip_output_constraint = uni_skip_params.output_claim_constraint();
+            let uniskip_output_constraint_challenge_values =
+                uni_skip_params.output_constraint_challenge_values(&[uni_skip_challenge]);
 
             let stage_result = StageVerifyResult::with_uniskip(
                 r_stage2,
@@ -731,6 +762,8 @@ impl<
                 input_constraint_challenge_values,
                 uniskip_input_constraint,
                 uniskip_input_constraint_challenge_values,
+                uniskip_output_constraint,
+                uniskip_output_constraint_challenge_values,
                 vec![uniskip_oc_ids, regular_oc_ids],
             );
 
@@ -1105,6 +1138,8 @@ impl<
         stage2_batched_input: &InputClaimConstraint,
         stage1_batched_input_values: &[F],
         stage2_batched_input_values: &[F],
+        uniskip_output_constraints: &[Option<OutputClaimConstraint>; 2],
+        uniskip_output_challenge_values: &[Vec<F>; 2],
         stage8_data: &Stage8VerifyData<F>,
         oc_blocks: Vec<Vec<OpeningId>>,
     ) -> Result<(), ProofVerifyError> {
@@ -1215,6 +1250,15 @@ impl<
                 Some(ClaimBindingConfig::with_constraint(constraint.clone()));
         }
 
+        // Add final_output configurations for uni-skip stages (stages 0-1)
+        for (i, constraint) in uniskip_output_constraints.iter().enumerate() {
+            if let Some(oc) = constraint {
+                let idx = uniskip_indices[i];
+                stage_configs[idx].final_output =
+                    Some(ClaimBindingConfig::with_constraint(oc.clone()));
+            }
+        }
+
         // Add initial_input configurations for regular first rounds (all 7 stages)
         // These use the batched input constraints from the stage results
         let regular_constraints = [
@@ -1269,13 +1313,25 @@ impl<
         }
 
         let mut baked_output_challenges: Vec<F> = Vec::new();
-        for expected_values in output_constraint_challenge_values.iter() {
+        for (stage_idx, expected_values) in output_constraint_challenge_values.iter().enumerate() {
+            if stage_idx < 2 && uniskip_output_constraints[stage_idx].is_some() {
+                baked_output_challenges
+                    .extend_from_slice(&uniskip_output_challenge_values[stage_idx]);
+            }
             baked_output_challenges.extend_from_slice(expected_values);
         }
 
+        // Count chains — ConstantInitialClaim paths index into this vector.
+        // Only chain 0 (outer uni-skip, initial_claim = zero) uses ConstantInitialClaim;
+        // all others use InitialClaimVar and won't read from here.
+        let num_chains = stage_configs
+            .iter()
+            .enumerate()
+            .filter(|(i, c)| *i == 0 || c.starts_new_chain)
+            .count();
         let baked = BakedPublicInputs {
             challenges: baked_challenges,
-            initial_claims: Vec::new(),
+            initial_claims: vec![F::zero(); num_chains],
             batching_coefficients: Vec::new(),
             output_constraint_challenges: baked_output_challenges,
             input_constraint_challenges: baked_input_challenges,


### PR DESCRIPTION
## Summary
- **J-35/J-36**: Constrain uni-skip initial claim and link output claims to OC region (existing commit)
- **J-30–J-34**: Resolve aliased OpeningIds in `VerifierR1CSBuilder::build()` so aliased IDs reuse the canonical variable instead of getting a fresh unconstrained variable. Propagate alias resolution to `BlindFoldWitness::assign_with_u` and `sample_random_satisfying_pair` for consistent witness layout.

Affected OpeningIds:
- J-30: LookupOutput
- J-31: UnexpandedPC
- J-32: Rs1Value + Rs2Value
- J-33: LeftInstructionInput + RightInstructionInput
- J-34: BytecodeRa(0)

## Test plan
- [x] `cargo nextest run -p jolt-core muldiv --features host` (standard mode)
- [x] `cargo nextest run -p jolt-core muldiv --features host,zk` (ZK mode)
- [x] `cargo clippy --all --features host` clean
- [x] `cargo clippy --all --features host,zk` clean
- [x] `cargo fmt` clean