### PR TITLE
ci: add SCANOSS license compliance scanning

### DIFF
--- a/.github/workflows/scanoss.yml
+++ b/.github/workflows/scanoss.yml
@@ -1,0 +1,128 @@
+name: SCANOSS License Compliance
+
+on:
+  pull_request:
+    branches: [main, master]
+  push:
+    branches: [main, master]
+
+permissions:
+  contents: read
+  pull-requests: write
+  checks: write
+
+concurrency:
+  group: scanoss-${{ github.repository }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  scanoss-pr:
+    name: SCANOSS License Scan (PR)
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: SCANOSS Delta Scan
+        uses: scanoss/gha-code-scan@v1
+        with:
+          api.key: ${{ secrets.SCANOSS_API_KEY }}
+          github.token: ${{ steps.app-token.outputs.token }}
+          policies: copyleft
+          policies.halt_on_failure: false
+          scanMode: delta
+          dependencies.enabled: false
+          output.filepath: scanoss-results.json
+
+  scanoss-full:
+    name: SCANOSS Full Scan (post-merge)
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Remove non-source files that crash SCANOSS
+        run: |
+          find . -type f \( \
+            -name '*.pcap' -o -name '*.pcapng' -o -name '*.tsv' -o -name '*.csv' \
+            -o -name '*.bin' -o -name '*.png' -o -name '*.jpg' -o -name '*.jpeg' \
+            -o -name '*.gif' -o -name '*.webp' -o -name '*.avif' -o -name '*.svg' \
+            -o -name '*.ico' -o -name '*.pdf' \
+            -o -name '*.mp3' -o -name '*.mp4' -o -name '*.mov' -o -name '*.wav' \
+            -o -name '*.woff' -o -name '*.woff2' -o -name '*.ttf' -o -name '*.otf' \
+            -o -name '*.eot' \
+            -o -name '*.gz' -o -name '*.tar' -o -name '*.zip' -o -name '*.whl' \
+            -o -name '*.7z' -o -name '*.rar' \
+            -o -name '*.o' -o -name '*.a' -o -name '*.so' -o -name '*.dylib' \
+            -o -name '*.dll' -o -name '*.exe' -o -name '*.class' -o -name '*.jar' \
+            -o -name '*.pyc' -o -name '*.pdi' -o -name '*.xsa' -o -name '*.elf' \
+            -o -name '*.hpu' -o -name '*.bcode' -o -name '*.cbor' \
+          \) -delete 2>/dev/null || true
+          rm -rf Datasets assets node_modules __pycache__ .venv bmenv .next dist build 2>/dev/null || true
+
+      - name: SCANOSS Full Scan
+        uses: scanoss/gha-code-scan@v1
+        with:
+          api.key: ${{ secrets.SCANOSS_API_KEY }}
+          github.token: ${{ steps.app-token.outputs.token }}
+          policies: copyleft
+          policies.halt_on_failure: false
+          scanMode: full
+          dependencies.enabled: false
+          output.filepath: scanoss-results.json
+
+  trigger-ort:
+    name: Trigger ORT Scan
+    if: github.event_name == 'push'
+    runs-on: self-hosted
+    steps:
+      - name: Check if ORT scan needed
+        id: check
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 2
+
+      - name: Skip if only NOTICE changed
+        id: filter
+        run: |
+          CHANGED=$(git diff --name-only HEAD~1 HEAD 2>/dev/null || echo "FORCE_SCAN")
+          if [ "$(echo "$CHANGED" | grep -v '^NOTICE$' | grep -v '^$')" = "" ]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Trigger ORT scan via webhook
+        if: steps.filter.outputs.skip != 'true'
+        run: |
+          REPO_NAME="${GITHUB_REPOSITORY#*/}"
+          HTTP_CODE=$(curl -s -o /tmp/ort-response.json -w "%{http_code}" -X POST "${{ vars.ORT_WEBHOOK_URL }}/scan" -H "Authorization: Bearer ${{ secrets.ORT_WEBHOOK_TOKEN }}" -H "Content-Type: application/json" -d "{\"repo\": \"${REPO_NAME}\"}")
+          echo "HTTP $HTTP_CODE"
+          cat /tmp/ort-response.json
+          if [ "$HTTP_CODE" = "202" ]; then
+            echo "::notice::ORT scan triggered for $REPO_NAME"
+          else
+            echo "::warning::ORT webhook returned $HTTP_CODE — scan may not have started"
+          fi

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,106 @@
+THIRD-PARTY SOFTWARE NOTICES AND INFORMATION
+============================================================
+
+Project: jolt-pqds
+Generated: 2026-04-24
+Tool: SCANOSS (snippet detection with License dataset)
+Components: 5
+
+This file lists all third-party software components detected
+in this repository, along with their licenses and copyright
+notices as required by those licenses.
+
+------------------------------------------------------------
+
+LICENSE SUMMARY
+
+  Apache-2.0: 5 component(s)
+  MIT: 3 component(s)
+
+------------------------------------------------------------
+
+COMPONENT ATTRIBUTIONS
+
+  cedar-spec
+  Version: v4.4.0
+  Source: https://github.com/cedar-policy/cedar-spec
+  PURL: pkg:github/cedar-policy/cedar-spec
+  Copyright:
+    Copyright Amazon.com; Inc. or its affiliates. All Rights Reserved.
+    Copyright copyright owner or entity authorized by
+  License: Apache-2.0
+
+  github.com/arithmic/jolt
+  Version: v0.0.0-20250612165522-e8c245607a4a
+  Source: https://proxy.golang.org/github.com/arithmic/jolt/@v/v0.0.0-20250612165522-e8c245607a4a.zip
+  PURL: pkg:golang/github.com/arithmic/jolt
+  License: Apache-2.0, MIT
+
+  jolt
+  Version: v0.2.0-alpha
+  Source: https://github.com/a16z/jolt
+  PURL: pkg:github/a16z/jolt
+  Copyright:
+    Copyright 2020 Takahiro
+    Copyright 2025 Galois Inc.
+  License: Apache-2.0, MIT
+
+  lasso
+  Version: 2343e36
+  Source: https://github.com/a16z/lasso
+  PURL: pkg:github/a16z/lasso
+  Copyright:
+    Copyright 2020 Takahiro
+    Copyright 2025 Galois Inc.
+    Copyright  c) Microsoft Corporation
+    Copyright (c) Microsoft Corporation
+    Copyright (c) Microsoft Corporation.
+  License: Apache-2.0, MIT
+
+  pb-jelly
+  Version: v0.0.12
+  Source: https://github.com/dropbox/pb-jelly
+  PURL: pkg:github/dropbox/pb-jelly
+  Copyright:
+    Copyright copyright owner or entity authorized by
+  License: Apache-2.0
+
+------------------------------------------------------------
+
+FULL LICENSE TEXTS
+
+--- Apache-2.0 ---
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+
+--- MIT ---
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+

--- a/NOTICE
+++ b/NOTICE
@@ -2,7 +2,7 @@ THIRD-PARTY SOFTWARE NOTICES AND INFORMATION
 ============================================================
 
 Project: jolt-pqds
-Generated: 2026-04-24
+Generated: 2026-04-25
 Tool: SCANOSS (snippet detection with License dataset)
 Components: 5
 

--- a/scanoss.json
+++ b/scanoss.json
@@ -1,0 +1,7 @@
+{
+  "bom": {
+    "include": [
+      {"purl":"pkg:github/a16z/jolt","comment":"Known upstream fork"}
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- Add SCANOSS GitHub Action for automated license compliance scanning
- Scans PRs (delta) and pushes to main (full) for copyleft license violations
- Posts findings as PR comments — does NOT block merges
- Add `scanoss.json` configuration for component declarations

Part of org-wide compliance initiative.

## Test plan
- [ ] Verify SCANOSS action runs on next PR
- [ ] Verify no false positives on existing code

🤖 Generated with [Claude Code](https://claude.com/claude-code)