### PR TITLE
Eval/arkworks algebra

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2776,6 +2776,7 @@ dependencies = [
  "eyre",
  "jolt-core",
  "jolt-eval-macros",
+ "jolt-field",
  "jolt-inlines-secp256k1",
  "jolt-inlines-sha2",
  "postcard",

--- a/jolt-eval/Cargo.toml
+++ b/jolt-eval/Cargo.toml
@@ -39,11 +39,27 @@ name = "bind_parallel_high_to_low"
 harness = false
 
 [[bench]]
-name = "naive_sort_time"
+name = "bind_parallel_low_to_high"
 harness = false
 
 [[bench]]
-name = "bind_parallel_low_to_high"
+name = "field_mul_i128"
+harness = false
+
+[[bench]]
+name = "field_mul_i64"
+harness = false
+
+[[bench]]
+name = "field_mul_u128"
+harness = false
+
+[[bench]]
+name = "field_mul_u64"
+harness = false
+
+[[bench]]
+name = "naive_sort_time"
 harness = false
 
 [[bench]]

--- a/jolt-eval/Cargo.toml
+++ b/jolt-eval/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 
 [dependencies]
 jolt-core = { workspace = true, features = ["host"] }
+jolt-field = { workspace = true }
 common = { workspace = true, features = ["std"] }
 tracer = { workspace = true }
 

--- a/jolt-eval/benches/field_mul_i128.rs
+++ b/jolt-eval/benches/field_mul_i128.rs
@@ -1,0 +1,2 @@
+use jolt_eval::objective::performance::field_mul::MulI128Objective;
+jolt_eval::bench_objective!(MulI128Objective);

--- a/jolt-eval/benches/field_mul_i64.rs
+++ b/jolt-eval/benches/field_mul_i64.rs
@@ -1,0 +1,2 @@
+use jolt_eval::objective::performance::field_mul::MulI64Objective;
+jolt_eval::bench_objective!(MulI64Objective);

--- a/jolt-eval/benches/field_mul_u128.rs
+++ b/jolt-eval/benches/field_mul_u128.rs
@@ -1,0 +1,2 @@
+use jolt_eval::objective::performance::field_mul::MulU128Objective;
+jolt_eval::bench_objective!(MulU128Objective);

--- a/jolt-eval/benches/field_mul_u64.rs
+++ b/jolt-eval/benches/field_mul_u64.rs
@@ -1,0 +1,2 @@
+use jolt_eval::objective::performance::field_mul::MulU64Objective;
+jolt_eval::bench_objective!(MulU64Objective);

--- a/jolt-eval/src/invariant/field_mul_scalar.rs
+++ b/jolt-eval/src/invariant/field_mul_scalar.rs
@@ -1,0 +1,171 @@
+use arbitrary::{Arbitrary, Unstructured};
+use jolt_field::arkworks::bn254::Fr;
+use jolt_field::Field;
+
+use crate::invariant::{CheckError, Invariant, InvariantViolation};
+
+/// Input for the field scalar-multiplication invariant.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, schemars::JsonSchema)]
+pub struct FieldMulScalarInput {
+    #[schemars(with = "[u8; 32]")]
+    pub field: Fr,
+    pub u64_scalar: u64,
+    pub i64_scalar: i64,
+    pub u128_scalar: u128,
+    pub i128_scalar: i128,
+}
+
+impl<'a> Arbitrary<'a> for FieldMulScalarInput {
+    fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
+        let bytes: [u8; 32] = u.arbitrary()?;
+        Ok(Self {
+            field: Fr::from_le_bytes_mod_order(&bytes),
+            u64_scalar: u.arbitrary()?,
+            i64_scalar: u.arbitrary()?,
+            u128_scalar: u.arbitrary()?,
+            i128_scalar: u.arbitrary()?,
+        })
+    }
+}
+
+/// `Field::mul_{u64,i64,u128,i128}` must agree with the reference
+/// formula `self * Self::from_*(scalar)` for every input.
+#[jolt_eval_macros::invariant(Test, Fuzz)]
+#[derive(Default)]
+pub struct FieldMulScalarInvariant;
+
+impl Invariant for FieldMulScalarInvariant {
+    type Setup = ();
+    type Input = FieldMulScalarInput;
+
+    fn name(&self) -> &str {
+        "field_mul_scalar"
+    }
+
+    fn description(&self) -> String {
+        "The optimized Field::mul_{u64,i64,u128,i128} methods on BN254 Fr \
+         must produce the same result as the reference `self * Self::from_*(n)`."
+            .to_string()
+    }
+
+    fn setup(&self) {}
+
+    fn check(&self, _setup: &(), input: FieldMulScalarInput) -> Result<(), CheckError> {
+        let f = input.field;
+
+        // mul_u64
+        let got = f.mul_u64(input.u64_scalar);
+        let expected = f * Fr::from_u64(input.u64_scalar);
+        if got != expected {
+            return Err(CheckError::Violation(InvariantViolation::with_details(
+                "mul_u64 mismatch",
+                format!(
+                    "field={f:?}, scalar={}, got={got:?}, expected={expected:?}",
+                    input.u64_scalar
+                ),
+            )));
+        }
+
+        // mul_i64
+        let got = f.mul_i64(input.i64_scalar);
+        let expected = f * Fr::from_i64(input.i64_scalar);
+        if got != expected {
+            return Err(CheckError::Violation(InvariantViolation::with_details(
+                "mul_i64 mismatch",
+                format!(
+                    "field={f:?}, scalar={}, got={got:?}, expected={expected:?}",
+                    input.i64_scalar
+                ),
+            )));
+        }
+
+        // mul_u128
+        let got = f.mul_u128(input.u128_scalar);
+        let expected = f * Fr::from_u128(input.u128_scalar);
+        if got != expected {
+            return Err(CheckError::Violation(InvariantViolation::with_details(
+                "mul_u128 mismatch",
+                format!(
+                    "field={f:?}, scalar={}, got={got:?}, expected={expected:?}",
+                    input.u128_scalar
+                ),
+            )));
+        }
+
+        // mul_i128
+        let got = f.mul_i128(input.i128_scalar);
+        let expected = f * Fr::from_i128(input.i128_scalar);
+        if got != expected {
+            return Err(CheckError::Violation(InvariantViolation::with_details(
+                "mul_i128 mismatch",
+                format!(
+                    "field={f:?}, scalar={}, got={got:?}, expected={expected:?}",
+                    input.i128_scalar
+                ),
+            )));
+        }
+
+        Ok(())
+    }
+
+    fn seed_corpus(&self) -> Vec<FieldMulScalarInput> {
+        vec![
+            // Zero field element, zero scalars
+            FieldMulScalarInput {
+                field: Fr::from_u64(0),
+                u64_scalar: 0,
+                i64_scalar: 0,
+                u128_scalar: 0,
+                i128_scalar: 0,
+            },
+            // Identity
+            FieldMulScalarInput {
+                field: Fr::from_u64(1),
+                u64_scalar: 1,
+                i64_scalar: 1,
+                u128_scalar: 1,
+                i128_scalar: 1,
+            },
+            // Max unsigned scalars
+            FieldMulScalarInput {
+                field: Fr::from_u64(42),
+                u64_scalar: u64::MAX,
+                i64_scalar: i64::MAX,
+                u128_scalar: u128::MAX,
+                i128_scalar: i128::MAX,
+            },
+            // Min signed scalars
+            FieldMulScalarInput {
+                field: Fr::from_u64(7),
+                u64_scalar: 0,
+                i64_scalar: i64::MIN,
+                u128_scalar: 0,
+                i128_scalar: i128::MIN,
+            },
+            // -1 scalars (should yield field negation)
+            FieldMulScalarInput {
+                field: Fr::from_u64(123_456_789),
+                u64_scalar: 0,
+                i64_scalar: -1,
+                u128_scalar: 0,
+                i128_scalar: -1,
+            },
+            // Large field element (high bits set)
+            FieldMulScalarInput {
+                field: Fr::from_i64(-1),
+                u64_scalar: u64::MAX,
+                i64_scalar: i64::MIN,
+                u128_scalar: u128::MAX,
+                i128_scalar: i128::MIN,
+            },
+            // Zero field element, non-trivial scalars
+            FieldMulScalarInput {
+                field: Fr::from_u64(0),
+                u64_scalar: 42,
+                i64_scalar: -42,
+                u128_scalar: 42,
+                i128_scalar: -42,
+            },
+        ]
+    }
+}

