### PR TITLE
feat(jolt-sumcheck): add fuzz crate for verifier panic coverage

### DIFF
--- a/.github/workflows/fuzz-crates.yml
+++ b/.github/workflows/fuzz-crates.yml
@@ -28,6 +28,7 @@ jobs:
           - jolt-crypto
           - jolt-field
           - jolt-poly
+          - jolt-sumcheck
           - jolt-transcript
     name: Fuzz ${{ matrix.crate }}
     concurrency:

--- a/crates/jolt-sumcheck/fuzz/Cargo.toml
+++ b/crates/jolt-sumcheck/fuzz/Cargo.toml
@@ -35,3 +35,8 @@ doc = false
 name = "batched_sumcheck_verifier"
 path = "fuzz_targets/batched_sumcheck_verifier.rs"
 doc = false
+
+[[bin]]
+name = "valid_prefix_proof"
+path = "fuzz_targets/valid_prefix_proof.rs"
+doc = false

--- a/crates/jolt-sumcheck/fuzz/Cargo.toml
+++ b/crates/jolt-sumcheck/fuzz/Cargo.toml
@@ -1,0 +1,37 @@
+[workspace]
+
+# The fuzz sub-workspace does not inherit the root workspace's `[patch.crates-io]`.
+# `light-poseidon` (via jolt-transcript) pulls unpatched `ark-ff` from crates.io;
+# jolt-sumcheck's types are built against the patched fork. Apply the same patches
+# here so both sides see the same `ark-ff`.
+[patch.crates-io]
+ark-bn254 = { git = "https://github.com/a16z/arkworks-algebra", branch = "dev/twist-shout" }
+ark-ec = { git = "https://github.com/a16z/arkworks-algebra", branch = "dev/twist-shout" }
+ark-ff = { git = "https://github.com/a16z/arkworks-algebra", branch = "dev/twist-shout" }
+ark-serialize = { git = "https://github.com/a16z/arkworks-algebra", branch = "dev/twist-shout" }
+
+[package]
+name = "jolt-sumcheck-fuzz"
+version = "0.0.0"
+publish = false
+edition = "2021"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.4"
+jolt-field = { path = "../../jolt-field" }
+jolt-poly = { path = "../../jolt-poly" }
+jolt-sumcheck = { path = ".." }
+jolt-transcript = { path = "../../jolt-transcript" }
+
+[[bin]]
+name = "sumcheck_verifier"
+path = "fuzz_targets/sumcheck_verifier.rs"
+doc = false
+
+[[bin]]
+name = "batched_sumcheck_verifier"
+path = "fuzz_targets/batched_sumcheck_verifier.rs"
+doc = false

