### PR TITLE
fix(verification): harden Claims deserialization and S64 diff_mul_field (J-26, J-45)

### DIFF
--- a/jolt-core/src/utils/small_scalar.rs
+++ b/jolt-core/src/utils/small_scalar.rs
@@ -277,7 +277,7 @@ impl SmallScalar for S64 {
         let a = self.to_i128();
         let b = other.to_i128();
         let diff = (a - b).unsigned_abs();
-        r.mul_u64(diff as u64)
+        r.mul_u128(diff)
     }
     #[inline]
     fn msm<G: VariableBaseMSM>(

--- a/jolt-core/src/zkvm/proof_serialization.rs
+++ b/jolt-core/src/zkvm/proof_serialization.rs
@@ -129,7 +129,11 @@ impl<F: JoltField> CanonicalDeserialize for Claims<F> {
         compress: Compress,
         validate: Validate,
     ) -> Result<Self, SerializationError> {
+        const MAX_CLAIMS: usize = 10_000;
         let size = usize::deserialize_with_mode(&mut reader, compress, validate)?;
+        if size > MAX_CLAIMS {
+            return Err(SerializationError::InvalidData);
+        }
         let mut claims = BTreeMap::new();
         for _ in 0..size {
             let key = OpeningId::deserialize_with_mode(&mut reader, compress, validate)?;


### PR DESCRIPTION
## Summary

Fixes two findings from the Jolt security audit (April 11-12, 2026) — J-26 and J-45. The remaining findings from J-22 onwards were investigated and determined to be false positives or already fixed (see analysis below).

- **J-26 (LOW — DoS):** `Claims` deserialization reads an unbounded `size` from the proof, allowing a malicious proof to trigger OOM. Adds a `MAX_CLAIMS = 10_000` bound check that rejects oversized payloads. Only affects non-ZK mode.
- **J-45 (INFO — latent correctness):** `S64::diff_mul_field` truncates a `u128` difference to `u64` via `as u64` cast. Two S64 values can differ by up to 2^65−1, overflowing `u64`. Changed to `mul_u128`. Currently dead code (no `CompactPolynomial<S64>` exists), but fixed to prevent future correctness issues.

### Findings reviewed and dismissed as false positives

| Finding | Severity | Reason |
|---------|----------|--------|
| J-22 | MEDIUM | Already fixed — `fiat_shamir_preamble` absorbs all config params |
| J-23 | MEDIUM | Already fixed — `trace_length` validated as power-of-two with upper bound |
| J-24 | LOW | Guest-side code (jolt-inlines); correct by construction for secp256k1 GLV |
| J-25 | INFO | Could not reproduce; debug_asserts found are structural invariants backed by `catch_unwind` |
| J-29 | INFO | Benign per report — final-cycle termination condition |
| J-37 | MEDIUM | `ArkGT::Add` is in the external dory crate, not Jolt; latent/unreachable |
| J-41 | LOW | OneHotPolynomial evaluate correctness confirmed by test suite |
| J-42 | LOW | Already mitigated by `catch_unwind` in release builds |
| J-43 | MEDIUM | Report claims fixed-capacity LC, but BlindFold `LinearCombination` uses `Vec` — no capacity limit |
| J-44 | INFO | `min()` can never truncate; second group is algebraically always ≤ domain size |

## Test plan

- [x] `cargo clippy` passes in both `--features host` and `--features host,zk`
- [x] `muldiv` e2e test passes in both standard and ZK mode
- [x] `advice` e2e tests pass (exercises non-ZK mode with advice polynomials)