--- a/jolt-eval/src/invariant/mod.rs
+++ b/jolt-eval/src/invariant/mod.rs
@@ -1,5 +1,6 @@
 #[cfg(test)]
 mod macro_tests;
+pub mod field_mul_scalar;
 pub mod soundness;
 pub mod split_eq_bind;
 pub mod synthesis;
@@ -133,6 +134,7 @@ pub trait InvariantTargets {
 pub enum JoltInvariants {
     SplitEqBindLowHigh(split_eq_bind::SplitEqBindLowHighInvariant),
     SplitEqBindHighLow(split_eq_bind::SplitEqBindHighLowInvariant),
+    FieldMulScalar(field_mul_scalar::FieldMulScalarInvariant),
     Soundness(soundness::SoundnessInvariant),
 }
 
@@ -141,6 +143,7 @@ macro_rules! dispatch {
         match $self {
             JoltInvariants::SplitEqBindLowHigh($inv) => $body,
             JoltInvariants::SplitEqBindHighLow($inv) => $body,
+            JoltInvariants::FieldMulScalar($inv) => $body,
             JoltInvariants::Soundness($inv) => $body,
         }
     };
@@ -151,6 +154,7 @@ impl JoltInvariants {
         vec![
             Self::SplitEqBindLowHigh(split_eq_bind::SplitEqBindLowHighInvariant),
             Self::SplitEqBindHighLow(split_eq_bind::SplitEqBindHighLowInvariant),
+            Self::FieldMulScalar(field_mul_scalar::FieldMulScalarInvariant),
             Self::Soundness(soundness::SoundnessInvariant),
         ]
     }

--- a/jolt-eval/src/invariant/mod.rs
+++ b/jolt-eval/src/invariant/mod.rs
@@ -1,6 +1,6 @@
+pub mod field_mul_scalar;
 #[cfg(test)]
 mod macro_tests;
-pub mod field_mul_scalar;
 pub mod soundness;
 pub mod split_eq_bind;
 pub mod synthesis;

--- a/jolt-eval/src/objective/mod.rs
+++ b/jolt-eval/src/objective/mod.rs
@@ -138,6 +138,10 @@ pub enum PerformanceObjective {
     BindLowToHigh(performance::binding::BindLowToHighObjective),
     BindHighToLow(performance::binding::BindHighToLowObjective),
     NaiveSortTime(performance::naive_sort::NaiveSortObjective),
+    MulU64(performance::field_mul::MulU64Objective),
+    MulI64(performance::field_mul::MulI64Objective),
+    MulU128(performance::field_mul::MulU128Objective),
+    MulI128(performance::field_mul::MulI128Objective),
 }
 
 impl PerformanceObjective {
@@ -146,6 +150,10 @@ impl PerformanceObjective {
             Self::BindLowToHigh(performance::binding::BindLowToHighObjective),
             Self::BindHighToLow(performance::binding::BindHighToLowObjective),
             Self::NaiveSortTime(performance::naive_sort::NaiveSortObjective),
+            Self::MulU64(performance::field_mul::MulU64Objective),
+            Self::MulI64(performance::field_mul::MulI64Objective),
+            Self::MulU128(performance::field_mul::MulU128Objective),
+            Self::MulI128(performance::field_mul::MulI128Objective),
         ]
     }
 
@@ -154,6 +162,10 @@ impl PerformanceObjective {
             Self::BindLowToHigh(o) => o.name(),
             Self::BindHighToLow(o) => o.name(),
             Self::NaiveSortTime(o) => o.name(),
+            Self::MulU64(o) => o.name(),
+            Self::MulI64(o) => o.name(),
+            Self::MulU128(o) => o.name(),
+            Self::MulI128(o) => o.name(),
         }
     }
 
