### PR TITLE
fix(dory): blind zk advice commitments

### DIFF
--- a/jolt-core/src/poly/commitment/dory/commitment_scheme.rs
+++ b/jolt-core/src/poly/commitment/dory/commitment_scheme.rs
@@ -31,15 +31,35 @@ use tracing::trace_span;
 pub struct DoryCommitmentScheme;
 
 #[derive(Clone, Debug, PartialEq)]
-pub struct DoryOpeningProofHint(Vec<ArkG1>);
+pub struct DoryOpeningProofHint {
+    row_commitments: Vec<ArkG1>,
+    commit_blind: ArkFr,
+}
 
 impl DoryOpeningProofHint {
-    fn new(row_commitments: Vec<ArkG1>) -> Self {
-        Self(row_commitments)
+    fn new(row_commitments: Vec<ArkG1>, commit_blind: ArkFr) -> Self {
+        Self {
+            row_commitments,
+            commit_blind,
+        }
     }
 
-    fn into_rows(self) -> Vec<ArkG1> {
-        self.0
+    fn into_parts(self) -> (Vec<ArkG1>, ArkFr) {
+        (self.row_commitments, self.commit_blind)
+    }
+}
+
+fn maybe_blind_commitment(setup: &ArkworksProverSetup, commitment: ArkGT) -> (ArkGT, ArkFr) {
+    #[cfg(feature = "zk")]
+    {
+        let commit_blind = <dory::ZK as dory::Mode>::sample::<ArkFr>();
+        let commitment = <dory::ZK as dory::Mode>::mask(commitment, &setup.ht, &commit_blind);
+        (commitment, commit_blind)
+    }
+    #[cfg(not(feature = "zk"))]
+    {
+        let _ = setup;
+        (commitment, <ArkFr as DoryField>::zero())
     }
 }
 
@@ -119,15 +139,23 @@ impl CommitmentScheme for DoryCommitmentScheme {
         let sigma = num_cols.log_2();
         let nu = num_rows.log_2();
 
-        let (tier_2, row_commitments, _commit_blind) =
+        #[cfg(feature = "zk")]
+        type DoryMode = dory::ZK;
+        #[cfg(not(feature = "zk"))]
+        type DoryMode = dory::Transparent;
+
+        let (tier_2, row_commitments, commit_blind) =
             <MultilinearPolynomial<ark_bn254::Fr> as Polynomial<ArkFr>>::commit::<
                 BN254,
-                dory::Transparent,
+                DoryMode,
                 JoltG1Routines,
             >(poly, nu, sigma, setup)
             .expect("commitment should succeed");
 
-        (tier_2, DoryOpeningProofHint::new(row_commitments))
+        (
+            tier_2,
+            DoryOpeningProofHint::new(row_commitments, commit_blind),
+        )
     }
 
     fn batch_commit<U>(
@@ -155,10 +183,10 @@ impl CommitmentScheme for DoryCommitmentScheme {
         let _span = trace_span!("DoryCommitmentScheme::prove").entered();
 
         let (row_commitments, commit_blind) = hint
-            .map(|h| (h.into_rows(), DoryField::zero()))
+            .map(DoryOpeningProofHint::into_parts)
             .unwrap_or_else(|| {
-                let (_commitment, row_commitments) = Self::commit(poly, setup);
-                (row_commitments.into_rows(), DoryField::zero())
+                let (_commitment, hint) = Self::commit(poly, setup);
+                hint.into_parts()
             });
 
         let num_cols = DoryGlobals::get_num_columns();
@@ -255,13 +283,20 @@ impl CommitmentScheme for DoryCommitmentScheme {
         let num_rows = DoryGlobals::get_max_num_rows();
 
         let mut rlc_hint = vec![ArkG1(G1Projective::zero()); num_rows];
-        for (coeff, mut hint) in coeffs.iter().zip(hints.into_iter()) {
-            hint.0.resize(num_rows, ArkG1(G1Projective::zero()));
+        let mut rlc_commit_blind = <ArkFr as DoryField>::zero();
+        for (coeff, hint) in coeffs.iter().zip(hints.into_iter()) {
+            let DoryOpeningProofHint {
+                mut row_commitments,
+                commit_blind,
+            } = hint;
+            row_commitments.resize(num_rows, ArkG1(G1Projective::zero()));
+            let ark_coeff = jolt_to_ark(coeff);
+            rlc_commit_blind = rlc_commit_blind + ark_coeff * commit_blind;
 
-            let row_commitments: &mut [G1Projective] = unsafe {
+            let row_commitment_projects: &mut [G1Projective] = unsafe {
                 std::slice::from_raw_parts_mut(
-                    hint.0.as_mut_ptr() as *mut G1Projective,
-                    hint.0.len(),
+                    row_commitments.as_mut_ptr() as *mut G1Projective,
+                    row_commitments.len(),
                 )
             };
 
@@ -273,15 +308,15 @@ impl CommitmentScheme for DoryCommitmentScheme {
             let _enter = _span.enter();
 
             jolt_optimizations::vector_scalar_mul_add_gamma_g1_online(
-                row_commitments,
+                row_commitment_projects,
                 *coeff,
                 rlc_row_commitments,
             );
 
-            let _ = std::mem::replace(&mut rlc_hint, hint.0);
+            let _ = std::mem::replace(&mut rlc_hint, row_commitments);
         }
 
-        DoryOpeningProofHint::new(rlc_hint)
+        DoryOpeningProofHint::new(rlc_hint, rlc_commit_blind)
     }
 
     /// Homomorphically combines multiple commitments using a random linear combination.
@@ -390,16 +425,24 @@ impl StreamingCommitmentScheme for DoryCommitmentScheme {
 
             let g2_bases = &setup.g2_vec[..num_rows];
             let tier_2 = <BN254 as PairingCurve>::multi_pair_g2_setup(&row_commitments, g2_bases);
+            let (tier_2, commit_blind) = maybe_blind_commitment(setup, tier_2);
 
-            (tier_2, DoryOpeningProofHint::new(row_commitments))
+            (
+                tier_2,
+                DoryOpeningProofHint::new(row_commitments, commit_blind),
+            )
         } else {
             let row_commitments: Vec<ArkG1> =
                 chunks.iter().flat_map(|chunk| chunk.clone()).collect();
 
             let g2_bases = &setup.g2_vec[..row_commitments.len()];
             let tier_2 = <BN254 as PairingCurve>::multi_pair_g2_setup(&row_commitments, g2_bases);
+            let (tier_2, commit_blind) = maybe_blind_commitment(setup, tier_2);
 
-            (tier_2, DoryOpeningProofHint::new(row_commitments))
+            (
+                tier_2,
+                DoryOpeningProofHint::new(row_commitments, commit_blind),
+            )
         }
     }
 }

--- a/jolt-core/src/poly/commitment/dory/tests.rs
+++ b/jolt-core/src/poly/commitment/dory/tests.rs
@@ -75,6 +75,26 @@ mod tests {
         (prover_setup, verifier_setup)
     }
 
+    #[cfg(feature = "zk")]
+    #[test]
+    #[serial]
+    fn test_dory_commitment_is_blinded_in_zk() {
+        let num_vars = 10;
+        let (prover_setup, _) = setup_dory_for_test(num_vars);
+
+        let mut rng = thread_rng();
+        let coeffs: Vec<Fr> = (0..(1 << num_vars)).map(|_| Fr::rand(&mut rng)).collect();
+        let poly = MultilinearPolynomial::LargeScalars(DensePolynomial::new(coeffs));
+
+        let (commitment_a, _) = DoryCommitmentScheme::commit(&poly, &prover_setup);
+        let (commitment_b, _) = DoryCommitmentScheme::commit(&poly, &prover_setup);
+
+        assert_ne!(
+            commitment_a, commitment_b,
+            "ZK Dory commitments should use fresh blinding"
+        );
+    }
+
     #[test]
     #[serial]
     fn test_dory_large_scalars() {
@@ -653,7 +673,9 @@ mod tests {
         let (direct_commitment, direct_hint) =
             DoryCommitmentScheme::commit(&combined_poly, &prover_setup);
 
-        // The commitments should match
+        // In transparent mode the RLC commitment is deterministic. In ZK mode, direct_commitment
+        // has a fresh Dory blind, so equality with the homomorphic RLC is not expected.
+        #[cfg(not(feature = "zk"))]
         assert_eq!(
             combined_commitment, direct_commitment,
             "Homomorphically combined commitment should match direct commitment to RLC"
@@ -809,10 +831,15 @@ mod tests {
         let poly2 = MultilinearPolynomial::LargeScalars(DensePolynomial::new(coeffs));
         let (commitment_addr_major, _) = DoryCommitmentScheme::commit(&poly2, &prover_setup);
 
+        #[cfg(not(feature = "zk"))]
         assert_eq!(
             commitment_cycle_major, commitment_addr_major,
             "Dense polynomials should produce the same commitment with any layout"
         );
+        #[cfg(feature = "zk")]
+        {
+            let _ = (commitment_cycle_major, commitment_addr_major);
+        }
         DoryGlobals::set_layout(DoryLayout::CycleMajor);
     }
 


### PR DESCRIPTION
## Summary
- Use Dory ZK blinding for zk-mode polynomial commitments instead of transparent commitments.
- Carry the Dory commitment blind in opening hints so stage-8 openings verify against blinded commitments.
- Add a zk regression test that repeated commitments to the same polynomial differ.

## Changes
- Updated DoryOpeningProofHint to store row commitments plus the Dory tier-2 commitment blind.
- Switched DoryCommitmentScheme::commit() to dory::ZK under the zk feature and preserved transparent behavior otherwise.
- Blinded streaming tier-2 commitments in zk mode and combined commitment blinds during RLC hint aggregation.
- Adjusted deterministic commitment equality assertions to apply only outside zk mode.

## Testing
- cargo fmt -q
- cargo clippy --all --features host -q --all-targets -- -D warnings
- cargo clippy --all --features host,zk -q --all-targets -- -D warnings
- cargo nextest run -p jolt-core muldiv --cargo-quiet --features host
- cargo nextest run -p jolt-core muldiv --cargo-quiet --features host,zk
- cargo nextest run -p jolt-core test_dory_commitment_is_blinded_in_zk test_dory_batch_commit_e2e test_dory_layout_dense_polynomials_same_commitment --cargo-quiet --features host,zk --no-fail-fast

Note: broader cargo nextest run -p jolt-core dory --cargo-quiet --features host,zk --no-fail-fast passed 31/32 locally; stdlib_e2e_dory failed before proving while compiling the guest target due a local rustc target-spec error (target-pointer-width type).