### PR TITLE
perf(jolt-poly): fuse 2-level butterfly in EqPolynomial::evals_parallel

### DIFF
--- a/crates/jolt-poly/benches/poly_ops.rs
+++ b/crates/jolt-poly/benches/poly_ops.rs
@@ -60,5 +60,30 @@ fn bench_evaluate(c: &mut Criterion) {
     });
 }
 
-criterion_group!(benches, bench_bind, bench_eq_evaluations, bench_evaluate);
+fn bench_eq_evals(c: &mut Criterion) {
+    let mut group = c.benchmark_group("EqPolynomial::evals");
+    for num_vars in [17, 19, 20, 22] {
+        let mut rng = ChaCha20Rng::seed_from_u64(300 + num_vars as u64);
+        let r: Vec<Fr> = (0..num_vars).map(|_| Fr::random(&mut rng)).collect();
+
+        group.bench_with_input(
+            BenchmarkId::from_parameter(num_vars),
+            &num_vars,
+            |bench, _| {
+                bench.iter(|| {
+                    EqPolynomial::<Fr>::evals(std::hint::black_box(&r), std::hint::black_box(None))
+                });
+            },
+        );
+    }
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_bind,
+    bench_eq_evaluations,
+    bench_evaluate,
+    bench_eq_evals,
+);
 criterion_main!(benches);

--- a/crates/jolt-poly/src/eq.rs
+++ b/crates/jolt-poly/src/eq.rs
@@ -252,8 +252,54 @@ impl<F: Field> EqPolynomial<F> {
         let mut evals: Vec<F> = unsafe_allocate_zero_vec(final_size);
         let mut size = 1;
         evals[0] = scaling_factor.unwrap_or(F::one());
+        let mut i = r.len();
 
-        for r in r.iter().rev() {
+        while i >= 2 {
+            let r_lo = r[i - 1];
+            let r_hi = r[i - 2];
+            i -= 2;
+
+            let (q0, rest) = evals.split_at_mut(size);
+            let (q1, rest) = rest.split_at_mut(size);
+            let (q2, rest) = rest.split_at_mut(size);
+            let (q3, _) = rest.split_at_mut(size);
+
+            #[cfg(feature = "parallel")]
+            {
+                use rayon::prelude::*;
+                q0.par_iter_mut()
+                    .zip(q1.par_iter_mut())
+                    .zip(q2.par_iter_mut())
+                    .zip(q3.par_iter_mut())
+                    .for_each(|(((x, q1_out), q2_out), q3_out)| {
+                        let with_lo = *x * r_lo;
+                        let without_lo = *x - with_lo;
+
+                        *q2_out = without_lo * r_hi;
+                        *x = without_lo - *q2_out;
+                        *q3_out = with_lo * r_hi;
+                        *q1_out = with_lo - *q3_out;
+                    });
+            }
+
+            #[cfg(not(feature = "parallel"))]
+            {
+                for j in 0..size {
+                    let x_val = q0[j];
+                    let with_lo = x_val * r_lo;
+                    let without_lo = x_val - with_lo;
+
+                    q2[j] = without_lo * r_hi;
+                    q0[j] = without_lo - q2[j];
+                    q3[j] = with_lo * r_hi;
+                    q1[j] = with_lo - q3[j];
+                }
+            }
+
+            size *= 4;
+        }
+
+        for r in r[..i].iter().rev() {
             let (evals_left, evals_right) = evals.split_at_mut(size);
             let (evals_right, _) = evals_right.split_at_mut(size);
 


### PR DESCRIPTION
## Summary

Ports the fused 2-level butterfly from
`jolt-core::poly::eq_poly::EqPolynomial::evals_parallel` (#1429, @mw2000)
into the modular `jolt-poly` crate.

The previous single-level butterfly does
`read s + write 2s + read 2s + write 4s = 9s` of memory traffic per pair
of challenges; the fused two-level pass does `read s + write 4s = 5s`
for the same work — ~44% less memory traffic per pair.

## Benchmark

`EqPolynomial::evals` for sizes hitting the parallel path (`n > 16`),
release build, M1 (apple-darwin):

| `n`  | baseline   | optimized  | speedup |
|------|------------|------------|---------|
| 17   | 1.03 ms    | 679 µs     | **34.0%** |
| 19   | 2.03 ms    | 1.61 ms    | **20.7%** |
| 20   | 3.33 ms    | 2.83 ms    | **15.0%** |
| 22   | 11.01 ms   | 10.04 ms   | **8.8%**  |

Adds `bench_eq_evals` to `crates/jolt-poly/benches/poly_ops.rs` so
maintainers can re-verify on their hardware.

## Implementation

Each fused iteration consumes two challenges `r_lo = r[i-1]` and
`r_hi = r[i-2]`, splits the working buffer into four disjoint quadrants
of `size` elements each, and writes all four eq-products from a single
input read using 3 multiplies + 3 subtracts. When `n` is odd the
remaining single challenge is handled by the original one-level
butterfly tail. Mirrors `jolt-core`'s implementation 1:1, including the
`(0..s) | (s..2s) | (2s..3s) | (3s..4s)` quadrant convention.

## Correctness

Algorithm is semantically equivalent to the previous single-level
implementation (same factored expansion of $\widetilde{eq}$). The
existing `evals_parallel_matches_serial` test pins this against
`evals_serial` across `n = 5, 10, 12`. Both `parallel` and
non-`parallel` build paths are updated.

## Test plan

- [x] `cargo fmt -q`
- [x] `cargo clippy -p jolt-poly --all-targets -- -D warnings`
- [x] `cargo clippy -p jolt-core --features host --all-targets -- -D warnings`
- [x] `cargo clippy -p jolt-core --features host,zk --all-targets -- -D warnings`
- [x] `cargo nextest run -p jolt-poly` — 160/160 pass
- [x] `cargo nextest run -p jolt-core muldiv --features host` — pass
- [x] `cargo nextest run -p jolt-core muldiv --features host,zk` — pass
- [x] `cargo bench -p jolt-poly --bench poly_ops -- EqPolynomial::evals` — speedup table above