### PR TITLE
test: fuzz-check instruction inputs against instruction input constraints

### DIFF
--- a/jolt-core/src/zkvm/instruction/test.rs
+++ b/jolt-core/src/zkvm/instruction/test.rs
@@ -139,6 +139,100 @@ mod flags {
     }
 }
 
+/// Fuzz-check that every instruction's `LookupQuery::to_instruction_inputs`
+/// agrees with the instruction input R1CS constraints:
+///
+///   left_input  = LeftOperandIsRs1Value  · Rs1Value     + LeftOperandIsPC   · UnexpandedPC
+///   right_input = RightOperandIsRs2Value · Rs2Value     + RightOperandIsImm · Imm
+///
+/// Source of truth for the constraint:
+/// `jolt-core/src/zkvm/spartan/instruction_input.rs::output_claim_constraint`.
+///
+/// A mismatch here means the trace witness polynomials `LeftInstructionInput` /
+/// `RightInstructionInput` disagree with what the constraint reconstructs from
+/// `Rs1Value` / `Rs2Value` / `Imm` / `UnexpandedPC` — causing a Stage 3 sumcheck
+/// verification failure whenever any high-order bits of a register value are set.
+mod r1cs_consistency {
+    use common::constants::XLEN;
+    use rand::{rngs::StdRng, SeedableRng};
+    use strum::IntoEnumIterator;
+    use tracer::instruction::Cycle;
+
+    use crate::zkvm::instruction::{Flags, InstructionFlags, LookupQuery, SupportedInstruction};
+
+    #[test]
+    fn instruction_inputs_match_constraint() {
+        let mut rng = StdRng::seed_from_u64(12345);
+        let mut failures: Vec<String> = Vec::new();
+
+        for default_cycle in Cycle::iter() {
+            // Skip enum variants without LookupQuery/Flags impls in jolt-core.
+            // These are either the structural variants (NoOp, INLINE) or
+            // architectural instructions that are always lowered to a virtual
+            // sequence before appearing in a trace (DIV, LW, AMOSWAP.W, ...).
+            let default_instr = default_cycle.instruction();
+            if !default_instr.is_supported_instruction() {
+                continue;
+            }
+            let variant: &'static str = (&default_instr).into();
+            let mut first_failure_for_variant: Option<String> = None;
+
+            for _ in 0..10_000 {
+                let cycle = default_cycle.random(&mut rng);
+                let instr = cycle.instruction();
+                let flags = instr.instruction_flags();
+                let norm = instr.normalize();
+
+                let rs1 = cycle.rs1_read().map(|(_, v)| v).unwrap_or(0);
+                let rs2 = cycle.rs2_read().map(|(_, v)| v).unwrap_or(0);
+                let unexpanded_pc = norm.address as u64;
+                let imm = norm.operands.imm;
+
+                let left_expected: u64 = if flags[InstructionFlags::LeftOperandIsRs1Value] {
+                    rs1
+                } else if flags[InstructionFlags::LeftOperandIsPC] {
+                    unexpanded_pc
+                } else {
+                    0
+                };
+                let right_expected: i128 = if flags[InstructionFlags::RightOperandIsRs2Value] {
+                    rs2 as i128
+                } else if flags[InstructionFlags::RightOperandIsImm] {
+                    imm
+                } else {
+                    0
+                };
+
+                let (left_actual, right_actual) =
+                    LookupQuery::<XLEN>::to_instruction_inputs(&cycle);
+
+                if left_actual != left_expected || right_actual != right_expected {
+                    first_failure_for_variant.get_or_insert_with(|| {
+                        format!(
+                            "{variant}: left actual={left_actual:#x} expected={left_expected:#x}; \
+                             right actual={right_actual} expected={right_expected}; \
+                             flags={flags:?}, rs1={rs1:#x}, rs2={rs2:#x}, \
+                             unexpanded_pc={unexpanded_pc:#x}, imm={imm}"
+                        )
+                    });
+                    break;
+                }
+            }
+            if let Some(msg) = first_failure_for_variant {
+                failures.push(msg);
+            }
+        }
+
+        if !failures.is_empty() {
+            panic!(
+                "{} instruction(s) violate the instruction input constraints:\n\n{}",
+                failures.len(),
+                failures.join("\n\n")
+            );
+        }
+    }
+}
+
 pub fn lookup_output_matches_trace_test<T>()
 where
     T: InstructionLookup<XLEN> + RISCVInstruction + RISCVTrace + Default + Flags + 'static,

--- a/jolt-core/src/zkvm/instruction/virtual_pow2.rs
+++ b/jolt-core/src/zkvm/instruction/virtual_pow2.rs
@@ -27,7 +27,6 @@ impl Flags for VirtualPow2 {
     fn instruction_flags(&self) -> [bool; NUM_INSTRUCTION_FLAGS] {
         let mut flags = [false; NUM_INSTRUCTION_FLAGS];
         flags[InstructionFlags::LeftOperandIsRs1Value] = true;
-        flags[InstructionFlags::RightOperandIsImm] = true;
         flags
     }
 }

