### PR TITLE
fix: address ZeroOS security review findings

### DIFF
--- a/book/src/how/architecture/emulation.md
+++ b/book/src/how/architecture/emulation.md
@@ -4,6 +4,34 @@ Jolt's [RISC-V](../appendix/risc-v.md) emulator is implemented within the `trace
 It originated as a fork of the [`riscv-rust`](https://github.com/takahirox/riscv-rust) project and has since evolved significantly to support Jolt’s unique requirements.
 The bulk of the emulator's logic resides in the `instruction` subdirectory of the `tracer` crate, which defines the behavior of individual RISC-V instructions.
 
+## Privilege and Trap Model
+
+Jolt's RISC-V implementation targets **M-mode-only** execution with **no interrupt hardware**.
+All guest programs run under [ZeroOS](https://github.com/a16z/zeroos), a minimal runtime that operates exclusively in Machine mode.
+There are no S-mode or U-mode privilege levels, no timer, no CLINT, no PLIC, and no external interrupt sources.
+
+This model has the following consequences for privileged instructions:
+
+- **ECALL** writes `mepc`, `mcause`, `mtval`, and `mstatus` to their virtual registers, then jumps to `mtvec`.
+  `mstatus` is set to `0x1800` (MPP = M-mode, MIE = 0, MPIE = 0) unconditionally rather than via read-modify-write.
+  This is correct because the privilege mode is always M-mode, and interrupt-enable bits are unused —
+  the MIE CSR (0x304) is not in the supported CSR whitelist and cannot be accessed by guest code.
+
+- **MRET** jumps to `mepc` and does not modify `mstatus`.
+  The full RISC-V spec requires restoring `MIE` from `MPIE` and resetting `MPP`,
+  but these fields are inert in the M-mode-only model.
+  The ZeroOS trap trampoline restores `mstatus` via `csrw` before executing `mret`,
+  so the virtual register always holds the correct value.
+
+- **CSR access** is restricted to a fixed whitelist: `mstatus` (0x300), `mtvec` (0x305),
+  `mscratch` (0x340), `mepc` (0x341), `mcause` (0x342), `mtval` (0x343).
+  Accessing any other CSR panics the tracer. Only `CSRRW` and `CSRRS` are implemented;
+  `CSRRC` and the immediate CSR variants are not supported.
+
+- **The R1CS constraint system has no privilege-mode or interrupt semantics.**
+  CSR virtual registers (vr34–vr39) are treated as ordinary registers by the memory-checking circuit.
+  The circuit verifies read/write consistency, not the architectural meaning of individual bits.
+
 ## Core traits
 
 Two key traits form the backbone of the RISC-V emulator:

--- a/jolt-inlines/p256/src/sdk.rs
+++ b/jolt-inlines/p256/src/sdk.rs
@@ -827,7 +827,7 @@ pub fn ecdsa_verify(z: P256Fr, r: P256Fr, s: P256Fr, q: P256Point) -> Result<(),
     if q.is_infinity() {
         return Err(P256Error::QAtInfinity);
     }
-    if r.is_zero() || s.is_zero() {
+    if r.is_zero() || s.is_zero() || z.is_zero() {
         return Err(P256Error::ROrSZero);
     }
 

--- a/jolt-inlines/p256/src/sdk.rs
+++ b/jolt-inlines/p256/src/sdk.rs
@@ -842,6 +842,34 @@ pub fn ecdsa_verify(z: P256Fr, r: P256Fr, s: P256Fr, q: P256Point) -> Result<(),
     // Step 3: Get R2 = u2*Q and decomposition via Fake GLV advice
     let (r2, a2_val, a2_sign, b2_val, b2_sign) = fake_glv_scalar_mul(&u2, &q);
 
+    verify_ecdsa_inner(
+        &u1, &u2, &r, &q, r1, a1_val, a1_sign, b1_val, b1_sign, r2, a2_val, a2_sign, b2_val,
+        b2_sign,
+    )
+}
+
+/// Inner verification logic, separated from `ecdsa_verify` so it can be tested
+/// with injected decomposition values (e.g. zero GLV attack vectors).
+#[expect(clippy::too_many_arguments)]
+#[inline(always)]
+pub(crate) fn verify_ecdsa_inner(
+    u1: &P256Fr,
+    u2: &P256Fr,
+    r: &P256Fr,
+    q: &P256Point,
+    r1: P256Point,
+    a1_val: u128,
+    a1_sign: bool,
+    b1_val: u128,
+    b1_sign: bool,
+    r2: P256Point,
+    a2_val: u128,
+    a2_sign: bool,
+    b2_val: u128,
+    b2_sign: bool,
+) -> Result<(), P256Error> {
+    let g = P256Point::generator();
+
     // Step 4: Verify R1, R2 are on curve
     if !r1.is_on_curve() {
         spoil_proof();
@@ -868,12 +896,12 @@ pub fn ecdsa_verify(z: P256Fr, r: P256Fr, s: P256Fr, q: P256Point) -> Result<(),
     let b2_fr = make_fr(b2_val, b2_sign);
 
     // Check b1*u1 = a1 (mod n)
-    let check1 = b1_fr.mul(&u1);
+    let check1 = b1_fr.mul(u1);
     if check1.e() != a1_fr.e() {
         spoil_proof();
     }
     // Check b2*u2 = a2 (mod n)
-    let check2 = b2_fr.mul(&u2);
+    let check2 = b2_fr.mul(u2);
     if check2.e() != a2_fr.e() {
         spoil_proof();
     }
@@ -896,7 +924,7 @@ pub fn ecdsa_verify(z: P256Fr, r: P256Fr, s: P256Fr, q: P256Point) -> Result<(),
     let scalars = [a1_val, a2_val, b1_val, b2_val];
     let points_arr = [
         if a1_sign { g.neg() } else { g },
-        if a2_sign { q.neg() } else { q },
+        if a2_sign { q.neg() } else { q.clone() },
         r1_adj,
         r2_adj,
     ];

--- a/jolt-inlines/p256/src/sdk.rs
+++ b/jolt-inlines/p256/src/sdk.rs
@@ -878,6 +878,12 @@ pub fn ecdsa_verify(z: P256Fr, r: P256Fr, s: P256Fr, q: P256Point) -> Result<(),
         spoil_proof();
     }
 
+    // Reject trivial zero decomposition: a=0, b=0 satisfies b*u=a for any u,
+    // collapsing the Shamir MSM and leaving R1/R2 unconstrained.
+    if b1_val == 0 || b2_val == 0 {
+        spoil_proof();
+    }
+
     // Step 6: Prepare points for 4-scalar 128-bit Shamir
     // We verify: a1*G + a2*Q - b1*R1 - b2*R2 = O
     // Which is: a1*G + a2*Q + (-b1)*R1 + (-b2)*R2 = O

--- a/jolt-inlines/p256/src/tests.rs
+++ b/jolt-inlines/p256/src/tests.rs
@@ -1069,6 +1069,23 @@ mod p256_tests {
         }
     }
 
+    /// Regression test: ecdsa_verify must reject z=0 (message hash of zero).
+    ///
+    /// Before the fix, a zero message hash was accepted, which allowed a
+    /// trivial forgery: with z=0 the verification equation degenerates to
+    /// u1*G = (0/s)*G = O, so the attacker only needs u2*Q to have the
+    /// right x-coordinate, which is easy to arrange.
+    #[test]
+    fn test_ecdsa_verify_rejects_zero_hash() {
+        use crate::sdk::{ecdsa_verify, P256Error, P256Fr, P256Point};
+        let g = P256Point::generator();
+        let zero = P256Fr::from_u64_arr(&[0, 0, 0, 0]).unwrap();
+        let r = P256Fr::from_u64_arr(&[1, 0, 0, 0]).unwrap();
+        let s = P256Fr::from_u64_arr(&[1, 0, 0, 0]).unwrap();
+        let result = ecdsa_verify(zero, r, s, g);
+        assert!(matches!(result, Err(P256Error::ROrSZero)));
+    }
+
     /// Verify that a zero GLV decomposition (a=0, b=0) is rejected.
     ///
     /// A malicious prover could supply a=0, b=0 as the Fake GLV decomposition,

--- a/jolt-inlines/p256/src/tests.rs
+++ b/jolt-inlines/p256/src/tests.rs
@@ -1068,4 +1068,45 @@ mod p256_tests {
             assert!(ecdsa_verify(z.clone(), bad_r, s.clone(), q.clone()).is_err());
         }
     }
+
+    /// Verify that a zero GLV decomposition (a=0, b=0) is rejected.
+    ///
+    /// A malicious prover could supply a=0, b=0 as the Fake GLV decomposition,
+    /// which trivially satisfies `b*u = a (mod n)` for any u and collapses the
+    /// Shamir MSM to the identity, leaving the prover-supplied points R1/R2
+    /// unconstrained. This test exercises the `b_val == 0` guard with an attack
+    /// vector that would otherwise pass all other checks.
+    #[test]
+    #[should_panic(expected = "proof spoiled")]
+    fn test_zero_glv_decomposition_rejected() {
+        use crate::sdk::{verify_ecdsa_inner, P256Fr, P256Point};
+
+        let g = P256Point::generator();
+        let r_fr = P256Fr::from_u64_arr(&[1, 0, 0, 0]).unwrap();
+        let s_fr = P256Fr::from_u64_arr(&[1, 0, 0, 0]).unwrap();
+        let z_fr = P256Fr::from_u64_arr(&[1, 0, 0, 0]).unwrap();
+
+        let u1 = z_fr.div_assume_nonzero(&s_fr);
+        let u2 = r_fr.div_assume_nonzero(&s_fr);
+
+        // Attack vector: all-zero decomposition with R1 = G (on-curve, x mod n = r)
+        // and R2 = infinity. With b=0, the Shamir MSM collapses to O, the
+        // decomposition check 0*u = 0 passes, and (R1 + R2).x mod n = G.x mod n.
+        let _ = verify_ecdsa_inner(
+            &u1,
+            &u2,
+            &r_fr,
+            &g,
+            g.clone(),
+            0,
+            false,
+            0,
+            false, // r1=G, a1=0, b1=0
+            P256Point::infinity(),
+            0,
+            false,
+            0,
+            false, // r2=O, a2=0, b2=0
+        );
+    }
 }