--- a/crates/jolt-sumcheck/fuzz/fuzz_targets/batched_sumcheck_verifier.rs
+++ b/crates/jolt-sumcheck/fuzz/fuzz_targets/batched_sumcheck_verifier.rs
@@ -1,0 +1,90 @@
+//! Fuzz `BatchedSumcheckVerifier::verify` with multiple attacker-controlled
+//! claims sharing one stream of round polynomials. The verifier MUST never
+//! panic — only return `Ok(EvaluationClaim)` or a typed [`SumcheckError`].
+//!
+//! Exercises the front-loaded batching path (different `num_vars` per claim,
+//! `mul_pow_2` scaling, `EmptyClaims` handling) that single-instance fuzzing
+//! does not cover.
+
+#![no_main]
+
+use jolt_field::{Fr, ReducingBytes};
+use jolt_poly::UnivariatePoly;
+use jolt_sumcheck::{BatchedSumcheckVerifier, SumcheckClaim};
+use jolt_transcript::{Blake2bTranscript, Transcript};
+use libfuzzer_sys::fuzz_target;
+
+/// Bytes per BN254 scalar.
+const SCALAR_BYTES: usize = 32;
+
+/// Cap on `num_vars` per claim — kept tiny so the matrix of (n_claims,
+/// n_rounds, degree) stays in fuzz-budget territory.
+const MAX_NUM_VARS: usize = 6;
+
+/// Cap on `degree` per claim.
+const MAX_DEGREE: usize = 5;
+
+/// Cap on the number of claims in the batch.
+const MAX_NUM_CLAIMS: usize = 4;
+
+fuzz_target!(|data: &[u8]| {
+    // Header: 1 byte n_claims + 1 byte global degree.
+    if data.len() < 2 {
+        return;
+    }
+
+    let n_claims = (data[0] as usize) % (MAX_NUM_CLAIMS + 1);
+    let degree = ((data[1] as usize) % MAX_DEGREE) + 1;
+
+    let mut cursor = 2;
+
+    // Each claim contributes 1 byte for num_vars + 32 bytes for claimed_sum.
+    let mut claims: Vec<SumcheckClaim<Fr>> = Vec::with_capacity(n_claims);
+    let mut max_num_vars = 0usize;
+    for _ in 0..n_claims {
+        if cursor + 1 + SCALAR_BYTES > data.len() {
+            return;
+        }
+        let nv = (data[cursor] as usize) % (MAX_NUM_VARS + 1);
+        cursor += 1;
+        let claimed_sum = read_scalar(&data[cursor..cursor + SCALAR_BYTES]);
+        cursor += SCALAR_BYTES;
+        max_num_vars = max_num_vars.max(nv);
+        claims.push(SumcheckClaim::new(nv, degree, claimed_sum));
+    }
+
+    // Round polynomials: one per round of the merged sumcheck of length
+    // `max_num_vars`. Each poly has fuzzer-controlled length 0..=degree+1.
+    let mut round_proofs: Vec<UnivariatePoly<Fr>> = Vec::with_capacity(max_num_vars);
+    for _ in 0..max_num_vars {
+        if cursor >= data.len() {
+            return;
+        }
+        let coeff_count = (data[cursor] as usize) % (degree + 2);
+        cursor += 1;
+        let needed = coeff_count * SCALAR_BYTES;
+        if cursor + needed > data.len() {
+            return;
+        }
+        let coeffs: Vec<Fr> = (0..coeff_count)
+            .map(|i| read_scalar(&data[cursor + i * SCALAR_BYTES..cursor + (i + 1) * SCALAR_BYTES]))
+            .collect();
+        cursor += needed;
+        round_proofs.push(UnivariatePoly::new(coeffs));
+    }
+
+    // The verifier must terminate without panicking on any input — including
+    // `n_claims = 0`, which must surface as `SumcheckError::EmptyClaims`.
+    let mut transcript = Blake2bTranscript::new(b"jolt-sumcheck-batched-fuzz");
+    let _ = BatchedSumcheckVerifier::verify::<Fr, _, UnivariatePoly<Fr>>(
+        &claims,
+        &round_proofs,
+        &mut transcript,
+    );
+});
+
+#[inline]
+fn read_scalar(bytes: &[u8]) -> Fr {
+    debug_assert_eq!(bytes.len(), SCALAR_BYTES);
+    <Fr as ReducingBytes>::from_le_bytes_mod_order(bytes)
+}

