### PR TITLE
Integrate jolt-eval into spec-driven workflow

### DIFF
--- a/.claude/skills/analyze-spec/SKILL.md
+++ b/.claude/skills/analyze-spec/SKILL.md
@@ -43,8 +43,9 @@ When in doubt, default to local mode (interactive).
    - If no match, fall back to finding any `specs/*.md` file that is NOT `TEMPLATE.md`.
    - If multiple specs match, prefer the one matching the PR number. If still ambiguous, ask the user.
 2. **Read the spec** thoroughly — understand all sections (Summary, Intent, Evaluation, Design, Execution).
-3. **Explore the codebase**: Run `explore` agent to map codebase areas relevant to the spec's intent.
-4. **Read prior context (remote mode)**: Read all existing PR comments via `gh pr view --json comments` to identify questions already asked and answers already given. Account for these when scoring — don't re-ask answered questions.
+3. **Read `jolt-eval/README.md`** so you understand the invariant/objective framework for scoring Success Criteria and generating questions.
+4. **Explore the codebase**: Run `explore` agent to map codebase areas relevant to the spec's intent.
+5. **Read prior context (remote mode)**: Read all existing PR comments via `gh pr view --json comments` to identify questions already asked and answers already given. Account for these when scoring — don't re-ask answered questions.
 
 ## Phase 2: Analyze
 
@@ -53,12 +54,12 @@ Score clarity across four dimensions (0.0–1.0 each):
 | Dimension | Weight | What to assess |
 |-----------|--------|---------------|
 | Goal Clarity | 0.35 | Is the primary objective unambiguous? Can you state it in one sentence? Are key entities and relationships clear? |
-| Constraint Clarity | 0.25 | Are boundaries, limitations, and non-goals clear? |
-| Success Criteria | 0.25 | Could you write a test that verifies success? Are acceptance criteria concrete? |
+| Constraint Clarity | 0.20 | Are boundaries, limitations, and non-goals clear? |
+| Success Criteria | 0.30 | Could you write a test that verifies success? Are acceptance criteria concrete? Are relevant `jolt-eval` invariants/objectives described? |
 | Context Clarity | 0.15 | Do we understand the existing system well enough to modify it safely? |
 
 **Calculate ambiguity:**
-`ambiguity = 1 - (goal × 0.35 + constraints × 0.25 + criteria × 0.25 + context × 0.15)`
+`ambiguity = 1 - (goal × 0.35 + constraints × 0.20 + criteria × 0.30 + context × 0.15)`
 
 For each dimension below 0.9, generate a targeted question that would improve it:
 - Questions should expose ASSUMPTIONS, not gather feature lists
@@ -130,8 +131,8 @@ Round {n} complete.
 | Dimension | Score | Weight | Weighted | Gap |
 |-----------|-------|--------|----------|-----|
 | Goal | {s} | 0.35 | {s*w} | {gap or "Clear"} |
-| Constraints | {s} | 0.25 | {s*w} | {gap or "Clear"} |
-| Success Criteria | {s} | 0.25 | {s*w} | {gap or "Clear"} |
+| Constraints | {s} | 0.20 | {s*w} | {gap or "Clear"} |
+| Success Criteria | {s} | 0.30 | {s*w} | {gap or "Clear"} |
 | Context | {s} | 0.15 | {s*w} | {gap or "Clear"} |
 | **Ambiguity** | | | **{score}%** | |
 