--- a/tracer/src/instruction/ebreak.rs
+++ b/tracer/src/instruction/ebreak.rs
@@ -55,6 +55,7 @@ impl RISCVTrace for EBREAK {
         let mut asm = InstrAssembler::new(self.address, self.is_compressed, xlen, allocator);
         let vr = allocator.allocate();
         asm.emit_j::<JAL>(*vr, 0);
+        drop(vr);
         asm.finalize()
     }
 }

--- a/tracer/src/instruction/ebreak.rs
+++ b/tracer/src/instruction/ebreak.rs
@@ -7,9 +7,16 @@
 
 use serde::{Deserialize, Serialize};
 
-use crate::{declare_riscv_instr, emulator::cpu::Cpu};
+use crate::{
+    declare_riscv_instr,
+    emulator::cpu::{Cpu, Xlen},
+    utils::inline_helpers::InstrAssembler,
+    utils::virtual_registers::VirtualRegisterAllocator,
+};
 
-use super::{format::format_i::FormatI, RISCVInstruction, RISCVTrace};
+use super::{
+    format::format_i::FormatI, jal::JAL, Cycle, Instruction, RISCVInstruction, RISCVTrace,
+};
 
 declare_riscv_instr!(
     name   = EBREAK,
@@ -27,4 +34,27 @@ impl EBREAK {
     }
 }
 