@@ -162,6 +174,10 @@ impl PerformanceObjective {
             Self::BindLowToHigh(o) => o.units(),
             Self::BindHighToLow(o) => o.units(),
             Self::NaiveSortTime(o) => o.units(),
+            Self::MulU64(o) => o.units(),
+            Self::MulI64(o) => o.units(),
+            Self::MulU128(o) => o.units(),
+            Self::MulI128(o) => o.units(),
         }
     }
 
@@ -170,6 +186,10 @@ impl PerformanceObjective {
             Self::BindLowToHigh(o) => o.description(),
             Self::BindHighToLow(o) => o.description(),
             Self::NaiveSortTime(o) => o.description(),
+            Self::MulU64(o) => o.description(),
+            Self::MulI64(o) => o.description(),
+            Self::MulU128(o) => o.description(),
+            Self::MulI128(o) => o.description(),
         }
     }
 
@@ -177,6 +197,9 @@ impl PerformanceObjective {
         match self {
             Self::BindLowToHigh(_) | Self::BindHighToLow(_) => &["jolt-core/"],
             Self::NaiveSortTime(_) => &["jolt-eval/src/sort_targets.rs"],
+            Self::MulU64(_) | Self::MulI64(_) | Self::MulU128(_) | Self::MulI128(_) => {
+                &["crates/jolt-field/"]
+            }
         }
     }
 }
