### PR TITLE
Fix global CSE Poseidon imports

### DIFF
--- a/transpiler/src/gnark_codegen.rs
+++ b/transpiler/src/gnark_codegen.rs
@@ -629,6 +629,14 @@ pub fn generate_circuit_from_bundle_with_stats(
         .map(|(idx, &node_id)| (node_id, idx))
         .collect();
     let has_global_cse = !global_node_map.is_empty();
+    if bundle
+        .global_cse
+        .bindings
+        .iter()
+        .any(|&node_id| node_requires_poseidon_import(&bundle.nodes, node_id))
+    {
+        stats.uses_poseidon = true;
+    }
 
     for (constraint_idx, c) in bundle.constraints.iter().enumerate() {
         // Use pre-computed CSE bindings from AstBundle
@@ -1243,6 +1251,29 @@ fn evaluate_constant_edge_in(nodes: &[Node], edge: Edge) -> Scalar {
     }
 }
 
+fn node_requires_poseidon_import(nodes: &[Node], root: usize) -> bool {
+    let mut stack = vec![root];
+    let mut visited = HashSet::new();
+
+    while let Some(node_id) = stack.pop() {
+        if !visited.insert(node_id) {
+            continue;
+        }
+
+        match &nodes[node_id] {
+            Node::Atom(_) => {}
+            Node::TranscriptHash(TranscriptHashData::Poseidon(_), _, _)
+            | Node::ByteReverse(_)
+            | Node::Truncate128Reverse(_)
+            | Node::Truncate128(_)
+            | Node::AppendU64Transform(_) => return true,
+            node => stack.extend(node_children(node)),
+        }
+    }
+
+    false
+}
+
 // =============================================================================
 // Tests
 // =============================================================================
@@ -1250,7 +1281,9 @@ fn evaluate_constant_edge_in(nodes: &[Node], edge: Edge) -> Scalar {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use zklean_extractor::ast_bundle::{Constraint, ConstraintCse, GlobalCse};
     use zklean_extractor::mle_ast::{AstBundle, TargetField, WitnessType};
+    use zklean_extractor::Assertion;
 
     /// Verifies that codegen panics with a clear error when non-native field variables are present.
     ///
@@ -1299,6 +1332,46 @@ mod tests {
             panic_msg.contains("Fq"),
             "Panic message should mention the field type, got: {panic_msg}"
         );
+    }
+
+    #[test]
+    fn test_global_poseidon_cse_adds_import() {
+        let hash = Node::TranscriptHash(
+            TranscriptHashData::Poseidon(Edge::Atom(Atom::Var(2))),
+            Edge::Atom(Atom::Var(0)),
+            Edge::Atom(Atom::Var(1)),
+        );
+        let assertion_0 = Node::Sub(Edge::NodeRef(0), Edge::Atom(Atom::Var(3)));
+        let assertion_1 = Node::Sub(Edge::NodeRef(0), Edge::Atom(Atom::Var(4)));
+
+        let mut bundle = AstBundle::new();
+        bundle.nodes = vec![hash, assertion_0, assertion_1];
+        bundle.global_cse = GlobalCse { bindings: vec![0] };
+        bundle.constraint_cse = vec![ConstraintCse::default(), ConstraintCse::default()];
+        for (idx, name) in ["state", "rounds", "data", "expected_0", "expected_1"]
+            .iter()
+            .enumerate()
+        {
+            bundle.add_input(idx as u16, *name, WitnessType::ProofData);
+        }
+        bundle.constraints = vec![
+            Constraint {
+                name: "assertion_0".to_string(),
+                root: 1,
+                assertion: Assertion::EqualZero,
+            },
+            Constraint {
+                name: "assertion_1".to_string(),
+                root: 2,
+                assertion: Assertion::EqualZero,
+            },
+        ];
+
+        let (code, stats) = generate_circuit_from_bundle_with_stats(&bundle, "TestCircuit", false);
+
+        assert!(stats.uses_poseidon);
+        assert!(code.contains("\"jolt_verifier/poseidon\""));
+        assert!(code.contains("poseidon.Hash(api,"));
     }
 
     // =========================================================================


### PR DESCRIPTION
## Summary
- Detect Poseidon usage in global CSE bindings before emitting generated Go imports
- Prevent generated gnark code from referencing `poseidon.Hash` without importing `jolt_verifier/poseidon`
- Add a regression test for a shared Poseidon hash hoisted entirely into `gcse`

## Context
PR #1414 added global CSE to the transpiler. The idea is to avoid recomputing expensive expressions, especially transcript hash chains, when multiple generated constraints use the same AST node. Instead of emitting the same Poseidon transcript hash inside several `verifyConstraintN` functions, codegen can compute it once in `computeGlobalCse` as `gcse[i]` and then have each constraint reuse that value.

That optimization is sound, but it exposed a codegen bookkeeping bug. The transpiler decides the generated Go imports before it emits the global CSE block. Before global CSE, per-constraint codegen would notice Poseidon usage and set `stats.uses_poseidon = true`, which caused this import to be emitted:

```go
import "jolt_verifier/poseidon"
```

After global CSE, all Poseidon usage can move out of the per-constraint code and into `computeGlobalCse`. In that shape, the import decision can happen before codegen has noticed that the generated file still needs the Poseidon helper package.

## Failure Mode
This is a generated Go compile bug, not a Jolt prover/verifier soundness issue.

The bad generated shape is roughly:

```go
func (circuit *JoltStagesCircuit) computeGlobalCse(api frontend.API) []frontend.Variable {
    gcse := make([]frontend.Variable, 1)
    gcse[0] = poseidon.Hash(api, state, rounds, data)
    return gcse
}
```

but without the corresponding `jolt_verifier/poseidon` import. Go then fails to compile because the generated file references `poseidon.Hash` without importing the package.

The bug can be masked when there is still some non-global Poseidon usage elsewhere in the generated circuit, because that per-constraint usage causes the import to be included. The broken case is when Poseidon use is fully hoisted into global CSE.

## Fix
Before writing the import block, scan the global CSE bindings and mark `stats.uses_poseidon = true` if any globally hoisted node requires the Poseidon helper package. This keeps import selection aligned with the full generated file, including `computeGlobalCse`.

The new regression test constructs the minimal affected shape: two constraints share a Poseidon transcript hash that is hoisted entirely into `gcse`, and generated code must include both `poseidon.Hash(...)` and the `jolt_verifier/poseidon` import.

## Tests
- `cargo nextest run -p transpiler test_global_poseidon_cse_adds_import --cargo-quiet`
- `cargo nextest run -p transpiler --cargo-quiet`
- `cargo clippy -p transpiler --all-targets -q -- -D warnings`
- `cargo nextest run -p jolt-core muldiv --cargo-quiet --features host`
- `cargo nextest run -p jolt-core muldiv --cargo-quiet --features host,zk`
- `cargo clippy --all --features host -q --all-targets -- -D warnings`
- `cargo clippy --all --features host,zk -q --all-targets -- -D warnings`

## Disclosure
Posted by the assistant on behalf of Quang Dao. AI-authored using GPT-5.
