### PR TITLE
fix: Hoist DoryGlobals initialization

### DIFF
--- a/jolt-core/src/zkvm/verifier.rs
+++ b/jolt-core/src/zkvm/verifier.rs
@@ -413,6 +413,15 @@ impl<
             &mut self.transcript,
         );
 
+        // Initialize DoryGlobals with the layout from the proof
+        // This ensures the verifier uses the same layout as the prover
+        let _guard = DoryGlobals::initialize_context(
+            1 << self.one_hot_params.log_k_chunk,
+            self.proof.trace_length.next_power_of_two(),
+            DoryContext::Main,
+            Some(self.proof.dory_layout),
+        );
+
         // Append commitments to transcript
         for commitment in &self.proof.commitments {
             self.transcript
@@ -1485,15 +1494,6 @@ impl<
 
     /// Stage 8: Dory batch opening verification.
     fn verify_stage8(&mut self) -> Result<Stage8VerifyData<F>, ProofVerifyError> {
-        // Initialize DoryGlobals with the layout from the proof
-        // This ensures the verifier uses the same layout as the prover
-        let _guard = DoryGlobals::initialize_context(
-            1 << self.one_hot_params.log_k_chunk,
-            self.proof.trace_length.next_power_of_two(),
-            DoryContext::Main,
-            Some(self.proof.dory_layout),
-        );
-
         // Get the unified opening point from HammingWeightClaimReduction
         // This contains (r_address_stage7 || r_cycle_stage6) in big-endian
         let (opening_point, _) = self.opening_accumulator.get_committed_polynomial_opening(


### PR DESCRIPTION
Fixes the following issue:

> The verifier path uses DoryGlobals::get_layout() during advice-related claim reduction before the verifier later re-initializes Dory state from proof.dory_layout in Stage 8. That allows backend verification behavior to depend on ambient mutable global state instead of depending only on the proof, statement, and verifier inputs.