-impl RISCVTrace for EBREAK {}
+impl RISCVTrace for EBREAK {
+    fn trace(&self, cpu: &mut Cpu, trace: Option<&mut Vec<Cycle>>) {
+        let inline_sequence = self.inline_sequence(&cpu.vr_allocator, cpu.xlen);
+        let mut trace = trace;
+        for instr in inline_sequence {
+            instr.trace(cpu, trace.as_deref_mut());
+        }
+    }
+
+    /// Expand EBREAK into a JAL-to-self (`j .`), which stalls the PC and
+    /// terminates execution. Using JAL gives the cycle a Jump flag, which
+    /// disables the NextUnexpPCUpdateOtherwise constraint at the NoOp
+    /// padding boundary.
+    fn inline_sequence(
+        &self,
+        allocator: &VirtualRegisterAllocator,
+        xlen: Xlen,
+    ) -> Vec<Instruction> {
+        let mut asm = InstrAssembler::new(self.address, self.is_compressed, xlen, allocator);
+        let vr = allocator.allocate();
+        asm.emit_j::<JAL>(*vr, 0);
+        asm.finalize()
+    }
+}

--- a/tracer/src/instruction/ecall.rs
+++ b/tracer/src/instruction/ecall.rs
@@ -2,6 +2,18 @@
 //!
 //! The inline sequence writes mepc, mcause, mtval, and mstatus to their
 //! virtual registers, then jumps unconditionally to the trap handler.
