### PR TITLE
fix(jolt-core): DIVW/REMW completeness — pass full 64-bit regs to ChangeDivisorW

### DIFF
--- a/jolt-core/src/zkvm/instruction/virtual_change_divisor_w.rs
+++ b/jolt-core/src/zkvm/instruction/virtual_change_divisor_w.rs
@@ -34,15 +34,13 @@ impl Flags for VirtualChangeDivisorW {
 
 impl<const XLEN: usize> LookupQuery<XLEN> for RISCVCycle<VirtualChangeDivisorW> {
     fn to_instruction_inputs(&self) -> (u64, i128) {
-        // Always treat as 32-bit values for W instructions
-        (
-            self.register_state.rs1 as u32 as u64,
-            self.register_state.rs2 as u32 as i128,
-        )
+        (self.register_state.rs1, self.register_state.rs2 as i128)
     }
 
     fn to_lookup_output(&self) -> u64 {
         let (dividend, divisor) = LookupQuery::<XLEN>::to_instruction_inputs(self);
+        // `as i32` truncates to the low 32 bits of each operand — the
+        // `W` semantics.
         let dividend = dividend as i32;
         let divisor = divisor as i32;
 


### PR DESCRIPTION
## Summary

Fixes a Stage 3 `SumcheckVerificationError` for **every** DIVW/REMW execution where the dividend or divisor has non-zero high-32-bits in its 64-bit register — which is universally the case for negative `i32` operands after Jolt's preceding `VirtualSignExtendWord`. Observed externally on the eth-act/zkevm-test-monitor harness for ACT4's `M-divw-00` and `M-remw-00` tests.

## Root cause

Stage 3's `InstructionInputSumcheck` enforces

```
LeftInstructionInput  = LeftOperandIsRs1Value  * Rs1Value
RightInstructionInput = RightOperandIsRs2Value * Rs2Value
```

where `Rs1Value` / `Rs2Value` come from `cycle.rs{1,2}_read().1` — the **full 64-bit** register values. But `VirtualChangeDivisorW::to_instruction_inputs` was narrowing:

```rust
(self.register_state.rs1 as u32 as u64, self.register_state.rs2 as u32 as i128)
```

This wrote a zero-extended low-32-bit value into the R1CS `LeftInstructionInput`/`RightInstructionInput` polynomials, while Stage 3 reconstructed those as `1 * <full 64-bit rs_value>`. Sumcheck → mismatch → prove succeeds, verify fails.

`VirtualChangeDivisorW` was the only `to_instruction_inputs` override in jolt-core for XLEN=64 that did this kind of truncation; MUL/ADD/SUB/XOR and the non-W `VirtualChangeDivisor` all return full 64-bit for XLEN=64. The truncation belongs inside the lookup table's arithmetic, which does it via `as i32`, not at the Stage-3 boundary.

## Fix

Return full 64-bit rs1/rs2 from `to_instruction_inputs`, matching every other XLEN=64 op. Soundness is preserved because the `VirtualChangeDivisorWTable` MLE only references bit positions corresponding to the low 32 bits of each operand (I traced this against the big-endian `r[]` convention and confirmed against the XLEN=8 `mle_full_hypercube` test); the lookup output is unchanged by this fix.

`to_lookup_output` already narrows via `as i32` — still correct either way.