### PR TITLE
Fix: Completeness issue in edge case identified from FV.

### DIFF
--- a/tracer/src/instruction/divw.rs
+++ b/tracer/src/instruction/divw.rs
@@ -142,7 +142,7 @@ impl RISCVTrace for DIVW {
         asm.emit_i::<VirtualSignExtendWord>(*t1, *a2, 0); // Sign-extend quotient to 64-bit
         asm.emit_b::<VirtualAssertEQ>(*t1, *a2, 0); // Assert quotient was valid 32-bit
 
-        asm.emit_i::<SRAI>(*t2, *a3, 31); // Sign bit of remainder
+        asm.emit_i::<SRAI>(*t2, *a3, 32); // Remainder advice fits in u32
         asm.emit_b::<VirtualAssertEQ>(*t2, 0, 0); // sign bit of remainder advice should be 0
 
         asm.emit_i::<SRAI>(*t2, *t4, 31); // Sign bit of dividend


### PR DESCRIPTION

## Summary

  Fixes a completeness issue in the bytecode expansion for `divw`.

  See: https://randomwalks.xyz/blog/bytecode-expansions/divw-bug/

## Changes

  - Updated the `divw` remainder-advice range check from `SRAI(..., 31)` to `SRAI(..., 32)`.

## Testing

  - [x] Ran tests for modified crates
  - [x] `cargo clippy` and `cargo fmt` pass

  Tested with:

  ```bash
  cargo test -p jolt-core
  cargo fmt --check
  cargo clippy -p tracer --all-targets -- -D warnings
```
## Security Considerations

This fixes a completeness issue, not a soundness issue.
The bytecode expansion still constrains the advised remainder to fit in the valid unsigned 32-bit range.

The change was validated in Lean.

## Breaking Changes

  None.