### PR TITLE
fix: add on-curve validation for public key Q in ECDSA verify

### DIFF
--- a/jolt-inlines/p256/src/sdk.rs
+++ b/jolt-inlines/p256/src/sdk.rs
@@ -817,11 +817,9 @@ fn shamir_4x128(scalars: [u128; 4], points: [P256Point; 4]) -> P256Point {
 ///
 /// This halves the doublings: 128 instead of 256, achieving ~1.7x speedup.
 ///
-/// Security: it is the responsibility of the caller to ensure
-/// 1. z, r, and s are well formed
-/// 2. q is a valid point on the curve
-///
-/// Note that these checks are automatically performed by the from_u64_arr constructors.
+/// Security: this function validates all inputs internally — z, r, s must be
+/// well-formed field elements (enforced by the `P256Fr` type), and q must be a
+/// non-infinity point on the P-256 curve (checked via `is_on_curve()`).
 #[inline(always)]
 pub fn ecdsa_verify(z: P256Fr, r: P256Fr, s: P256Fr, q: P256Point) -> Result<(), P256Error> {
     if q.is_infinity() {

--- a/jolt-inlines/p256/src/sdk.rs
+++ b/jolt-inlines/p256/src/sdk.rs
@@ -827,6 +827,9 @@ pub fn ecdsa_verify(z: P256Fr, r: P256Fr, s: P256Fr, q: P256Point) -> Result<(),
     if q.is_infinity() {
         return Err(P256Error::QAtInfinity);
     }
+    if !q.is_on_curve() {
+        return Err(P256Error::NotOnCurve);
+    }
     if r.is_zero() || s.is_zero() || z.is_zero() {
         return Err(P256Error::ROrSZero);
     }

--- a/jolt-inlines/secp256k1/src/sdk.rs
+++ b/jolt-inlines/secp256k1/src/sdk.rs
@@ -857,11 +857,9 @@ fn conditional_negate(x: Secp256k1Point, cond: bool) -> Secp256k1Point {
 /// q is the uncompressed public key point
 /// returns Ok(()) if the signature is valid
 /// returns Err(Secp256k1Error) if at any point, the verification fails
-/// Security: it is the responsibility of the caller to ensure
-/// 1. z, r, and s are well formed
-/// 2. q is a valid point on the curve
-///
-/// Note that these checks are automatically performed by the from_u64_arr constructors.
+/// Security: this function validates all inputs internally — z, r, s must be
+/// well-formed field elements (enforced by the `Secp256k1Fr` type), and q must
+/// be a non-infinity point on the secp256k1 curve (checked via `is_on_curve()`).
 #[inline(always)]
 pub fn ecdsa_verify(
     z: Secp256k1Fr,

--- a/jolt-inlines/secp256k1/src/sdk.rs
+++ b/jolt-inlines/secp256k1/src/sdk.rs
@@ -873,6 +873,9 @@ pub fn ecdsa_verify(
     if q.is_infinity() {
         return Result::Err(Secp256k1Error::QAtInfinity);
     }
+    if !q.is_on_curve() {
+        return Result::Err(Secp256k1Error::NotOnCurve);
+    }
     // step 1: check that r and s are in the correct range
     if r.is_zero() || s.is_zero() {
         return Result::Err(Secp256k1Error::ROrSZero);


### PR DESCRIPTION
Check q.is_on_curve() inside both P-256 and secp256k1 ecdsa_verify before using Q in the Shamir MSM. Without this, a caller using an unchecked point constructor could pass an off-curve Q, enabling invalid-curve attacks against the ECDSA verification.

Measured cost: +1,870 cycles on P-256 ECDSA verify (282,630 → 284,500), identical to the per-check cost of the existing R1/R2 on-curve checks. This matches the standard set by non-zkVM ECDSA libraries (RustCrypto, OpenSSL) which validate the public key internally.