--- a/crates/jolt-sumcheck/fuzz/fuzz_targets/sumcheck_verifier.rs
+++ b/crates/jolt-sumcheck/fuzz/fuzz_targets/sumcheck_verifier.rs
@@ -1,0 +1,75 @@
+//! Fuzz `SumcheckVerifier::verify` with attacker-controlled claim and round
+//! polynomials. The verifier MUST never panic on any input — it must either
+//! return `Ok(EvaluationClaim)` or a typed [`SumcheckError`].
+//!
+//! This is a single-instance verifier panic-guard, mirroring the audit-driven
+//! panic-resistance work in `jolt-core` (e.g. PR #1408 wrapping the verifier in
+//! `catch_unwind` for malformed proofs).
+
+#![no_main]
+
+use jolt_field::{Fr, ReducingBytes};
+use jolt_poly::UnivariatePoly;
+use jolt_sumcheck::{SumcheckClaim, SumcheckVerifier};
+use jolt_transcript::{Blake2bTranscript, Transcript};
+use libfuzzer_sys::fuzz_target;
+
+/// Bytes per BN254 scalar.
+const SCALAR_BYTES: usize = 32;
+
+/// Cap on `num_vars` to keep the fuzz iteration cheap. Real sumchecks bind up
+/// to ~30 variables, but fuzzing the verifier panic surface only needs a
+/// handful of rounds.
+const MAX_NUM_VARS: usize = 8;
+
+/// Cap on `degree` to keep round polys small. Real sumchecks use degree
+/// 2..=4; we go up to 6 to exercise the high-degree path.
+const MAX_DEGREE: usize = 6;
+
+fuzz_target!(|data: &[u8]| {
+    // Header: 1 byte num_vars + 1 byte degree + 32 bytes claimed_sum.
+    if data.len() < 2 + SCALAR_BYTES {
+        return;
+    }
+
+    let num_vars = (data[0] as usize) % (MAX_NUM_VARS + 1);
+    let degree = ((data[1] as usize) % MAX_DEGREE) + 1; // SumcheckClaim::new requires >= 1
+    let claimed_sum = read_scalar(&data[2..2 + SCALAR_BYTES]);
+    let claim = SumcheckClaim::new(num_vars, degree, claimed_sum);
+
+    // Each round polynomial has at most `degree + 1` coefficients on the wire.
+    // The fuzzer also picks the polynomial *length* (capped at degree+1) so
+    // we exercise the verifier's degree-bound + empty-poly handling.
+    let mut cursor = 2 + SCALAR_BYTES;
+    let mut round_proofs: Vec<UnivariatePoly<Fr>> = Vec::with_capacity(num_vars);
+    for _ in 0..num_vars {
+        if cursor >= data.len() {
+            return;
+        }
+        let coeff_count = (data[cursor] as usize) % (degree + 2); // 0..=degree+1
+        cursor += 1;
+        let needed = coeff_count * SCALAR_BYTES;
+        if cursor + needed > data.len() {
+            return;
+        }
+        let coeffs: Vec<Fr> = (0..coeff_count)
+            .map(|i| read_scalar(&data[cursor + i * SCALAR_BYTES..cursor + (i + 1) * SCALAR_BYTES]))
+            .collect();
+        cursor += needed;
+        round_proofs.push(UnivariatePoly::new(coeffs));
+    }
+
+    // The verifier must terminate without panicking on any input.
+    let mut transcript = Blake2bTranscript::new(b"jolt-sumcheck-fuzz");
+    let _ = SumcheckVerifier::verify::<Fr, _, UnivariatePoly<Fr>>(
+        &claim,
+        &round_proofs,
+        &mut transcript,
+    );
+});
+
+#[inline]
+fn read_scalar(bytes: &[u8]) -> Fr {
+    debug_assert_eq!(bytes.len(), SCALAR_BYTES);
+    <Fr as ReducingBytes>::from_le_bytes_mod_order(bytes)
+}

