### PR TITLE
feat(jolt-eval): stream Claude Code events to stderr

### DIFF
--- a/jolt-eval/bin/optimize.rs
+++ b/jolt-eval/bin/optimize.rs
@@ -268,7 +268,7 @@ fn main() -> eyre::Result<()> {
         );
         println!("Baseline sort time: {baseline_score:.8}s");
         println!();
-        let agent = ClaudeCodeAgent::new(&cli.model, cli.max_turns);
+        let agent = ClaudeCodeAgent::new(&cli.model, cli.max_turns, cli.verbose);
         let result = auto_optimize(&agent, &mut env, objective, &config, &repo_dir);
         println!("Best score: {:.8}s", result.best_score);
         println!(
@@ -312,7 +312,7 @@ fn main() -> eyre::Result<()> {
     let baseline_score = (objective.evaluate)(&baseline, &baseline);
     println!("Objective: {} = {:.8}\n", objective.name, baseline_score);
 
-    let agent = ClaudeCodeAgent::new(&cli.model, cli.max_turns);
+    let agent = ClaudeCodeAgent::new(&cli.model, cli.max_turns, cli.verbose);
     let config = OptimizeConfig {
         num_iterations: cli.iterations,
         hint: cli.hint.clone(),

--- a/jolt-eval/bin/redteam.rs
+++ b/jolt-eval/bin/redteam.rs
@@ -92,7 +92,7 @@ fn main() -> eyre::Result<()> {
         hint: cli.hint,
         verbose: cli.verbose,
     };
-    let agent = ClaudeCodeAgent::new(&cli.model, cli.max_turns);
+    let agent = ClaudeCodeAgent::new(&cli.model, cli.max_turns, cli.verbose);
     let repo_dir = std::env::current_dir()?;
 
     info!(

--- a/jolt-eval/src/agent/claude.rs
+++ b/jolt-eval/src/agent/claude.rs
@@ -1,30 +1,42 @@
+use std::io::{BufRead, BufReader};
 use std::path::{Path, PathBuf};
-use std::process::Command;
+use std::process::{Command, Stdio};
+
+use serde_json::Value;
 
 use super::{AgentError, AgentHarness, AgentResponse, DiffScope};
 
 /// Agent implementation that invokes the Claude Code CLI in an isolated
 /// git worktree.
+///
+/// Runs the CLI with `--output-format stream-json`, parses the
+/// newline-delimited event stream as it arrives, and pretty-prints a
+/// running log of assistant text, thinking, and tool calls to stderr.
+/// The final `result` event (which carries either `structured_output` or
+/// `result`) is preserved for the caller.
 pub struct ClaudeCodeAgent {
     pub model: String,
     pub max_turns: usize,
+    /// When true, tool results are also printed. Text, thinking, and
+    /// tool-use summaries are always streamed.
+    pub verbose: bool,
 }
 
 impl ClaudeCodeAgent {
-    pub fn new(model: impl Into<String>, max_turns: usize) -> Self {
+    pub fn new(model: impl Into<String>, max_turns: usize, verbose: bool) -> Self {
         Self {
             model: model.into(),
             max_turns,
+            verbose,
         }
     }
 
-    fn run_cli(
+    fn run_streaming(
         &self,
         worktree_dir: &Path,
         prompt: &str,
         extra_args: &[&str],
-        verbose: bool,
-    ) -> Result<std::process::Output, AgentError> {
+    ) -> Result<StreamOutcome, AgentError> {
         tracing::info!(
             "Invoking claude (model={}, max_turns={})...",
             self.model,
@@ -38,21 +50,77 @@ impl ClaudeCodeAgent {
             .arg(&self.model)
             .arg("--max-turns")
             .arg(self.max_turns.to_string())
-            .arg("--dangerously-skip-permissions");
-        if verbose {
-            cmd.arg("--verbose");
-        }
+            .arg("--dangerously-skip-permissions")
+            .arg("--output-format")
+            .arg("stream-json")
+            // stream-json requires --verbose on the CLI side; this is
+            // independent of our printer verbosity.
+            .arg("--verbose");
         for arg in extra_args {
             cmd.arg(arg);
         }
-        cmd.output().map_err(|e| {
+        cmd.stdout(Stdio::piped()).stderr(Stdio::inherit());
+
+        let mut child = cmd.spawn().map_err(|e| {
             AgentError::new(format!(
                 "Failed to invoke claude: {e}. \
                  Make sure the `claude` CLI is installed and on your PATH. \
                  Install via: npm install -g @anthropic-ai/claude-code"
             ))
+        })?;
+
+        let stdout = child.stdout.take().expect("stdout was piped");
+        let reader = BufReader::new(stdout);
+
+        let mut final_event: Option<Value> = None;
+        let mut accumulated_text = String::new();
+
+        for line in reader.lines() {
+            let line = match line {
+                Ok(l) => l,
+                Err(e) => {
+                    tracing::warn!("claude stdout read error: {e}");
+                    continue;
+                }
+            };
+            if line.trim().is_empty() {
+                continue;
+            }
+            let event: Value = match serde_json::from_str(&line) {
+                Ok(v) => v,
+                Err(e) => {
+                    tracing::warn!(
+                        "unparsable claude event: {e}; line: {}",
+                        super::truncate(&line, 200)
+                    );
+                    continue;
+                }
+            };
+
+            accumulate_text(&event, &mut accumulated_text);
+            print_event(&event, self.verbose);
+
+            if event.get("type").and_then(Value::as_str) == Some("result") {
+                final_event = Some(event);
+            }
+        }
+
+        let status = child
+            .wait()
+            .map_err(|e| AgentError::new(format!("wait for claude: {e}")))?;
+
+        Ok(StreamOutcome {
+            status,
+            final_event,
+            accumulated_text,
         })
     }
+}
+
+struct StreamOutcome {
+    status: std::process::ExitStatus,
+    final_event: Option<Value>,
+    accumulated_text: String,
 }
 
 impl AgentHarness for ClaudeCodeAgent {
@@ -65,7 +133,7 @@ impl AgentHarness for ClaudeCodeAgent {
         let worktree_dir = create_worktree(repo_dir)?;
         tracing::info!("Created worktree at {}", worktree_dir.display());
 
-        let result = self.run_cli(&worktree_dir, prompt, &[], true);
+        let result = self.run_streaming(&worktree_dir, prompt, &[]);
 
         let diff = capture_diff(&worktree_dir, diff_scope);
 
@@ -73,22 +141,21 @@ impl AgentHarness for ClaudeCodeAgent {
         remove_worktree(repo_dir, &worktree_dir);
         let _ = std::fs::remove_dir_all(&worktree_dir);
 
-        let output = result?;
-        let stdout = String::from_utf8_lossy(&output.stdout);
-        let stderr = String::from_utf8_lossy(&output.stderr);
+        let outcome = result?;
 
-        if !output.status.success() {
-            tracing::warn!("claude exited with status {}", output.status);
-            if !stderr.is_empty() {
-                tracing::warn!("stderr: {}", super::truncate(&stderr, 500));
-            }
+        if !outcome.status.success() {
+            tracing::warn!("claude exited with status {}", outcome.status);
         }
 
-        let text = if stdout.trim().is_empty() {
-            stderr.to_string()
-        } else {
-            stdout.to_string()
-        };
+        // Prefer the final `result` event's text (canonical), fall back to
+        // accumulated assistant text if missing.
+        let text = outcome
+            .final_event
+            .as_ref()
+            .and_then(|e| e.get("result"))
+            .and_then(Value::as_str)
+            .map(str::to_string)
+            .unwrap_or(outcome.accumulated_text);
 
         if text.trim().is_empty() && diff.is_none() {
             return Err(AgentError::new("Agent produced no output"));
@@ -110,12 +177,7 @@ impl AgentHarness for ClaudeCodeAgent {
         let schema_str = serde_json::to_string(schema)
             .map_err(|e| AgentError::new(format!("schema serialization: {e}")))?;
 
-        let result = self.run_cli(
-            &worktree_dir,
-            prompt,
-            &["--output-format", "json", "--json-schema", &schema_str],
-            false,
-        );
+        let result = self.run_streaming(&worktree_dir, prompt, &["--json-schema", &schema_str]);
 
         let diff = capture_diff(&worktree_dir, diff_scope);
 
@@ -123,57 +185,184 @@ impl AgentHarness for ClaudeCodeAgent {
         remove_worktree(repo_dir, &worktree_dir);
         let _ = std::fs::remove_dir_all(&worktree_dir);
 
-        let output = result?;
-        let stdout = String::from_utf8_lossy(&output.stdout);
+        let outcome = result?;
 
-        // Parse the JSON envelope — even on non-zero exit (e.g. max_turns
-        // reached), Claude may still have produced structured output.
-        let envelope: serde_json::Value = match serde_json::from_str(&stdout) {
-            Ok(v) => v,
-            Err(e) => {
-                if !output.status.success() {
-                    let stderr = String::from_utf8_lossy(&output.stderr);
-                    let detail = if stderr.trim().is_empty() {
-                        super::truncate(&stdout, 1000)
-                    } else {
-                        super::truncate(&stderr, 1000)
-                    };
-                    return Err(AgentError::new(format!(
-                        "claude exited with status {}: {}",
-                        output.status, detail
-                    )));
-                }
-                return Err(AgentError::new(format!(
-                    "failed to parse CLI JSON envelope: {e}"
-                )));
-            }
+        let Some(final_event) = outcome.final_event.as_ref() else {
+            return Err(AgentError::new(format!(
+                "claude exited with status {} before emitting a result event",
+                outcome.status
+            )));
         };
 
-        let text = if let Some(structured) = envelope.get("structured_output") {
-            serde_json::to_string(structured)
-                .map_err(|e| AgentError::new(format!("re-serialize structured_output: {e}")))?
-        } else if let Some(result) = envelope.get("result") {
-            match result {
-                serde_json::Value::String(s) => s.clone(),
+        if let Some(structured) = final_event.get("structured_output") {
+            let text = serde_json::to_string(structured)
+                .map_err(|e| AgentError::new(format!("re-serialize structured_output: {e}")))?;
+            return Ok(AgentResponse { text, diff });
+        }
+
+        if let Some(result_val) = final_event.get("result") {
+            let text = match result_val {
+                Value::String(s) => s.clone(),
                 other => serde_json::to_string(other)
                     .map_err(|e| AgentError::new(format!("re-serialize result: {e}")))?,
-            }
-        } else if !output.status.success() {
-            let errors = envelope
+            };
+            return Ok(AgentResponse { text, diff });
+        }
+
+        if !outcome.status.success() {
+            let errors = final_event
                 .get("errors")
                 .and_then(|e| serde_json::to_string(e).ok())
                 .unwrap_or_default();
             return Err(AgentError::new(format!(
                 "claude exited with status {}: {}",
-                output.status, errors
+                outcome.status, errors
             )));
-        } else {
-            return Err(AgentError::new(
-                "CLI JSON envelope contained neither structured_output nor result",
-            ));
-        };
+        }
 
-        Ok(AgentResponse { text, diff })
+        Err(AgentError::new(
+            "result event contained neither structured_output nor result",
+        ))
+    }
+}
+
+/// Accumulate the text content of assistant messages for the
+/// fallback-when-missing-result-event path in [`ClaudeCodeAgent::invoke`].
+fn accumulate_text(event: &Value, out: &mut String) {
+    if event.get("type").and_then(Value::as_str) != Some("assistant") {
+        return;
+    }
+    let Some(content) = event
+        .get("message")
+        .and_then(|m| m.get("content"))
+        .and_then(Value::as_array)
+    else {
+        return;
+    };
+    for block in content {
+        if block.get("type").and_then(Value::as_str) == Some("text") {
+            if let Some(text) = block.get("text").and_then(Value::as_str) {
+                out.push_str(text);
+            }
+        }
+    }
+}
+
+/// Pretty-print an event to stderr.
+///
+/// Always printed: assistant text, thinking blocks, and a one-line
+/// summary of tool-use calls. Only printed when `verbose`: tool results.
+fn print_event(event: &Value, verbose: bool) {
+    let Some(ty) = event.get("type").and_then(Value::as_str) else {
+        return;
+    };
+    match ty {
+        "assistant" => print_assistant(event),
+        "user" if verbose => print_tool_result(event),
+        "result" => print_result(event),
+        _ => {}
+    }
+}
+
+fn print_assistant(event: &Value) {
+    let Some(content) = event
+        .get("message")
+        .and_then(|m| m.get("content"))
+        .and_then(Value::as_array)
+    else {
+        return;
+    };
+    for block in content {
+        match block.get("type").and_then(Value::as_str) {
+            Some("text") => {
+                let text = block.get("text").and_then(Value::as_str).unwrap_or("");
+                for line in text.lines() {
+                    eprintln!("│ {line}");
+                }
+            }
+            Some("thinking") => {
+                let text = block.get("thinking").and_then(Value::as_str).unwrap_or("");
+                for line in text.lines() {
+                    eprintln!("┊ {line}");
+                }
+            }
+            Some("tool_use") => {
+                let name = block.get("name").and_then(Value::as_str).unwrap_or("?");
+                let summary = tool_input_summary(block.get("input").unwrap_or(&Value::Null));
+                eprintln!("◇ {name}({summary})");
+            }
+            _ => {}
+        }
+    }
+}
+
+fn print_tool_result(event: &Value) {
+    let Some(content) = event
+        .get("message")
+        .and_then(|m| m.get("content"))
+        .and_then(Value::as_array)
+    else {
+        return;
+    };
+    for block in content {
+        if block.get("type").and_then(Value::as_str) == Some("tool_result") {
+            let text = tool_result_text(block);
+            let preview = super::truncate(&text, 400);
+            let ellipsis = if preview.len() < text.len() {
+                "…"
+            } else {
+                ""
+            };
+            eprintln!("  → {preview}{ellipsis}");
+        }
+    }
+}
+
+fn print_result(event: &Value) {
+    let is_err = event
+        .get("is_error")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    if is_err {
+        eprintln!("✗ run reported error");
+    } else {
+        eprintln!("✓ done");
+    }
+}
+
+/// Render tool input as a one-line summary. Prefer a well-known field
+/// over dumping the whole JSON object.
+fn tool_input_summary(input: &Value) -> String {
+    for key in [
+        "file_path",
+        "path",
+        "command",
+        "query",
+        "pattern",
+        "url",
+        "description",
+    ] {
+        if let Some(v) = input.get(key).and_then(Value::as_str) {
+            return format!("{key}={}", super::truncate(v, 120));
+        }
+    }
+    let s = input.to_string();
+    super::truncate(&s, 120).to_string()
+}
+
+fn tool_result_text(block: &Value) -> String {
+    match block.get("content") {
+        Some(Value::String(s)) => s.clone(),
+        Some(Value::Array(arr)) => {
+            let mut out = String::new();
+            for item in arr {
+                if let Some(t) = item.get("text").and_then(Value::as_str) {
+                    out.push_str(t);
+                }
+            }
+            out
+        }
+        _ => String::new(),
     }
 }
 

--- a/jolt-eval/src/sort_e2e.rs
+++ b/jolt-eval/src/sort_e2e.rs
@@ -112,7 +112,7 @@ pub fn run_redteam_test(
     verbose: bool,
 ) {
     let invariant = CandidateSortInvariant;
-    let agent = ClaudeCodeAgent::new(model, max_turns);
+    let agent = ClaudeCodeAgent::new(model, max_turns, verbose);
     let repo_dir = std::env::current_dir().expect("current dir");
     let config = RedTeamConfig {
         num_iterations: iterations,


### PR DESCRIPTION
## Summary
- Replace buffered `cmd.output()` in `ClaudeCodeAgent` with a streaming reader over `--output-format stream-json`
- Assistant text, thinking blocks, and tool-use summaries are printed to stderr as they arrive; tool results are gated behind a new `--verbose` flag
- Final `result` event is preserved so `invoke_structured` still extracts `structured_output`

## Test plan
- [ ] `cargo clippy -p jolt-eval --all-targets -- -D warnings`
- [ ] Run an `optimize`/`redteam` invocation end-to-end and confirm live streaming of Claude output to stderr
- [ ] Verify `--verbose` toggles tool-result printing without affecting structured-output parsing

🤖 Generated with [Claude Code](https://claude.com/claude-code)