### PR TITLE
fix(jolt-sumcheck): allow zero-round claims

### DIFF
--- a/crates/jolt-sumcheck/src/claim.rs
+++ b/crates/jolt-sumcheck/src/claim.rs
@@ -23,17 +23,7 @@ pub struct SumcheckClaim<F: Field> {
 
 impl<F: Field> SumcheckClaim<F> {
     /// Construct a sumcheck claim.
-    ///
-    /// # Panics
-    ///
-    /// Panics if `degree == 0 && num_vars > 0`. Sumcheck round polynomials
-    /// must have degree ≥ 1 once a round exists; the zero-round `num_vars == 0`
-    /// case is allowed and reduces directly to an oracle check.
     pub fn new(num_vars: usize, degree: usize, claimed_sum: F) -> Self {
-        assert!(
-            degree >= 1 || num_vars == 0,
-            "sumcheck round polynomial must have degree >= 1 when num_vars > 0, got degree={degree}, num_vars={num_vars}"
-        );
         Self {
             num_vars,
             degree,

--- a/crates/jolt-sumcheck/src/claim.rs
+++ b/crates/jolt-sumcheck/src/claim.rs
@@ -26,12 +26,13 @@ impl<F: Field> SumcheckClaim<F> {
     ///
     /// # Panics
     ///
-    /// Panics if `degree == 0`. Sumcheck round polynomials must have
-    /// degree ≥ 1; a constant round poly is meaningless.
+    /// Panics if `degree == 0 && num_vars > 0`. Sumcheck round polynomials
+    /// must have degree ≥ 1 once a round exists; the zero-round `num_vars == 0`
+    /// case is allowed and reduces directly to an oracle check.
     pub fn new(num_vars: usize, degree: usize, claimed_sum: F) -> Self {
         assert!(
-            degree >= 1,
-            "sumcheck round polynomial must have degree >= 1, got {degree}"
+            degree >= 1 || num_vars == 0,
+            "sumcheck round polynomial must have degree >= 1 when num_vars > 0, got degree={degree}, num_vars={num_vars}"
         );
         Self {
             num_vars,

--- a/crates/jolt-sumcheck/src/tests.rs
+++ b/crates/jolt-sumcheck/src/tests.rs
@@ -554,3 +554,11 @@ fn verify_dispatches_through_round_verifier_trait() {
 fn sumcheck_claim_new_rejects_degree_zero() {
     let _ = SumcheckClaim::<Fr>::new(3, 0, Fr::from_u64(0));
 }
+
+#[test]
+fn sumcheck_claim_new_allows_zero_round_zero_degree() {
+    let claim = SumcheckClaim::<Fr>::new(0, 0, Fr::from_u64(7));
+    assert_eq!(claim.num_vars, 0);
+    assert_eq!(claim.degree, 0);
+    assert_eq!(claim.claimed_sum, Fr::from_u64(7));
+}

--- a/crates/jolt-sumcheck/src/tests.rs
+++ b/crates/jolt-sumcheck/src/tests.rs
@@ -110,6 +110,36 @@ fn verify_valid_degree1_proof() {
 }
 
 #[test]
+fn verify_valid_degree_zero_proof() {
+    let c = F::from_u64(7);
+    let round_polys = vec![
+        UnivariatePoly::new(vec![F::from_u64(28)]),
+        UnivariatePoly::new(vec![F::from_u64(14)]),
+        UnivariatePoly::new(vec![c]),
+    ];
+    let claim = SumcheckClaim {
+        num_vars: 3,
+        degree: 0,
+        claimed_sum: F::from_u64(56),
+    };
+
+    let mut vt = Blake2bTranscript::new(b"sumcheck-test");
+    let result = SumcheckVerifier::verify(&claim, &round_polys, &mut vt);
+    assert!(
+        result.is_ok(),
+        "degree-zero verification failed: {:?}",
+        result.err()
+    );
+
+    let EvaluationClaim {
+        point: challenges,
+        value: final_eval,
+    } = result.unwrap();
+    assert_eq!(challenges.len(), 3);
+    assert_eq!(final_eval, c);
+}
+
+#[test]
 fn verify_single_variable() {
     // f(x) = 3 + 7x, evals = [3, 10]
     let evals = vec![F::from_u64(3), F::from_u64(10)];
@@ -550,9 +580,11 @@ fn verify_dispatches_through_round_verifier_trait() {
 }
 
 #[test]
-#[should_panic(expected = "degree >= 1")]
-fn sumcheck_claim_new_rejects_degree_zero() {
-    let _ = SumcheckClaim::<Fr>::new(3, 0, Fr::from_u64(0));
+fn sumcheck_claim_new_allows_degree_zero() {
+    let claim = SumcheckClaim::<Fr>::new(3, 0, Fr::from_u64(7));
+    assert_eq!(claim.num_vars, 3);
+    assert_eq!(claim.degree, 0);
+    assert_eq!(claim.claimed_sum, Fr::from_u64(7));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Allow `SumcheckClaim::new` to accept degree-zero claims generally.
- Cover a nonzero-variable constant sumcheck with degree-zero round polynomials.
- Keep the zero-round constructor regression test.

## Test plan
- `cargo fmt -q`
- `cargo nextest run -p jolt-sumcheck degree_zero sumcheck_claim_new --cargo-quiet`

Posted by Cursor assistant (model: GPT-5.5) on behalf of the user (Quang Dao) with approval.