+//!
+//! # Privilege model
+//!
+//! Jolt targets M-mode-only execution (no S/U privilege levels) with no
+//! interrupt hardware. mstatus is written as a constant `0x1800` (MPP=M-mode,
+//! MIE=0, MPIE=0) rather than via read-modify-write. This is correct because:
+//! - The privilege mode is always Machine — MPP is always 3.
+//! - The MIE CSR (0x304) is not in the supported CSR whitelist and cannot be
+//!   accessed by guest code. No interrupt sources exist (no timer, no CLINT,
+//!   no PLIC), so MIE/MPIE bits are unused.
+//! - The ZeroOS trap trampoline restores mstatus via `csrw` before `mret`,
+//!   so the virtual register always holds the correct value across traps.
 
 use serde::{Deserialize, Serialize};
 
@@ -76,7 +88,8 @@ impl RISCVTrace for ECALL {
         asm.emit_i::<ADDI>(vr_mcause, 0, MCAUSE_ECALL_FROM_MMODE);
         asm.emit_i::<ADDI>(vr_mtval, 0, 0);
 
-        // mstatus = 0x1800 (MPP=3 at bits 12:11)
+        // mstatus = 0x1800 (MPP=3 at bits 12:11). Written unconditionally —
+        // see module-level docs for why this is correct in the M-mode-only model.
         let three = allocator.allocate();
         asm.emit_i::<ADDI>(*three, 0, 3);
         asm.emit_i::<SLLI>(vr_mstatus, *three, 11);

--- a/tracer/src/instruction/mod.rs
+++ b/tracer/src/instruction/mod.rs
@@ -552,7 +552,16 @@ macro_rules! define_rv32im_enums {
                 let normalized = self.normalize();
                 // Rewrite instructions with rd=x0 via inline_sequence so the
                 // constraint system never sees rd=x0.
-                if normalized.operands.rd == Some(0) {
+                if normalized.operands.rd == Some(0)
+                    && !matches!(
+                        self,
+                        Instruction::SCW(_)
+                            | Instruction::SCD(_)
+                            | Instruction::LRW(_)
+                            | Instruction::LRD(_)
+                            | Instruction::INLINE(_)
+                    )
+                {
                     let inline_sequence = self.inline_sequence(&cpu.vr_allocator, cpu.xlen);
                     let mut trace = trace;
                     for instr in inline_sequence {

--- a/tracer/src/instruction/mret.rs
+++ b/tracer/src/instruction/mret.rs
@@ -2,11 +2,20 @@
 //!
 //! Encoding: 0x30200073 (SYSTEM opcode, funct3=000, imm=0x302)
 //!
-//! For ZeroOS M-mode-only operation:
-//! - Reads mepc (from virtual register vr36) and sets PC to that value
-//! - In full RISC-V, MRET also restores privilege mode from mstatus.MPP
-//!   and sets mstatus.MIE from mstatus.MPIE, but for single-privilege
-//!   M-mode-only execution, these bits don't need to change.
+//! # Privilege model
+//!
+//! Jolt targets M-mode-only execution with no interrupt hardware. MRET is
+//! implemented as a single JALR to mepc — it does not modify mstatus.
+//!
+//! The full RISC-V spec requires MRET to restore MIE from MPIE, set MPIE=1,
+//! and reset MPP to the least-privileged mode. These operations are omitted
+//! because:
+//! - There is only one privilege level (Machine) — MPP is always 3.
+//! - No interrupt sources exist and the MIE CSR (0x304) is inaccessible,
+//!   so MIE/MPIE bits are unused.
+//! - The ZeroOS trap trampoline restores mstatus via `csrw mstatus, <saved>`
+//!   before executing `mret`, so the virtual register holds the correct value
+//!   without MRET needing to manipulate it.
 
 use serde::{Deserialize, Serialize};
 
@@ -39,14 +48,8 @@ impl MRET {
         let mepc = cpu.read_csr_raw(CSR_MEPC_ADDRESS);
         cpu.pc = mepc;
 
-        // In a full implementation, we would also:
-        // 1. Set privilege mode to mstatus.MPP
-        // 2. Set mstatus.MIE to mstatus.MPIE
-        // 3. Set mstatus.MPP to U-mode (or M-mode if only M-mode is supported)
-        // 4. Set mstatus.MPIE to 1
-        //
-        // For ZeroOS M-mode-only, single-core, no-interrupt use case,
-        // privilege mode stays M and interrupt enable bits don't matter.
+        // mstatus is not modified — see module-level docs for why this is
+        // correct in the M-mode-only model.
     }
 }
 

--- a/tracer/src/instruction/mulhsu.rs
+++ b/tracer/src/instruction/mulhsu.rs
@@ -31,7 +31,7 @@ impl MULHSU {
                         >> 32,
                 ),
                 Xlen::Bit64 => {
-                    ((cpu.x[self.operands.rs1 as usize] as u128)
+                    ((cpu.x[self.operands.rs1 as usize] as i128 as u128)
                         .wrapping_mul(cpu.x[self.operands.rs2 as usize] as u64 as u128)
                         >> 64) as i64
                 }

--- a/tracer/src/instruction/mulhsu.rs
+++ b/tracer/src/instruction/mulhsu.rs
@@ -40,6 +40,16 @@ impl MULHSU {
     }
 }
 
+impl MULHSU {
+    /// Construct a MULHSU with given register operands.
+    #[cfg(test)]
+    fn with_regs(rd: u8, rs1: u8, rs2: u8) -> Self {
+        // Build a valid instruction word from the MATCH constant.
+        let word = Self::MATCH | ((rd as u32) << 7) | ((rs1 as u32) << 15) | ((rs2 as u32) << 20);
+        Self::new(word, 0x1000, true, false)
+    }
+}
+
 impl RISCVTrace for MULHSU {
     fn trace(&self, cpu: &mut Cpu, trace: Option<&mut Vec<Cycle>>) {
         let inline_sequence = self.inline_sequence(&cpu.vr_allocator, cpu.xlen);
@@ -74,5 +84,44 @@ impl RISCVTrace for MULHSU {
         asm.emit_r::<ADD>(self.operands.rd, *v3, *v0);
 
         asm.finalize()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::emulator::{cpu::Cpu, default_terminal::DefaultTerminal};
+
+    /// Regression test: MULHSU with negative rs1.
+    ///
+    /// MULHSU computes the upper 64 bits of (rs1 as signed) * (rs2 as unsigned).
+    /// Before the fix, rs2 was zero-extended incorrectly (as i64 as u128 instead
+    /// of as u64 as u128), causing sign-extension of negative rs1 to leak into
+    /// the unsigned operand, producing wrong results for negative rs1 values.
+    #[test]
+    fn test_mulhsu_negative_rs1() {
+        let mut cpu = Cpu::new(Box::new(DefaultTerminal::default()));
+        cpu.update_xlen(Xlen::Bit64);
+
+        // MULHSU rd=x1, rs1=x2, rs2=x3
+        let instr = MULHSU::with_regs(1, 2, 3);
+
+        // rs1 = -1 (signed), rs2 = 2 (unsigned)
+        cpu.x[2] = -1_i64;
+        cpu.x[3] = 2;
+
+        instr.exec(&mut cpu, &mut ());
+
+        // (-1_i128) * (2_u128 treated as 128-bit) = -2_i128
+        // -2 in two's complement 128-bit = 0xFFFF...FFFE
+        // upper 64 bits = 0xFFFFFFFFFFFFFFFF
+        //
+        // Before the fix, the incorrect zero-extension computed:
+        //   0xFFFFFFFFFFFFFFFF_u128 * 2_u128 = 0x1_FFFFFFFFFFFFFFFE
+        //   upper 64 = 1 (WRONG)
+        assert_eq!(
+            cpu.x[1] as u64, 0xFFFFFFFFFFFFFFFF,
+            "MULHSU(-1, 2) upper 64 bits should be all-ones"
+        );
     }
 }

--- a/tracer/src/instruction/scw.rs
+++ b/tracer/src/instruction/scw.rs
@@ -394,4 +394,40 @@ mod tests {
             "SC.W after LR.D should fail (mixed width, rd=1)"
         );
     }
+
+    /// Regression test: SC.W with rd=x0 must still succeed when a reservation
+    /// is held. Before the fix, dispatching through the generic rd=x0 rewrite
+    /// path bypassed VirtualAdvice patching, so the prover-supplied success
+    /// flag was always 0 (failure) — causing the store to be a no-op even with
+    /// a valid reservation.
+    #[test]
+    fn test_scw_rd_x0_preserves_reservation_semantics() {
+        let mut cpu = setup_cpu();
+        let addr = DRAM_BASE;
+        let original_val: u32 = 0xDEADBEEF;
+        let store_val: u32 = 0x12345678;
+        cpu.mmu.store_word(addr, original_val).unwrap();
+
+        cpu.x[11] = addr as i64;
+        cpu.x[12] = store_val as i64;
+
+        // LR.W with rd=x0: establishes a reservation but discards the loaded value.
+        // Use Instruction::trace() (the enum dispatch) to exercise the exclusion list.
+        let decoded = Instruction::decode(encode_lrw(0, 11), 0x1000, false).unwrap();
+        let mut trace = Vec::new();
+        decoded.trace(&mut cpu, Some(&mut trace));
+
+        // SC.W with rd=x0: should succeed (reservation is held) and write memory.
+        // Again use Instruction::trace() to exercise the enum dispatch path.
+        let decoded = Instruction::decode(encode_scw(0, 11, 12), 0x1004, false).unwrap();
+        let mut trace = Vec::new();
+        decoded.trace(&mut cpu, Some(&mut trace));
+
+        // The store must have succeeded: memory should contain the new value.
+        let (val, _) = cpu.mmu.load_word(addr).unwrap();
+        assert_eq!(
+            val, store_val,
+            "SC.W with rd=x0 should still store when reservation is held"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

Soundness fixes:
- P-256 ECDSA: reject trivial zero GLV decomposition (a=0, b=0) that collapses the Shamir MSM and allows signature forgery for any message and public key. secp256k1 is not affected.
- rd=x0 allowlist: exclude SCW/SCD/LRW/LRD/INLINE from the generic rd=x0 trace rewriting path so their custom trace() methods run, preserving VirtualAdvice patching and reservation state management.

Completeness fix:
- EBREAK: expand into a JAL-to-self virtual sequence so the Jump flag disables the NextUnexpPCUpdateOtherwise constraint at the NoOp padding boundary.

Emulator fix:
- MULHSU exec(): sign-extend rs1 via `as i128 as u128` instead of zero-extending via `as u128`. Only affects non-tracing emulator mode; proof generation uses the correct inline_sequence path.

Documentation:
- Document the M-mode-only privilege and trap model in the book and in ecall.rs/mret.rs code comments. ECALL's constant mstatus write and MRET's omitted mstatus restoration are correct by design for the single-privilege, no-interrupt execution model.

## Testing

<!-- How was this tested? Which tests cover this change? -->

- [x] Ran tests for modified crates
- [x] `cargo clippy` and `cargo fmt` pass

## Security Considerations

<!-- Every change to a zkVM has security implications. Describe them.
     Does this affect proof soundness? Verifier correctness? Private inputs? -->

## Breaking Changes

<!-- List any breaking changes to public APIs, proof formats, or serialization. Write "None" if not applicable. -->

None
