### PR TITLE
fix: univariate skip soundness bug

### DIFF
--- a/jolt-core/src/subprotocols/univariate_skip.rs
+++ b/jolt-core/src/subprotocols/univariate_skip.rs
@@ -261,13 +261,18 @@ impl<F: JoltField, T: Transcript> UniSkipFirstRoundProof<F, T> {
 
         // Check symmetric-domain sum equals zero (initial claim), and compute next claim s1(r0)
         let input_claim = sumcheck_instance.input_claim(opening_accumulator);
-        let ok = proof
+        let input_claim_ok = proof
             .uni_poly
             .check_sum_evals::<N, FIRST_ROUND_POLY_NUM_COEFFS>(input_claim);
+
         sumcheck_instance.cache_openings(opening_accumulator, &[r0]);
+        let expected_output = proof.uni_poly.evaluate(&r0);
+        let claimed_output = sumcheck_instance.expected_output_claim(opening_accumulator, &[r0]);
+        let output_claim_ok = claimed_output == expected_output;
+
         opening_accumulator.flush_to_transcript(transcript);
 
-        if !ok {
+        if !input_claim_ok || !output_claim_ok {
             Err(ProofVerifyError::UniSkipVerificationError)
         } else {
             Ok(r0)

--- a/jolt-core/src/zkvm/spartan/outer.rs
+++ b/jolt-core/src/zkvm/spartan/outer.rs
@@ -331,10 +331,14 @@ impl<F: JoltField, T: Transcript, A: AbstractVerifierOpeningAccumulator<F>>
 
     fn expected_output_claim(
         &self,
-        _accumulator: &A,
+        accumulator: &A,
         _sumcheck_challenges: &[<F as JoltField>::Challenge],
     ) -> F {
-        unimplemented!("Unused for univariate skip")
+        let (_, claim) = accumulator.get_virtual_polynomial_opening(
+            VirtualPolynomial::UnivariateSkip,
+            SumcheckId::SpartanOuter,
+        );
+        claim
     }
 
     fn cache_openings(

--- a/jolt-core/src/zkvm/spartan/product.rs
+++ b/jolt-core/src/zkvm/spartan/product.rs
@@ -352,10 +352,14 @@ impl<F: JoltField, T: Transcript, A: AbstractVerifierOpeningAccumulator<F>>
 
     fn expected_output_claim(
         &self,
-        _accumulator: &A,
+        accumulator: &A,
         _sumcheck_challenges: &[<F as JoltField>::Challenge],
     ) -> F {
-        unimplemented!("Unused for univariate skip")
+        let (_, claim) = accumulator.get_virtual_polynomial_opening(
+            VirtualPolynomial::UnivariateSkip,
+            SumcheckId::SpartanProductVirtualization,
+        );
+        claim
     }
 
     fn cache_openings(


### PR DESCRIPTION
Univariate skip was assuming that the output claim provided in the proof is honest. This PR adds a check that the claim matches the univariate poly evaluation. 

Thanks to [Minsun Kim](https://github.com/soon-haari) for finding and reporting!