@@ -199,6 +200,20 @@ streaming produces the same commitments as the non-streaming path? And what
 is the acceptable performance threshold (e.g., memory usage, throughput)?
 ```
 Why good: One question, targets weakest dimension, specific to the spec content.
+</Good>
+
+<Good>
+Probing jolt-eval coverage:
+```
+The Intent → Invariants section says "streaming must produce the same
+commitments as the non-streaming path." That looks like a binary property —
+have you considered capturing it as a new `jolt-eval` invariant? The existing
+`split_eq_bind_low_high` in `jolt-eval/src/invariant/` is a close model
+(reference vs. optimized implementation comparison). If this is out of scope,
+the Invariants section should say so explicitly.
+```
+Why good: Names a concrete existing invariant as a model, leaves the N/A
+door open, doesn't force a fit.
 </Good>
 
 <Good>

--- a/.claude/skills/implement-spec/SKILL.md
+++ b/.claude/skills/implement-spec/SKILL.md
@@ -26,13 +26,18 @@ This skill runs locally or in Claude Code cloud (claude.ai/code) — NOT in CI. 
 
 1. **Read the spec**: Find the `specs/*.md` file in this PR (exclude `TEMPLATE.md`). If a path is provided in `{{ARGUMENTS}}`, use that.
 2. **Read CLAUDE.md**: Understand architecture, conventions, testing requirements.
-3. **Explore relevant code**: Use `explore` agents to understand the modules, types, and patterns the implementation will touch.
-4. **Create implementation plan**: Based on the spec's Intent and Execution sections, determine:
+3. **Read `jolt-eval/README.md`**: Understand the eval framework — the spec's Intent → Invariants and Evaluation → Performance sections may reference it.
+4. **Explore relevant code**: Use `explore` agents to understand the modules, types, and patterns the implementation will touch.
+5. **Extract evals**: Scan the spec's Intent → Invariants and Evaluation → Performance sections for `jolt-eval` references and list:
+   - New invariants to add → each becomes a `/new-invariant <name>` subtask.
+   - New objectives to add → each becomes a `/new-objective <name>` subtask.
+   - Existing invariants/objectives that need to be changed.
+6. **Create implementation plan**: Based on the spec's Intent and Execution sections, determine:
    - Files to create, modify, or remove
    - Order of changes (dependencies first)
    - How existing patterns and abstractions should be extended
    - Which tasks can run in parallel vs. sequential
-5. **Post the plan** as a PR comment for visibility:
+7. **Post the plan** as a PR comment for visibility:
 
 ```
 **Implementation plan for: {spec title}**
@@ -48,11 +53,15 @@ This skill runs locally or in Claude Code cloud (claude.ai/code) — NOT in CI. 
 
 ## Phase 2: Execute
 
-1. **Implement** all changes from the plan.
+1. **Add jolt-eval scaffolding first**: For each new invariant/objective extracted in Phase 1, invoke the corresponding skill so the mechanical checks are in place before the implementation lands:
+   - `/new-invariant <name>` for each new invariant
+   - `/new-objective <name>` for each new objective
+   Commit these additions as their own logical units.
+2. **Implement** all changes from the plan.
    - Run independent tasks in parallel using agents where beneficial.
    - Follow project code style and conventions from CLAUDE.md.
    - Performance is critical — avoid regressions in hot paths.
-2. **Commit** with clear, well-scoped messages as logical units complete.
+3. **Commit** with clear, well-scoped messages as logical units complete.
 
 ## Phase 3: QA
 
@@ -65,6 +74,7 @@ Cycle until all checks pass (up to 5 cycles):
 3. **Test**: Run evaluation criteria from the spec, plus:
    - `cargo nextest run -p jolt-core muldiv --cargo-quiet --features host`
    - `cargo nextest run -p jolt-core muldiv --cargo-quiet --features host,zk`
+   - `cargo nextest run -p jolt-eval --cargo-quiet` — runs every invariant's seed-corpus + random-inputs tests; any named in the spec must pass.
 4. **Fix** any failures and repeat.
 
 If the same error persists 3 times, stop and post a PR comment describing the fundamental issue.
@@ -74,8 +84,9 @@ If the same error persists 3 times, stop and post a PR comment describing the fu
 Run parallel validation:
 
 1. **Correctness**: All spec evaluation criteria pass.
-2. **Code review**: Self-review for consistency with existing patterns, missing edge cases, unnecessary changes beyond the spec.
-3. **Security**: Check for OWASP top 10 patterns if the changes touch input handling or external data.
+2. **Mechanical checks (jolt-eval)**: For each objective named in the spec's Evaluation → Performance section, run `cargo run -p jolt-eval --bin measure-objectives -- --objective <name>` and confirm it moved in the declared direction (or stayed within the declared tolerance). All invariants named or introduced in the spec's Intent → Invariants section must pass — the Phase 3 `cargo nextest run -p jolt-eval` covers seed corpus + random inputs.
+3. **Code review**: Self-review for consistency with existing patterns, missing edge cases, unnecessary changes beyond the spec.
+4. **Security**: Check for OWASP top 10 patterns if the changes touch input handling or external data.
 
 Fix any issues found and re-validate.
 

--- a/.claude/skills/new-spec/SKILL.md
+++ b/.claude/skills/new-spec/SKILL.md
@@ -14,7 +14,8 @@ Create a new spec file in `specs/` by interviewing the user to fill each section
 2. Get the GitHub username: run `gh api user --jq .login`.
 3. Get today's date in `YYYY-MM-DD` format.
 4. Read `specs/TEMPLATE.md` to understand the required sections.
-5. Explore the codebase to understand what areas the feature name suggests — run an `explore` agent to gather context. This informs your questions.
+5. Read `jolt-eval/README.md` to understand the eval framework — you'll reference it when prompting the user about mechanical verifiability.
+6. Explore the codebase to understand what areas the feature name suggests — run an `explore` agent to gather context. This informs your questions.
 
 ### 2. Interview — Section by Section
 
@@ -29,7 +30,25 @@ Ask: "In one paragraph, what problem does this solve and why does it matter?"
 Ask: "What are we building? Can you state the primary objective in one sentence?" Follow up on abstractions, types, boundaries if unclear.
 
 #### Intent — Invariants
-Ask: "What properties must always hold? What would break if the implementation is wrong?" For ZK features, probe prover/verifier consistency. Cite codebase context — e.g., "I see `SumcheckInstanceParams` requires `input_claim` and `input_claim_constraint` to stay in sync. Does this feature touch sumcheck?"
+
+Before asking the user anything, form a hypothesis from the Summary and Goal:
+1. Read `jolt-eval/src/invariant/` (listed in `jolt-eval/README.md`). For each existing invariant, judge whether this feature is likely to touch it. If yes, note whether the feature looks like it should *preserve* the invariant as-is or *modify* it (e.g., extend input type, change the reference implementation).
+2. Independently, imagine the binary properties that would have to hold for the Goal to be "correct." Which of those are not yet covered by an existing `jolt-eval` invariant? Each is a candidate for `/new-invariant`.
+
+Present the hypothesis to the user in one pass:
+```
+Based on the Summary and Goal, I think this feature likely:
+- May need to modify: {existing invariant Z — because ...}
+- Warrants new invariants: {A — "...", B — "..."}
+
+Does this match your intent? What would you add, remove, or change?
+```
+
+Then follow up with the open-ended prompt: "What other properties must always hold? What would break if the implementation is wrong?"
+
+For any new properties the user adds that don't map to an existing `jolt-eval` invariant but look amenable to mechanical verification, ask: "your invariant 'X must equal Y' looks like a candidate for `/new-invariant` — want to capture it so it's mechanically checked during `/implement-spec`?"
+
+Record changes to existing `jolt-eval` invariants and any new ones to add in the "Invariants" section of the template.
 
 #### Intent — Non-Goals
 Ask: "What is explicitly out of scope?" Push back if non-goals are vague — "you said 'not performance-critical', but the hot path in `poly/` multiplies across thousands of rounds. Is there a concrete budget?"
@@ -41,7 +60,25 @@ Ask: "What test would prove this works? Give me concrete, checkable criteria." E
 Ask: "Which existing tests must keep passing? What new tests are needed? Does this need both `--features host` and `--features host,zk` coverage?"
 
 #### Evaluation — Performance
-Ask: "What are the performance expectations? Benchmarks, memory budgets, throughput targets? Or is 'no regression' sufficient — and if so, which benchmark verifies that?"
+
+Before asking the user anything, form a hypothesis from the information collected so far:
+1. Read `jolt-eval/src/objective/` (listed in `jolt-eval/README.md`). For each existing performance objective, judge whether this feature is likely to move it, and in which direction.
+2. Independently, imagine what "success" looks like as a measurable quantity. If it is not captured by an existing performance objective, this may be a candidate for `/new-objective`.
+
+Present the hypothesis to the user in one pass:
+```
+Based on the Summary, Goal, and Invariants, I think this feature likely:
+- Moves existing objectives: {X — direction, rough magnitude}, {Y — ...}
+- Warrants new objectives: {A — "...", B — "..."}
+
+Does this match your expectations? What would you add, remove, or change?
+```
+
+Then follow up with the open-ended prompt: "Beyond these, are there other performance expectations? Benchmarks, memory budgets, throughput targets? Or is 'no regression' sufficient — and if so, which benchmark verifies that?"
+
+For any new expectations the user adds that don't map to an existing `jolt-eval` objective but look measurable, ask: "should we add a new objective via `/new-objective` so the optimizer can track it?"
+
+Record both changes to existing `jolt-eval` objectives and any new ones to add directly in the "Performance" section.
 
 #### Design — Architecture
 Ask: "How does this fit into the existing system?" Use codebase exploration to suggest which modules are affected. Ask about type parameters, trait implementations, module boundaries.

--- a/specs/TEMPLATE.md
+++ b/specs/TEMPLATE.md
@@ -21,6 +21,8 @@ What are we building? State the primary objective in one sentence without qualif
 
 What properties must hold? List the correctness, safety, or consistency invariants that the implementation must preserve. For ZK features, include prover/verifier consistency requirements.
 
+Whenever possible, use the [`jolt-eval`](../jolt-eval/README.md) framework: describe any existing `jolt-eval/src/invariant/` entries that need to be changed, and describe any new invariants to add via `/new-invariant` during implementation.
+
 ### Non-Goals
 
 What is explicitly out of scope? Listing non-goals prevents scope creep and clarifies the feature's boundaries.
@@ -42,6 +44,8 @@ Which existing tests must continue passing? What new tests are needed? Specify b
 ### Performance
 
 What are the performance expectations? Specify benchmarks, acceptable regressions, memory budgets, or throughput targets. "No regression" is acceptable if there is a benchmark to verify against.
+
+Whenever possible, use the [`jolt-eval`](../jolt-eval/README.md) framework: list existing entries from `jolt-eval/src/objective/` this feature is expected to move (with direction and estimated magnitude), and describe any new objectives to add via `/new-objective` during implementation.
 
 ## Design
 


### PR DESCRIPTION
## Summary

- Fold jolt-eval invariants/objectives into the spec template's existing Intent → Invariants and Evaluation → Performance sections (optional but strongly encouraged).
- `new-spec` now hypothesizes candidate existing/new invariants and objectives from the Summary/Goal before asking the user — leading the interview with repo-grounded suggestions rather than a cold open.
- `analyze-spec` rubric scores whether `jolt-eval` invariants/objectives are described under Success Criteria.
- `implement-spec` extracts declared invariants/objectives from the spec, scaffolds new ones via `/new-invariant` and `/new-objective` before the core implementation, runs `cargo nextest run -p jolt-eval` in QA, and validates declared objectives with `measure-objectives`.

## Test plan

- [ ] Run `/new-spec <feature>` and verify the Intent — Invariants and Evaluation — Performance prompts lead with a jolt-eval-grounded hypothesis.
- [ ] Run `/analyze-spec` on a spec that names invariants/objectives vs. one that doesn't; confirm Success Criteria score differs.
- [ ] Run `/implement-spec` on a spec that declares a new invariant; confirm `/new-invariant` is invoked and `cargo nextest run -p jolt-eval` is included in QA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)