### PR TITLE
ci: fire Claude routines via labels on fork PRs

### DIFF
--- a/.github/workflows/_fire-claude-routine.yml
+++ b/.github/workflows/_fire-claude-routine.yml
@@ -1,0 +1,94 @@
+name: Fire Claude Routine
+
+# Reusable workflow that POSTs to the Claude Code routines fire endpoint and
+# posts a PR comment with the returned session URL. Called by
+# `claude-routines.yml` for each label/routine pairing.
+
+on:
+  workflow_call:
+    inputs:
+      routine_id:
+        description: Anthropic routine id (`trig_...`)
+        required: true
+        type: string
+      session_kind:
+        description: Human-readable session kind used in logs and PR comments
+        required: true
+        type: string
+    secrets:
+      routine_token:
+        description: Anthropic per-routine bearer token (`sk-ant-oat01-...`)
+        required: true
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  fire:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Fire routine
+        env:
+          ROUTINE_ID: ${{ inputs.routine_id }}
+          ROUTINE_TOKEN: ${{ secrets.routine_token }}
+          SESSION_KIND: ${{ inputs.session_kind }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          PR_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          BASE_REPO: ${{ github.event.pull_request.base.repo.full_name }}
+        run: |
+          set -euo pipefail
+
+          payload=$(jq -n \
+            --arg num "$PR_NUMBER" \
+            --arg title "$PR_TITLE" \
+            --arg url "$PR_URL" \
+            --arg sha "$PR_HEAD_SHA" \
+            --arg head "$PR_HEAD_REF" \
+            --arg base "$PR_BASE_REF" \
+            --arg author "$PR_AUTHOR" \
+            --arg source_repo "$PR_REPO" \
+            --arg base_repo "$BASE_REPO" \
+            --arg kind "$SESSION_KIND" \
+            '{text: "Claude \($kind) requested for PR #\($num): \($title)\nRepository: \($base_repo)\nURL: \($url)\nAuthor: @\($author)\nHead: \($source_repo) \($head) @ \($sha)\nBase: \($base)"}')
+
+          http=$(curl -sS \
+            --max-time 30 --connect-timeout 10 \
+            --retry 2 --retry-all-errors --retry-delay 5 \
+            -o response.json -w "%{http_code}" \
+            -X POST "https://api.anthropic.com/v1/claude_code/routines/${ROUTINE_ID}/fire" \
+            -H "Authorization: Bearer ${ROUTINE_TOKEN}" \
+            -H "anthropic-version: 2023-06-01" \
+            -H "anthropic-beta: experimental-cc-routine-2026-04-01" \
+            -H "Content-Type: application/json" \
+            -d "$payload")
+
+          echo "HTTP $http"
+
+          if [ "$http" != "200" ]; then
+            err=$(jq -r '.error.message // "unparseable response"' response.json 2>/dev/null || echo "unparseable response")
+            echo "::error::Routine fire failed (HTTP $http): $err"
+            exit 1
+          fi
+
+          session_id=$(jq -r 'select(.claude_code_session_id|type=="string") | .claude_code_session_id // empty' response.json)
+          session_url=$(jq -r 'select(.claude_code_session_url|type=="string") | .claude_code_session_url // empty' response.json)
+
+          if [ -n "$session_id" ]; then
+            echo "::notice::Started Claude $SESSION_KIND session $session_id"
+          fi
+
+          if [ -n "$session_url" ]; then
+            gh pr comment "$PR_NUMBER" --repo "$BASE_REPO" \
+              --body "Claude $SESSION_KIND session started: <$session_url>"
+          else
+            echo "::warning::Routine fired but no session URL returned"
+          fi

--- a/.github/workflows/claude-routines.yml
+++ b/.github/workflows/claude-routines.yml
@@ -10,6 +10,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: write
 
 jobs:
   code-review:
@@ -21,6 +22,8 @@ jobs:
         env:
           ROUTINE_ID: trig_0184QxNSKDj7Y9akvnEmo3s2
           ROUTINE_TOKEN: ${{ secrets.ANTHROPIC_REVIEW_AUTHORIZATION }}
+          SESSION_KIND: code review
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           PR_TITLE: ${{ github.event.pull_request.title }}
           PR_URL: ${{ github.event.pull_request.html_url }}
@@ -43,7 +46,8 @@ jobs:
             --arg author "$PR_AUTHOR" \
             --arg source_repo "$PR_REPO" \
             --arg base_repo "$BASE_REPO" \
-            '{text: "Code review requested for PR #\($num): \($title)\nRepository: \($base_repo)\nURL: \($url)\nAuthor: @\($author)\nHead: \($source_repo) \($head) @ \($sha)\nBase: \($base)"}')
+            --arg kind "$SESSION_KIND" \
+            '{text: "\($kind | ascii_upcase) requested for PR #\($num): \($title)\nRepository: \($base_repo)\nURL: \($url)\nAuthor: @\($author)\nHead: \($source_repo) \($head) @ \($sha)\nBase: \($base)"}')
 
           http=$(curl -sS -o response.json -w "%{http_code}" \
             -X POST "https://api.anthropic.com/v1/claude_code/routines/${ROUTINE_ID}/fire" \
@@ -61,8 +65,14 @@ jobs:
           fi
 
           session_id=$(jq -r '.claude_code_session_id // empty' response.json)
+          session_url=$(jq -r '.claude_code_session_url // empty' response.json)
+
           if [ -n "$session_id" ]; then
-            echo "::notice::Started Claude session $session_id"
+            echo "::notice::Started Claude $SESSION_KIND session $session_id"
+          fi
+
+          if [ -n "$session_url" ]; then
+            gh pr comment "$PR_NUMBER" --repo "$BASE_REPO" --body "Claude $SESSION_KIND session started: $session_url"
           fi
 
   spec-review:
@@ -74,6 +84,8 @@ jobs:
         env:
           ROUTINE_ID: trig_01JBnYKwfoAgiruS15s3CcP7
           ROUTINE_TOKEN: ${{ secrets.ANTHROPIC_SPEC_REVIEW_AUTHORIZATION }}
+          SESSION_KIND: spec review
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           PR_TITLE: ${{ github.event.pull_request.title }}
           PR_URL: ${{ github.event.pull_request.html_url }}
@@ -96,7 +108,8 @@ jobs:
             --arg author "$PR_AUTHOR" \
             --arg source_repo "$PR_REPO" \
             --arg base_repo "$BASE_REPO" \
-            '{text: "Spec review requested for PR #\($num): \($title)\nRepository: \($base_repo)\nURL: \($url)\nAuthor: @\($author)\nHead: \($source_repo) \($head) @ \($sha)\nBase: \($base)"}')
+            --arg kind "$SESSION_KIND" \
+            '{text: "\($kind | ascii_upcase) requested for PR #\($num): \($title)\nRepository: \($base_repo)\nURL: \($url)\nAuthor: @\($author)\nHead: \($source_repo) \($head) @ \($sha)\nBase: \($base)"}')
 
           http=$(curl -sS -o response.json -w "%{http_code}" \
             -X POST "https://api.anthropic.com/v1/claude_code/routines/${ROUTINE_ID}/fire" \
@@ -114,8 +127,14 @@ jobs:
           fi
 
           session_id=$(jq -r '.claude_code_session_id // empty' response.json)
+          session_url=$(jq -r '.claude_code_session_url // empty' response.json)
+
           if [ -n "$session_id" ]; then
-            echo "::notice::Started Claude session $session_id"
+            echo "::notice::Started Claude $SESSION_KIND session $session_id"
+          fi
+
+          if [ -n "$session_url" ]; then
+            gh pr comment "$PR_NUMBER" --repo "$BASE_REPO" --body "Claude $SESSION_KIND session started: $session_url"
           fi
 
   implement:
@@ -127,6 +146,8 @@ jobs:
         env:
           ROUTINE_ID: trig_01CzBwCbrD2q5m8QHCWU16r5
           ROUTINE_TOKEN: ${{ secrets.ANTHROPIC_IMPLEMENT_AUTHORIZATION }}
+          SESSION_KIND: implement-spec
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           PR_TITLE: ${{ github.event.pull_request.title }}
           PR_URL: ${{ github.event.pull_request.html_url }}
@@ -149,7 +170,8 @@ jobs:
             --arg author "$PR_AUTHOR" \
             --arg source_repo "$PR_REPO" \
             --arg base_repo "$BASE_REPO" \
-            '{text: "Implementation requested for PR #\($num): \($title)\nRepository: \($base_repo)\nURL: \($url)\nAuthor: @\($author)\nHead: \($source_repo) \($head) @ \($sha)\nBase: \($base)"}')
+            --arg kind "$SESSION_KIND" \
+            '{text: "\($kind | ascii_upcase) requested for PR #\($num): \($title)\nRepository: \($base_repo)\nURL: \($url)\nAuthor: @\($author)\nHead: \($source_repo) \($head) @ \($sha)\nBase: \($base)"}')
 
           http=$(curl -sS -o response.json -w "%{http_code}" \
             -X POST "https://api.anthropic.com/v1/claude_code/routines/${ROUTINE_ID}/fire" \
@@ -167,6 +189,12 @@ jobs:
           fi
 
           session_id=$(jq -r '.claude_code_session_id // empty' response.json)
+          session_url=$(jq -r '.claude_code_session_url // empty' response.json)
+
           if [ -n "$session_id" ]; then
-            echo "::notice::Started Claude session $session_id"
+            echo "::notice::Started Claude $SESSION_KIND session $session_id"
+          fi
+
+          if [ -n "$session_url" ]; then
+            gh pr comment "$PR_NUMBER" --repo "$BASE_REPO" --body "Claude $SESSION_KIND session started: $session_url"
           fi

--- a/.github/workflows/claude-routines.yml
+++ b/.github/workflows/claude-routines.yml
@@ -1,0 +1,172 @@
+name: Claude Routines
+
+# Fires Claude Code routines when specific labels are added to a PR.
+# Uses `pull_request_target` so secrets are available on PRs from forks
+# (label application itself is already gated on write/triage permission).
+
+on:
+  pull_request_target:
+    types: [labeled]
+
+permissions:
+  contents: read
+
+jobs:
+  code-review:
+    name: Claude code review
+    if: github.event.label.name == 'claude-review-request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fire routine
+        env:
+          ROUTINE_ID: trig_0184QxNSKDj7Y9akvnEmo3s2
+          ROUTINE_TOKEN: ${{ secrets.ANTHROPIC_REVIEW_AUTHORIZATION }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          PR_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          BASE_REPO: ${{ github.event.pull_request.base.repo.full_name }}
+        run: |
+          set -euo pipefail
+
+          payload=$(jq -n \
+            --arg num "$PR_NUMBER" \
+            --arg title "$PR_TITLE" \
+            --arg url "$PR_URL" \
+            --arg sha "$PR_HEAD_SHA" \
+            --arg head "$PR_HEAD_REF" \
+            --arg base "$PR_BASE_REF" \
+            --arg author "$PR_AUTHOR" \
+            --arg source_repo "$PR_REPO" \
+            --arg base_repo "$BASE_REPO" \
+            '{text: "Code review requested for PR #\($num): \($title)\nRepository: \($base_repo)\nURL: \($url)\nAuthor: @\($author)\nHead: \($source_repo) \($head) @ \($sha)\nBase: \($base)"}')
+
+          http=$(curl -sS -o response.json -w "%{http_code}" \
+            -X POST "https://api.anthropic.com/v1/claude_code/routines/${ROUTINE_ID}/fire" \
+            -H "Authorization: Bearer ${ROUTINE_TOKEN}" \
+            -H "anthropic-version: 2023-06-01" \
+            -H "anthropic-beta: experimental-cc-routine-2026-04-01" \
+            -H "Content-Type: application/json" \
+            -d "$payload")
+
+          echo "HTTP $http"
+          jq . response.json 2>/dev/null || cat response.json
+          if [ "$http" != "200" ]; then
+            echo "::error::Routine fire failed with HTTP $http"
+            exit 1
+          fi
+
+          session_id=$(jq -r '.claude_code_session_id // empty' response.json)
+          if [ -n "$session_id" ]; then
+            echo "::notice::Started Claude session $session_id"
+          fi
+
+  spec-review:
+    name: Claude spec review
+    if: github.event.label.name == 'claude-spec-review-request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fire routine
+        env:
+          ROUTINE_ID: trig_01JBnYKwfoAgiruS15s3CcP7
+          ROUTINE_TOKEN: ${{ secrets.ANTHROPIC_SPEC_REVIEW_AUTHORIZATION }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          PR_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          BASE_REPO: ${{ github.event.pull_request.base.repo.full_name }}
+        run: |
+          set -euo pipefail
+
+          payload=$(jq -n \
+            --arg num "$PR_NUMBER" \
+            --arg title "$PR_TITLE" \
+            --arg url "$PR_URL" \
+            --arg sha "$PR_HEAD_SHA" \
+            --arg head "$PR_HEAD_REF" \
+            --arg base "$PR_BASE_REF" \
+            --arg author "$PR_AUTHOR" \
+            --arg source_repo "$PR_REPO" \
+            --arg base_repo "$BASE_REPO" \
+            '{text: "Spec review requested for PR #\($num): \($title)\nRepository: \($base_repo)\nURL: \($url)\nAuthor: @\($author)\nHead: \($source_repo) \($head) @ \($sha)\nBase: \($base)"}')
+
+          http=$(curl -sS -o response.json -w "%{http_code}" \
+            -X POST "https://api.anthropic.com/v1/claude_code/routines/${ROUTINE_ID}/fire" \
+            -H "Authorization: Bearer ${ROUTINE_TOKEN}" \
+            -H "anthropic-version: 2023-06-01" \
+            -H "anthropic-beta: experimental-cc-routine-2026-04-01" \
+            -H "Content-Type: application/json" \
+            -d "$payload")
+
+          echo "HTTP $http"
+          jq . response.json 2>/dev/null || cat response.json
+          if [ "$http" != "200" ]; then
+            echo "::error::Routine fire failed with HTTP $http"
+            exit 1
+          fi
+
+          session_id=$(jq -r '.claude_code_session_id // empty' response.json)
+          if [ -n "$session_id" ]; then
+            echo "::notice::Started Claude session $session_id"
+          fi
+
+  implement:
+    name: Claude implement spec
+    if: github.event.label.name == 'claude-implement-spec'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fire routine
+        env:
+          ROUTINE_ID: trig_01CzBwCbrD2q5m8QHCWU16r5
+          ROUTINE_TOKEN: ${{ secrets.ANTHROPIC_IMPLEMENT_AUTHORIZATION }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          PR_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          BASE_REPO: ${{ github.event.pull_request.base.repo.full_name }}
+        run: |
+          set -euo pipefail
+
+          payload=$(jq -n \
+            --arg num "$PR_NUMBER" \
+            --arg title "$PR_TITLE" \
+            --arg url "$PR_URL" \
+            --arg sha "$PR_HEAD_SHA" \
+            --arg head "$PR_HEAD_REF" \
+            --arg base "$PR_BASE_REF" \
+            --arg author "$PR_AUTHOR" \
+            --arg source_repo "$PR_REPO" \
+            --arg base_repo "$BASE_REPO" \
+            '{text: "Implementation requested for PR #\($num): \($title)\nRepository: \($base_repo)\nURL: \($url)\nAuthor: @\($author)\nHead: \($source_repo) \($head) @ \($sha)\nBase: \($base)"}')
+
+          http=$(curl -sS -o response.json -w "%{http_code}" \
+            -X POST "https://api.anthropic.com/v1/claude_code/routines/${ROUTINE_ID}/fire" \
+            -H "Authorization: Bearer ${ROUTINE_TOKEN}" \
+            -H "anthropic-version: 2023-06-01" \
+            -H "anthropic-beta: experimental-cc-routine-2026-04-01" \
+            -H "Content-Type: application/json" \
+            -d "$payload")
+
+          echo "HTTP $http"
+          jq . response.json 2>/dev/null || cat response.json
+          if [ "$http" != "200" ]; then
+            echo "::error::Routine fire failed with HTTP $http"
+            exit 1
+          fi
+
+          session_id=$(jq -r '.claude_code_session_id // empty' response.json)
+          if [ -n "$session_id" ]; then
+            echo "::notice::Started Claude session $session_id"
+          fi

--- a/.github/workflows/claude-routines.yml
+++ b/.github/workflows/claude-routines.yml
@@ -8,193 +8,33 @@ on:
   pull_request_target:
     types: [labeled]
 
-permissions:
-  contents: read
-  pull-requests: write
-
 jobs:
   code-review:
     name: Claude code review
     if: github.event.label.name == 'claude-review-request'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Fire routine
-        env:
-          ROUTINE_ID: trig_0184QxNSKDj7Y9akvnEmo3s2
-          ROUTINE_TOKEN: ${{ secrets.ANTHROPIC_REVIEW_AUTHORIZATION }}
-          SESSION_KIND: code review
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          PR_TITLE: ${{ github.event.pull_request.title }}
-          PR_URL: ${{ github.event.pull_request.html_url }}
-          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-          PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
-          PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
-          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
-          PR_REPO: ${{ github.event.pull_request.head.repo.full_name }}
-          BASE_REPO: ${{ github.event.pull_request.base.repo.full_name }}
-        run: |
-          set -euo pipefail
-
-          payload=$(jq -n \
-            --arg num "$PR_NUMBER" \
-            --arg title "$PR_TITLE" \
-            --arg url "$PR_URL" \
-            --arg sha "$PR_HEAD_SHA" \
-            --arg head "$PR_HEAD_REF" \
-            --arg base "$PR_BASE_REF" \
-            --arg author "$PR_AUTHOR" \
-            --arg source_repo "$PR_REPO" \
-            --arg base_repo "$BASE_REPO" \
-            --arg kind "$SESSION_KIND" \
-            '{text: "\($kind | ascii_upcase) requested for PR #\($num): \($title)\nRepository: \($base_repo)\nURL: \($url)\nAuthor: @\($author)\nHead: \($source_repo) \($head) @ \($sha)\nBase: \($base)"}')
-
-          http=$(curl -sS -o response.json -w "%{http_code}" \
-            -X POST "https://api.anthropic.com/v1/claude_code/routines/${ROUTINE_ID}/fire" \
-            -H "Authorization: Bearer ${ROUTINE_TOKEN}" \
-            -H "anthropic-version: 2023-06-01" \
-            -H "anthropic-beta: experimental-cc-routine-2026-04-01" \
-            -H "Content-Type: application/json" \
-            -d "$payload")
-
-          echo "HTTP $http"
-          jq . response.json 2>/dev/null || cat response.json
-          if [ "$http" != "200" ]; then
-            echo "::error::Routine fire failed with HTTP $http"
-            exit 1
-          fi
-
-          session_id=$(jq -r '.claude_code_session_id // empty' response.json)
-          session_url=$(jq -r '.claude_code_session_url // empty' response.json)
-
-          if [ -n "$session_id" ]; then
-            echo "::notice::Started Claude $SESSION_KIND session $session_id"
-          fi
-
-          if [ -n "$session_url" ]; then
-            gh pr comment "$PR_NUMBER" --repo "$BASE_REPO" --body "Claude $SESSION_KIND session started: $session_url"
-          fi
+    uses: ./.github/workflows/_fire-claude-routine.yml
+    with:
+      routine_id: trig_0184QxNSKDj7Y9akvnEmo3s2
+      session_kind: code review
+    secrets:
+      routine_token: ${{ secrets.ANTHROPIC_REVIEW_AUTHORIZATION }}
 
   spec-review:
     name: Claude spec review
     if: github.event.label.name == 'claude-spec-review-request'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Fire routine
-        env:
-          ROUTINE_ID: trig_01JBnYKwfoAgiruS15s3CcP7
-          ROUTINE_TOKEN: ${{ secrets.ANTHROPIC_SPEC_REVIEW_AUTHORIZATION }}
-          SESSION_KIND: spec review
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          PR_TITLE: ${{ github.event.pull_request.title }}
-          PR_URL: ${{ github.event.pull_request.html_url }}
-          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-          PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
-          PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
-          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
-          PR_REPO: ${{ github.event.pull_request.head.repo.full_name }}
-          BASE_REPO: ${{ github.event.pull_request.base.repo.full_name }}
-        run: |
-          set -euo pipefail
-
-          payload=$(jq -n \
-            --arg num "$PR_NUMBER" \
-            --arg title "$PR_TITLE" \
-            --arg url "$PR_URL" \
-            --arg sha "$PR_HEAD_SHA" \
-            --arg head "$PR_HEAD_REF" \
-            --arg base "$PR_BASE_REF" \
-            --arg author "$PR_AUTHOR" \
-            --arg source_repo "$PR_REPO" \
-            --arg base_repo "$BASE_REPO" \
-            --arg kind "$SESSION_KIND" \
-            '{text: "\($kind | ascii_upcase) requested for PR #\($num): \($title)\nRepository: \($base_repo)\nURL: \($url)\nAuthor: @\($author)\nHead: \($source_repo) \($head) @ \($sha)\nBase: \($base)"}')
-
-          http=$(curl -sS -o response.json -w "%{http_code}" \
-            -X POST "https://api.anthropic.com/v1/claude_code/routines/${ROUTINE_ID}/fire" \
-            -H "Authorization: Bearer ${ROUTINE_TOKEN}" \
-            -H "anthropic-version: 2023-06-01" \
-            -H "anthropic-beta: experimental-cc-routine-2026-04-01" \
-            -H "Content-Type: application/json" \
-            -d "$payload")
-
-          echo "HTTP $http"
-          jq . response.json 2>/dev/null || cat response.json
-          if [ "$http" != "200" ]; then
-            echo "::error::Routine fire failed with HTTP $http"
-            exit 1
-          fi
-
-          session_id=$(jq -r '.claude_code_session_id // empty' response.json)
-          session_url=$(jq -r '.claude_code_session_url // empty' response.json)
-
-          if [ -n "$session_id" ]; then
-            echo "::notice::Started Claude $SESSION_KIND session $session_id"
-          fi
-
-          if [ -n "$session_url" ]; then
-            gh pr comment "$PR_NUMBER" --repo "$BASE_REPO" --body "Claude $SESSION_KIND session started: $session_url"
-          fi
+    uses: ./.github/workflows/_fire-claude-routine.yml
+    with:
+      routine_id: trig_01JBnYKwfoAgiruS15s3CcP7
+      session_kind: spec review
+    secrets:
+      routine_token: ${{ secrets.ANTHROPIC_SPEC_REVIEW_AUTHORIZATION }}
 
   implement:
     name: Claude implement spec
     if: github.event.label.name == 'claude-implement-spec'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Fire routine
-        env:
-          ROUTINE_ID: trig_01CzBwCbrD2q5m8QHCWU16r5
-          ROUTINE_TOKEN: ${{ secrets.ANTHROPIC_IMPLEMENT_AUTHORIZATION }}
-          SESSION_KIND: implement-spec
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          PR_TITLE: ${{ github.event.pull_request.title }}
-          PR_URL: ${{ github.event.pull_request.html_url }}
-          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-          PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
-          PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
-          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
-          PR_REPO: ${{ github.event.pull_request.head.repo.full_name }}
-          BASE_REPO: ${{ github.event.pull_request.base.repo.full_name }}
-        run: |
-          set -euo pipefail
-
-          payload=$(jq -n \
-            --arg num "$PR_NUMBER" \
-            --arg title "$PR_TITLE" \
-            --arg url "$PR_URL" \
-            --arg sha "$PR_HEAD_SHA" \
-            --arg head "$PR_HEAD_REF" \
-            --arg base "$PR_BASE_REF" \
-            --arg author "$PR_AUTHOR" \
-            --arg source_repo "$PR_REPO" \
-            --arg base_repo "$BASE_REPO" \
-            --arg kind "$SESSION_KIND" \
-            '{text: "\($kind | ascii_upcase) requested for PR #\($num): \($title)\nRepository: \($base_repo)\nURL: \($url)\nAuthor: @\($author)\nHead: \($source_repo) \($head) @ \($sha)\nBase: \($base)"}')
-
-          http=$(curl -sS -o response.json -w "%{http_code}" \
-            -X POST "https://api.anthropic.com/v1/claude_code/routines/${ROUTINE_ID}/fire" \
-            -H "Authorization: Bearer ${ROUTINE_TOKEN}" \
-            -H "anthropic-version: 2023-06-01" \
-            -H "anthropic-beta: experimental-cc-routine-2026-04-01" \
-            -H "Content-Type: application/json" \
-            -d "$payload")
-
-          echo "HTTP $http"
-          jq . response.json 2>/dev/null || cat response.json
-          if [ "$http" != "200" ]; then
-            echo "::error::Routine fire failed with HTTP $http"
-            exit 1
-          fi
-
-          session_id=$(jq -r '.claude_code_session_id // empty' response.json)
-          session_url=$(jq -r '.claude_code_session_url // empty' response.json)
-
-          if [ -n "$session_id" ]; then
-            echo "::notice::Started Claude $SESSION_KIND session $session_id"
-          fi
-
-          if [ -n "$session_url" ]; then
-            gh pr comment "$PR_NUMBER" --repo "$BASE_REPO" --body "Claude $SESSION_KIND session started: $session_url"
-          fi
+    uses: ./.github/workflows/_fire-claude-routine.yml
+    with:
+      routine_id: trig_01CzBwCbrD2q5m8QHCWU16r5
+      session_kind: implement-spec
+    secrets:
+      routine_token: ${{ secrets.ANTHROPIC_IMPLEMENT_AUTHORIZATION }}

--- a/.github/workflows/spec-tracking.yml
+++ b/.github/workflows/spec-tracking.yml
@@ -29,7 +29,7 @@ jobs:
           HEAD: ${{ github.event.pull_request.head.sha }}
         run: |
 
-          CHANGED=$(git diff --name-only "$BASE" "$HEAD")
+          CHANGED=$(git diff --name-only "$BASE"..."$HEAD")
 
           HAS_SPEC=false
           HAS_CODE=false
@@ -101,12 +101,14 @@ jobs:
           HEAD: ${{ github.event.pull_request.head.sha }}
         run: |
 
-          # Count changed lines (additions + deletions), excluding spec files
-          LINES=$(git diff --numstat "$BASE" "$HEAD" -- . ':!specs/' | \
+          # Count changed lines (additions + deletions), excluding spec files.
+          # Three-dot diff (`BASE...HEAD`) diffs the merge-base against HEAD so
+          # unrelated progress on the base branch isn't counted as PR changes.
+          LINES=$(git diff --numstat "$BASE"..."$HEAD" -- . ':!specs/' | \
             awk '$1 != "-" && $2 != "-" { added += $1; removed += $2 } END { print (added + removed) ? added + removed : 0 }')
 
           # Check if any spec file exists in the diff
-          HAS_SPEC=$(git diff --name-only "$BASE" "$HEAD" -- 'specs/*.md' | grep -v 'README.md' | grep -v 'TEMPLATE.md' | head -1)
+          HAS_SPEC=$(git diff --name-only "$BASE"..."$HEAD" -- 'specs/*.md' | grep -v 'README.md' | grep -v 'TEMPLATE.md' | head -1)
 
           if [ "$LINES" -gt 500 ] && [ -z "$HAS_SPEC" ]; then
             EXISTING=$(gh pr view "$PR_NUMBER" --json comments --jq '.comments[].body' | grep -c "more than 500 changed lines" || true)


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/claude-routines.yml` that fires Claude Code routines when specific labels are added to a PR.
- Uses `pull_request_target: labeled` so the token secrets are available on PRs opened from forks (the previous label-driven workflows didn't run on forks because secrets aren't exposed to `pull_request` events from forks). Label application itself is already gated on triage/write permissions, so the trigger is self-gating.
- Three label → routine mappings, each with its own secret:
  | Label | Routine | Secret |
  |---|---|---|
  | `claude-review-request` | `trig_0184QxNSKDj7Y9akvnEmo3s2` | `ANTHROPIC_REVIEW_AUTHORIZATION` |
  | `claude-spec-review-request` | `trig_01JBnYKwfoAgiruS15s3CcP7` | `ANTHROPIC_SPEC_REVIEW_AUTHORIZATION` |
  | `claude-implement-spec` | `trig_01CzBwCbrD2q5m8QHCWU16r5` | `ANTHROPIC_IMPLEMENT_AUTHORIZATION` |
- Each job POSTs to `POST /v1/claude_code/routines/{id}/fire` with a `text` payload containing PR number, title, URL, author, head repo/ref/sha, and base ref. Fails the check on non-200, emits `::notice::` with the session id on success.
- No checkout, minimal `contents: read` permission — the workflow never touches fork code, so the secrets cannot leak to PR content.

## Test plan

- [ ] Apply `claude-review-request` to a fork PR → `Claude code review` job fires, new session appears in claude.ai/code.
- [ ] Apply `claude-spec-review-request` to a fork PR → `Claude spec review` job fires.
- [ ] Apply `claude-implement-spec` to a fork PR → `Claude implement spec` job fires.
- [ ] Apply an unrelated label (e.g. `spec`) → all three jobs skip (no API call).
- [ ] Re-apply a trigger label → workflow re-fires and creates a new session (expected; the endpoint has no idempotency key).