### PR TITLE
fix(tracer): use wrapping_add in alignment assertions

### DIFF
--- a/tracer/src/instruction/virtual_assert_halfword_alignment.rs
+++ b/tracer/src/instruction/virtual_assert_halfword_alignment.rs
@@ -18,7 +18,7 @@ impl VirtualAssertHalfwordAlignment {
         cpu: &mut Cpu,
         _: &mut <VirtualAssertHalfwordAlignment as RISCVInstruction>::RAMAccess,
     ) {
-        let address = cpu.x[self.operands.rs1 as usize] + self.operands.imm;
+        let address = cpu.x[self.operands.rs1 as usize].wrapping_add(self.operands.imm);
         assert!(
             address & 1 == 0,
             "RAM access (LH or LHU) is not halfword aligned: {address:x}"
@@ -27,3 +27,29 @@ impl VirtualAssertHalfwordAlignment {
 }
 
 impl RISCVTrace for VirtualAssertHalfwordAlignment {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::emulator::cpu::Cpu;
+    use crate::emulator::terminal::DummyTerminal;
+    use crate::instruction::format::format_assert_align::FormatAssert;
+
+    /// See [`VirtualAssertWordAlignment`] tests for the rationale.
+    #[test]
+    fn wraps_on_overflow() {
+        let mut cpu = Cpu::new(Box::new(DummyTerminal::default()));
+        cpu.x[1] = i64::MAX;
+        let instr = VirtualAssertHalfwordAlignment {
+            address: 0,
+            operands: FormatAssert { rs1: 1, imm: 1 },
+            virtual_sequence_remaining: None,
+            is_first_in_sequence: false,
+            is_compressed: false,
+        };
+        let mut ram_access = ();
+        // i64::MAX.wrapping_add(1) == i64::MIN, whose low bit is 0, so this
+        // must execute without panicking.
+        instr.execute(&mut cpu, &mut ram_access);
+    }
+}

--- a/tracer/src/instruction/virtual_assert_word_alignment.rs
+++ b/tracer/src/instruction/virtual_assert_word_alignment.rs
@@ -18,7 +18,7 @@ impl VirtualAssertWordAlignment {
         cpu: &mut Cpu,
         _: &mut <VirtualAssertWordAlignment as RISCVInstruction>::RAMAccess,
     ) {
-        let address = cpu.x[self.operands.rs1 as usize] + self.operands.imm;
+        let address = cpu.x[self.operands.rs1 as usize].wrapping_add(self.operands.imm);
         assert!(
             address & 3 == 0,
             "RAM access (LW or LWU) is not word aligned: {address:x}"
@@ -27,3 +27,34 @@ impl VirtualAssertWordAlignment {
 }
 
 impl RISCVTrace for VirtualAssertWordAlignment {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::emulator::cpu::Cpu;
+    use crate::emulator::terminal::DummyTerminal;
+    use crate::instruction::format::format_assert_align::FormatAssert;
+
+    /// `rs1 + imm` must use wrapping arithmetic to match RV64 semantics
+    /// (effective addresses are mod 2^64) and the convention used by every
+    /// other tracer instruction (LB/LBU/LH/LHU/LW/LWU/LD, SB/SH/SW/SD,
+    /// VirtualLW/VirtualSW, AMO*). Plain `+` panics on i64 overflow in
+    /// debug builds for any rs1/imm pair whose signed sum falls outside
+    /// `[i64::MIN, i64::MAX]`.
+    #[test]
+    fn wraps_on_overflow() {
+        let mut cpu = Cpu::new(Box::new(DummyTerminal::default()));
+        cpu.x[1] = i64::MAX;
+        let instr = VirtualAssertWordAlignment {
+            address: 0,
+            operands: FormatAssert { rs1: 1, imm: 1 },
+            virtual_sequence_remaining: None,
+            is_first_in_sequence: false,
+            is_compressed: false,
+        };
+        let mut ram_access = ();
+        // i64::MAX.wrapping_add(1) == i64::MIN, whose low 2 bits are 0,
+        // so this must execute without panicking.
+        instr.execute(&mut cpu, &mut ram_access);
+    }
+}


### PR DESCRIPTION
## Summary

`VirtualAssertWordAlignment::exec` and `VirtualAssertHalfwordAlignment::exec`
compute the effective address via `cpu.x[rs1] + imm`. Both operands are
`i64`, so the bare `+` panics in debug builds when the signed sum falls
outside `[i64::MIN, i64::MAX]`. The other 30+ memory-touching tracer
instructions (LB/LBU/LH/LHU/LW/LWU/LD, SB/SH/SW/SD, VirtualLW/VirtualSW,
AMO*) all use `wrapping_add`; these two are the only outliers.

## Reproducer

```rust
let mut cpu = Cpu::new(Box::new(DummyTerminal::default()));
cpu.x[1] = i64::MAX;
let instr = VirtualAssertWordAlignment {
    address: 0,
    operands: FormatAssert { rs1: 1, imm: 1 },
    virtual_sequence_remaining: None,
    is_first_in_sequence: false,
    is_compressed: false,
};
let mut ram_access = ();
instr.execute(&mut cpu, &mut ram_access);
// thread '...' panicked at virtual_assert_word_alignment.rs:21:23:
// attempt to add with overflow
```

## Why this is correct

- **RV64 spec**: effective addresses are `rs1 + sign_ext(imm)` mod 2^64
  (per the audit Finding 1 framing in #1442).
- **Codebase convention**: every other memory-touching tracer instruction
  uses `wrapping_add` for the same operation. Verified via
  `grep -rn 'as usize\] +' tracer/src/instruction/` — only these two
  files match before this fix.
- **No release-mode change**: signed `+` already wraps in release, and
  the alignment check operates on the same low bits in both forms. The
  fix only stops the spurious debug-build panic on overflow.

## Test plan

- [x] `cargo fmt -q`
- [x] `cargo clippy -p jolt-core --features host --message-format=short -q --all-targets -- -D warnings`
- [x] `cargo clippy -p jolt-core --features host,zk --message-format=short -q --all-targets -- -D warnings`
- [x] `cargo nextest run -p tracer` — 114/114 pass (includes 2 new regression tests, both red on the un-fixed code)
- [x] `cargo nextest run -p jolt-core muldiv --cargo-quiet --features host` — pass
- [x] `cargo nextest run -p jolt-core muldiv --cargo-quiet --features host,zk` — pass