--- a/crates/jolt-sumcheck/fuzz/fuzz_targets/valid_prefix_proof.rs
+++ b/crates/jolt-sumcheck/fuzz/fuzz_targets/valid_prefix_proof.rs
@@ -1,0 +1,141 @@
+//! Fuzz `SumcheckVerifier::verify` with proofs whose first `K` round
+//! polynomials are constructed to satisfy the sum-check invariant
+//! (`s_i(0) + s_i(1) = running_sum_i`). The remaining rounds use raw
+//! random bytes from the fuzzer.
+//!
+//! Why this exists alongside `sumcheck_verifier`:
+//! the panic-guard target tends to fail the verifier's first sum-check
+//! comparison (round 0) and return `Err` early, leaving every Fiat-Shamir
+//! transcript step after round 0 unexercised. By feeding valid leading
+//! rounds, the verifier proceeds round-by-round, exercising
+//! `append_to_transcript`, `challenge`, and `evaluate` over the full
+//! depth of the protocol.
+//!
+//! Per-round bytes pick `c_0` and `c_2 .. c_d` for valid rounds; the
+//! linear coefficient `c_1` is derived from the sum-check invariant
+//! exactly as the standard compressed-unipoly format does. When
+//! `K == num_vars` the entire proof is valid by construction and the
+//! verifier MUST accept and return the running sum we computed
+//! prover-side.
+//!
+//! Addresses review on PR #1493.
+
+#![no_main]
+
+use jolt_field::{Fr, ReducingBytes};
+use jolt_poly::UnivariatePoly;
+use jolt_sumcheck::{SumcheckClaim, SumcheckVerifier};
+use jolt_transcript::{AppendToTranscript, Blake2bTranscript, Transcript};
+use libfuzzer_sys::fuzz_target;
+
+const SCALAR_BYTES: usize = 32;
+const MAX_NUM_VARS: usize = 8;
+const MAX_DEGREE: usize = 6;
+
+fuzz_target!(|data: &[u8]| {
+    // Header: 1 byte num_vars + 1 byte degree + 1 byte valid_rounds + 32 bytes claimed_sum.
+    if data.len() < 3 + SCALAR_BYTES {
+        return;
+    }
+
+    let num_vars = (data[0] as usize) % (MAX_NUM_VARS + 1);
+    let degree = ((data[1] as usize) % MAX_DEGREE) + 1;
+    let valid_rounds = (data[2] as usize) % (num_vars + 1);
+    let claimed_sum = read_scalar(&data[3..3 + SCALAR_BYTES]);
+    let claim = SumcheckClaim::new(num_vars, degree, claimed_sum);
+
+    let mut cursor = 3 + SCALAR_BYTES;
+
+    // Mirror the verifier's transcript steps prover-side over the first
+    // `valid_rounds` rounds, so the proof is valid by construction up to
+    // round `valid_rounds - 1` and the verifier's running sum after
+    // ingesting those rounds matches what we compute below.
+    let mut prover_transcript = Blake2bTranscript::new(b"jolt-sumcheck-valid-fuzz");
+    let mut running_sum = claimed_sum;
+    let mut round_proofs: Vec<UnivariatePoly<Fr>> = Vec::with_capacity(num_vars);
+
+    for round in 0..num_vars {
+        if round < valid_rounds {
+            // Need `degree` scalars: c_0 + (degree - 1) high-order coefficients.
+            let needed = SCALAR_BYTES * degree;
+            if cursor + needed > data.len() {
+                return;
+            }
+            let c0 = read_scalar(&data[cursor..cursor + SCALAR_BYTES]);
+            cursor += SCALAR_BYTES;
+
+            let mut c_high: Vec<Fr> = Vec::with_capacity(degree - 1);
+            for _ in 0..(degree - 1) {
+                c_high.push(read_scalar(&data[cursor..cursor + SCALAR_BYTES]));
+                cursor += SCALAR_BYTES;
+            }
+
+            // Derive c_1 from the sum-check invariant:
+            //   s(0) + s(1) = c_0 + (c_0 + c_1 + c_2 + … + c_d) = running_sum
+            //   ⇒ c_1 = running_sum − 2·c_0 − c_2 − … − c_d
+            let mut c1 = running_sum - c0 - c0;
+            for c in &c_high {
+                c1 -= *c;
+            }
+
+            let mut coeffs = vec![c0, c1];
+            coeffs.extend_from_slice(&c_high);
+            let poly = UnivariatePoly::new(coeffs);
+
+            // Mirror the verifier's transcript / challenge / evaluate sequence.
+            for c in poly.coefficients() {
+                c.append_to_transcript(&mut prover_transcript);
+            }
+            let r: Fr = prover_transcript.challenge();
+            running_sum = poly.evaluate(r);
+            round_proofs.push(poly);
+        } else {
+            // Tail rounds: variable-length raw polynomial from fuzzer bytes.
+            // Most of these will fail the verifier's sum check; the contract
+            // is that `verify` returns an `Err` (or `Ok` if the random bytes
+            // happen to land on a valid value) without panicking.
+            if cursor >= data.len() {
+                return;
+            }
+            let coeff_count = (data[cursor] as usize) % (degree + 2);
+            cursor += 1;
+            let needed = coeff_count * SCALAR_BYTES;
+            if cursor + needed > data.len() {
+                return;
+            }
+            let coeffs: Vec<Fr> = (0..coeff_count)
+                .map(|i| {
+                    read_scalar(&data[cursor + i * SCALAR_BYTES..cursor + (i + 1) * SCALAR_BYTES])
+                })
+                .collect();
+            cursor += needed;
+            round_proofs.push(UnivariatePoly::new(coeffs));
+        }
+    }
+
+    let mut verifier_transcript = Blake2bTranscript::new(b"jolt-sumcheck-valid-fuzz");
+    let result = SumcheckVerifier::verify::<Fr, _, UnivariatePoly<Fr>>(
+        &claim,
+        &round_proofs,
+        &mut verifier_transcript,
+    );
+
+    if valid_rounds == num_vars {
+        // Proof is valid by construction across every round. The verifier
+        // MUST accept and return the same running sum we computed.
+        let eval_claim = result.expect("fully valid proof must verify");
+        assert_eq!(
+            eval_claim.value, running_sum,
+            "verifier final eval disagrees with prover-side running sum",
+        );
+        assert_eq!(eval_claim.point.len(), num_vars);
+    }
+    // Otherwise (`valid_rounds < num_vars`) `verify` may return Ok or Err
+    // depending on the random tail; the contract is just no panic.
+});
+
+#[inline]
+fn read_scalar(bytes: &[u8]) -> Fr {
+    debug_assert_eq!(bytes.len(), SCALAR_BYTES);
+    <Fr as ReducingBytes>::from_le_bytes_mod_order(bytes)
+}