@@ -193,6 +216,7 @@ pub use code_quality::cognitive::COGNITIVE_COMPLEXITY;
 pub use code_quality::halstead_bugs::HALSTEAD_BUGS;
 pub use code_quality::lloc::LLOC;
 pub use performance::binding::{BIND_HIGH_TO_LOW, BIND_LOW_TO_HIGH};
+pub use performance::field_mul::{MUL_I128, MUL_I64, MUL_U128, MUL_U64};
 pub use performance::naive_sort::NAIVE_SORT_TIME;
 
 impl OptimizationObjective {

--- a/jolt-eval/src/objective/objective_fn/mod.rs
+++ b/jolt-eval/src/objective/objective_fn/mod.rs
@@ -4,7 +4,7 @@ use crate::agent::DiffScope;
 
 use super::{
     OptimizationObjective, BIND_HIGH_TO_LOW, BIND_LOW_TO_HIGH, COGNITIVE_COMPLEXITY, HALSTEAD_BUGS,
-    LLOC, NAIVE_SORT_TIME,
+    LLOC, MUL_I128, MUL_I64, MUL_U128, MUL_U64, NAIVE_SORT_TIME,
 };
 
 /// A concrete objective function that the optimizer minimizes.
@@ -35,6 +35,10 @@ impl ObjectiveFunction {
             MINIMIZE_BIND_LOW_TO_HIGH,
             MINIMIZE_BIND_HIGH_TO_LOW,
             MINIMIZE_NAIVE_SORT_TIME,
+            MINIMIZE_MUL_U64,
+            MINIMIZE_MUL_I64,
+            MINIMIZE_MUL_U128,
+            MINIMIZE_MUL_I128,
         ]
     }
 
@@ -96,6 +100,30 @@ pub const MINIMIZE_NAIVE_SORT_TIME: ObjectiveFunction = ObjectiveFunction {
     name: "minimize_naive_sort_time",
     inputs: &[NAIVE_SORT_TIME],
     evaluate: |m, _| m.get(&NAIVE_SORT_TIME).copied().unwrap_or(f64::INFINITY),
+};
+
+pub const MINIMIZE_MUL_U64: ObjectiveFunction = ObjectiveFunction {
+    name: "minimize_mul_u64",
+    inputs: &[MUL_U64],
+    evaluate: |m, _| m.get(&MUL_U64).copied().unwrap_or(f64::INFINITY),
+};
+
+pub const MINIMIZE_MUL_I64: ObjectiveFunction = ObjectiveFunction {
+    name: "minimize_mul_i64",
+    inputs: &[MUL_I64],
+    evaluate: |m, _| m.get(&MUL_I64).copied().unwrap_or(f64::INFINITY),
+};
+
+pub const MINIMIZE_MUL_U128: ObjectiveFunction = ObjectiveFunction {
+    name: "minimize_mul_u128",
+    inputs: &[MUL_U128],
+    evaluate: |m, _| m.get(&MUL_U128).copied().unwrap_or(f64::INFINITY),
+};
+
+pub const MINIMIZE_MUL_I128: ObjectiveFunction = ObjectiveFunction {
+    name: "minimize_mul_i128",
+    inputs: &[MUL_I128],
+    evaluate: |m, _| m.get(&MUL_I128).copied().unwrap_or(f64::INFINITY),
 };
 
 #[cfg(test)]

--- a/jolt-eval/src/objective/optimize.rs
+++ b/jolt-eval/src/objective/optimize.rs
@@ -377,8 +377,7 @@ fn build_optimize_prompt(
          3. Focus your changes on the paths listed above -- do NOT modify `jolt-eval/` unless \
             it is explicitly listed.\n\
          4. Prefer changes that are safe, correct, and unlikely to break invariants.\n\
-         5. Run `cargo clippy -p jolt-core --features host --message-format=short -q` \
-            to verify your changes compile.\n\
+         5. Run clippy to verify your changes compile.\n\
          6. Summarize what you changed and why you expect improvement.\n\n",
     );
 

--- a/jolt-eval/src/objective/performance/field_mul.rs
+++ b/jolt-eval/src/objective/performance/field_mul.rs
@@ -14,39 +14,13 @@ pub const MUL_I128: OptimizationObjective =
 
 const NUM_ITERS: usize = 10_000;
 
