### PR TITLE
Add side_effects=true to load instructions

### DIFF
--- a/tracer/src/instruction/lb.rs
+++ b/tracer/src/instruction/lb.rs
@@ -24,7 +24,8 @@ declare_riscv_instr!(
     mask   = 0x0000707f,
     match  = 0x00000003,
     format = FormatLoad,
-    ram    = RAMRead
+    ram    = RAMRead,
+    side_effects = true
 );
 
 impl LB {

--- a/tracer/src/instruction/lbu.rs
+++ b/tracer/src/instruction/lbu.rs
@@ -25,7 +25,8 @@ declare_riscv_instr!(
     mask   = 0x0000707f,
     match  = 0x00004003,
     format = FormatLoad,
-    ram    = RAMRead
+    ram    = RAMRead,
+    side_effects = true
 );
 
 impl LBU {

--- a/tracer/src/instruction/ld.rs
+++ b/tracer/src/instruction/ld.rs
@@ -9,7 +9,8 @@ declare_riscv_instr!(
     mask   = 0x0000707f,
     match  = 0x00003003,
     format = FormatLoad,
-    ram    = super::RAMRead
+    ram    = super::RAMRead,
+    side_effects = true
 );
 
 impl LD {

--- a/tracer/src/instruction/lh.rs
+++ b/tracer/src/instruction/lh.rs
@@ -26,7 +26,8 @@ declare_riscv_instr!(
     mask   = 0x0000707f,
     match  = 0x00001003,
     format = FormatLoad,
-    ram    = RAMRead
+    ram    = RAMRead,
+    side_effects = true
 );
 
 impl LH {

--- a/tracer/src/instruction/lhu.rs
+++ b/tracer/src/instruction/lhu.rs
@@ -24,7 +24,8 @@ declare_riscv_instr!(
     mask   = 0x0000707f,
     match  = 0x00005003,
     format = FormatLoad,
-    ram    = RAMRead
+    ram    = RAMRead,
+    side_effects = true
 );
 
 impl LHU {

--- a/tracer/src/instruction/lw.rs
+++ b/tracer/src/instruction/lw.rs
@@ -25,7 +25,8 @@ declare_riscv_instr!(
     mask   = 0x0000707f,
     match  = 0x00002003,
     format = FormatLoad,
-    ram    = RAMRead
+    ram    = RAMRead,
+    side_effects = true
 );
 
 impl LW {

--- a/tracer/src/instruction/lwu.rs
+++ b/tracer/src/instruction/lwu.rs
@@ -21,7 +21,8 @@ declare_riscv_instr!(
     mask   = 0x0000707f,
     match  = 0x00006003,
     format = FormatLoad,
-    ram    = super::RAMRead
+    ram    = super::RAMRead,
+    side_effects = true
 );
 
 impl LWU {


### PR DESCRIPTION
Fixes the following issue: 

> Jolt rewrites instructions with rd = x0 before the constraint system sees them. For loads, that rewrite happens early enough that the trace path can collapse the instruction into a non-faulting inline sequence instead of performing the memory read. As a result, the proved execution trace no longer matches RV64IMAC load semantics.

By setting `side_effects = true` for load instructions, we substitute a virtual register for rd, instead of replacing the load instruction with a non-faulting NOP (ADDI 0 0 0)