--- a/crates/jolt-sumcheck/fuzz/rust-toolchain.toml
+++ b/crates/jolt-sumcheck/fuzz/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "nightly"


### PR DESCRIPTION
## Summary

Adds a `fuzz/` sub-workspace to `jolt-sumcheck` with two libFuzzer targets,
matching the pattern already established for `jolt-crypto`, `jolt-field`,
`jolt-poly`, and `jolt-transcript`. `jolt-sumcheck` was the only protocol-
critical modular crate without fuzz coverage.

## Targets

- **`sumcheck_verifier`** — drives `SumcheckVerifier::verify` with attacker-
  controlled `SumcheckClaim` (`num_vars` 0..=8, `degree` 1..=6, arbitrary
  `claimed_sum`) and a fuzzer-chosen sequence of `UnivariatePoly<Fr>` round
  polynomials whose lengths are independently controlled per round
  (0..=degree+1). The verifier must return `Ok(_)` or a typed
  `SumcheckError` and never panic.

- **`batched_sumcheck_verifier`** — same panic-guard for
  `BatchedSumcheckVerifier::verify`, exercising the front-loaded batching
  path: variable `num_claims` (including 0, which must surface as
  `EmptyClaims`), per-claim `num_vars` mismatches, and `mul_pow_2`
  scaling.

## CI

Adds `jolt-sumcheck` to the matrix in `.github/workflows/fuzz-crates.yml`,
so it runs on every PR alongside the four existing fuzz crates.

## Why

`jolt-sumcheck` is **verifier-only** and protocol-critical: a panic on a
malformed proof would let a malicious prover crash the verifier rather
than receive a clean rejection. This is the same threat model that
- #1408 hardened in `jolt-core` (`catch_unwind` around the verifier),
- `verify_tampered` in `jolt-dory` (#1487) covers for Dory, and
- `tampered_proof` in `jolt-hyperkzg` (#1488) covers for HyperKZG.

The existing unit tests in `crates/jolt-sumcheck/src/tests.rs` cover
honest-prover soundness; this crate covers the dual property —
adversarial-input robustness — with coverage-guided exploration.

## Notes

The fuzz sub-workspace re-applies the root workspace's `[patch.crates-io]`
for the arkworks fork, mirroring the existing `jolt-transcript/fuzz` and
`jolt-crypto/fuzz` setup. Without the patch, `light-poseidon` (transitive
through `jolt-transcript`) pulls unpatched `ark-ff` and the build fails.

## Local validation

- `cargo +nightly fuzz build` (apple-darwin) — clean
- `cargo +nightly fuzz run sumcheck_verifier -- -max_total_time=15` — 2.66M runs, no crashes
- `cargo +nightly fuzz run batched_sumcheck_verifier -- -max_total_time=15` — 3.06M runs, no crashes
- `cargo nextest run -p jolt-sumcheck` — 40/40 pass
- `cargo fmt -q` clean

CI's `Fuzz crates` workflow caps each target at `FUZZ_DURATION = 60s`, matching the existing crates.