-struct MulShared {
-    field: Fr,
-    u64_scalar: u64,
-    i64_scalar: i64,
-    u128_scalar: u128,
-    i128_scalar: i128,
-}
-
-impl MulShared {
-    fn new() -> Self {
-        let mut rng = rand::thread_rng();
-        Self {
-            field: Fr::random(&mut rng),
-            u64_scalar: rand::Rng::gen(&mut rng),
-            i64_scalar: rand::Rng::gen(&mut rng),
-            u128_scalar: rand::Rng::gen(&mut rng),
-            i128_scalar: rand::Rng::gen(&mut rng),
-        }
-    }
-}
-
 // -- mul_u64 --
-
-pub struct MulU64Setup {
-    pub field: Fr,
-    pub scalar: u64,
-}
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, Hash)]
 pub struct MulU64Objective;
 
 impl Objective for MulU64Objective {
-    type Setup = MulU64Setup;
+    type Setup = (Fr, u64);
 
     fn name(&self) -> &str {
         "field_mul_u64"
@@ -56,18 +30,16 @@ impl Objective for MulU64Objective {
         format!("Wall-clock time of Field::mul_u64 ({NUM_ITERS} iterations)")
     }
 
-    fn setup(&self) -> MulU64Setup {
-        thread_local! { static SHARED: MulShared = MulShared::new(); }
-        SHARED.with(|s| MulU64Setup {
-            field: s.field,
-            scalar: s.u64_scalar,
-        })
+    fn setup(&self) -> Self::Setup {
+        let mut rng = rand::thread_rng();
+        (Fr::random(&mut rng), rand::Rng::gen(&mut rng))
     }
 
-    fn run(&self, setup: MulU64Setup) {
-        let mut acc = setup.field;
+    fn run(&self, setup: Self::Setup) {
+        let (field, scalar) = setup;
+        let mut acc = field;
         for _ in 0..NUM_ITERS {
-            acc = acc.mul_u64(setup.scalar);
+            acc = acc.mul_u64(scalar);
         }
         std::hint::black_box(acc);
     }
@@ -79,16 +51,11 @@ impl Objective for MulU64Objective {
 
 // -- mul_i64 --
 
-pub struct MulI64Setup {
-    pub field: Fr,
-    pub scalar: i64,
-}
-
 #[derive(Clone, Copy, Default, PartialEq, Eq, Hash)]
 pub struct MulI64Objective;
 
 impl Objective for MulI64Objective {
-    type Setup = MulI64Setup;
+    type Setup = (Fr, i64);
 
     fn name(&self) -> &str {
         "field_mul_i64"
@@ -98,18 +65,16 @@ impl Objective for MulI64Objective {
         format!("Wall-clock time of Field::mul_i64 ({NUM_ITERS} iterations)")
     }
 
-    fn setup(&self) -> MulI64Setup {
-        thread_local! { static SHARED: MulShared = MulShared::new(); }
-        SHARED.with(|s| MulI64Setup {
-            field: s.field,
-            scalar: s.i64_scalar,
-        })
+    fn setup(&self) -> Self::Setup {
+        let mut rng = rand::thread_rng();
+        (Fr::random(&mut rng), rand::Rng::gen(&mut rng))
     }
 
-    fn run(&self, setup: MulI64Setup) {
-        let mut acc = setup.field;
+    fn run(&self, setup: Self::Setup) {
+        let (field, scalar) = setup;
+        let mut acc = field;
         for _ in 0..NUM_ITERS {
-            acc = acc.mul_i64(setup.scalar);
+            acc = acc.mul_i64(scalar);
         }
         std::hint::black_box(acc);
     }
@@ -121,16 +86,11 @@ impl Objective for MulI64Objective {
 
 // -- mul_u128 --
 
-pub struct MulU128Setup {
-    pub field: Fr,
-    pub scalar: u128,
-}
-
 #[derive(Clone, Copy, Default, PartialEq, Eq, Hash)]
 pub struct MulU128Objective;
 
 impl Objective for MulU128Objective {
-    type Setup = MulU128Setup;
+    type Setup = (Fr, u128);
 
     fn name(&self) -> &str {
         "field_mul_u128"
@@ -140,18 +100,16 @@ impl Objective for MulU128Objective {
         format!("Wall-clock time of Field::mul_u128 ({NUM_ITERS} iterations)")
     }
 
-    fn setup(&self) -> MulU128Setup {
-        thread_local! { static SHARED: MulShared = MulShared::new(); }
-        SHARED.with(|s| MulU128Setup {
-            field: s.field,
-            scalar: s.u128_scalar,
-        })
+    fn setup(&self) -> Self::Setup {
+        let mut rng = rand::thread_rng();
+        (Fr::random(&mut rng), rand::Rng::gen(&mut rng))
     }
 
-    fn run(&self, setup: MulU128Setup) {
-        let mut acc = setup.field;
+    fn run(&self, setup: Self::Setup) {
+        let (field, scalar) = setup;
+        let mut acc = field;
         for _ in 0..NUM_ITERS {
-            acc = acc.mul_u128(setup.scalar);
+            acc = acc.mul_u128(scalar);
         }
         std::hint::black_box(acc);
     }
@@ -163,16 +121,11 @@ impl Objective for MulU128Objective {
 
 // -- mul_i128 --
 
-pub struct MulI128Setup {
-    pub field: Fr,
-    pub scalar: i128,
-}
-
 #[derive(Clone, Copy, Default, PartialEq, Eq, Hash)]
 pub struct MulI128Objective;
 
 impl Objective for MulI128Objective {
-    type Setup = MulI128Setup;
+    type Setup = (Fr, i128);
 
     fn name(&self) -> &str {
         "field_mul_i128"
@@ -182,18 +135,16 @@ impl Objective for MulI128Objective {
         format!("Wall-clock time of Field::mul_i128 ({NUM_ITERS} iterations)")
     }
 
-    fn setup(&self) -> MulI128Setup {
-        thread_local! { static SHARED: MulShared = MulShared::new(); }
-        SHARED.with(|s| MulI128Setup {
-            field: s.field,
-            scalar: s.i128_scalar,
-        })
+    fn setup(&self) -> Self::Setup {
+        let mut rng = rand::thread_rng();
+        (Fr::random(&mut rng), rand::Rng::gen(&mut rng))
     }
 
-    fn run(&self, setup: MulI128Setup) {
-        let mut acc = setup.field;
+    fn run(&self, setup: Self::Setup) {
+        let (field, scalar) = setup;
+        let mut acc = field;
         for _ in 0..NUM_ITERS {
-            acc = acc.mul_i128(setup.scalar);
+            acc = acc.mul_i128(scalar);
         }
         std::hint::black_box(acc);
     }

--- a/jolt-eval/src/objective/performance/field_mul.rs
+++ b/jolt-eval/src/objective/performance/field_mul.rs
@@ -1,0 +1,204 @@
+use jolt_field::arkworks::bn254::Fr;
+use jolt_field::Field;
+
+use crate::objective::{Objective, OptimizationObjective, PerformanceObjective};
+
+pub const MUL_U64: OptimizationObjective =
+    OptimizationObjective::Performance(PerformanceObjective::MulU64(MulU64Objective));
+pub const MUL_I64: OptimizationObjective =
+    OptimizationObjective::Performance(PerformanceObjective::MulI64(MulI64Objective));
+pub const MUL_U128: OptimizationObjective =
+    OptimizationObjective::Performance(PerformanceObjective::MulU128(MulU128Objective));
+pub const MUL_I128: OptimizationObjective =
+    OptimizationObjective::Performance(PerformanceObjective::MulI128(MulI128Objective));
+
+const NUM_ITERS: usize = 10_000;
+
+struct MulShared {
+    field: Fr,
+    u64_scalar: u64,
+    i64_scalar: i64,
+    u128_scalar: u128,
+    i128_scalar: i128,
+}
+
+impl MulShared {
+    fn new() -> Self {
+        let mut rng = rand::thread_rng();
+        Self {
+            field: Fr::random(&mut rng),
+            u64_scalar: rand::Rng::gen(&mut rng),
+            i64_scalar: rand::Rng::gen(&mut rng),
+            u128_scalar: rand::Rng::gen(&mut rng),
+            i128_scalar: rand::Rng::gen(&mut rng),
+        }
+    }
+}
+
+// -- mul_u64 --
+
+pub struct MulU64Setup {
+    pub field: Fr,
+    pub scalar: u64,
+}
+
+#[derive(Clone, Copy, Default, PartialEq, Eq, Hash)]
+pub struct MulU64Objective;
+
+impl Objective for MulU64Objective {
+    type Setup = MulU64Setup;
+
+    fn name(&self) -> &str {
+        "field_mul_u64"
+    }
+
+    fn description(&self) -> String {
+        format!("Wall-clock time of Field::mul_u64 ({NUM_ITERS} iterations)")
+    }
+
+    fn setup(&self) -> MulU64Setup {
+        thread_local! { static SHARED: MulShared = MulShared::new(); }
+        SHARED.with(|s| MulU64Setup {
+            field: s.field,
+            scalar: s.u64_scalar,
+        })
+    }
+
+    fn run(&self, setup: MulU64Setup) {
+        let mut acc = setup.field;
+        for _ in 0..NUM_ITERS {
+            acc = acc.mul_u64(setup.scalar);
+        }
+        std::hint::black_box(acc);
+    }
+
+    fn units(&self) -> Option<&str> {
+        Some("s")
+    }
+}
+
+// -- mul_i64 --
+
+pub struct MulI64Setup {
+    pub field: Fr,
+    pub scalar: i64,
+}
+
+#[derive(Clone, Copy, Default, PartialEq, Eq, Hash)]
+pub struct MulI64Objective;
+
+impl Objective for MulI64Objective {
+    type Setup = MulI64Setup;
+
+    fn name(&self) -> &str {
+        "field_mul_i64"
+    }
+
+    fn description(&self) -> String {
+        format!("Wall-clock time of Field::mul_i64 ({NUM_ITERS} iterations)")
+    }
+
+    fn setup(&self) -> MulI64Setup {
+        thread_local! { static SHARED: MulShared = MulShared::new(); }
+        SHARED.with(|s| MulI64Setup {
+            field: s.field,
+            scalar: s.i64_scalar,
+        })
+    }
+
+    fn run(&self, setup: MulI64Setup) {
+        let mut acc = setup.field;
+        for _ in 0..NUM_ITERS {
+            acc = acc.mul_i64(setup.scalar);
+        }
+        std::hint::black_box(acc);
+    }
+
+    fn units(&self) -> Option<&str> {
+        Some("s")
+    }
+}
+
+// -- mul_u128 --
+
+pub struct MulU128Setup {
+    pub field: Fr,
+    pub scalar: u128,
+}
+
+#[derive(Clone, Copy, Default, PartialEq, Eq, Hash)]
+pub struct MulU128Objective;
+
+impl Objective for MulU128Objective {
+    type Setup = MulU128Setup;
+
+    fn name(&self) -> &str {
+        "field_mul_u128"
+    }
+
+    fn description(&self) -> String {
+        format!("Wall-clock time of Field::mul_u128 ({NUM_ITERS} iterations)")
+    }
+
+    fn setup(&self) -> MulU128Setup {
+        thread_local! { static SHARED: MulShared = MulShared::new(); }
+        SHARED.with(|s| MulU128Setup {
+            field: s.field,
+            scalar: s.u128_scalar,
+        })
+    }
+
+    fn run(&self, setup: MulU128Setup) {
+        let mut acc = setup.field;
+        for _ in 0..NUM_ITERS {
+            acc = acc.mul_u128(setup.scalar);
+        }
+        std::hint::black_box(acc);
+    }
+
+    fn units(&self) -> Option<&str> {
+        Some("s")
+    }
+}
+
+// -- mul_i128 --
+
+pub struct MulI128Setup {
+    pub field: Fr,
+    pub scalar: i128,
+}
+
+#[derive(Clone, Copy, Default, PartialEq, Eq, Hash)]
+pub struct MulI128Objective;
+
+impl Objective for MulI128Objective {
+    type Setup = MulI128Setup;
+
+    fn name(&self) -> &str {
+        "field_mul_i128"
+    }
+
+    fn description(&self) -> String {
+        format!("Wall-clock time of Field::mul_i128 ({NUM_ITERS} iterations)")
+    }
+
+    fn setup(&self) -> MulI128Setup {
+        thread_local! { static SHARED: MulShared = MulShared::new(); }
+        SHARED.with(|s| MulI128Setup {
+            field: s.field,
+            scalar: s.i128_scalar,
+        })
+    }
+
+    fn run(&self, setup: MulI128Setup) {
+        let mut acc = setup.field;
+        for _ in 0..NUM_ITERS {
+            acc = acc.mul_i128(setup.scalar);
+        }
+        std::hint::black_box(acc);
+    }
+
+    fn units(&self) -> Option<&str> {
+        Some("s")
+    }
+}

--- a/jolt-eval/src/objective/performance/mod.rs
+++ b/jolt-eval/src/objective/performance/mod.rs
@@ -1,4 +1,5 @@
 pub mod binding;
+pub mod field_mul;
 pub mod naive_sort;
 pub mod prover_time;
 


### PR DESCRIPTION
## Summary

This pull request adds comprehensive support for benchmarking and verifying the correctness of scalar multiplication methods in the `jolt-field` crate, specifically for BN254 field elements. It introduces new performance objectives and invariants for `mul_u64`, `mul_i64`, `mul_u128`, and `mul_i128` methods, along with corresponding benchmarks and integration into the evaluation framework #1406. Additionally, some minor improvements and cleanup are made to existing code and documentation.

## Changes

<!-- Bulleted list of key changes. -->

**Field multiplication benchmarking and invariants:**

* Added new performance objectives for field multiplication methods (`mul_u64`, `mul_i64`, `mul_u128`, `mul_i128`) to `PerformanceObjective`, including their names, units, descriptions, and affected diff paths (`crates/jolt-field/`). [[1]](diffhunk://#diff-ffa821f13ea4e6ad0ea9eba2a180e7feb4230b8fbf0f40a31e56625c0d101a7dR141-R144) [[2]](diffhunk://#diff-ffa821f13ea4e6ad0ea9eba2a180e7feb4230b8fbf0f40a31e56625c0d101a7dR153-R156) [[3]](diffhunk://#diff-ffa821f13ea4e6ad0ea9eba2a180e7feb4230b8fbf0f40a31e56625c0d101a7dR165-R168) [[4]](diffhunk://#diff-ffa821f13ea4e6ad0ea9eba2a180e7feb4230b8fbf0f40a31e56625c0d101a7dR189-R202)
* Introduced a new invariant `FieldMulScalarInvariant` to check the correctness of the optimized field multiplication methods against reference implementations, with fuzzing and seed corpus for thorough testing (`jolt-eval/src/invariant/field_mul_scalar.rs`).
* Registered the new invariant in the invariants module and dispatch logic (`jolt-eval/src/invariant/mod.rs`). [[1]](diffhunk://#diff-6009116741c33fbfa19035a774ec5fde17197fc05c4d3352eacb30367fca3133R3) [[2]](diffhunk://#diff-6009116741c33fbfa19035a774ec5fde17197fc05c4d3352eacb30367fca3133R137) [[3]](diffhunk://#diff-6009116741c33fbfa19035a774ec5fde17197fc05c4d3352eacb30367fca3133R146) [[4]](diffhunk://#diff-6009116741c33fbfa19035a774ec5fde17197fc05c4d3352eacb30367fca3133R157)

**Benchmarking infrastructure:**

* Added new benchmark binaries for each field multiplication method (`field_mul_u64`, `field_mul_i64`, `field_mul_u128`, `field_mul_i128`) and updated `Cargo.toml` to register them. [[1]](diffhunk://#diff-b2b6c29e701da4733719635ffce1c4bbad4ca55ad7e75f61149d20dbf375855aL41-R62) [[2]](diffhunk://#diff-00b109236db4749d04e6eb08a700982382265f458fc3e8bf2b6f3eaeb7ea2afbR1-R2) [[3]](diffhunk://#diff-d81fd92f83330facc9250af4461523c8327197b2fd01289200b0c3ec43d42937R1-R2) [[4]](diffhunk://#diff-69b2e38b40869056173743c59ba868da4078df134d683866d6bdbacabb6712daR1-R2) [[5]](diffhunk://#diff-39e7f92a00f1aeb33756fd0e4778828b273c2fcba35b2757f04e7597e6af57ebR1-R2)
* Added `jolt-field` as a dependency in `jolt-eval/Cargo.toml` to support the new benchmarks.

**Objective function and evaluation updates:**

* Added new minimization objective functions for the field multiplication performance objectives, and included them in the list of all objective functions. [[1]](diffhunk://#diff-3b5cbd433b223180e94b29f2dee655df92a6c037681f8edc7b82ac39c641ea72L7-R7) [[2]](diffhunk://#diff-3b5cbd433b223180e94b29f2dee655df92a6c037681f8edc7b82ac39c641ea72R38-R41) [[3]](diffhunk://#diff-3b5cbd433b223180e94b29f2dee655df92a6c037681f8edc7b82ac39c641ea72R105-R128)
* Exported the new performance objective constants for use throughout the codebase.
* Removed outdated or redundant tests related to the previous count of optimization objectives. [[1]](diffhunk://#diff-ffa821f13ea4e6ad0ea9eba2a180e7feb4230b8fbf0f40a31e56625c0d101a7dL328-L335) [[2]](diffhunk://#diff-3b5cbd433b223180e94b29f2dee655df92a6c037681f8edc7b82ac39c641ea72L136-L140)

**Minor improvements:**

* Clarified the instructions in the optimization prompt regarding running clippy for code verification.
-

## Testing

<!-- How was this tested? Which tests cover this change? -->

- [x] Ran tests for modified crates
- [x] `cargo clippy` and `cargo fmt` pass

## Security Considerations

<!-- Every change to a zkVM has security implications. Describe them.
     Does this affect proof soundness? Verifier correctness? Private inputs? -->

## Breaking Changes

<!-- List any breaking changes to public APIs, proof formats, or serialization. Write "None" if not applicable. -->

None
