### PR TITLE
fix: use independent per-point Shamirs in P-256 Fake GLV ECDSA verify

### DIFF
--- a/jolt-inlines/p256/src/lib.rs
+++ b/jolt-inlines/p256/src/lib.rs
@@ -5,8 +5,9 @@
 //! Each inline verifies `a*b + w*p = 2^256*w + c` where the prover supplies `w`
 //! as non-deterministic advice.
 //!
-//! Uses "Fake GLV" (Latincrypt 2025) to decompose 256-bit scalars into 128-bit
-//! pairs via half-GCD, enabling 4-scalar Shamir's trick without an endomorphism.
+//! Uses "Fake GLV" to decompose 256-bit scalars into 128-bit pairs via
+//! half-GCD, verifying each scalar multiplication with an independent
+//! 2-scalar Shamir MSM — no endomorphism required.
 //!
 //! ```rust,ignore
 //! use jolt_inlines_p256::{P256Fr, P256Point, ecdsa_verify, UnwrapOrSpoilProof};

--- a/jolt-inlines/p256/src/sdk.rs
+++ b/jolt-inlines/p256/src/sdk.rs
@@ -928,17 +928,17 @@ pub(crate) fn verify_ecdsa_inner(
     // Reference: https://ethresear.ch/t/fake-glv-you-dont-need-an-efficient-endomorphism-to-implement-glv-like-scalar-multiplication-in-snark-circuits/20394
 
     // Check R1: a1*G - b1*R1 = O  (binds R1 = u1*G)
-    let r1_neg = if b1_sign { r1.clone() } else { r1.neg() };
+    let r1_adj = if b1_sign { r1.clone() } else { r1.neg() };
     let g_adj = if a1_sign { g.neg() } else { g };
-    let check1 = shamir_2x128([a1_val, b1_val], [g_adj, r1_neg]);
+    let check1 = shamir_2x128([a1_val, b1_val], [g_adj, r1_adj]);
     if !check1.is_infinity() {
         spoil_proof();
     }
 
     // Check R2: a2*Q - b2*R2 = O  (binds R2 = u2*Q)
-    let r2_neg = if b2_sign { r2.clone() } else { r2.neg() };
+    let r2_adj = if b2_sign { r2.clone() } else { r2.neg() };
     let q_adj = if a2_sign { q.neg() } else { q.clone() };
-    let check2 = shamir_2x128([a2_val, b2_val], [q_adj, r2_neg]);
+    let check2 = shamir_2x128([a2_val, b2_val], [q_adj, r2_adj]);
     if !check2.is_infinity() {
         spoil_proof();
     }

--- a/jolt-inlines/p256/src/sdk.rs
+++ b/jolt-inlines/p256/src/sdk.rs
@@ -747,39 +747,21 @@ fn fake_glv_scalar_mul(_s: &P256Fr, _p: &P256Point) -> (P256Point, u128, bool, u
     panic!("fake_glv_scalar_mul not available on this target");
 }
 
-/// 4-scalar 128-bit Shamir's trick.
+/// 2-scalar 128-bit Shamir's trick.
+///
+/// Computes `scalars[0] * points[0] + scalars[1] * points[1]` using
+/// simultaneous double-and-add with a 4-entry precomputed table.
+///
+/// Used by the Fake GLV verification to check each scalar multiplication
+/// independently: `a_i * P - b_i * R_i = O` binds R_i = u_i * P.
 #[inline(always)]
-fn shamir_4x128(scalars: [u128; 4], points: [P256Point; 4]) -> P256Point {
-    // Build 16-entry lookup table from 4 base points
+fn shamir_2x128(scalars: [u128; 2], points: [P256Point; 2]) -> P256Point {
     let p01 = points[0].add(&points[1]);
-    let p02 = points[0].add(&points[2]);
-    let p03 = points[0].add(&points[3]);
-    let p12 = points[1].add(&points[2]);
-    let p13 = points[1].add(&points[3]);
-    let p23 = points[2].add(&points[3]);
-    let p012 = p01.add(&points[2]);
-    let p013 = p01.add(&points[3]);
-    let p023 = p02.add(&points[3]);
-    let p123 = p12.add(&points[3]);
-    let p0123 = p012.add(&points[3]);
-
     let table = [
         P256Point::infinity(),
         points[0].clone(),
         points[1].clone(),
         p01,
-        points[2].clone(),
-        p02,
-        p12,
-        p012,
-        points[3].clone(),
-        p03,
-        p13,
-        p013,
-        p23,
-        p023,
-        p123,
-        p0123,
     ];
 
     let mut res = P256Point::infinity();
@@ -812,10 +794,13 @@ fn shamir_4x128(scalars: [u128; 4], points: [P256Point; 4]) -> P256Point {
 /// The guest verifies:
 ///   1. b1*u1 = a1 (mod n) and b2*u2 = a2 (mod n) -- scalar field checks
 ///   2. R1, R2 on curve -- point validity
-///   3. a1*G - b1*R1 + a2*Q - b2*R2 = O -- 4-scalar 128-bit Shamir (the main savings)
-///   4. (R1 + R2).x mod n == r -- ECDSA final check
+///   3. a1*G - b1*R1 = O -- 2-scalar 128-bit Shamir (binds R1 = u1*G)
+///   4. a2*Q - b2*R2 = O -- 2-scalar 128-bit Shamir (binds R2 = u2*Q)
+///   5. (R1 + R2).x mod n == r -- ECDSA final check
 ///
-/// This halves the doublings: 128 instead of 256, achieving ~1.7x speedup.
+/// Each scalar multiplication is verified independently to prevent
+/// cross-cancellation attacks. See:
+/// <https://ethresear.ch/t/fake-glv-you-dont-need-an-efficient-endomorphism-to-implement-glv-like-scalar-multiplication-in-snark-circuits/20394>
 ///
 /// All inputs are validated internally — no caller-side validation is required.
 #[inline(always)]
@@ -925,36 +910,40 @@ pub(crate) fn verify_ecdsa_inner(
         spoil_proof();
     }
 
-    // Reject trivial zero decomposition: a=0, b=0 satisfies b*u=a for any u,
-    // collapsing the Shamir MSM and leaving R1/R2 unconstrained.
+    // Reject trivial zero decomposition: a=0, b=0 makes the independent
+    // Shamirs return infinity trivially (0*P + 0*(-R) = O), bypassing the check.
     if b1_val == 0 || b2_val == 0 {
         spoil_proof();
     }
 
-    // Step 6: Prepare points for 4-scalar 128-bit Shamir
-    // We verify: a1*G + a2*Q - b1*R1 - b2*R2 = O
-    // Which is: a1*G + a2*Q + (-b1)*R1 + (-b2)*R2 = O
-    // Negate the sign of b1, b2 by negating the points R1, R2 if b is positive,
-    // or keeping them if b is negative (since -b * R = |b| * (-R))
-    let r1_adj = if b1_sign { r1.clone() } else { r1.neg() };
-    let r2_adj = if b2_sign { r2.clone() } else { r2.neg() };
+    // Step 6: Verify each scalar multiplication independently.
+    //
+    // Each R_i is bound by its OWN 2-scalar 128-bit Shamir MSM:
+    //   a_i * P - b_i * R_i = O  ⟹  R_i = (a_i / b_i) * P = u_i * P
+    //
+    // Combining both into a single 4-scalar check would give the prover a
+    // cross-cancellation degree of freedom (one equation, two free point
+    // variables). Independent checks eliminate this.
+    //
+    // Reference: https://ethresear.ch/t/fake-glv-you-dont-need-an-efficient-endomorphism-to-implement-glv-like-scalar-multiplication-in-snark-circuits/20394
 
-    // Scalars for the 4-scalar Shamir: a1, a2, |b1|, |b2| (all <= 128 bits)
-    let scalars = [a1_val, a2_val, b1_val, b2_val];
-    let points_arr = [
-        if a1_sign { g.neg() } else { g },
-        if a2_sign { q.neg() } else { q.clone() },
-        r1_adj,
-        r2_adj,
-    ];
-
-    // Step 7: 4-scalar 128-bit Shamir -- should equal O (infinity)
-    let check_point = shamir_4x128(scalars, points_arr);
-    if !check_point.is_infinity() {
+    // Check R1: a1*G - b1*R1 = O  (binds R1 = u1*G)
+    let r1_neg = if b1_sign { r1.clone() } else { r1.neg() };
+    let g_adj = if a1_sign { g.neg() } else { g };
+    let check1 = shamir_2x128([a1_val, b1_val], [g_adj, r1_neg]);
+    if !check1.is_infinity() {
         spoil_proof();
     }
 
-    // Step 8: Check (R1 + R2).x mod n == r
+    // Check R2: a2*Q - b2*R2 = O  (binds R2 = u2*Q)
+    let r2_neg = if b2_sign { r2.clone() } else { r2.neg() };
+    let q_adj = if a2_sign { q.neg() } else { q.clone() };
+    let check2 = shamir_2x128([a2_val, b2_val], [q_adj, r2_neg]);
+    if !check2.is_infinity() {
+        spoil_proof();
+    }
+
+    // Step 7: Check (R1 + R2).x mod n == r
     let r_sum = r1.add(&r2);
     if r_sum.is_infinity() {
         return Err(P256Error::RxMismatch);

--- a/jolt-inlines/p256/src/tests.rs
+++ b/jolt-inlines/p256/src/tests.rs
@@ -1119,6 +1119,42 @@ mod p256_tests {
         assert!(matches!(result, Err(P256Error::ROrSZero)));
     }
 
+    /// Verify that a cross-cancellation attack with correlated forged advice is
+    /// rejected by the independent per-point Shamir checks.
+    ///
+    /// The attack supplies R1=2G, R2=3G with correlated decompositions that
+    /// satisfy a combined 4-scalar equation but NOT the independent per-point
+    /// equations. With the old combined check, the weighted sum cancels:
+    ///   1*G + (-2)*G - 1*(2G) + 1*(3G) = O
+    /// But each independent check fails:
+    ///   a1*G - b1*R1 = 1*G - 1*(2G) = -G ≠ O
+    #[test]
+    #[should_panic(expected = "proof spoiled")]
+    fn test_cross_cancellation_attack_rejected() {
+        use crate::sdk::{verify_ecdsa_inner, P256Fr, P256Point};
+
+        let g = P256Point::generator();
+        let two = P256Fr::from_u64_arr(&[2, 0, 0, 0]).unwrap();
+        let one = P256Fr::from_u64_arr(&[1, 0, 0, 0]).unwrap();
+
+        let two_g = g.double();
+        let three_g = g.double_and_add(&g);
+        let five_g = two_g.double_and_add(&g);
+
+        let n = limbs_to_biguint(&P256_ORDER);
+        let mut r_big = limbs_to_biguint(&five_g.x().e());
+        if r_big >= n {
+            r_big -= &n;
+        }
+        let r_fr = P256Fr::from_u64_arr(&biguint_to_limbs(&r_big)).unwrap();
+
+        // u1 = z/s = 1, u2 = r/s = 2 (with s = r/2, z = s)
+        let _ = verify_ecdsa_inner(
+            &one, &two, &r_fr, &g, two_g, 1, false, 1, false, // R1=2G, a1=1, b1=1
+            three_g, 2, true, 1, true, // R2=3G, a2=-2, b2=-1
+        );
+    }
+
     /// Verify that a zero GLV decomposition (a=0, b=0) is rejected.
     ///
     /// A malicious prover could supply a=0, b=0 as the Fake GLV decomposition,


### PR DESCRIPTION
```
P-256 Fake-GLV advice can be forged to prove an invalid signature end-to-end
```

The previous 4-scalar combined Shamir check (a1*G + a2*Q - b1*R1 - b2*R2 = O) had a cross-cancellation vulnerability.
Replace with two independent 2-scalar 128-bit Shamirs that bind each point individually, matching the original Fake GLV construction.

Performance: ~497K cycles vs 3.8M native p256 crate. Still 7.7x faster than native.

Reference: https://ethresear.ch/t/fake-glv-you-dont-need-an-efficient-endomorphism-to-implement-glv-like-scalar-multiplication-in-snark-circuits/20394