### PR TITLE
ci(claude): sanitize API strings, harden spec-tracking pipefail

### DIFF
--- a/.github/workflows/_fire-claude-routine.yml
+++ b/.github/workflows/_fire-claude-routine.yml
@@ -47,6 +47,13 @@ jobs:
         run: |
           set -euo pipefail
 
+          # Strip control chars and encode `%` so a hostile API response
+          # can't inject `::set-output`/`::add-mask`/etc. into workflow
+          # logs or sneak extra markdown past the PR comment body.
+          sanitize() {
+            printf '%s' "$1" | tr -d '\000-\037' | sed -e 's/%/%25/g'
+          }
+
           payload=$(jq -n \
             --arg num "$PR_NUMBER" \
             --arg title "$PR_TITLE" \
@@ -75,7 +82,7 @@ jobs:
 
           if [ "$http" != "200" ]; then
             err=$(jq -r '.error.message // "unparseable response"' response.json 2>/dev/null || echo "unparseable response")
-            echo "::error::Routine fire failed (HTTP $http): $err"
+            echo "::error::Routine fire failed (HTTP $http): $(sanitize "$err")"
             exit 1
           fi
 
@@ -83,12 +90,12 @@ jobs:
           session_url=$(jq -r 'select(.claude_code_session_url|type=="string") | .claude_code_session_url // empty' response.json)
 
           if [ -n "$session_id" ]; then
-            echo "::notice::Started Claude $SESSION_KIND session $session_id"
+            echo "::notice::Started Claude $SESSION_KIND session $(sanitize "$session_id")"
           fi
 
-          if [ -n "$session_url" ]; then
+          if [[ "$session_url" =~ ^https://[A-Za-z0-9._/-]+$ ]]; then
             gh pr comment "$PR_NUMBER" --repo "$BASE_REPO" \
               --body "Claude $SESSION_KIND session started: <$session_url>"
           else
-            echo "::warning::Routine fired but no session URL returned"
+            echo "::warning::Routine fired but session URL missing or malformed"
           fi

--- a/.github/workflows/spec-tracking.yml
+++ b/.github/workflows/spec-tracking.yml
@@ -28,6 +28,7 @@ jobs:
           BASE: ${{ github.event.pull_request.base.sha }}
           HEAD: ${{ github.event.pull_request.head.sha }}
         run: |
+          set -euo pipefail
 
           CHANGED=$(git diff --name-only "$BASE"..."$HEAD")
 
@@ -100,6 +101,7 @@ jobs:
           BASE: ${{ github.event.pull_request.base.sha }}
           HEAD: ${{ github.event.pull_request.head.sha }}
         run: |
+          set -euo pipefail
 
           # Count changed lines (additions + deletions), excluding spec files.
           # Three-dot diff (`BASE...HEAD`) diffs the merge-base against HEAD so
@@ -107,8 +109,10 @@ jobs:
           LINES=$(git diff --numstat "$BASE"..."$HEAD" -- . ':!specs/' | \
             awk '$1 != "-" && $2 != "-" { added += $1; removed += $2 } END { print (added + removed) ? added + removed : 0 }')
 
-          # Check if any spec file exists in the diff
-          HAS_SPEC=$(git diff --name-only "$BASE"..."$HEAD" -- 'specs/*.md' | grep -v 'README.md' | grep -v 'TEMPLATE.md' | head -1)
+          # Check if any spec file exists in the diff. Pathspec excludes
+          # README/TEMPLATE directly so the pipeline has no `grep -v`
+          # (which exits 1 on empty input and would trip `pipefail`).
+          HAS_SPEC=$(git diff --name-only "$BASE"..."$HEAD" -- 'specs/*.md' ':!specs/README.md' ':!specs/TEMPLATE.md' | head -1)
 
           if [ "$LINES" -gt 500 ] && [ -z "$HAS_SPEC" ]; then
             EXISTING=$(gh pr view "$PR_NUMBER" --json comments --jq '.comments[].body' | grep -c "more than 500 changed lines" || true)


### PR DESCRIPTION
## Summary

Follow-ups from a second security + code-quality audit of the workflows merged in #1443.

**`.github/workflows/_fire-claude-routine.yml`**
- Add a `sanitize()` helper that strips control chars and encodes `%` → `%25`. Apply it to API-supplied strings (`session_id` and the error-envelope `.error.message`) before they hit `::notice::` / `::error::` workflow commands, so a hostile API response can't inject `::set-output` / `::add-mask` / etc.
- Replace the plain non-empty check on `session_url` with a strict regex (`^https://[A-Za-z0-9._/-]+$`) before embedding in the PR comment body. Rejects `http://`, query strings, newlines, and markdown-breakout attempts.

**`.github/workflows/spec-tracking.yml`**
- Add `set -euo pipefail` to both `run:` blocks. The runner defaults to `-eo pipefail`, but explicit is safer against future edits that add non-guarded pipelines.
- Swap the `grep -v README.md | grep -v TEMPLATE.md` pipeline for pathspec excludes (`':!specs/README.md' ':!specs/TEMPLATE.md'`). `grep -v` on empty input exits 1, which would trip `pipefail` on PRs that don't touch any spec files — pathspec excludes return cleanly.

## Test plan

- [ ] Apply `claude-review-request` to a PR — workflow fires, PR comment lands, `::notice::` visible in logs.
- [ ] Force the API to return a malformed `session_url` (e.g. via a test routine) — workflow emits `::warning::`, no malformed comment posted.
- [ ] Open a PR touching only code (no specs) — spec-tracking labels it `no-spec` without erroring.
- [ ] Open a PR touching only `specs/README.md` — spec-tracking labels it `no-spec` (README excluded).
- [ ] Open a PR touching `specs/<new>.md` — spec-tracking labels it `spec`.