### PR TITLE
feat(jolt-hyperkzg): add HyperKZG multilinear commitment scheme

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2847,6 +2847,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "jolt-hyperkzg"
+version = "0.1.0"
+dependencies = [
+ "criterion",
+ "jolt-crypto",
+ "jolt-field",
+ "jolt-openings",
+ "jolt-poly",
+ "jolt-transcript",
+ "num-traits",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+ "rayon",
+ "serde",
+ "thiserror 2.0.18",
+ "tracing",
+]
+
+[[package]]
 name = "jolt-inlines-bigint"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ members = [
   "crates/jolt-sumcheck",
   "crates/jolt-openings",
   "crates/jolt-dory",
+  "crates/jolt-hyperkzg",
   "crates/jolt-riscv",
   "crates/jolt-transcript",
   "crates/jolt-profiling",

--- a/crates/jolt-hyperkzg/Cargo.toml
+++ b/crates/jolt-hyperkzg/Cargo.toml
@@ -1,0 +1,35 @@
+[package]
+name = "jolt-hyperkzg"
+version = "0.1.0"
+edition = "2021"
+license = "MIT"
+description = "HyperKZG multilinear polynomial commitment scheme for the Jolt zkVM"
+
+[lints]
+workspace = true
+
+[dependencies]
+jolt-crypto = { path = "../jolt-crypto" }
+jolt-field = { path = "../jolt-field" }
+jolt-poly = { path = "../jolt-poly" }
+jolt-transcript = { path = "../jolt-transcript" }
+jolt-openings = { path = "../jolt-openings" }
+serde = { workspace = true, features = ["derive"] }
+tracing.workspace = true
+num-traits = { workspace = true }
+rayon = { workspace = true }
+thiserror = { workspace = true }
+rand_core = { workspace = true }
+rand_chacha = { workspace = true }
+
+[dev-dependencies]
+jolt-field = { path = "../jolt-field", features = ["bn254"] }
+criterion = { workspace = true }
+rand = { workspace = true }
+
+[[bench]]
+name = "hyperkzg"
+harness = false
+
+[package.metadata.cargo-machete]
+ignored = ["rand_core", "rand_chacha", "rand"]

--- a/crates/jolt-hyperkzg/Cargo.toml
+++ b/crates/jolt-hyperkzg/Cargo.toml
@@ -19,7 +19,7 @@ tracing.workspace = true
 num-traits = { workspace = true }
 rayon = { workspace = true }
 thiserror = { workspace = true }
-rand_core = { workspace = true }
+rand_core = { workspace = true, features = ["getrandom"] }
 rand_chacha = { workspace = true }
 
 [dev-dependencies]

--- a/crates/jolt-hyperkzg/README.md
+++ b/crates/jolt-hyperkzg/README.md
@@ -1,0 +1,49 @@
+# jolt-hyperkzg
+
+HyperKZG multilinear polynomial commitment scheme for the Jolt zkVM.
+
+Part of the [Jolt](https://github.com/a16z/jolt) zkVM.
+
+## Overview
+
+HyperKZG reduces multilinear polynomial commitments to univariate KZG using the Gemini transformation ([section 2.4.2](https://eprint.iacr.org/2022/420.pdf)), operating directly on evaluation-form polynomials (no FFT/interpolation).
+
+This crate is generic over `PairingGroup` from `jolt-crypto` and implements `CommitmentScheme` and `AdditivelyHomomorphic` from `jolt-openings`.
+
+### Protocol
+
+1. **Commit** — MSM of evaluations against SRS G1 powers.
+2. **Open** (Gemini reduction) — fold the multilinear polynomial `ℓ-1` times producing intermediate commitments, derive challenge `r`, batch KZG open at `[r, -r, r²]`.
+3. **Verify** — evaluation consistency check, then batch KZG pairing check.
+
+## Public API
+
+- **`HyperKZGScheme<P>`** — Main entry point. Implements `CommitmentScheme` and `AdditivelyHomomorphic`.
+- **`HyperKZGCommitment<P>`** — A commitment (G1 point).
+- **`HyperKZGProof<P>`** — Opening proof containing intermediate commitments and evaluations.
+- **`HyperKZGProverSetup<P>`** / **`HyperKZGVerifierSetup<P>`** — Structured reference strings.
+
+### Submodules
+
+- **`kzg`** — Univariate KZG primitives (commit, open, batch verify).
+- **`error`** — Error types.
+
+## Dependency Position
+
+```
+jolt-field ─┐
+jolt-crypto ─┤
+jolt-poly  ─┼─► jolt-hyperkzg
+jolt-transcript ─┤
+jolt-openings ─┘
+```
+
+Used by `jolt-zkvm`.
+
+## Feature Flags
+
+This crate has no feature flags.
+
+## License
+
+MIT

--- a/crates/jolt-hyperkzg/benches/hyperkzg.rs
+++ b/crates/jolt-hyperkzg/benches/hyperkzg.rs
@@ -1,0 +1,182 @@
+#![allow(unused_results)]
+
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+
+use jolt_crypto::Bn254;
+use jolt_field::{Field, Fr};
+use jolt_hyperkzg::{HyperKZGProverSetup, HyperKZGScheme, HyperKZGVerifierSetup};
+use jolt_openings::{AdditivelyHomomorphic, CommitmentScheme};
+use jolt_poly::Polynomial;
+use jolt_transcript::Transcript;
+use rand_chacha::ChaCha20Rng;
+use rand_core::SeedableRng;
+
+type TestScheme = HyperKZGScheme<Bn254>;
+
+fn make_setup(max_degree: usize) -> (HyperKZGProverSetup<Bn254>, HyperKZGVerifierSetup<Bn254>) {
+    let mut rng = ChaCha20Rng::seed_from_u64(0xbe0c);
+    let g1 = Bn254::g1_generator();
+    let g2 = Bn254::g2_generator();
+    let pk = TestScheme::setup(&mut rng, max_degree, g1, g2);
+    let vk = TestScheme::verifier_setup(&pk);
+    (pk, vk)
+}
+
+fn bench_commit(c: &mut Criterion) {
+    let mut group = c.benchmark_group("hyperkzg_commit");
+    for num_vars in [8, 10, 12, 14] {
+        let n = 1 << num_vars;
+        let (pk, _) = make_setup(n);
+        group.bench_with_input(
+            BenchmarkId::from_parameter(num_vars),
+            &num_vars,
+            |b, &nv| {
+                b.iter_batched(
+                    || {
+                        let mut rng = ChaCha20Rng::seed_from_u64(0);
+                        Polynomial::<Fr>::random(nv, &mut rng)
+                    },
+                    |poly| TestScheme::commit(poly.evaluations(), &pk),
+                    criterion::BatchSize::SmallInput,
+                );
+            },
+        );
+    }
+    group.finish();
+}
+
+fn bench_open(c: &mut Criterion) {
+    let mut group = c.benchmark_group("hyperkzg_open");
+    for num_vars in [8, 10, 12, 14] {
+        let n = 1 << num_vars;
+        let (pk, _) = make_setup(n);
+        group.bench_with_input(
+            BenchmarkId::from_parameter(num_vars),
+            &num_vars,
+            |b, &nv| {
+                b.iter_batched(
+                    || {
+                        let mut rng = ChaCha20Rng::seed_from_u64(0);
+                        let poly = Polynomial::<Fr>::random(nv, &mut rng);
+                        let point: Vec<Fr> =
+                            (0..nv).map(|_| <Fr as Field>::random(&mut rng)).collect();
+                        let eval = poly.evaluate(&point);
+                        (poly, point, eval)
+                    },
+                    |(poly, point, eval)| {
+                        let mut transcript = jolt_transcript::Blake2bTranscript::new(b"bench-open");
+                        <TestScheme as CommitmentScheme>::open(
+                            &poly,
+                            &point,
+                            eval,
+                            &pk,
+                            None,
+                            &mut transcript,
+                        )
+                    },
+                    criterion::BatchSize::SmallInput,
+                );
+            },
+        );
+    }
+    group.finish();
+}
+
+fn bench_verify(c: &mut Criterion) {
+    let mut group = c.benchmark_group("hyperkzg_verify");
+    for num_vars in [8, 10, 12, 14] {
+        let n = 1 << num_vars;
+        let (pk, vk) = make_setup(n);
+        group.bench_with_input(
+            BenchmarkId::from_parameter(num_vars),
+            &num_vars,
+            |b, &nv| {
+                b.iter_batched(
+                    || {
+                        let mut rng = ChaCha20Rng::seed_from_u64(0);
+                        let poly = Polynomial::<Fr>::random(nv, &mut rng);
+                        let point: Vec<Fr> =
+                            (0..nv).map(|_| <Fr as Field>::random(&mut rng)).collect();
+                        let eval = poly.evaluate(&point);
+                        let (commitment, ()) = TestScheme::commit(poly.evaluations(), &pk);
+                        let mut transcript =
+                            jolt_transcript::Blake2bTranscript::new(b"bench-verify");
+                        let proof = <TestScheme as CommitmentScheme>::open(
+                            &poly,
+                            &point,
+                            eval,
+                            &pk,
+                            None,
+                            &mut transcript,
+                        );
+                        (commitment, point, eval, proof)
+                    },
+                    |(commitment, point, eval, proof)| {
+                        let mut transcript =
+                            jolt_transcript::Blake2bTranscript::new(b"bench-verify");
+                        <TestScheme as CommitmentScheme>::verify(
+                            &commitment,
+                            &point,
+                            eval,
+                            &proof,
+                            &vk,
+                            &mut transcript,
+                        )
+                    },
+                    criterion::BatchSize::SmallInput,
+                );
+            },
+        );
+    }
+    group.finish();
+}
+
+fn bench_combine(c: &mut Criterion) {
+    let mut group = c.benchmark_group("hyperkzg_combine");
+    for count in [2, 4, 8, 16] {
+        let num_vars = 10;
+        let n = 1 << num_vars;
+        let (pk, _) = make_setup(n);
+        let mut rng = ChaCha20Rng::seed_from_u64(0);
+
+        let commitments: Vec<_> = (0..count)
+            .map(|_| {
+                let poly = Polynomial::<Fr>::random(num_vars, &mut rng);
+                let (c, ()) = TestScheme::commit(poly.evaluations(), &pk);
+                c
+            })
+            .collect();
+        let scalars: Vec<Fr> = (0..count).map(|_| Fr::random(&mut rng)).collect();
+
+        group.bench_with_input(BenchmarkId::from_parameter(count), &count, |b, _| {
+            b.iter(|| TestScheme::combine(&commitments, &scalars));
+        });
+    }
+    group.finish();
+}
+
+fn bench_setup(c: &mut Criterion) {
+    let mut group = c.benchmark_group("hyperkzg_setup");
+    for num_vars in [8, 10, 12] {
+        let n = 1 << num_vars;
+        group.bench_with_input(BenchmarkId::from_parameter(num_vars), &num_vars, |b, _| {
+            b.iter(|| {
+                let mut rng = ChaCha20Rng::seed_from_u64(0xbe0c);
+                let g1 = Bn254::g1_generator();
+                let g2 = Bn254::g2_generator();
+                TestScheme::setup(&mut rng, n, g1, g2)
+            });
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_setup,
+    bench_commit,
+    bench_open,
+    bench_verify,
+    bench_combine,
+);
+criterion_main!(benches);

--- a/crates/jolt-hyperkzg/benches/hyperkzg.rs
+++ b/crates/jolt-hyperkzg/benches/hyperkzg.rs
@@ -1,9 +1,7 @@
-#![allow(unused_results)]
-
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 
 use jolt_crypto::Bn254;
-use jolt_field::{Field, Fr};
+use jolt_field::{Fr, RandomSampling};
 use jolt_hyperkzg::{HyperKZGProverSetup, HyperKZGScheme, HyperKZGVerifierSetup};
 use jolt_openings::{AdditivelyHomomorphic, CommitmentScheme};
 use jolt_poly::Polynomial;
@@ -27,7 +25,7 @@ fn bench_commit(c: &mut Criterion) {
     for num_vars in [8, 10, 12, 14] {
         let n = 1 << num_vars;
         let (pk, _) = make_setup(n);
-        group.bench_with_input(
+        let _ = group.bench_with_input(
             BenchmarkId::from_parameter(num_vars),
             &num_vars,
             |b, &nv| {
@@ -50,7 +48,7 @@ fn bench_open(c: &mut Criterion) {
     for num_vars in [8, 10, 12, 14] {
         let n = 1 << num_vars;
         let (pk, _) = make_setup(n);
-        group.bench_with_input(
+        let _ = group.bench_with_input(
             BenchmarkId::from_parameter(num_vars),
             &num_vars,
             |b, &nv| {
@@ -58,8 +56,7 @@ fn bench_open(c: &mut Criterion) {
                     || {
                         let mut rng = ChaCha20Rng::seed_from_u64(0);
                         let poly = Polynomial::<Fr>::random(nv, &mut rng);
-                        let point: Vec<Fr> =
-                            (0..nv).map(|_| <Fr as Field>::random(&mut rng)).collect();
+                        let point: Vec<Fr> = (0..nv).map(|_| Fr::random(&mut rng)).collect();
                         let eval = poly.evaluate(&point);
                         (poly, point, eval)
                     },
@@ -87,7 +84,7 @@ fn bench_verify(c: &mut Criterion) {
     for num_vars in [8, 10, 12, 14] {
         let n = 1 << num_vars;
         let (pk, vk) = make_setup(n);
-        group.bench_with_input(
+        let _ = group.bench_with_input(
             BenchmarkId::from_parameter(num_vars),
             &num_vars,
             |b, &nv| {
@@ -95,8 +92,7 @@ fn bench_verify(c: &mut Criterion) {
                     || {
                         let mut rng = ChaCha20Rng::seed_from_u64(0);
                         let poly = Polynomial::<Fr>::random(nv, &mut rng);
-                        let point: Vec<Fr> =
-                            (0..nv).map(|_| <Fr as Field>::random(&mut rng)).collect();
+                        let point: Vec<Fr> = (0..nv).map(|_| Fr::random(&mut rng)).collect();
                         let eval = poly.evaluate(&point);
                         let (commitment, ()) = TestScheme::commit(poly.evaluations(), &pk);
                         let mut transcript =
@@ -148,7 +144,7 @@ fn bench_combine(c: &mut Criterion) {
             .collect();
         let scalars: Vec<Fr> = (0..count).map(|_| Fr::random(&mut rng)).collect();
 
-        group.bench_with_input(BenchmarkId::from_parameter(count), &count, |b, _| {
+        let _ = group.bench_with_input(BenchmarkId::from_parameter(count), &count, |b, _| {
             b.iter(|| TestScheme::combine(&commitments, &scalars));
         });
     }
@@ -159,7 +155,7 @@ fn bench_setup(c: &mut Criterion) {
     let mut group = c.benchmark_group("hyperkzg_setup");
     for num_vars in [8, 10, 12] {
         let n = 1 << num_vars;
-        group.bench_with_input(BenchmarkId::from_parameter(num_vars), &num_vars, |b, _| {
+        let _ = group.bench_with_input(BenchmarkId::from_parameter(num_vars), &num_vars, |b, _| {
             b.iter(|| {
                 let mut rng = ChaCha20Rng::seed_from_u64(0xbe0c);
                 let g1 = Bn254::g1_generator();

--- a/crates/jolt-hyperkzg/fuzz/Cargo.toml
+++ b/crates/jolt-hyperkzg/fuzz/Cargo.toml
@@ -1,0 +1,36 @@
+[workspace]
+
+[package]
+name = "jolt-hyperkzg-fuzz"
+version = "0.0.0"
+publish = false
+edition = "2021"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.4"
+jolt-hyperkzg = { path = ".." }
+jolt-crypto = { path = "../../jolt-crypto" }
+jolt-field = { path = "../../jolt-field", features = ["bn254"] }
+jolt-openings = { path = "../../jolt-openings" }
+jolt-poly = { path = "../../jolt-poly" }
+jolt-transcript = { path = "../../jolt-transcript" }
+rand_chacha = "0.3"
+rand_core = "0.6"
+
+[[bin]]
+name = "commit_open_verify"
+path = "fuzz_targets/commit_open_verify.rs"
+doc = false
+
+[[bin]]
+name = "tampered_proof"
+path = "fuzz_targets/tampered_proof.rs"
+doc = false
+
+[[bin]]
+name = "wrong_eval"
+path = "fuzz_targets/wrong_eval.rs"
+doc = false

--- a/crates/jolt-hyperkzg/fuzz/fuzz_targets/commit_open_verify.rs
+++ b/crates/jolt-hyperkzg/fuzz/fuzz_targets/commit_open_verify.rs
@@ -1,0 +1,45 @@
+#![no_main]
+
+//! Fuzz: random polynomial + random point must always commit-open-verify successfully.
+
+use jolt_crypto::Bn254;
+use jolt_field::{Field, Fr};
+use jolt_hyperkzg::HyperKZGScheme;
+use jolt_openings::CommitmentScheme;
+use jolt_poly::Polynomial;
+use jolt_transcript::{Blake2bTranscript, Transcript};
+use libfuzzer_sys::fuzz_target;
+use rand_chacha::ChaCha20Rng;
+use rand_core::SeedableRng;
+
+type TestScheme = HyperKZGScheme<Bn254>;
+
+fuzz_target!(|data: &[u8]| {
+    if data.len() < 8 {
+        return;
+    }
+
+    let seed = u64::from_le_bytes(data[..8].try_into().unwrap());
+    let num_vars = (data.len() % 4) + 1; // 1..=4 variables
+    let n = 1usize << num_vars;
+
+    let mut rng = ChaCha20Rng::seed_from_u64(seed);
+    let g1 = Bn254::g1_generator();
+    let g2 = Bn254::g2_generator();
+    let pk = TestScheme::setup(&mut rng, n, g1, g2);
+    let vk = TestScheme::verifier_setup(&pk);
+
+    let poly = Polynomial::<Fr>::random(num_vars, &mut rng);
+    let point: Vec<Fr> = (0..num_vars).map(|_| Fr::random(&mut rng)).collect();
+    let eval = poly.evaluate(&point);
+
+    let (commitment, ()) = TestScheme::commit(poly.evaluations(), &pk);
+
+    let mut pt = Blake2bTranscript::new(b"fuzz");
+    let proof =
+        <TestScheme as CommitmentScheme>::open(&poly, &point, eval, &pk, None, &mut pt);
+
+    let mut vt = Blake2bTranscript::new(b"fuzz");
+    <TestScheme as CommitmentScheme>::verify(&commitment, &point, eval, &proof, &vk, &mut vt)
+        .expect("valid proof must verify");
+});

--- a/crates/jolt-hyperkzg/fuzz/fuzz_targets/tampered_proof.rs
+++ b/crates/jolt-hyperkzg/fuzz/fuzz_targets/tampered_proof.rs
@@ -1,0 +1,65 @@
+#![no_main]
+
+//! Fuzz: tamper with proof evaluation bytes and verify that verification rejects.
+//!
+//! We generate a valid proof, then corrupt an evaluation entry using fuzzer-chosen bytes.
+
+use jolt_crypto::Bn254;
+use jolt_field::{Field, Fr};
+use jolt_hyperkzg::HyperKZGScheme;
+use jolt_openings::CommitmentScheme;
+use jolt_poly::Polynomial;
+use jolt_transcript::{Blake2bTranscript, Transcript};
+use libfuzzer_sys::fuzz_target;
+use rand_chacha::ChaCha20Rng;
+use rand_core::SeedableRng;
+
+type TestScheme = HyperKZGScheme<Bn254>;
+
+fuzz_target!(|data: &[u8]| {
+    if data.len() < 10 {
+        return;
+    }
+
+    let num_vars = 3;
+    let n = 1usize << num_vars;
+
+    let mut rng = ChaCha20Rng::seed_from_u64(0xfade);
+    let g1 = Bn254::g1_generator();
+    let g2 = Bn254::g2_generator();
+    let pk = TestScheme::setup(&mut rng, n, g1, g2);
+    let vk = TestScheme::verifier_setup(&pk);
+
+    let poly = Polynomial::<Fr>::random(num_vars, &mut rng);
+    let point: Vec<Fr> = (0..num_vars).map(|_| Fr::random(&mut rng)).collect();
+    let eval = poly.evaluate(&point);
+
+    let (commitment, ()) = TestScheme::commit(poly.evaluations(), &pk);
+
+    let mut pt = Blake2bTranscript::new(b"fuzz-tamper");
+    let proof =
+        <TestScheme as CommitmentScheme>::open(&poly, &point, eval, &pk, None, &mut pt);
+
+    let tamper_row = (data[0] as usize) % proof.v.len();
+    let tamper_col = (data[1] as usize) % proof.v[tamper_row].len();
+    let tamper_val = Fr::from_bytes(&data[2..]);
+
+    // Skip if the corruption is a no-op
+    if tamper_val == proof.v[tamper_row][tamper_col] {
+        return;
+    }
+
+    let mut tampered = proof.clone();
+    tampered.v[tamper_row][tamper_col] = tamper_val;
+
+    let mut vt = Blake2bTranscript::new(b"fuzz-tamper");
+    let result = <TestScheme as CommitmentScheme>::verify(
+        &commitment,
+        &point,
+        eval,
+        &tampered,
+        &vk,
+        &mut vt,
+    );
+    assert!(result.is_err(), "tampered proof must be rejected");
+});

--- a/crates/jolt-hyperkzg/fuzz/fuzz_targets/tampered_proof.rs
+++ b/crates/jolt-hyperkzg/fuzz/fuzz_targets/tampered_proof.rs
@@ -1,10 +1,11 @@
 #![no_main]
 
-//! Fuzz: tamper with proof evaluation bytes and verify that verification rejects.
+//! Fuzz: tamper with proof fields and verify that verification rejects.
 //!
-//! We generate a valid proof, then corrupt an evaluation entry using fuzzer-chosen bytes.
+//! We generate a valid proof, then corrupt either an evaluation entry,
+//! an intermediate commitment, or a witness commitment using fuzzer-chosen bytes.
 
-use jolt_crypto::Bn254;
+use jolt_crypto::{Bn254, JoltGroup};
 use jolt_field::{Field, Fr};
 use jolt_hyperkzg::HyperKZGScheme;
 use jolt_openings::CommitmentScheme;
@@ -40,17 +41,41 @@ fuzz_target!(|data: &[u8]| {
     let proof =
         <TestScheme as CommitmentScheme>::open(&poly, &point, eval, &pk, None, &mut pt);
 
-    let tamper_row = (data[0] as usize) % proof.v.len();
-    let tamper_col = (data[1] as usize) % proof.v[tamper_row].len();
-    let tamper_val = Fr::from_bytes(&data[2..]);
-
-    // Skip if the corruption is a no-op
-    if tamper_val == proof.v[tamper_row][tamper_col] {
-        return;
-    }
-
     let mut tampered = proof.clone();
-    tampered.v[tamper_row][tamper_col] = tamper_val;
+
+    match data[0] % 3 {
+        0 => {
+            // Tamper evaluation entries (exercises folding consistency checks)
+            let tamper_row = (data[1] as usize) % tampered.v.len();
+            let tamper_col = (data[2] as usize) % tampered.v[tamper_row].len();
+            let tamper_val = Fr::from_bytes(&data[3..]);
+            if tamper_val == proof.v[tamper_row][tamper_col] {
+                return;
+            }
+            tampered.v[tamper_row][tamper_col] = tamper_val;
+        }
+        1 => {
+            // Tamper intermediate commitments (exercises pairing check)
+            if tampered.com.is_empty() {
+                return;
+            }
+            let idx = (data[1] as usize) % tampered.com.len();
+            let scalar = Fr::from_bytes(&data[2..]);
+            tampered.com[idx] = tampered.com[idx].scalar_mul(&scalar);
+            if tampered.com[idx] == proof.com[idx] {
+                return;
+            }
+        }
+        _ => {
+            // Tamper witness commitments (exercises pairing check)
+            let idx = (data[1] as usize) % tampered.w.len();
+            let scalar = Fr::from_bytes(&data[2..]);
+            tampered.w[idx] = tampered.w[idx].scalar_mul(&scalar);
+            if tampered.w[idx] == proof.w[idx] {
+                return;
+            }
+        }
+    }
 
     let mut vt = Blake2bTranscript::new(b"fuzz-tamper");
     let result = <TestScheme as CommitmentScheme>::verify(

--- a/crates/jolt-hyperkzg/fuzz/fuzz_targets/wrong_eval.rs
+++ b/crates/jolt-hyperkzg/fuzz/fuzz_targets/wrong_eval.rs
@@ -1,0 +1,59 @@
+#![no_main]
+
+//! Fuzz: claim a wrong evaluation and verify that verification rejects.
+//!
+//! The prover generates a valid proof for the correct evaluation. The
+//! verifier checks against a fuzzer-derived wrong evaluation. Must reject.
+
+use jolt_crypto::Bn254;
+use jolt_field::{Field, Fr};
+use jolt_hyperkzg::HyperKZGScheme;
+use jolt_openings::CommitmentScheme;
+use jolt_poly::Polynomial;
+use jolt_transcript::{Blake2bTranscript, Transcript};
+use libfuzzer_sys::fuzz_target;
+use rand_chacha::ChaCha20Rng;
+use rand_core::SeedableRng;
+
+type TestScheme = HyperKZGScheme<Bn254>;
+
+fuzz_target!(|data: &[u8]| {
+    if data.len() < 32 {
+        return;
+    }
+
+    let num_vars = 3;
+    let n = 1usize << num_vars;
+
+    let mut rng = ChaCha20Rng::seed_from_u64(0xface);
+    let g1 = Bn254::g1_generator();
+    let g2 = Bn254::g2_generator();
+    let pk = TestScheme::setup(&mut rng, n, g1, g2);
+    let vk = TestScheme::verifier_setup(&pk);
+
+    let poly = Polynomial::<Fr>::random(num_vars, &mut rng);
+    let point: Vec<Fr> = (0..num_vars).map(|_| Fr::random(&mut rng)).collect();
+    let eval = poly.evaluate(&point);
+
+    let wrong_eval = Fr::from_bytes(data);
+    if wrong_eval == eval {
+        return;
+    }
+
+    let (commitment, ()) = TestScheme::commit(poly.evaluations(), &pk);
+
+    let mut pt = Blake2bTranscript::new(b"fuzz-wrong-eval");
+    let proof =
+        <TestScheme as CommitmentScheme>::open(&poly, &point, eval, &pk, None, &mut pt);
+
+    let mut vt = Blake2bTranscript::new(b"fuzz-wrong-eval");
+    let result = <TestScheme as CommitmentScheme>::verify(
+        &commitment,
+        &point,
+        wrong_eval,
+        &proof,
+        &vk,
+        &mut vt,
+    );
+    assert!(result.is_err(), "wrong evaluation must be rejected");
+});

--- a/crates/jolt-hyperkzg/fuzz/rust-toolchain.toml
+++ b/crates/jolt-hyperkzg/fuzz/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "nightly"

--- a/crates/jolt-hyperkzg/src/error.rs
+++ b/crates/jolt-hyperkzg/src/error.rs
@@ -1,0 +1,14 @@
+//! Error types for HyperKZG operations.
+
+/// Errors produced by the HyperKZG commitment scheme.
+#[derive(Debug, thiserror::Error)]
+pub enum HyperKZGError {
+    #[error("SRS too small: have {have} powers, need {need}")]
+    SrsTooSmall { have: usize, need: usize },
+
+    #[error("proof verification failed")]
+    VerificationFailed,
+
+    #[error("invalid proof structure: {0}")]
+    InvalidProof(&'static str),
+}

--- a/crates/jolt-hyperkzg/src/error.rs
+++ b/crates/jolt-hyperkzg/src/error.rs
@@ -9,14 +9,8 @@ pub enum HyperKZGError {
     #[error("expected {expected} intermediate commitments, got {got}")]
     WrongCommitmentCount { expected: usize, got: usize },
 
-    #[error("expected 3 evaluation rows, got {got}")]
-    WrongEvaluationRowCount { got: usize },
-
     #[error("each evaluation row must have {expected} entries")]
     WrongEvaluationWidth { expected: usize },
-
-    #[error("expected 3 witness commitments, got {got}")]
-    WrongWitnessCount { got: usize },
 
     #[error("polynomial must have at least 1 variable")]
     EmptyPoint,

--- a/crates/jolt-hyperkzg/src/error.rs
+++ b/crates/jolt-hyperkzg/src/error.rs
@@ -6,9 +6,27 @@ pub enum HyperKZGError {
     #[error("SRS too small: have {have} powers, need {need}")]
     SrsTooSmall { have: usize, need: usize },
 
-    #[error("proof verification failed")]
-    VerificationFailed,
+    #[error("expected {expected} intermediate commitments, got {got}")]
+    WrongCommitmentCount { expected: usize, got: usize },
 
-    #[error("invalid proof structure: {0}")]
-    InvalidProof(&'static str),
+    #[error("expected 3 evaluation rows, got {got}")]
+    WrongEvaluationRowCount { got: usize },
+
+    #[error("each evaluation row must have {expected} entries")]
+    WrongEvaluationWidth { expected: usize },
+
+    #[error("expected 3 witness commitments, got {got}")]
+    WrongWitnessCount { got: usize },
+
+    #[error("polynomial must have at least 1 variable")]
+    EmptyPoint,
+
+    #[error("folding consistency check failed at level {level}")]
+    FoldingConsistencyFailed { level: usize },
+
+    #[error("batch KZG pairing check failed")]
+    PairingCheckFailed,
+
+    #[error("degenerate Fiat-Shamir challenge: r = 0")]
+    DegenerateChallenge,
 }

--- a/crates/jolt-hyperkzg/src/kzg.rs
+++ b/crates/jolt-hyperkzg/src/kzg.rs
@@ -1,0 +1,263 @@
+//! Univariate KZG primitives: commit, witness polynomial, batch open/verify.
+//!
+//! These are the building blocks consumed by the HyperKZG protocol.
+//! All operations are generic over `P: PairingGroup`.
+
+#![allow(non_snake_case)]
+
+use jolt_crypto::{JoltGroup, PairingGroup};
+use jolt_field::Field;
+use jolt_transcript::{AppendToTranscript, Transcript};
+use num_traits::{One, Zero};
+use rayon::prelude::*;
+
+use crate::error::HyperKZGError;
+use crate::types::{HyperKZGProverSetup, HyperKZGVerifierSetup};
+
+/// Commits to a polynomial (given as evaluation/coefficient vector) using MSM against SRS G1 powers.
+pub(crate) fn kzg_commit<P: PairingGroup>(
+    coeffs: &[P::ScalarField],
+    setup: &HyperKZGProverSetup<P>,
+) -> Result<P::G1, HyperKZGError> {
+    if setup.g1_powers.len() < coeffs.len() {
+        return Err(HyperKZGError::SrsTooSmall {
+            have: setup.g1_powers.len(),
+            need: coeffs.len(),
+        });
+    }
+    Ok(P::G1::msm(&setup.g1_powers[..coeffs.len()], coeffs))
+}
+
+/// Computes the KZG witness polynomial `h(x) = f(x) / (x - u)`.
+///
+/// Uses Horner's method in reverse: `h[i-1] = f[i] + h[i] * u`.
+/// The remainder is `f(u)`, but we don't need it since the verifier
+/// can derive it from the evaluation vectors.
+pub(crate) fn compute_witness_polynomial<F: Field>(f: &[F], u: F) -> Vec<F> {
+    let d = f.len();
+    let mut h = vec![F::zero(); d];
+    for i in (1..d).rev() {
+        h[i - 1] = f[i] + h[i] * u;
+    }
+    h
+}
+
+/// Evaluates a polynomial (in evaluation/coefficient form) at a point.
+///
+/// Standard Horner evaluation: `f(u) = f[0] + f[1]*u + f[2]*u^2 + ...`
+pub(crate) fn eval_univariate<F: Field>(coeffs: &[F], u: F) -> F {
+    let mut result = F::zero();
+    let mut power = F::one();
+    for &c in coeffs {
+        result += c * power;
+        power *= u;
+    }
+    result
+}
+
+/// Batch KZG opening: commits to witness polynomials for each evaluation point.
+///
+/// Given polynomials `f[0..k]` and evaluation points `u[0..t]`, computes:
+/// - `v[i][j]` = f_j(u_i) for all i, j
+/// - Linear combination `B = sum_j q^j * f_j` using Fiat-Shamir challenge
+/// - Witness commitments `w[i]` = commit(B(x) / (x - u_i))
+///
+/// Returns `(w, v)`.
+pub(crate) fn kzg_open_batch<P, T>(
+    f: &[Vec<P::ScalarField>],
+    u: &[P::ScalarField],
+    setup: &HyperKZGProverSetup<P>,
+    transcript: &mut T,
+) -> (Vec<P::G1>, Vec<Vec<P::ScalarField>>)
+where
+    P: PairingGroup,
+    T: Transcript<Challenge = P::ScalarField>,
+    P::ScalarField: AppendToTranscript,
+    P::G1: AppendToTranscript,
+{
+    let k = f.len();
+
+    // Compute evaluations v[i][j] = f_j(u_i)
+    let v: Vec<Vec<P::ScalarField>> = u
+        .par_iter()
+        .map(|ui| f.iter().map(|fj| eval_univariate(fj, *ui)).collect())
+        .collect();
+
+    // Absorb all evaluations into transcript
+    for row in &v {
+        for val in row {
+            transcript.append(val);
+        }
+    }
+
+    // Derive batching challenge and compute powers q, q^2, ..., q^{k-1}
+    let q: P::ScalarField = transcript.challenge();
+    let q_powers = challenge_powers(q, k);
+
+    // B(x) = sum_j q^j * f_j(x)
+    let poly_len = f[0].len();
+    let mut b_poly = vec![P::ScalarField::zero(); poly_len];
+    for (fj, &qj) in f.iter().zip(q_powers.iter()) {
+        for (b, &c) in b_poly.iter_mut().zip(fj.iter()) {
+            *b += qj * c;
+        }
+    }
+
+    // Compute witness polynomials and commit
+    let w: Vec<P::G1> = u
+        .par_iter()
+        .map(|ui| {
+            let h = compute_witness_polynomial::<P::ScalarField>(&b_poly, *ui);
+            P::G1::msm(&setup.g1_powers[..h.len()], &h)
+        })
+        .collect();
+
+    // Absorb witness commitments and derive one more challenge to keep
+    // prover/verifier transcripts in sync
+    for wi in &w {
+        transcript.append(wi);
+    }
+    let _: P::ScalarField = transcript.challenge();
+
+    (w, v)
+}
+
+/// Batch KZG verification: checks that commitments open correctly at all points.
+///
+/// Optimized for the t=3 case used by HyperKZG. The pairing check verifies:
+/// `e(L, g2) == e(R, beta_g2)`
+pub(crate) fn kzg_verify_batch<P, T>(
+    vk: &HyperKZGVerifierSetup<P>,
+    com: &[P::G1],
+    wit: &[P::G1],
+    u: &[P::ScalarField],
+    v: &[Vec<P::ScalarField>],
+    transcript: &mut T,
+) -> bool
+where
+    P: PairingGroup,
+    T: Transcript<Challenge = P::ScalarField>,
+    P::ScalarField: AppendToTranscript,
+    P::G1: AppendToTranscript,
+{
+    let k = com.len();
+
+    // Absorb evaluations
+    for row in v {
+        for val in row {
+            transcript.append(val);
+        }
+    }
+
+    let q: P::ScalarField = transcript.challenge();
+    let q_powers = challenge_powers(q, k);
+
+    // Absorb witness commitments
+    for wi in wit {
+        transcript.append(wi);
+    }
+    let d_0: P::ScalarField = transcript.challenge();
+    let d_1 = d_0 * d_0;
+
+    assert_eq!(
+        wit.len(),
+        3,
+        "HyperKZG requires exactly 3 evaluation points"
+    );
+
+    // q_power_multiplier = 1 + d_0 + d_1
+    let q_power_multiplier = P::ScalarField::one() + d_0 + d_1;
+    let q_powers_multiplied: Vec<P::ScalarField> =
+        q_powers.iter().map(|qp| *qp * q_power_multiplier).collect();
+
+    // B(u_i) = sum_j q^j * v[i][j]
+    let b_u: Vec<P::ScalarField> = v
+        .iter()
+        .map(|v_i| {
+            v_i.iter()
+                .zip(q_powers.iter())
+                .map(|(&a, &b)| a * b)
+                .fold(P::ScalarField::zero(), |acc, x| acc + x)
+        })
+        .collect();
+
+    // L = MSM over [C_0..C_{k-1}, W_0, W_1, W_2, g1] with scalars
+    //   [q_powers_multiplied, u_0, u_1*d_0, u_2*d_1, -(b_u[0] + d_0*b_u[1] + d_1*b_u[2])]
+    let mut bases = Vec::with_capacity(k + 4);
+    bases.extend_from_slice(&com[..k]);
+    bases.push(wit[0]);
+    bases.push(wit[1]);
+    bases.push(wit[2]);
+    bases.push(vk.g1);
+
+    let mut scalars = Vec::with_capacity(k + 4);
+    scalars.extend_from_slice(&q_powers_multiplied[..k]);
+    scalars.push(u[0]);
+    scalars.push(u[1] * d_0);
+    scalars.push(u[2] * d_1);
+    scalars.push(-(b_u[0] + d_0 * b_u[1] + d_1 * b_u[2]));
+
+    let lhs = P::G1::msm(&bases, &scalars);
+
+    // R = W[0] + d_0*W[1] + d_1*W[2]
+    let rhs = wit[0] + wit[1].scalar_mul(&d_0) + wit[2].scalar_mul(&d_1);
+
+    // e(L, g2) * e(-R, beta_g2) == identity
+    let result = P::multi_pairing(&[lhs, -rhs], &[vk.g2, vk.beta_g2]);
+    result.is_identity()
+}
+
+/// Computes `[1, c, c^2, ..., c^{n-1}]`.
+pub(crate) fn challenge_powers<F: Field>(c: F, n: usize) -> Vec<F> {
+    let mut powers = Vec::with_capacity(n);
+    let mut cur = F::one();
+    for _ in 0..n {
+        powers.push(cur);
+        cur *= c;
+    }
+    powers
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use jolt_field::Fr;
+    use num_traits::Zero;
+
+    #[test]
+    fn witness_polynomial_division() {
+        // f(x) = 1 + 2x + 3x^2 + 4x^3
+        // f(2) = 1 + 4 + 12 + 32 = 49
+        // h(x) = f(x)/(x-2), so f(x) = (x-2)*h(x) + f(2)
+        let f = vec![
+            Fr::from_u64(1),
+            Fr::from_u64(2),
+            Fr::from_u64(3),
+            Fr::from_u64(4),
+        ];
+        let u = Fr::from_u64(2);
+        let h = compute_witness_polynomial::<Fr>(&f, u);
+
+        // Verify: (x-u)*h(x) + f(u) should reconstruct f(x)
+        for x_val in [0u64, 1, 3, 5, 100] {
+            let x = Fr::from_u64(x_val);
+            let fx = eval_univariate(&f, x);
+            let hx = eval_univariate(&h, x);
+            let fu = eval_univariate(&f, u);
+            assert_eq!(fx, (x - u) * hx + fu);
+        }
+    }
+
+    #[test]
+    fn eval_univariate_at_zero() {
+        let f = vec![Fr::from_u64(42), Fr::from_u64(7), Fr::from_u64(3)];
+        assert_eq!(eval_univariate(&f, Fr::zero()), Fr::from_u64(42));
+    }
+
+    #[test]
+    fn eval_univariate_linear() {
+        // f(x) = 3 + 5x, f(2) = 13
+        let f = vec![Fr::from_u64(3), Fr::from_u64(5)];
+        assert_eq!(eval_univariate(&f, Fr::from_u64(2)), Fr::from_u64(13));
+    }
+}

--- a/crates/jolt-hyperkzg/src/kzg.rs
+++ b/crates/jolt-hyperkzg/src/kzg.rs
@@ -3,8 +3,6 @@
 //! These are the building blocks consumed by the HyperKZG protocol.
 //! All operations are generic over `P: PairingGroup`.
 
-#![allow(non_snake_case)]
-
 use jolt_crypto::{JoltGroup, PairingGroup};
 use jolt_field::Field;
 use jolt_transcript::{AppendToTranscript, Transcript};
@@ -142,6 +140,10 @@ where
 {
     let k = com.len();
 
+    if wit.len() != 3 || u.len() != 3 || v.len() != 3 || v.iter().any(|row| row.len() != k) {
+        return false;
+    }
+
     // Absorb evaluations
     for row in v {
         for val in row {
@@ -158,12 +160,6 @@ where
     }
     let d_0: P::ScalarField = transcript.challenge();
     let d_1 = d_0 * d_0;
-
-    assert_eq!(
-        wit.len(),
-        3,
-        "HyperKZG requires exactly 3 evaluation points"
-    );
 
     // q_power_multiplier = 1 + d_0 + d_1
     let q_power_multiplier = P::ScalarField::one() + d_0 + d_1;
@@ -221,7 +217,7 @@ pub(crate) fn challenge_powers<F: Field>(c: F, n: usize) -> Vec<F> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use jolt_field::Fr;
+    use jolt_field::{Fr, FromPrimitiveInt};
     use num_traits::Zero;
 
     #[test]

--- a/crates/jolt-hyperkzg/src/kzg.rs
+++ b/crates/jolt-hyperkzg/src/kzg.rs
@@ -33,8 +33,12 @@ pub(crate) fn kzg_commit<P: PairingGroup>(
 /// can derive it from the evaluation vectors.
 pub(crate) fn compute_witness_polynomial<F: Field>(f: &[F], u: F) -> Vec<F> {
     let d = f.len();
-    let mut h = vec![F::zero(); d];
-    for i in (1..d).rev() {
+    if d <= 1 {
+        return vec![];
+    }
+    let mut h = vec![F::zero(); d - 1];
+    h[d - 2] = f[d - 1];
+    for i in (1..d - 1).rev() {
         h[i - 1] = f[i] + h[i] * u;
     }
     h
@@ -110,12 +114,12 @@ where
         })
         .collect();
 
-    // Absorb witness commitments and derive one more challenge to keep
-    // prover/verifier transcripts in sync
+    // Absorb witness commitments and mirror the verifier's `d_0` challenge
+    // to keep prover/verifier transcripts in sync.
     for wi in &w {
         transcript.append(wi);
     }
-    let _: P::ScalarField = transcript.challenge();
+    let _d_0: P::ScalarField = transcript.challenge();
 
     (w, v)
 }

--- a/crates/jolt-hyperkzg/src/kzg.rs
+++ b/crates/jolt-hyperkzg/src/kzg.rs
@@ -7,7 +7,6 @@ use jolt_crypto::{JoltGroup, PairingGroup};
 use jolt_field::Field;
 use jolt_transcript::{AppendToTranscript, Transcript};
 use num_traits::{One, Zero};
-use rayon::prelude::*;
 
 use crate::error::HyperKZGError;
 use crate::types::{HyperKZGProverSetup, HyperKZGVerifierSetup};
@@ -67,10 +66,10 @@ pub(crate) fn eval_univariate<F: Field>(coeffs: &[F], u: F) -> F {
 /// Returns `(w, v)`.
 pub(crate) fn kzg_open_batch<P, T>(
     f: &[Vec<P::ScalarField>],
-    u: &[P::ScalarField],
+    u: &[P::ScalarField; 3],
     setup: &HyperKZGProverSetup<P>,
     transcript: &mut T,
-) -> (Vec<P::G1>, Vec<Vec<P::ScalarField>>)
+) -> ([P::G1; 3], [Vec<P::ScalarField>; 3])
 where
     P: PairingGroup,
     T: Transcript<Challenge = P::ScalarField>,
@@ -79,11 +78,9 @@ where
 {
     let k = f.len();
 
-    // Compute evaluations v[i][j] = f_j(u_i)
-    let v: Vec<Vec<P::ScalarField>> = u
-        .par_iter()
-        .map(|ui| f.iter().map(|fj| eval_univariate(fj, *ui)).collect())
-        .collect();
+    // Compute evaluations v[t][j] = f_j(u_t)
+    let v: [Vec<P::ScalarField>; 3] =
+        (*u).map(|ui| f.iter().map(|fj| eval_univariate(fj, ui)).collect());
 
     // Absorb all evaluations into transcript
     for row in &v {
@@ -106,13 +103,10 @@ where
     }
 
     // Compute witness polynomials and commit
-    let w: Vec<P::G1> = u
-        .par_iter()
-        .map(|ui| {
-            let h = compute_witness_polynomial::<P::ScalarField>(&b_poly, *ui);
-            P::G1::msm(&setup.g1_powers[..h.len()], &h)
-        })
-        .collect();
+    let w: [P::G1; 3] = (*u).map(|ui| {
+        let h = compute_witness_polynomial::<P::ScalarField>(&b_poly, ui);
+        P::G1::msm(&setup.g1_powers[..h.len()], &h)
+    });
 
     // Absorb witness commitments and mirror the verifier's `d_0` challenge
     // to keep prover/verifier transcripts in sync.
@@ -131,9 +125,9 @@ where
 pub(crate) fn kzg_verify_batch<P, T>(
     vk: &HyperKZGVerifierSetup<P>,
     com: &[P::G1],
-    wit: &[P::G1],
-    u: &[P::ScalarField],
-    v: &[Vec<P::ScalarField>],
+    wit: &[P::G1; 3],
+    u: &[P::ScalarField; 3],
+    v: &[Vec<P::ScalarField>; 3],
     transcript: &mut T,
 ) -> bool
 where
@@ -144,7 +138,7 @@ where
 {
     let k = com.len();
 
-    if wit.len() != 3 || u.len() != 3 || v.len() != 3 || v.iter().any(|row| row.len() != k) {
+    if v.iter().any(|row| row.len() != k) {
         return false;
     }
 

--- a/crates/jolt-hyperkzg/src/lib.rs
+++ b/crates/jolt-hyperkzg/src/lib.rs
@@ -1,0 +1,28 @@
+//! HyperKZG multilinear polynomial commitment scheme.
+//!
+//! HyperKZG reduces multilinear polynomial commitments to univariate KZG using
+//! the Gemini transformation (section 2.4.2 of <https://eprint.iacr.org/2022/420.pdf>),
+//! operating directly on evaluation-form polynomials (no FFT/interpolation).
+//!
+//! This crate is generic over `PairingGroup` from `jolt-crypto` and implements
+//! the `CommitmentScheme` and `AdditivelyHomomorphic` traits from `jolt-openings`.
+//!
+//! # Protocol overview
+//!
+//! 1. **Commit**: MSM of evaluations against SRS G1 powers (treating the
+//!    multilinear evaluation table as univariate coefficients).
+//! 2. **Open** (Gemini reduction):
+//!    - Phase 1: Fold the multilinear polynomial `ell - 1` times, producing
+//!      intermediate polynomial commitments.
+//!    - Phase 2: Derive challenge `r` and evaluation points `[r, -r, r^2]`.
+//!    - Phase 3: Batch KZG opening of all intermediate polynomials at three points.
+//! 3. **Verify**: Check evaluation consistency across the three evaluation vectors,
+//!    then batch KZG pairing check.
+
+pub mod error;
+pub mod kzg;
+pub mod scheme;
+pub mod types;
+
+pub use scheme::HyperKZGScheme;
+pub use types::{HyperKZGCommitment, HyperKZGProof, HyperKZGProverSetup, HyperKZGVerifierSetup};

--- a/crates/jolt-hyperkzg/src/scheme.rs
+++ b/crates/jolt-hyperkzg/src/scheme.rs
@@ -1,0 +1,605 @@
+//! HyperKZG commitment scheme implementing `jolt-openings` traits.
+//!
+//! [`HyperKZGScheme`] is generic over `P: PairingGroup` — instantiate with
+//! `Bn254` for the concrete BN254 curve.
+
+#![expect(
+    clippy::expect_used,
+    reason = "KZG operations return Result for API symmetry; with a correctly-sized SRS and well-formed inputs these errors are unreachable"
+)]
+
+use std::marker::PhantomData;
+
+use jolt_crypto::{Commitment, DeriveSetup, JoltGroup, PairingGroup, PedersenSetup};
+use jolt_field::Field;
+use jolt_openings::{AdditivelyHomomorphic, CommitmentScheme, OpeningsError};
+use jolt_poly::Polynomial;
+use jolt_transcript::{AppendToTranscript, Label, LabelWithCount, Transcript};
+use num_traits::{One, Zero};
+use rayon::prelude::*;
+
+use crate::error::HyperKZGError;
+use crate::kzg::{self, kzg_open_batch, kzg_verify_batch};
+use crate::types::{HyperKZGCommitment, HyperKZGProof, HyperKZGProverSetup, HyperKZGVerifierSetup};
+
+/// HyperKZG multilinear polynomial commitment scheme.
+///
+/// Generic over `P: PairingGroup`. Implements [`CommitmentScheme`] and
+/// [`AdditivelyHomomorphic`] from `jolt-openings`.
+#[derive(Clone)]
+pub struct HyperKZGScheme<P: PairingGroup> {
+    _phantom: PhantomData<P>,
+}
+
+impl<P: PairingGroup> HyperKZGScheme<P>
+where
+    P::ScalarField: AppendToTranscript,
+    P::G1: AppendToTranscript,
+{
+    /// Generates an SRS from a random generator and secret scalar.
+    ///
+    /// `max_degree` is the maximum polynomial length (number of evaluations).
+    /// The SRS will contain `max_degree + 1` G1 powers and 2 G2 powers.
+    pub fn setup<R: rand_core::RngCore>(
+        rng: &mut R,
+        max_degree: usize,
+        g1: P::G1,
+        g2: P::G2,
+    ) -> HyperKZGProverSetup<P> {
+        let beta = P::ScalarField::random(rng);
+        Self::setup_from_secret(beta, max_degree, g1, g2)
+    }
+
+    /// Generates SRS from a known secret (for deterministic testing).
+    pub fn setup_from_secret(
+        beta: P::ScalarField,
+        max_degree: usize,
+        g1: P::G1,
+        g2: P::G2,
+    ) -> HyperKZGProverSetup<P> {
+        let mut g1_powers = Vec::with_capacity(max_degree + 1);
+        let mut cur = g1;
+        for _ in 0..=max_degree {
+            g1_powers.push(cur);
+            cur = cur.scalar_mul(&beta);
+        }
+
+        let g2_powers = vec![g2, g2.scalar_mul(&beta)];
+
+        HyperKZGProverSetup {
+            g1_powers,
+            g2_powers,
+        }
+    }
+
+    /// Phase 1 of the HyperKZG protocol: fold the multilinear polynomial.
+    ///
+    /// Given polynomial $P$ with $2^\ell$ evaluations and opening point
+    /// $x = (x_1, \ldots, x_\ell)$, produces $\ell$ polynomials
+    /// $P_0 = P, P_1, \ldots, P_{\ell-1}$ where each $P_i$ has half
+    /// the length of $P_{i-1}$.
+    ///
+    /// The folding relation is:
+    /// $P_i[j] = (1 - x_{\ell-i}) \cdot P_{i-1}[2j] + x_{\ell-i} \cdot P_{i-1}[2j+1]$
+    fn fold_polynomials(
+        evals: &[P::ScalarField],
+        point: &[P::ScalarField],
+    ) -> Vec<Vec<P::ScalarField>> {
+        let ell = point.len();
+        let mut polys = Vec::with_capacity(ell);
+        polys.push(evals.to_vec());
+
+        for i in 0..ell - 1 {
+            let prev = &polys[i];
+            let half = prev.len() / 2;
+            let xi = point[ell - i - 1];
+            let mut pi = vec![P::ScalarField::zero(); half];
+            pi.par_iter_mut().enumerate().for_each(|(j, pj)| {
+                *pj = prev[2 * j] + xi * (prev[2 * j + 1] - prev[2 * j]);
+            });
+            polys.push(pi);
+        }
+
+        polys
+    }
+
+    /// Full HyperKZG opening proof.
+    #[tracing::instrument(skip_all, name = "HyperKZG::open")]
+    pub fn open<T: Transcript<Challenge = P::ScalarField>>(
+        setup: &HyperKZGProverSetup<P>,
+        evals: &[P::ScalarField],
+        point: &[P::ScalarField],
+        transcript: &mut T,
+    ) -> Result<HyperKZGProof<P>, HyperKZGError> {
+        let ell = point.len();
+        let n = evals.len();
+        assert_eq!(n, 1 << ell, "evaluation count must be 2^ell");
+
+        // Phase 1: fold
+        let polys = Self::fold_polynomials(evals, point);
+        assert_eq!(polys.len(), ell);
+        assert_eq!(polys[ell - 1].len(), 2);
+
+        // Commit to intermediate polynomials (skip polys[0] — already committed)
+        let com: Vec<P::G1> = polys[1..]
+            .par_iter()
+            .map(|p| kzg::kzg_commit::<P>(p, setup).expect("SRS large enough for intermediate"))
+            .collect();
+
+        // Phase 2: derive challenge r
+        for c in &com {
+            transcript.append(c);
+        }
+        let r: P::ScalarField = transcript.challenge();
+        let u = vec![r, -r, r * r];
+
+        // Phase 3: batch open all polynomials at the three points
+        let (w, v) = kzg_open_batch::<P, T>(&polys, &u, setup, transcript);
+
+        Ok(HyperKZGProof { com, w, v })
+    }
+
+    /// HyperKZG verification.
+    #[tracing::instrument(skip_all, name = "HyperKZG::verify")]
+    pub fn verify<T: Transcript<Challenge = P::ScalarField>>(
+        vk: &HyperKZGVerifierSetup<P>,
+        commitment: &HyperKZGCommitment<P>,
+        point: &[P::ScalarField],
+        claimed_eval: &P::ScalarField,
+        proof: &HyperKZGProof<P>,
+        transcript: &mut T,
+    ) -> Result<(), HyperKZGError> {
+        let ell = point.len();
+
+        let mut com = proof.com.clone();
+
+        // Absorb intermediate commitments
+        for c in &com {
+            transcript.append(c);
+        }
+        let r: P::ScalarField = transcript.challenge();
+
+        if r.is_zero() {
+            return Err(HyperKZGError::VerificationFailed);
+        }
+
+        // Prepend the original commitment as C_0
+        com.insert(0, commitment.point);
+
+        let u = vec![r, -r, r * r];
+
+        // Validate proof dimensions
+        let v = &proof.v;
+        if v.len() != 3 {
+            return Err(HyperKZGError::InvalidProof("v must have 3 evaluation rows"));
+        }
+        if v[0].len() != ell || v[1].len() != ell || v[2].len() != ell {
+            return Err(HyperKZGError::InvalidProof(
+                "each v row must have ell entries",
+            ));
+        }
+
+        let ypos = &v[0]; // evaluations at r
+        let yneg = &v[1]; // evaluations at -r
+        let mut y_sq = v[2].clone(); // evaluations at r^2
+        y_sq.push(*claimed_eval);
+
+        // Consistency check: the folding relation must hold across evaluations
+        //
+        // For each level i, the polynomial P_i is defined by:
+        //   P_i(x) = (1 - x_{ell-i}) * P_{i-1,even}(x) + x_{ell-i} * P_{i-1,odd}(x)
+        //
+        // This implies:
+        //   2*r * P_{i+1}(r^2) = r * (1 - x_{ell-i-1}) * (P_i(r) + P_i(-r))
+        //                       + x_{ell-i-1} * (P_i(r) - P_i(-r))
+        let two = P::ScalarField::from_u64(2);
+        for i in 0..ell {
+            let lhs = two * r * y_sq[i + 1];
+            let rhs = r * (P::ScalarField::one() - point[ell - i - 1]) * (ypos[i] + yneg[i])
+                + point[ell - i - 1] * (ypos[i] - yneg[i]);
+            if lhs != rhs {
+                return Err(HyperKZGError::VerificationFailed);
+            }
+        }
+
+        // Batch KZG pairing check
+        if !kzg_verify_batch::<P, T>(vk, &com, &proof.w, &u, &proof.v, transcript) {
+            return Err(HyperKZGError::VerificationFailed);
+        }
+
+        Ok(())
+    }
+}
+
+impl<P: PairingGroup> DeriveSetup<HyperKZGProverSetup<P>> for PedersenSetup<P::G1> {
+    fn derive(source: &HyperKZGProverSetup<P>, capacity: usize) -> Self {
+        assert!(
+            source.g1_powers.len() > capacity,
+            "SRS has {} G1 powers, need at least {} (capacity + 1 for blinding)",
+            source.g1_powers.len(),
+            capacity + 1,
+        );
+        let message_generators = source.g1_powers[..capacity].to_vec();
+        let blinding_generator = source.g1_powers[capacity];
+        PedersenSetup::new(message_generators, blinding_generator)
+    }
+}
+
+impl<P: PairingGroup> Commitment for HyperKZGScheme<P> {
+    type Output = HyperKZGCommitment<P>;
+}
+
+impl<P: PairingGroup> CommitmentScheme for HyperKZGScheme<P>
+where
+    P::ScalarField: AppendToTranscript,
+    P::G1: AppendToTranscript,
+{
+    type Field = P::ScalarField;
+    type Proof = HyperKZGProof<P>;
+    type ProverSetup = HyperKZGProverSetup<P>;
+    type VerifierSetup = HyperKZGVerifierSetup<P>;
+    type Polynomial = Polynomial<P::ScalarField>;
+    type OpeningHint = ();
+    type SetupParams = (usize, P::G1, P::G2);
+
+    fn setup(
+        (max_num_vars, g1, g2): Self::SetupParams,
+    ) -> (Self::ProverSetup, Self::VerifierSetup) {
+        use rand_chacha::{rand_core::SeedableRng, ChaCha20Rng};
+        let mut rng = ChaCha20Rng::seed_from_u64(0);
+        let max_degree = 1usize << max_num_vars;
+        let prover =
+            HyperKZGScheme::setup_from_secret(P::ScalarField::random(&mut rng), max_degree, g1, g2);
+        let verifier = Self::verifier_setup(&prover);
+        (prover, verifier)
+    }
+
+    fn verifier_setup(prover_setup: &Self::ProverSetup) -> Self::VerifierSetup {
+        HyperKZGVerifierSetup::from(prover_setup)
+    }
+
+    fn commit<S: jolt_poly::MultilinearPoly<Self::Field> + ?Sized>(
+        poly: &S,
+        setup: &Self::ProverSetup,
+    ) -> (Self::Output, Self::OpeningHint) {
+        // HyperKZG always works on dense evaluations.
+        let mut evaluations = Vec::with_capacity(1 << poly.num_vars());
+        poly.for_each_row(poly.num_vars(), &mut |_, row| {
+            evaluations.extend_from_slice(row);
+        });
+        let point = kzg::kzg_commit::<P>(&evaluations, setup)
+            .expect("SRS must be large enough for the polynomial");
+        (HyperKZGCommitment { point }, ())
+    }
+
+    fn open(
+        poly: &Self::Polynomial,
+        point: &[Self::Field],
+        _eval: Self::Field,
+        setup: &Self::ProverSetup,
+        _hint: Option<Self::OpeningHint>,
+        transcript: &mut impl Transcript<Challenge = Self::Field>,
+    ) -> Self::Proof {
+        Self::open(setup, poly.evaluations(), point, transcript)
+            .expect("HyperKZG open should not fail with valid inputs")
+    }
+
+    fn verify(
+        commitment: &Self::Output,
+        point: &[Self::Field],
+        eval: Self::Field,
+        proof: &Self::Proof,
+        setup: &Self::VerifierSetup,
+        transcript: &mut impl Transcript<Challenge = Self::Field>,
+    ) -> Result<(), OpeningsError> {
+        Self::verify(setup, commitment, point, &eval, proof, transcript)
+            .map_err(|_| OpeningsError::VerificationFailed)
+    }
+
+    fn bind_opening_inputs(
+        transcript: &mut impl Transcript<Challenge = Self::Field>,
+        point: &[Self::Field],
+        eval: &Self::Field,
+    ) {
+        transcript.append(&LabelWithCount(
+            b"hyperkzg_opening_point",
+            point.len() as u64,
+        ));
+        for p in point {
+            p.append_to_transcript(transcript);
+        }
+        transcript.append(&Label(b"hyperkzg_opening_eval"));
+        eval.append_to_transcript(transcript);
+    }
+}
+
+impl<P: PairingGroup> AdditivelyHomomorphic for HyperKZGScheme<P>
+where
+    P::ScalarField: AppendToTranscript,
+    P::G1: AppendToTranscript,
+{
+    fn combine(commitments: &[Self::Output], scalars: &[Self::Field]) -> Self::Output {
+        assert_eq!(commitments.len(), scalars.len());
+        let combined = commitments
+            .iter()
+            .zip(scalars.iter())
+            .map(|(c, s)| c.point.scalar_mul(s))
+            .fold(P::G1::identity(), |acc, x| acc + x);
+        HyperKZGCommitment { point: combined }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use jolt_crypto::Bn254;
+    use jolt_field::Fr;
+    use jolt_poly::Polynomial;
+    use jolt_transcript::Blake2bTranscript;
+    use rand_chacha::ChaCha20Rng;
+    use rand_core::SeedableRng;
+
+    type TestScheme = HyperKZGScheme<Bn254>;
+
+    fn test_setup(max_degree: usize) -> (HyperKZGProverSetup<Bn254>, HyperKZGVerifierSetup<Bn254>) {
+        let mut rng = ChaCha20Rng::seed_from_u64(0xdead_beef);
+        let g1 = Bn254::g1_generator();
+        let g2 = Bn254::g2_generator();
+        let prover = TestScheme::setup(&mut rng, max_degree, g1, g2);
+        let verifier = TestScheme::verifier_setup(&prover);
+        (prover, verifier)
+    }
+
+    #[test]
+    fn commit_open_verify_roundtrip() {
+        for ell in [2, 3, 4, 6, 8] {
+            let n = 1 << ell;
+            let mut rng = ChaCha20Rng::seed_from_u64(ell as u64);
+            let (pk, vk) = test_setup(n);
+
+            let poly = Polynomial::<Fr>::random(ell, &mut rng);
+            let point: Vec<Fr> = (0..ell).map(|_| Fr::random(&mut rng)).collect();
+            let eval = poly.evaluate(&point);
+
+            let (commitment, ()) = TestScheme::commit(poly.evaluations(), &pk);
+
+            let mut prover_transcript = Blake2bTranscript::new(b"test");
+            let proof = <TestScheme as CommitmentScheme>::open(
+                &poly,
+                &point,
+                eval,
+                &pk,
+                None,
+                &mut prover_transcript,
+            );
+
+            let mut verifier_transcript = Blake2bTranscript::new(b"test");
+            let result = <TestScheme as CommitmentScheme>::verify(
+                &commitment,
+                &point,
+                eval,
+                &proof,
+                &vk,
+                &mut verifier_transcript,
+            );
+            assert!(result.is_ok(), "ell={ell}: verification failed: {result:?}");
+        }
+    }
+
+    #[test]
+    fn wrong_eval_rejects() {
+        let ell = 4;
+        let n = 1 << ell;
+        let mut rng = ChaCha20Rng::seed_from_u64(42);
+        let (pk, vk) = test_setup(n);
+
+        let poly = Polynomial::<Fr>::random(ell, &mut rng);
+        let point: Vec<Fr> = (0..ell).map(|_| Fr::random(&mut rng)).collect();
+        let eval = poly.evaluate(&point);
+        let wrong_eval = eval + Fr::from_u64(1);
+
+        let (commitment, ()) = TestScheme::commit(poly.evaluations(), &pk);
+
+        let mut prover_transcript = Blake2bTranscript::new(b"test-bad");
+        let proof = <TestScheme as CommitmentScheme>::open(
+            &poly,
+            &point,
+            eval,
+            &pk,
+            None,
+            &mut prover_transcript,
+        );
+
+        let mut verifier_transcript = Blake2bTranscript::new(b"test-bad");
+        let result = <TestScheme as CommitmentScheme>::verify(
+            &commitment,
+            &point,
+            wrong_eval,
+            &proof,
+            &vk,
+            &mut verifier_transcript,
+        );
+        assert!(result.is_err(), "wrong evaluation should be rejected");
+    }
+
+    #[test]
+    fn tampered_proof_rejects() {
+        let ell = 4;
+        let n = 1 << ell;
+        let mut rng = ChaCha20Rng::seed_from_u64(99);
+        let (pk, vk) = test_setup(n);
+
+        let poly = Polynomial::<Fr>::random(ell, &mut rng);
+        let point: Vec<Fr> = (0..ell).map(|_| Fr::random(&mut rng)).collect();
+        let eval = poly.evaluate(&point);
+
+        let (commitment, ()) = TestScheme::commit(poly.evaluations(), &pk);
+
+        let mut prover_transcript = Blake2bTranscript::new(b"test-tamper");
+        let mut proof = <TestScheme as CommitmentScheme>::open(
+            &poly,
+            &point,
+            eval,
+            &pk,
+            None,
+            &mut prover_transcript,
+        );
+
+        // Tamper with proof: swap v[0] and v[1]
+        let v1 = proof.v[1].clone();
+        proof.v[0].clone_from(&v1);
+
+        let mut verifier_transcript = Blake2bTranscript::new(b"test-tamper");
+        let result = <TestScheme as CommitmentScheme>::verify(
+            &commitment,
+            &point,
+            eval,
+            &proof,
+            &vk,
+            &mut verifier_transcript,
+        );
+        assert!(result.is_err(), "tampered proof should be rejected");
+    }
+
+    #[test]
+    fn combine_is_homomorphic() {
+        let ell = 3;
+        let n = 1 << ell;
+        let mut rng = ChaCha20Rng::seed_from_u64(300);
+        let (pk, _vk) = test_setup(n);
+
+        let poly_a = Polynomial::<Fr>::random(ell, &mut rng);
+        let poly_b = Polynomial::<Fr>::random(ell, &mut rng);
+
+        let (ca, ()) = TestScheme::commit(poly_a.evaluations(), &pk);
+        let (cb, ()) = TestScheme::commit(poly_b.evaluations(), &pk);
+
+        let sum_evals: Vec<Fr> = poly_a
+            .evaluations()
+            .iter()
+            .zip(poly_b.evaluations().iter())
+            .map(|(a, b)| *a + *b)
+            .collect();
+        let (c_sum_direct, ()) = TestScheme::commit(&sum_evals, &pk);
+
+        let c_sum_combined = TestScheme::combine(&[ca, cb], &[Fr::from_u64(1), Fr::from_u64(1)]);
+
+        assert_eq!(
+            c_sum_direct, c_sum_combined,
+            "combine([1,1]) must match commitment to sum"
+        );
+    }
+
+    #[test]
+    fn combine_with_scalars() {
+        let ell = 3;
+        let n = 1 << ell;
+        let mut rng = ChaCha20Rng::seed_from_u64(400);
+        let (pk, _vk) = test_setup(n);
+
+        let poly_a = Polynomial::<Fr>::random(ell, &mut rng);
+        let poly_b = Polynomial::<Fr>::random(ell, &mut rng);
+        let s_a = Fr::random(&mut rng);
+        let s_b = Fr::random(&mut rng);
+
+        let (ca, ()) = TestScheme::commit(poly_a.evaluations(), &pk);
+        let (cb, ()) = TestScheme::commit(poly_b.evaluations(), &pk);
+
+        let combined_evals: Vec<Fr> = poly_a
+            .evaluations()
+            .iter()
+            .zip(poly_b.evaluations().iter())
+            .map(|(a, b)| s_a * *a + s_b * *b)
+            .collect();
+        let (c_direct, ()) = TestScheme::commit(&combined_evals, &pk);
+
+        let c_combined = TestScheme::combine(&[ca, cb], &[s_a, s_b]);
+
+        assert_eq!(c_direct, c_combined);
+    }
+
+    #[test]
+    fn open_verify_with_random_points() {
+        let mut rng = ChaCha20Rng::seed_from_u64(0xcafe);
+
+        for _ in 0..5 {
+            let ell = 4;
+            let n = 1 << ell;
+            let (pk, vk) = test_setup(n);
+
+            let poly = Polynomial::<Fr>::random(ell, &mut rng);
+            let point: Vec<Fr> = (0..ell).map(|_| Fr::random(&mut rng)).collect();
+            let eval = poly.evaluate(&point);
+
+            let (commitment, ()) = TestScheme::commit(poly.evaluations(), &pk);
+
+            let mut pt = Blake2bTranscript::new(b"rand-test");
+            let proof =
+                <TestScheme as CommitmentScheme>::open(&poly, &point, eval, &pk, None, &mut pt);
+
+            let mut vt = Blake2bTranscript::new(b"rand-test");
+            <TestScheme as CommitmentScheme>::verify(
+                &commitment,
+                &point,
+                eval,
+                &proof,
+                &vk,
+                &mut vt,
+            )
+            .expect("random instance should verify");
+        }
+    }
+
+    #[test]
+    fn extract_vc_setup_produces_valid_pedersen() {
+        use jolt_crypto::{Pedersen, VectorCommitment};
+
+        let n = 1 << 4;
+        let (pk, _vk) = test_setup(n);
+
+        let capacity = 5;
+        let vc_setup = PedersenSetup::<jolt_crypto::Bn254G1>::derive(&pk, capacity);
+
+        assert_eq!(
+            <Pedersen<jolt_crypto::Bn254G1> as VectorCommitment>::capacity(&vc_setup),
+            capacity,
+        );
+
+        // Commit and verify a small vector.
+        let values = vec![Fr::one(), Fr::from_u64(2), Fr::from_u64(3)];
+        let blinding = Fr::from_u64(42);
+        let commitment = <Pedersen<jolt_crypto::Bn254G1> as VectorCommitment>::commit(
+            &vc_setup, &values, &blinding,
+        );
+        assert!(
+            <Pedersen<jolt_crypto::Bn254G1> as VectorCommitment>::verify(
+                &vc_setup,
+                &commitment,
+                &values,
+                &blinding,
+            )
+        );
+    }
+
+    #[test]
+    fn trivial_polynomial() {
+        // 1-variable polynomial: [a, b]
+        let ell = 1;
+        let n = 1 << ell;
+        let mut rng = ChaCha20Rng::seed_from_u64(777);
+        let (pk, vk) = test_setup(n);
+
+        let poly = Polynomial::<Fr>::random(ell, &mut rng);
+        let point: Vec<Fr> = (0..ell).map(|_| Fr::random(&mut rng)).collect();
+        let eval = poly.evaluate(&point);
+
+        let (commitment, ()) = TestScheme::commit(poly.evaluations(), &pk);
+
+        let mut pt = Blake2bTranscript::new(b"trivial");
+        let proof = <TestScheme as CommitmentScheme>::open(&poly, &point, eval, &pk, None, &mut pt);
+
+        let mut vt = Blake2bTranscript::new(b"trivial");
+        <TestScheme as CommitmentScheme>::verify(&commitment, &point, eval, &proof, &vk, &mut vt)
+            .expect("trivial polynomial should verify");
+    }
+}

--- a/crates/jolt-hyperkzg/src/scheme.rs
+++ b/crates/jolt-hyperkzg/src/scheme.rs
@@ -138,7 +138,7 @@ where
             transcript.append(c);
         }
         let r: P::ScalarField = transcript.challenge();
-        let u = vec![r, -r, r * r];
+        let u = [r, -r, r * r];
 
         // Phase 3: batch open all polynomials at the three points
         let (w, v) = kzg_open_batch::<P, T>(&polys, &u, setup, transcript);
@@ -168,16 +168,10 @@ where
             });
         }
 
-        // Validate proof dimensions before mutating the transcript.
+        // Validate inner evaluation widths before mutating the transcript.
         let v = &proof.v;
-        if v.len() != 3 {
-            return Err(HyperKZGError::WrongEvaluationRowCount { got: v.len() });
-        }
         if v[0].len() != ell || v[1].len() != ell || v[2].len() != ell {
             return Err(HyperKZGError::WrongEvaluationWidth { expected: ell });
-        }
-        if proof.w.len() != 3 {
-            return Err(HyperKZGError::WrongWitnessCount { got: proof.w.len() });
         }
 
         // Absorb intermediate commitments
@@ -195,7 +189,7 @@ where
         com.push(commitment.point);
         com.extend_from_slice(&proof.com);
 
-        let u = vec![r, -r, r * r];
+        let u = [r, -r, r * r];
 
         let ypos = &v[0]; // evaluations at r
         let yneg = &v[1]; // evaluations at -r
@@ -477,45 +471,6 @@ mod tests {
         assert!(matches!(
             result,
             Err(HyperKZGError::WrongCommitmentCount { .. })
-        ));
-    }
-
-    #[test]
-    fn malformed_witness_commitments_reject_without_panic() {
-        let ell = 4;
-        let n = 1 << ell;
-        let mut rng = ChaCha20Rng::seed_from_u64(44);
-        let (pk, vk) = test_setup(n);
-
-        let poly = Polynomial::<Fr>::random(ell, &mut rng);
-        let point: Vec<Fr> = (0..ell).map(|_| Fr::random(&mut rng)).collect();
-        let eval = poly.evaluate(&point);
-
-        let (commitment, ()) = TestScheme::commit(poly.evaluations(), &pk);
-
-        let mut prover_transcript = Blake2bTranscript::new(b"test-short-w");
-        let mut proof = <TestScheme as CommitmentScheme>::open(
-            &poly,
-            &point,
-            eval,
-            &pk,
-            None,
-            &mut prover_transcript,
-        );
-        let _ = proof.w.pop();
-
-        let mut verifier_transcript = Blake2bTranscript::new(b"test-short-w");
-        let result = TestScheme::verify(
-            &vk,
-            &commitment,
-            &point,
-            &eval,
-            &proof,
-            &mut verifier_transcript,
-        );
-        assert!(matches!(
-            result,
-            Err(HyperKZGError::WrongWitnessCount { .. })
         ));
     }
 

--- a/crates/jolt-hyperkzg/src/scheme.rs
+++ b/crates/jolt-hyperkzg/src/scheme.rs
@@ -116,6 +116,9 @@ where
         transcript: &mut T,
     ) -> Result<HyperKZGProof<P>, HyperKZGError> {
         let ell = point.len();
+        if ell == 0 {
+            return Err(HyperKZGError::EmptyPoint);
+        }
         let n = evals.len();
         assert_eq!(n, 1 << ell, "evaluation count must be 2^ell");
 
@@ -154,27 +157,27 @@ where
         transcript: &mut T,
     ) -> Result<(), HyperKZGError> {
         let ell = point.len();
+        if ell == 0 {
+            return Err(HyperKZGError::EmptyPoint);
+        }
 
         if proof.com.len() + 1 != ell {
-            return Err(HyperKZGError::InvalidProof(
-                "com must contain ell - 1 intermediate commitments",
-            ));
+            return Err(HyperKZGError::WrongCommitmentCount {
+                expected: ell - 1,
+                got: proof.com.len(),
+            });
         }
 
         // Validate proof dimensions before mutating the transcript.
         let v = &proof.v;
         if v.len() != 3 {
-            return Err(HyperKZGError::InvalidProof("v must have 3 evaluation rows"));
+            return Err(HyperKZGError::WrongEvaluationRowCount { got: v.len() });
         }
         if v[0].len() != ell || v[1].len() != ell || v[2].len() != ell {
-            return Err(HyperKZGError::InvalidProof(
-                "each v row must have ell entries",
-            ));
+            return Err(HyperKZGError::WrongEvaluationWidth { expected: ell });
         }
         if proof.w.len() != 3 {
-            return Err(HyperKZGError::InvalidProof(
-                "w must have 3 witness commitments",
-            ));
+            return Err(HyperKZGError::WrongWitnessCount { got: proof.w.len() });
         }
 
         // Absorb intermediate commitments
@@ -184,7 +187,7 @@ where
         let r: P::ScalarField = transcript.challenge();
 
         if r.is_zero() {
-            return Err(HyperKZGError::VerificationFailed);
+            return Err(HyperKZGError::DegenerateChallenge);
         }
 
         // Prepend the original commitment as C_0
@@ -213,19 +216,24 @@ where
             let rhs = r * (P::ScalarField::one() - point[ell - i - 1]) * (ypos[i] + yneg[i])
                 + point[ell - i - 1] * (ypos[i] - yneg[i]);
             if lhs != rhs {
-                return Err(HyperKZGError::VerificationFailed);
+                return Err(HyperKZGError::FoldingConsistencyFailed { level: i });
             }
         }
 
         // Batch KZG pairing check
         if !kzg_verify_batch::<P, T>(vk, &com, &proof.w, &u, &proof.v, transcript) {
-            return Err(HyperKZGError::VerificationFailed);
+            return Err(HyperKZGError::PairingCheckFailed);
         }
 
         Ok(())
     }
 }
 
+/// # Security note
+///
+/// Uses KZG SRS powers as Pedersen generators — Pedersen binding shares the
+/// KZG trapdoor `beta`. Both are sound once `beta` is destroyed, but the two
+/// schemes do not have independent security assumptions.
 impl<P: PairingGroup> DeriveSetup<HyperKZGProverSetup<P>> for PedersenSetup<P::G1> {
     fn derive(source: &HyperKZGProverSetup<P>, capacity: usize) -> Self {
         assert!(
@@ -333,12 +341,10 @@ where
 {
     fn combine(commitments: &[Self::Output], scalars: &[Self::Field]) -> Self::Output {
         assert_eq!(commitments.len(), scalars.len());
-        let combined = commitments
-            .iter()
-            .zip(scalars.iter())
-            .map(|(c, s)| c.point.scalar_mul(s))
-            .fold(P::G1::identity(), |acc, x| acc + x);
-        HyperKZGCommitment { point: combined }
+        let bases: Vec<P::G1> = commitments.iter().map(|c| c.point).collect();
+        HyperKZGCommitment {
+            point: P::G1::msm(&bases, scalars),
+        }
     }
 }
 
@@ -468,7 +474,10 @@ mod tests {
             &proof,
             &mut verifier_transcript,
         );
-        assert!(matches!(result, Err(HyperKZGError::InvalidProof(_))));
+        assert!(matches!(
+            result,
+            Err(HyperKZGError::WrongCommitmentCount { .. })
+        ));
     }
 
     #[test]
@@ -504,7 +513,10 @@ mod tests {
             &proof,
             &mut verifier_transcript,
         );
-        assert!(matches!(result, Err(HyperKZGError::InvalidProof(_))));
+        assert!(matches!(
+            result,
+            Err(HyperKZGError::WrongWitnessCount { .. })
+        ));
     }
 
     #[test]

--- a/crates/jolt-hyperkzg/src/scheme.rs
+++ b/crates/jolt-hyperkzg/src/scheme.rs
@@ -11,7 +11,7 @@
 use std::marker::PhantomData;
 
 use jolt_crypto::{Commitment, DeriveSetup, JoltGroup, PairingGroup, PedersenSetup};
-use jolt_field::Field;
+use jolt_field::{FromPrimitiveInt, RandomSampling};
 use jolt_openings::{AdditivelyHomomorphic, CommitmentScheme, OpeningsError};
 use jolt_poly::Polynomial;
 use jolt_transcript::{AppendToTranscript, Label, LabelWithCount, Transcript};
@@ -50,7 +50,11 @@ where
         Self::setup_from_secret(beta, max_degree, g1, g2)
     }
 
-    /// Generates SRS from a known secret (for deterministic testing).
+    /// Generates SRS from a known secret.
+    ///
+    /// WARNING: this is only appropriate for deterministic tests or trusted
+    /// setup tooling that destroys `beta`; anyone who knows `beta` can break
+    /// KZG binding.
     pub fn setup_from_secret(
         beta: P::ScalarField,
         max_degree: usize,
@@ -151,24 +155,13 @@ where
     ) -> Result<(), HyperKZGError> {
         let ell = point.len();
 
-        let mut com = proof.com.clone();
-
-        // Absorb intermediate commitments
-        for c in &com {
-            transcript.append(c);
-        }
-        let r: P::ScalarField = transcript.challenge();
-
-        if r.is_zero() {
-            return Err(HyperKZGError::VerificationFailed);
+        if proof.com.len() + 1 != ell {
+            return Err(HyperKZGError::InvalidProof(
+                "com must contain ell - 1 intermediate commitments",
+            ));
         }
 
-        // Prepend the original commitment as C_0
-        com.insert(0, commitment.point);
-
-        let u = vec![r, -r, r * r];
-
-        // Validate proof dimensions
+        // Validate proof dimensions before mutating the transcript.
         let v = &proof.v;
         if v.len() != 3 {
             return Err(HyperKZGError::InvalidProof("v must have 3 evaluation rows"));
@@ -178,6 +171,28 @@ where
                 "each v row must have ell entries",
             ));
         }
+        if proof.w.len() != 3 {
+            return Err(HyperKZGError::InvalidProof(
+                "w must have 3 witness commitments",
+            ));
+        }
+
+        // Absorb intermediate commitments
+        for c in &proof.com {
+            transcript.append(c);
+        }
+        let r: P::ScalarField = transcript.challenge();
+
+        if r.is_zero() {
+            return Err(HyperKZGError::VerificationFailed);
+        }
+
+        // Prepend the original commitment as C_0
+        let mut com = Vec::with_capacity(ell);
+        com.push(commitment.point);
+        com.extend_from_slice(&proof.com);
+
+        let u = vec![r, -r, r * r];
 
         let ypos = &v[0]; // evaluations at r
         let yneg = &v[1]; // evaluations at -r
@@ -245,11 +260,9 @@ where
     fn setup(
         (max_num_vars, g1, g2): Self::SetupParams,
     ) -> (Self::ProverSetup, Self::VerifierSetup) {
-        use rand_chacha::{rand_core::SeedableRng, ChaCha20Rng};
-        let mut rng = ChaCha20Rng::seed_from_u64(0);
+        let mut rng = rand_core::OsRng;
         let max_degree = 1usize << max_num_vars;
-        let prover =
-            HyperKZGScheme::setup_from_secret(P::ScalarField::random(&mut rng), max_degree, g1, g2);
+        let prover = HyperKZGScheme::setup(&mut rng, max_degree, g1, g2);
         let verifier = Self::verifier_setup(&prover);
         (prover, verifier)
     }
@@ -420,6 +433,89 @@ mod tests {
             &mut verifier_transcript,
         );
         assert!(result.is_err(), "wrong evaluation should be rejected");
+    }
+
+    #[test]
+    fn missing_intermediate_commitment_rejects() {
+        let ell = 4;
+        let n = 1 << ell;
+        let mut rng = ChaCha20Rng::seed_from_u64(43);
+        let (pk, vk) = test_setup(n);
+
+        let poly = Polynomial::<Fr>::random(ell, &mut rng);
+        let point: Vec<Fr> = (0..ell).map(|_| Fr::random(&mut rng)).collect();
+        let eval = poly.evaluate(&point);
+
+        let (commitment, ()) = TestScheme::commit(poly.evaluations(), &pk);
+
+        let mut prover_transcript = Blake2bTranscript::new(b"test-missing-com");
+        let mut proof = <TestScheme as CommitmentScheme>::open(
+            &poly,
+            &point,
+            eval,
+            &pk,
+            None,
+            &mut prover_transcript,
+        );
+        let _ = proof.com.pop();
+
+        let mut verifier_transcript = Blake2bTranscript::new(b"test-missing-com");
+        let result = TestScheme::verify(
+            &vk,
+            &commitment,
+            &point,
+            &eval,
+            &proof,
+            &mut verifier_transcript,
+        );
+        assert!(matches!(result, Err(HyperKZGError::InvalidProof(_))));
+    }
+
+    #[test]
+    fn malformed_witness_commitments_reject_without_panic() {
+        let ell = 4;
+        let n = 1 << ell;
+        let mut rng = ChaCha20Rng::seed_from_u64(44);
+        let (pk, vk) = test_setup(n);
+
+        let poly = Polynomial::<Fr>::random(ell, &mut rng);
+        let point: Vec<Fr> = (0..ell).map(|_| Fr::random(&mut rng)).collect();
+        let eval = poly.evaluate(&point);
+
+        let (commitment, ()) = TestScheme::commit(poly.evaluations(), &pk);
+
+        let mut prover_transcript = Blake2bTranscript::new(b"test-short-w");
+        let mut proof = <TestScheme as CommitmentScheme>::open(
+            &poly,
+            &point,
+            eval,
+            &pk,
+            None,
+            &mut prover_transcript,
+        );
+        let _ = proof.w.pop();
+
+        let mut verifier_transcript = Blake2bTranscript::new(b"test-short-w");
+        let result = TestScheme::verify(
+            &vk,
+            &commitment,
+            &point,
+            &eval,
+            &proof,
+            &mut verifier_transcript,
+        );
+        assert!(matches!(result, Err(HyperKZGError::InvalidProof(_))));
+    }
+
+    #[test]
+    fn trait_setup_uses_fresh_randomness() {
+        let g1 = Bn254::g1_generator();
+        let g2 = Bn254::g2_generator();
+
+        let (_pk1, vk1) = <TestScheme as CommitmentScheme>::setup((4, g1, g2));
+        let (_pk2, vk2) = <TestScheme as CommitmentScheme>::setup((4, g1, g2));
+
+        assert_ne!(vk1.beta_g2, vk2.beta_g2);
     }
 
     #[test]

--- a/crates/jolt-hyperkzg/src/types.rs
+++ b/crates/jolt-hyperkzg/src/types.rs
@@ -1,0 +1,118 @@
+//! Commitment, proof, and setup types for HyperKZG.
+//!
+//! All types are generic over `P: PairingGroup` — no arkworks leakage.
+
+use jolt_crypto::{HomomorphicCommitment, JoltGroup, PairingGroup};
+use serde::{Deserialize, Serialize};
+
+/// Commitment to a multilinear polynomial: a single G1 element.
+#[derive(Serialize, Deserialize)]
+#[serde(bound(
+    serialize = "P::G1: Serialize",
+    deserialize = "P::G1: for<'a> Deserialize<'a>"
+))]
+pub struct HyperKZGCommitment<P: PairingGroup> {
+    pub(crate) point: P::G1,
+}
+
+impl<P: PairingGroup> Copy for HyperKZGCommitment<P> {}
+
+#[expect(
+    clippy::expl_impl_clone_on_copy,
+    reason = "explicit impl is required because PairingGroup is not bounded by Clone"
+)]
+impl<P: PairingGroup> Clone for HyperKZGCommitment<P> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<P: PairingGroup> std::fmt::Debug for HyperKZGCommitment<P> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("HyperKZGCommitment")
+            .field("point", &self.point)
+            .finish()
+    }
+}
+
+impl<P: PairingGroup> PartialEq for HyperKZGCommitment<P> {
+    fn eq(&self, other: &Self) -> bool {
+        self.point == other.point
+    }
+}
+
+impl<P: PairingGroup> Eq for HyperKZGCommitment<P> {}
+
+impl<P: PairingGroup, F: jolt_field::Field> HomomorphicCommitment<F> for HyperKZGCommitment<P> {
+    #[inline]
+    fn linear_combine(c1: &Self, c2: &Self, scalar: &F) -> Self {
+        Self {
+            point: HomomorphicCommitment::linear_combine(&c1.point, &c2.point, scalar),
+        }
+    }
+}
+
+impl<P: PairingGroup> Default for HyperKZGCommitment<P> {
+    fn default() -> Self {
+        Self {
+            point: P::G1::identity(),
+        }
+    }
+}
+
+/// Opening proof for the HyperKZG protocol.
+///
+/// - `com`: intermediate polynomial commitments from the Gemini folding (ell - 1 elements)
+/// - `w`: KZG witness commitments for the three evaluation points `[r, -r, r^2]`
+/// - `v`: evaluations of all intermediate polynomials at the three points
+///   (`v[t][k]` = polynomial k evaluated at point t)
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(bound(
+    serialize = "P::G1: Serialize, P::ScalarField: Serialize",
+    deserialize = "P::G1: for<'a> Deserialize<'a>, P::ScalarField: for<'a> Deserialize<'a>"
+))]
+pub struct HyperKZGProof<P: PairingGroup> {
+    pub com: Vec<P::G1>,
+    pub w: Vec<P::G1>,
+    pub v: Vec<Vec<P::ScalarField>>,
+}
+
+/// Prover setup: SRS G1 and G2 powers.
+///
+/// G1 powers: `[g1, beta * g1, beta^2 * g1, ..., beta^n * g1]`
+/// G2 powers: `[g2, beta * g2]` (only two needed for KZG verification).
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(bound(
+    serialize = "P::G1: Serialize, P::G2: Serialize",
+    deserialize = "P::G1: for<'a> Deserialize<'a>, P::G2: for<'a> Deserialize<'a>"
+))]
+pub struct HyperKZGProverSetup<P: PairingGroup> {
+    pub(crate) g1_powers: Vec<P::G1>,
+    pub(crate) g2_powers: Vec<P::G2>,
+}
+
+/// Verifier setup: the four G1/G2 elements needed for pairing checks.
+///
+/// - `g1`: generator $g$
+/// - `g2`: generator $h$
+/// - `beta_g2`: $\beta \cdot h$ (for KZG pairing check)
+#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
+#[serde(bound(
+    serialize = "P::G1: Serialize, P::G2: Serialize",
+    deserialize = "P::G1: for<'a> Deserialize<'a>, P::G2: for<'a> Deserialize<'a>"
+))]
+pub struct HyperKZGVerifierSetup<P: PairingGroup> {
+    pub(crate) g1: P::G1,
+    pub(crate) g2: P::G2,
+    pub(crate) beta_g2: P::G2,
+}
+
+impl<P: PairingGroup> From<&HyperKZGProverSetup<P>> for HyperKZGVerifierSetup<P> {
+    fn from(prover: &HyperKZGProverSetup<P>) -> Self {
+        Self {
+            g1: prover.g1_powers[0],
+            g2: prover.g2_powers[0],
+            beta_g2: prover.g2_powers[1],
+        }
+    }
+}

--- a/crates/jolt-hyperkzg/src/types.rs
+++ b/crates/jolt-hyperkzg/src/types.rs
@@ -73,8 +73,8 @@ impl<P: PairingGroup> Default for HyperKZGCommitment<P> {
 ))]
 pub struct HyperKZGProof<P: PairingGroup> {
     pub com: Vec<P::G1>,
-    pub w: Vec<P::G1>,
-    pub v: Vec<Vec<P::ScalarField>>,
+    pub w: [P::G1; 3],
+    pub v: [Vec<P::ScalarField>; 3],
 }
 
 /// Prover setup: SRS G1 and G2 powers.

--- a/crates/jolt-hyperkzg/tests/commit_open_verify.rs
+++ b/crates/jolt-hyperkzg/tests/commit_open_verify.rs
@@ -1,0 +1,224 @@
+//! Integration tests for HyperKZG commit → open → verify pipeline with BN254.
+
+#![expect(clippy::expect_used, reason = "tests may panic on assertion failures")]
+
+use jolt_crypto::Bn254;
+use jolt_field::{Field, Fr};
+use jolt_hyperkzg::{HyperKZGProverSetup, HyperKZGScheme, HyperKZGVerifierSetup};
+use jolt_openings::{AdditivelyHomomorphic, CommitmentScheme};
+use jolt_poly::Polynomial;
+use jolt_transcript::{Blake2bTranscript, Transcript};
+use rand_chacha::ChaCha20Rng;
+use rand_core::SeedableRng;
+
+type KzgPCS = HyperKZGScheme<Bn254>;
+
+fn make_setup(max_degree: usize) -> (HyperKZGProverSetup<Bn254>, HyperKZGVerifierSetup<Bn254>) {
+    let mut rng = ChaCha20Rng::seed_from_u64(0xdead_beef);
+    let g1 = Bn254::g1_generator();
+    let g2 = Bn254::g2_generator();
+    let pk = KzgPCS::setup(&mut rng, max_degree, g1, g2);
+    let vk = KzgPCS::verifier_setup(&pk);
+    (pk, vk)
+}
+
+fn commit_open_verify(
+    poly: &Polynomial<Fr>,
+    point: &[Fr],
+    pk: &HyperKZGProverSetup<Bn254>,
+    vk: &HyperKZGVerifierSetup<Bn254>,
+    label: &'static [u8],
+) {
+    let eval = poly.evaluate(point);
+    let (commitment, ()) = <KzgPCS as CommitmentScheme>::commit(poly.evaluations(), pk);
+
+    let mut t_p = Blake2bTranscript::new(label);
+    let proof = <KzgPCS as CommitmentScheme>::open(poly, point, eval, pk, None, &mut t_p);
+
+    let mut t_v = Blake2bTranscript::new(label);
+    <KzgPCS as CommitmentScheme>::verify(&commitment, point, eval, &proof, vk, &mut t_v)
+        .expect("verification should succeed");
+}
+
+// Basic roundtrip for various polynomial sizes
+
+#[test]
+fn roundtrip_num_vars_1_to_8() {
+    let mut rng = ChaCha20Rng::seed_from_u64(1000);
+    for nv in 1..=8 {
+        let (pk, vk) = make_setup(1 << nv);
+        let poly = Polynomial::<Fr>::random(nv, &mut rng);
+        let point: Vec<Fr> = (0..nv).map(|_| Fr::random(&mut rng)).collect();
+        commit_open_verify(&poly, &point, &pk, &vk, b"kzg-sizes");
+    }
+}
+
+// Edge cases
+
+/// All-zero polynomial commits to identity point and still verifies.
+#[test]
+fn zero_polynomial_roundtrip() {
+    let nv = 3;
+    let (pk, vk) = make_setup(1 << nv);
+    let poly = Polynomial::<Fr>::zeros(nv);
+    let point = vec![Fr::from_u64(42); nv];
+    commit_open_verify(&poly, &point, &pk, &vk, b"kzg-zero");
+}
+
+/// Single-variable polynomial (2 evaluations).
+#[test]
+fn single_variable_polynomial() {
+    let mut rng = ChaCha20Rng::seed_from_u64(2000);
+    let (pk, vk) = make_setup(2);
+    let poly = Polynomial::<Fr>::random(1, &mut rng);
+    let point = vec![Fr::random(&mut rng)];
+    commit_open_verify(&poly, &point, &pk, &vk, b"kzg-single-var");
+}
+
+/// Constant polynomial (all evaluations are the same value).
+#[test]
+fn constant_polynomial() {
+    let nv = 3;
+    let (pk, vk) = make_setup(1 << nv);
+    let val = Fr::from_u64(42);
+    let poly = Polynomial::new(vec![val; 1 << nv]);
+    let mut rng = ChaCha20Rng::seed_from_u64(2001);
+    let point: Vec<Fr> = (0..nv).map(|_| Fr::random(&mut rng)).collect();
+    commit_open_verify(&poly, &point, &pk, &vk, b"kzg-constant");
+}
+
+// Wrong evaluation rejection
+
+#[test]
+fn wrong_eval_rejected() {
+    let mut rng = ChaCha20Rng::seed_from_u64(3000);
+    let nv = 4;
+    let (pk, vk) = make_setup(1 << nv);
+    let poly = Polynomial::<Fr>::random(nv, &mut rng);
+    let point: Vec<Fr> = (0..nv).map(|_| Fr::random(&mut rng)).collect();
+
+    let correct_eval = poly.evaluate(&point);
+    let wrong_eval = correct_eval + Fr::from_u64(1);
+    let (commitment, ()) = <KzgPCS as CommitmentScheme>::commit(poly.evaluations(), &pk);
+
+    // Prover opens with correct eval
+    let mut t_p = Blake2bTranscript::new(b"kzg-wrong");
+    let proof =
+        <KzgPCS as CommitmentScheme>::open(&poly, &point, correct_eval, &pk, None, &mut t_p);
+
+    // Verifier checks with wrong eval
+    let mut t_v = Blake2bTranscript::new(b"kzg-wrong");
+    let result = <KzgPCS as CommitmentScheme>::verify(
+        &commitment,
+        &point,
+        wrong_eval,
+        &proof,
+        &vk,
+        &mut t_v,
+    );
+    assert!(result.is_err(), "wrong evaluation must be rejected");
+}
+
+// Homomorphic properties
+
+/// combine([C_a, C_b], [1, 1]) == commit(a + b).
+#[test]
+fn homomorphic_sum() {
+    let mut rng = ChaCha20Rng::seed_from_u64(4000);
+    let nv = 4;
+    let (pk, vk) = make_setup(1 << nv);
+    let a = Polynomial::<Fr>::random(nv, &mut rng);
+    let b = Polynomial::<Fr>::random(nv, &mut rng);
+
+    let (com_a, ()) = <KzgPCS as CommitmentScheme>::commit(a.evaluations(), &pk);
+    let (com_b, ()) = <KzgPCS as CommitmentScheme>::commit(b.evaluations(), &pk);
+    let combined_com = <KzgPCS as AdditivelyHomomorphic>::combine(
+        &[com_a, com_b],
+        &[Fr::from_u64(1), Fr::from_u64(1)],
+    );
+
+    let sum_poly = a + b;
+    let point: Vec<Fr> = (0..nv).map(|_| Fr::random(&mut rng)).collect();
+    let eval = sum_poly.evaluate(&point);
+
+    let mut t_p = Blake2bTranscript::new(b"kzg-homo");
+    let proof = <KzgPCS as CommitmentScheme>::open(&sum_poly, &point, eval, &pk, None, &mut t_p);
+
+    let mut t_v = Blake2bTranscript::new(b"kzg-homo");
+    <KzgPCS as CommitmentScheme>::verify(&combined_com, &point, eval, &proof, &vk, &mut t_v)
+        .expect("homomorphic sum must verify");
+}
+
+/// combine with arbitrary scalars: s_a·C_a + s_b·C_b == commit(s_a·a + s_b·b).
+#[test]
+fn homomorphic_weighted_combination() {
+    let mut rng = ChaCha20Rng::seed_from_u64(4001);
+    let nv = 3;
+    let (pk, vk) = make_setup(1 << nv);
+    let a = Polynomial::<Fr>::random(nv, &mut rng);
+    let b = Polynomial::<Fr>::random(nv, &mut rng);
+    let s_a = Fr::random(&mut rng);
+    let s_b = Fr::random(&mut rng);
+
+    let (com_a, ()) = <KzgPCS as CommitmentScheme>::commit(a.evaluations(), &pk);
+    let (com_b, ()) = <KzgPCS as CommitmentScheme>::commit(b.evaluations(), &pk);
+    let combined_com = <KzgPCS as AdditivelyHomomorphic>::combine(&[com_a, com_b], &[s_a, s_b]);
+
+    let weighted_poly = a * s_a + b * s_b;
+    let point: Vec<Fr> = (0..nv).map(|_| Fr::random(&mut rng)).collect();
+    let eval = weighted_poly.evaluate(&point);
+
+    let mut t_p = Blake2bTranscript::new(b"kzg-weighted");
+    let proof =
+        <KzgPCS as CommitmentScheme>::open(&weighted_poly, &point, eval, &pk, None, &mut t_p);
+
+    let mut t_v = Blake2bTranscript::new(b"kzg-weighted");
+    <KzgPCS as CommitmentScheme>::verify(&combined_com, &point, eval, &proof, &vk, &mut t_v)
+        .expect("weighted combination must verify");
+}
+
+// Deterministic setup
+
+#[test]
+fn deterministic_setup_from_secret() {
+    let g1 = Bn254::g1_generator();
+    let g2 = Bn254::g2_generator();
+    let beta = Fr::from_u64(12345);
+
+    let pk1 = KzgPCS::setup_from_secret(beta, 16, g1, g2);
+    let pk2 = KzgPCS::setup_from_secret(beta, 16, g1, g2);
+    let _vk1 = KzgPCS::verifier_setup(&pk1);
+    let vk2 = KzgPCS::verifier_setup(&pk2);
+
+    // Same setup yields same commitments
+    let poly = Polynomial::new(vec![Fr::from_u64(1), Fr::from_u64(2)]);
+    let (com1, ()) = <KzgPCS as CommitmentScheme>::commit(poly.evaluations(), &pk1);
+    let (com2, ()) = <KzgPCS as CommitmentScheme>::commit(poly.evaluations(), &pk2);
+    assert_eq!(
+        com1, com2,
+        "deterministic setups must produce same commitments"
+    );
+
+    // Verify with either setup
+    let point = vec![Fr::from_u64(7)];
+    let eval = poly.evaluate(&point);
+    let mut t = Blake2bTranscript::new(b"det-setup");
+    let proof = <KzgPCS as CommitmentScheme>::open(&poly, &point, eval, &pk1, None, &mut t);
+    let mut t = Blake2bTranscript::new(b"det-setup");
+    <KzgPCS as CommitmentScheme>::verify(&com1, &point, eval, &proof, &vk2, &mut t)
+        .expect("cross-setup verification must work");
+}
+
+// Property test: random polynomials always verify
+
+#[test]
+fn property_random_polynomials_always_verify() {
+    for seed in 5000..5010 {
+        let mut rng = ChaCha20Rng::seed_from_u64(seed);
+        let nv = 2 + (seed as usize % 5); // 2..6
+        let (pk, vk) = make_setup(1 << nv);
+        let poly = Polynomial::<Fr>::random(nv, &mut rng);
+        let point: Vec<Fr> = (0..nv).map(|_| Fr::random(&mut rng)).collect();
+        commit_open_verify(&poly, &point, &pk, &vk, b"kzg-property");
+    }
+}

--- a/crates/jolt-hyperkzg/tests/commit_open_verify.rs
+++ b/crates/jolt-hyperkzg/tests/commit_open_verify.rs
@@ -3,7 +3,7 @@
 #![expect(clippy::expect_used, reason = "tests may panic on assertion failures")]
 
 use jolt_crypto::Bn254;
-use jolt_field::{Field, Fr};
+use jolt_field::{Fr, FromPrimitiveInt, RandomSampling};
 use jolt_hyperkzg::{HyperKZGProverSetup, HyperKZGScheme, HyperKZGVerifierSetup};
 use jolt_openings::{AdditivelyHomomorphic, CommitmentScheme};
 use jolt_poly::Polynomial;


### PR DESCRIPTION
## Summary
- Introduces `jolt-hyperkzg`, a pairing-based multilinear polynomial commitment scheme implementing the `jolt-openings` trait surface
- Generic over `P: PairingGroup`; BN254 is the production instantiation
- Builds on univariate KZG primitives (commit, evaluate, witness polynomial division) reused internally by the multilinear protocol

## Changes
- `src/scheme.rs` — `HyperKZGScheme` implementing `CommitmentScheme` and `AdditivelyHomomorphic`; prove/verify built on KZG univariate openings
- `src/kzg.rs` — univariate KZG primitives used internally
- `src/types.rs` — `HyperKZGCommitment`, `HyperKZGProof`, `HyperKZGProverSetup`, `HyperKZGVerifierSetup`
- `src/error.rs` — `HyperKzgError` enum
- `tests/commit_open_verify.rs` — end-to-end commit/open/verify coverage
- `benches/hyperkzg.rs` — perf benchmarks
- `fuzz/` — three fuzz targets: `commit_open_verify`, `tampered_proof`, `wrong_eval`

## Testing
- `cargo nextest run -p jolt-hyperkzg`
- Fuzz targets exercise tampering and wrong-eval paths