--- a/jolt-core/src/zkvm/instruction/virtual_shift_right_bitmask.rs
+++ b/jolt-core/src/zkvm/instruction/virtual_shift_right_bitmask.rs
@@ -27,7 +27,6 @@ impl Flags for VirtualShiftRightBitmask {
     fn instruction_flags(&self) -> [bool; NUM_INSTRUCTION_FLAGS] {
         let mut flags = [false; NUM_INSTRUCTION_FLAGS];
         flags[InstructionFlags::LeftOperandIsRs1Value] = true;
-        flags[InstructionFlags::RightOperandIsImm] = true;
         flags
     }
 }

--- a/tracer/src/instruction/mod.rs
+++ b/tracer/src/instruction/mod.rs
@@ -545,6 +545,20 @@ macro_rules! define_rv32im_enums {
                     Cycle::INLINE(cycle) => cycle.instruction.into(),
                 }
             }
+
+            /// Returns a freshly randomized cycle of the same variant.
+            /// Used by jolt-core fuzz tests that need to iterate all
+            /// instruction variants via `Cycle::iter()`.
+            #[cfg(any(feature = "test-utils", test))]
+            pub fn random(&self, rng: &mut rand::rngs::StdRng) -> Self {
+                match self {
+                    Cycle::NoOp => Cycle::NoOp,
+                    $(
+                        Cycle::$instr(cycle) => Cycle::$instr(cycle.random(rng)),
+                    )*
+                    Cycle::INLINE(cycle) => Cycle::INLINE(cycle.random(rng)),
+                }
+            }
         }
 
         impl Instruction {


### PR DESCRIPTION
## Summary

- Adds a blanket `Cycle::iter()`-driven fuzz test (10k random cycles × every supported instruction) that cross-checks `LookupQuery::to_instruction_inputs` against the Stage 3 `InstructionInputSumcheck` constraint from `jolt-core/src/zkvm/spartan/instruction_input.rs`:
  ```
  left_input  = LeftOperandIsRs1Value  · Rs1Value    + LeftOperandIsPC   · UnexpandedPC
  right_input = RightOperandIsRs2Value · Rs2Value    + RightOperandIsImm · Imm
  ```
- Directly targets the bug class from #1468 (DIVW/REMW): an instruction's `to_instruction_inputs` returning a narrower / different value than what the R1CS reconstructs from `Rs1Value` / `Rs2Value` / `Imm` / `UnexpandedPC`, which causes a Stage 3 sumcheck verification failure.
- Fixes two instances the new test surfaced: `VirtualPow2` and `VirtualShiftRightBitmask` each declared `RightOperandIsImm = true` but returned `(rs1, 0)` from `to_instruction_inputs`.

**Note — the VirtualPow2 / VirtualShiftRightBitmask cases are *not* directly exploitable.** Every current emitter (`SLL` for `VirtualPow2`; `SRA`, `SRAW`, `SRL`, `SRLW` for `VirtualShiftRightBitmask`) already hardcodes `imm = 0` at the call site, so the constraint `right_input = 1 · imm = 0` happens to match the zero witness. What this PR removes is the latent **contract requirement** that every future caller also pass `imm = 0` — a hazard that would have silently broken verification for any caller that deviated, just as it did for `VirtualChangeDivisorW`. Aligning the flag declaration with the instruction's actual semantics (neither `Pow2` nor `ShiftRightBitmask` uses the immediate) eliminates the requirement.

### Files changed

- `tracer/src/instruction/mod.rs` — add `Cycle::random(&self, rng)` dispatcher in `define_rv32im_enums!` (enables the blanket test to iterate all variants).
- `jolt-core/src/zkvm/instruction/test.rs` — add `mod r1cs_consistency` with a single `#[test]` that collects all mismatches before failing (so first-run output gives the full picture).
- `jolt-core/src/zkvm/instruction/virtual_pow2.rs` — drop `RightOperandIsImm` flag.
- `jolt-core/src/zkvm/instruction/virtual_shift_right_bitmask.rs` — drop `RightOperandIsImm` flag.

New instructions will be covered by the fuzz test automatically (no per-instruction registration required).

## Test plan

- [x] `cargo nextest run -p jolt-core r1cs_consistency --features host` — passes (was failing on the two flag bugs before the fix).
- [x] `cargo nextest run -p jolt-core virtual_pow2::test:: virtual_shift_right_bitmask::test:: --features host` — existing per-instruction tests still pass.
- [x] `cargo nextest run -p jolt-core muldiv_e2e_dory --features host` — passes.
- [x] `cargo nextest run -p jolt-core muldiv_e2e_dory --features host,zk` — passes.
- [x] `cargo clippy -p jolt-core --features host --all-targets -- -D warnings` — clean.
- [x] `cargo clippy -p jolt-core --features host,zk --all-targets -- -D warnings` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)