### PR TITLE
fix: reject unsupported CSRs and restrict LR/SC addresses to RAM region

### DIFF
--- a/tests/arch-tests/skip.txt
+++ b/tests/arch-tests/skip.txt
@@ -32,3 +32,9 @@ Zicntr-csrrc-00
 Zicntr-csrrs-00
 Zihpm-csrrc-00
 
+# ---------------------------------------------------------------------------
+# Jolt does not support the Zihpm extension (hardware performance counters
+# hpmcounter3-31). Reads of these CSRs are rejected at decode time.
+# ---------------------------------------------------------------------------
+Zihpm-csrrs-00
+

--- a/tracer/src/instruction/csrrs.rs
+++ b/tracer/src/instruction/csrrs.rs
@@ -95,9 +95,11 @@ impl RISCVTrace for CSRRS {
             return vec![Instruction::NoOp];
         }
 
-        let virtual_reg = allocator
-            .csr_to_virtual_register(csr_addr)
-            .unwrap_or_else(|| panic!("CSRRS: Unsupported CSR 0x{csr_addr:03x}"));
+        // Other unsupported CSRs are rejected at decode time (see
+        // Instruction::decode), so the trace path should never see one.
+        let virtual_reg = allocator.csr_to_virtual_register(csr_addr).unwrap_or_else(|| {
+            unreachable!("Unsupported CSR 0x{csr_addr:03x}; decode should have rejected it")
+        });
 
         let mut asm = InstrAssembler::new(self.address, self.is_compressed, xlen, allocator);
 
@@ -146,6 +148,19 @@ mod tests {
             }
             _ => panic!("Expected CSRRS instruction, got {decoded:?}"),
         }
+    }
+
+    /// `decode` must reject unsupported CSRs with a typed error instead of
+    /// letting them reach the inline-sequence path.
+    #[test]
+    fn test_csrrs_unsupported_csr_rejected_at_decode() {
+        // satp = 0x180 — valid RISC-V supervisor CSR but not modelled by Jolt.
+        // Encoding: 0x180 << 20 | 0 << 15 | 2 << 12 | 5 << 7 | 0x73
+        let instr: u32 = (0x180 << 20) | (2 << 12) | (5 << 7) | 0x73;
+        let err = Instruction::decode(instr, 0x1000, false).expect_err(
+            "decode must reject unsupported CSR (satp) with an Err, not panic",
+        );
+        assert!(err.contains("CSR"), "error should mention CSR: {err}");
     }
 
     /// Test decoding with rs1 != 0 (full csrrs)

--- a/tracer/src/instruction/csrrs.rs
+++ b/tracer/src/instruction/csrrs.rs
@@ -97,9 +97,11 @@ impl RISCVTrace for CSRRS {
 
         // Other unsupported CSRs are rejected at decode time (see
         // Instruction::decode), so the trace path should never see one.
-        let virtual_reg = allocator.csr_to_virtual_register(csr_addr).unwrap_or_else(|| {
-            unreachable!("Unsupported CSR 0x{csr_addr:03x}; decode should have rejected it")
-        });
+        let virtual_reg = allocator
+            .csr_to_virtual_register(csr_addr)
+            .unwrap_or_else(|| {
+                unreachable!("Unsupported CSR 0x{csr_addr:03x}; decode should have rejected it")
+            });
 
         let mut asm = InstrAssembler::new(self.address, self.is_compressed, xlen, allocator);
 
@@ -157,9 +159,8 @@ mod tests {
         // satp = 0x180 — valid RISC-V supervisor CSR but not modelled by Jolt.
         // Encoding: 0x180 << 20 | 0 << 15 | 2 << 12 | 5 << 7 | 0x73
         let instr: u32 = (0x180 << 20) | (2 << 12) | (5 << 7) | 0x73;
-        let err = Instruction::decode(instr, 0x1000, false).expect_err(
-            "decode must reject unsupported CSR (satp) with an Err, not panic",
-        );
+        let err = Instruction::decode(instr, 0x1000, false)
+            .expect_err("decode must reject unsupported CSR (satp) with an Err, not panic");
         assert!(err.contains("CSR"), "error should mention CSR: {err}");
     }
 

--- a/tracer/src/instruction/csrrw.rs
+++ b/tracer/src/instruction/csrrw.rs
@@ -107,15 +107,16 @@ impl RISCVTrace for CSRRW {
     ) -> Vec<Instruction> {
         let csr_addr = self.csr_address();
 
-        // Validate CSR address is supported
-        // CSR 0 is never valid - return no-op for default-constructed instructions
+        // CSR 0 is never valid - return no-op for default-constructed instructions.
+        // Other unsupported CSRs are rejected at decode time (see Instruction::decode),
+        // so the trace path should never see one.
         match csr_addr {
             0 => {
                 warn!("CSRRW with CSR address 0 is invalid, returning NoOp");
                 return vec![Instruction::NoOp];
             }
             CSR_MSTATUS | CSR_MTVEC | CSR_MSCRATCH | CSR_MEPC | CSR_MCAUSE | CSR_MTVAL => {}
-            _ => panic!("CSRRW: Unsupported CSR 0x{csr_addr:03x}"),
+            _ => unreachable!("Unsupported CSR 0x{csr_addr:03x}; decode should have rejected it"),
         };
 
         // Map CSR address to virtual register
@@ -176,6 +177,20 @@ mod tests {
             }
             _ => panic!("Expected CSRRW instruction, got {decoded:?}"),
         }
+    }
+
+    /// `decode` must reject unsupported CSRs with a typed error instead of
+    /// letting them reach the inline-sequence path, which would previously
+    /// panic the prover process.
+    #[test]
+    fn test_csrrw_unsupported_csr_rejected_at_decode() {
+        // satp = 0x180 — valid RISC-V supervisor CSR but not modelled by Jolt.
+        // Encoding: 0x180 << 20 | 5 << 15 | 1 << 12 | 0 << 7 | 0x73
+        let instr: u32 = (0x180 << 20) | (5 << 15) | (1 << 12) | 0x73;
+        let err = Instruction::decode(instr, 0x1000, false).expect_err(
+            "decode must reject unsupported CSR (satp) with an Err, not panic",
+        );
+        assert!(err.contains("CSR"), "error should mention CSR: {err}");
     }
 
     /// Test decoding with rd != 0 (full csrrw, not just csrw pseudo-instruction)

--- a/tracer/src/instruction/csrrw.rs
+++ b/tracer/src/instruction/csrrw.rs
@@ -187,9 +187,8 @@ mod tests {
         // satp = 0x180 — valid RISC-V supervisor CSR but not modelled by Jolt.
         // Encoding: 0x180 << 20 | 5 << 15 | 1 << 12 | 0 << 7 | 0x73
         let instr: u32 = (0x180 << 20) | (5 << 15) | (1 << 12) | 0x73;
-        let err = Instruction::decode(instr, 0x1000, false).expect_err(
-            "decode must reject unsupported CSR (satp) with an Err, not panic",
-        );
+        let err = Instruction::decode(instr, 0x1000, false)
+            .expect_err("decode must reject unsupported CSR (satp) with an Err, not panic");
         assert!(err.contains("CSR"), "error should mention CSR: {err}");
     }
 

--- a/tracer/src/instruction/lrd.rs
+++ b/tracer/src/instruction/lrd.rs
@@ -1,3 +1,4 @@
+use common::constants::RAM_START_ADDRESS;
 use serde::{Deserialize, Serialize};
 
 use crate::utils::inline_helpers::InstrAssembler;
@@ -10,6 +11,8 @@ use crate::{
 use super::addi::ADDI;
 use super::format::format_r::FormatR;
 use super::ld::LD;
+use super::lui::LUI;
+use super::virtual_assert_lte::VirtualAssertLTE;
 use super::{Cycle, Instruction, RISCVInstruction, RISCVTrace};
 
 declare_riscv_instr!(
@@ -78,10 +81,66 @@ impl RISCVTrace for LRD {
         let v_reservation_w = allocator.reservation_w_register();
         let mut asm = InstrAssembler::new(self.address, self.is_compressed, xlen, allocator);
 
+        // Restrict LR.D to the RAM region (rs1 >= RAM_START_ADDRESS). Mirrors
+        // the SC.D constraint so the reservation address is always in RAM.
+        let v_ram_start = allocator.allocate();
+        asm.emit_u::<LUI>(*v_ram_start, RAM_START_ADDRESS);
+        asm.emit_b::<VirtualAssertLTE>(*v_ram_start, self.operands.rs1, 0);
+        drop(v_ram_start);
+
         asm.emit_i::<ADDI>(v_reservation_d, self.operands.rs1, 0);
         asm.emit_i::<ADDI>(v_reservation_w, self.operands.rs1, 0);
         asm.emit_ld::<LD>(self.operands.rd, self.operands.rs1, 0);
 
         asm.finalize()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::emulator::{cpu::Cpu, default_terminal::DefaultTerminal};
+    use crate::instruction::{Instruction, RISCVTrace};
+
+    const TEST_MEM_SIZE: u64 = 1024 * 1024;
+
+    fn setup_cpu() -> Cpu {
+        let mut cpu = Cpu::new(Box::new(DefaultTerminal::default()));
+        let memory_config = common::jolt_device::MemoryConfig {
+            heap_size: TEST_MEM_SIZE,
+            program_size: Some(1024),
+            ..Default::default()
+        };
+        cpu.get_mut_mmu().jolt_device = Some(common::jolt_device::JoltDevice::new(&memory_config));
+        cpu.get_mut_mmu().init_memory(TEST_MEM_SIZE);
+        cpu
+    }
+
+    fn encode_lrd(rd: u8, rs1: u8) -> u32 {
+        (0b00010 << 27) | ((rs1 as u32) << 15) | (0b011 << 12) | ((rd as u32) << 7) | 0x2F
+    }
+
+    /// FJ-ACT-H-03: LR.D to a non-RAM (I/O) address is rejected by the
+    /// RAM-range constraint. Mirrors SC.D coverage.
+    #[test]
+    #[should_panic(expected = "assertion failed")]
+    fn test_lrd_to_io_rejected() {
+        let mut cpu = setup_cpu();
+        let panic_addr = cpu
+            .get_mut_mmu()
+            .jolt_device
+            .as_ref()
+            .unwrap()
+            .memory_layout
+            .panic;
+
+        cpu.x[11] = panic_addr as i64;
+
+        let decoded = Instruction::decode(encode_lrd(10, 11), 0x1000, false).unwrap();
+        let Instruction::LRD(lrd) = decoded else {
+            panic!("Expected LRD");
+        };
+
+        let mut trace = Vec::new();
+        lrd.trace(&mut cpu, Some(&mut trace));
     }
 }

--- a/tracer/src/instruction/lrd.rs
+++ b/tracer/src/instruction/lrd.rs
@@ -119,8 +119,8 @@ mod tests {
         (0b00010 << 27) | ((rs1 as u32) << 15) | (0b011 << 12) | ((rd as u32) << 7) | 0x2F
     }
 
-    /// FJ-ACT-H-03: LR.D to a non-RAM (I/O) address is rejected by the
-    /// RAM-range constraint. Mirrors SC.D coverage.
+    /// LR.D to a non-RAM (I/O) address is rejected by the RAM-range
+    /// constraint. Mirrors SC.D coverage.
     #[test]
     #[should_panic(expected = "assertion failed")]
     fn test_lrd_to_io_rejected() {

--- a/tracer/src/instruction/lrw.rs
+++ b/tracer/src/instruction/lrw.rs
@@ -139,9 +139,8 @@ mod tests {
         (0b00010 << 27) | ((rs1 as u32) << 15) | (0b010 << 12) | ((rd as u32) << 7) | 0x2F
     }
 
-    /// FJ-ACT-H-03: LR.W to a non-RAM (I/O) address is rejected by the
-    /// RAM-range constraint. Mirrors SC.W coverage so the LR/SC pair is
-    /// consistent.
+    /// LR.W to a non-RAM (I/O) address is rejected by the RAM-range
+    /// constraint. Mirrors SC.W coverage so the LR/SC pair is consistent.
     #[test]
     #[should_panic(expected = "assertion failed")]
     fn test_lrw_to_io_rejected() {

--- a/tracer/src/instruction/lrw.rs
+++ b/tracer/src/instruction/lrw.rs
@@ -1,3 +1,4 @@
+use common::constants::RAM_START_ADDRESS;
 use serde::{Deserialize, Serialize};
 
 use crate::utils::inline_helpers::InstrAssembler;
@@ -9,7 +10,9 @@ use crate::{
 
 use super::addi::ADDI;
 use super::format::format_r::FormatR;
+use super::lui::LUI;
 use super::lw::LW;
+use super::virtual_assert_lte::VirtualAssertLTE;
 use super::virtual_lw::VirtualLW;
 use super::{Cycle, Instruction, RAMRead, RISCVInstruction, RISCVTrace};
 
@@ -79,6 +82,13 @@ impl LRW {
         let v_reservation_d = allocator.reservation_d_register();
         let mut asm = InstrAssembler::new(self.address, self.is_compressed, Xlen::Bit32, allocator);
 
+        // Restrict LR.W to the RAM region (rs1 >= RAM_START_ADDRESS). Mirrors
+        // the SC.W constraint so the reservation address is always in RAM.
+        let v_ram_start = allocator.allocate();
+        asm.emit_u::<LUI>(*v_ram_start, RAM_START_ADDRESS);
+        asm.emit_b::<VirtualAssertLTE>(*v_ram_start, self.operands.rs1, 0);
+        drop(v_ram_start);
+
         asm.emit_i::<ADDI>(v_reservation_w, self.operands.rs1, 0);
         asm.emit_i::<ADDI>(v_reservation_d, 0, 0); // clear D reservation
         asm.emit_i::<VirtualLW>(self.operands.rd, self.operands.rs1, 0);
@@ -91,10 +101,67 @@ impl LRW {
         let v_reservation_d = allocator.reservation_d_register();
         let mut asm = InstrAssembler::new(self.address, self.is_compressed, Xlen::Bit64, allocator);
 
+        // Restrict LR.W to the RAM region (rs1 >= RAM_START_ADDRESS). Mirrors
+        // the SC.W constraint so the reservation address is always in RAM.
+        let v_ram_start = allocator.allocate();
+        asm.emit_u::<LUI>(*v_ram_start, RAM_START_ADDRESS);
+        asm.emit_b::<VirtualAssertLTE>(*v_ram_start, self.operands.rs1, 0);
+        drop(v_ram_start);
+
         asm.emit_i::<ADDI>(v_reservation_w, self.operands.rs1, 0);
         asm.emit_i::<ADDI>(v_reservation_d, 0, 0); // clear D reservation
         asm.emit_ld::<LW>(self.operands.rd, self.operands.rs1, 0);
 
         asm.finalize()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::emulator::{cpu::Cpu, default_terminal::DefaultTerminal};
+    use crate::instruction::{Instruction, RISCVTrace};
+
+    const TEST_MEM_SIZE: u64 = 1024 * 1024;
+
+    fn setup_cpu() -> Cpu {
+        let mut cpu = Cpu::new(Box::new(DefaultTerminal::default()));
+        let memory_config = common::jolt_device::MemoryConfig {
+            heap_size: TEST_MEM_SIZE,
+            program_size: Some(1024),
+            ..Default::default()
+        };
+        cpu.get_mut_mmu().jolt_device = Some(common::jolt_device::JoltDevice::new(&memory_config));
+        cpu.get_mut_mmu().init_memory(TEST_MEM_SIZE);
+        cpu
+    }
+
+    fn encode_lrw(rd: u8, rs1: u8) -> u32 {
+        (0b00010 << 27) | ((rs1 as u32) << 15) | (0b010 << 12) | ((rd as u32) << 7) | 0x2F
+    }
+
+    /// FJ-ACT-H-03: LR.W to a non-RAM (I/O) address is rejected by the
+    /// RAM-range constraint. Mirrors SC.W coverage so the LR/SC pair is
+    /// consistent.
+    #[test]
+    #[should_panic(expected = "assertion failed")]
+    fn test_lrw_to_io_rejected() {
+        let mut cpu = setup_cpu();
+        let panic_addr = cpu
+            .get_mut_mmu()
+            .jolt_device
+            .as_ref()
+            .unwrap()
+            .memory_layout
+            .panic;
+
+        cpu.x[11] = panic_addr as i64;
+
+        let decoded = Instruction::decode(encode_lrw(10, 11), 0x1000, false).unwrap();
+        let Instruction::LRW(lrw) = decoded else {
+            panic!("Expected LRW");
+        };
+
+        let mut trace = Vec::new();
+        lrw.trace(&mut cpu, Some(&mut trace));
     }
 }

--- a/tracer/src/instruction/mod.rs
+++ b/tracer/src/instruction/mod.rs
@@ -153,7 +153,7 @@ use virtual_zero_extend_word::VirtualZeroExtendWord;
 use self::inline::INLINE;
 
 use crate::emulator::cpu::{Cpu, Xlen};
-use crate::utils::virtual_registers::VirtualRegisterAllocator;
+use crate::utils::virtual_registers::{is_supported_csr, VirtualRegisterAllocator};
 use derive_more::From;
 use format::{InstructionFormat, InstructionRegisterState, NormalizedOperands};
 
@@ -1095,10 +1095,24 @@ impl Instruction {
                     (0, 0x18, 2) if instr == 0x30200073 => {
                         Ok(MRET::new(instr, address, true, compressed).into())
                     }
-                    // CSRRW: funct3=1
-                    (1, _, _) => Ok(CSRRW::new(instr, address, true, compressed).into()),
-                    // CSRRS: funct3=2
-                    (2, _, _) => Ok(CSRRS::new(instr, address, true, compressed).into()),
+                    // CSRRW: funct3=1. Reject unsupported CSRs at decode time
+                    // so the trace path never reaches an unmodelled CSR — the
+                    // inline_sequence path would otherwise panic the prover.
+                    (1, _, _) => {
+                        let csr_addr = ((instr >> 20) & 0xFFF) as u16;
+                        if !is_supported_csr(csr_addr) {
+                            return Err("Unsupported CSR in CSRRW");
+                        }
+                        Ok(CSRRW::new(instr, address, true, compressed).into())
+                    }
+                    // CSRRS: funct3=2. Same rationale as CSRRW above.
+                    (2, _, _) => {
+                        let csr_addr = ((instr >> 20) & 0xFFF) as u16;
+                        if !is_supported_csr(csr_addr) {
+                            return Err("Unsupported CSR in CSRRS");
+                        }
+                        Ok(CSRRS::new(instr, address, true, compressed).into())
+                    }
                     _ => Err("Unsupported SYSTEM instruction"),
                 }
             }

--- a/tracer/src/instruction/scd.rs
+++ b/tracer/src/instruction/scd.rs
@@ -1,3 +1,4 @@
+use common::constants::RAM_START_ADDRESS;
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -11,6 +12,7 @@ use super::add::ADD;
 use super::addi::ADDI;
 use super::format::format_r::FormatR;
 use super::ld::LD;
+use super::lui::LUI;
 use super::mul::MUL;
 use super::sd::SD;
 use super::sub::SUB;
@@ -62,10 +64,17 @@ impl RISCVTrace for SCD {
 
         let mut inline_sequence = self.inline_sequence(&cpu.vr_allocator, cpu.xlen);
 
-        // VirtualAdvice is at index 0 — advise v_success (1=success, 0=failure)
-        if let Instruction::VirtualAdvice(instr) = &mut inline_sequence[0] {
-            instr.advice = success as u64;
-        }
+        // Patch v_success (1=success, 0=failure) into the first VirtualAdvice
+        // in the sequence. Locating it by type avoids fragility against
+        // changes to the sequence's prelude.
+        let advice = inline_sequence
+            .iter_mut()
+            .find_map(|i| match i {
+                Instruction::VirtualAdvice(v) => Some(v),
+                _ => None,
+            })
+            .expect("SC.D inline sequence must contain a VirtualAdvice");
+        advice.advice = success as u64;
 
         let mut trace = trace;
         for instr in inline_sequence {
@@ -90,6 +99,18 @@ impl RISCVTrace for SCD {
         let v_reservation = allocator.reservation_d_register();
         let v_reservation_w = allocator.reservation_w_register();
         let mut asm = InstrAssembler::new(self.address, self.is_compressed, xlen, allocator);
+
+        // Restrict SC.D to the RAM region (rs1 >= RAM_START_ADDRESS). The
+        // failure path of the inline sequence still emits a store of the
+        // loaded value back to rs1; for I/O addresses below RAM, the device
+        // store handler has value-independent side effects (flips the panic
+        // flag, extends the output buffer), so a failed SC into the I/O
+        // region would diverge from native SC semantics and let a malicious
+        // prover mutate the proof's public I/O.
+        let v_ram_start = allocator.allocate();
+        asm.emit_u::<LUI>(*v_ram_start, RAM_START_ADDRESS);
+        asm.emit_b::<VirtualAssertLTE>(*v_ram_start, self.operands.rs1, 0);
+        drop(v_ram_start);
 
         // 0: Prover supplies success flag (1=success, 0=failure)
         let v_success = allocator.allocate();
@@ -273,6 +294,32 @@ mod tests {
             cleared_regs.contains(&33),
             "SC.D inline sequence must clear reservation_d (vr33)"
         );
+    }
+
+    /// FJ-ACT-H-03: SC.D to a non-RAM (I/O) address must be rejected by the
+    /// inline-sequence RAM-range constraint. Same rationale as SC.W.
+    #[test]
+    #[should_panic(expected = "assertion failed")]
+    fn test_scd_to_io_rejected() {
+        let mut cpu = setup_cpu();
+        let panic_addr = cpu
+            .get_mut_mmu()
+            .jolt_device
+            .as_ref()
+            .unwrap()
+            .memory_layout
+            .panic;
+
+        cpu.x[11] = panic_addr as i64;
+        cpu.x[12] = 0x1234_5678_9ABC_DEF0u64 as i64;
+
+        let decoded = Instruction::decode(encode_scd(13, 11, 12), 0x1000, false).unwrap();
+        let Instruction::SCD(scd) = decoded else {
+            panic!("Expected SCD");
+        };
+
+        let mut trace = Vec::new();
+        scd.trace(&mut cpu, Some(&mut trace));
     }
 
     #[test]

--- a/tracer/src/instruction/scd.rs
+++ b/tracer/src/instruction/scd.rs
@@ -296,7 +296,7 @@ mod tests {
         );
     }
 
-    /// FJ-ACT-H-03: SC.D to a non-RAM (I/O) address must be rejected by the
+    /// SC.D to a non-RAM (I/O) address must be rejected by the
     /// inline-sequence RAM-range constraint. Same rationale as SC.W.
     #[test]
     #[should_panic(expected = "assertion failed")]

--- a/tracer/src/instruction/scw.rs
+++ b/tracer/src/instruction/scw.rs
@@ -479,7 +479,7 @@ mod tests {
         );
     }
 
-    /// FJ-ACT-H-03: SC.W to a non-RAM (I/O) address must be rejected by the
+    /// SC.W to a non-RAM (I/O) address must be rejected by the
     /// inline-sequence RAM-range constraint. Without this constraint, the
     /// failure-path store would flip the device's panic flag via the
     /// byte-level store handler, mutating the proof's public I/O.

--- a/tracer/src/instruction/scw.rs
+++ b/tracer/src/instruction/scw.rs
@@ -1,3 +1,4 @@
+use common::constants::RAM_START_ADDRESS;
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -10,6 +11,7 @@ use crate::{
 use super::add::ADD;
 use super::addi::ADDI;
 use super::format::format_r::FormatR;
+use super::lui::LUI;
 use super::lw::LW;
 use super::mul::MUL;
 use super::sub::SUB;
@@ -66,10 +68,17 @@ impl RISCVTrace for SCW {
 
         let mut inline_sequence = self.inline_sequence(&cpu.vr_allocator, cpu.xlen);
 
-        // VirtualAdvice is at index 0 — advise v_success (1=success, 0=failure)
-        if let Instruction::VirtualAdvice(instr) = &mut inline_sequence[0] {
-            instr.advice = success as u64;
-        }
+        // Patch v_success (1=success, 0=failure) into the first VirtualAdvice
+        // in the sequence. Locating it by type avoids fragility against
+        // changes to the sequence's prelude.
+        let advice = inline_sequence
+            .iter_mut()
+            .find_map(|i| match i {
+                Instruction::VirtualAdvice(v) => Some(v),
+                _ => None,
+            })
+            .expect("SC.W inline sequence must contain a VirtualAdvice");
+        advice.advice = success as u64;
 
         let mut trace = trace;
         for instr in inline_sequence {
@@ -102,24 +111,36 @@ impl SCW {
         let v_reservation_d = allocator.reservation_d_register();
         let mut asm = InstrAssembler::new(self.address, self.is_compressed, Xlen::Bit32, allocator);
 
-        // 0: Prover supplies success flag (1=success, 0=failure)
+        // Restrict SC.W to the RAM region (rs1 >= RAM_START_ADDRESS). The
+        // failure path of the inline sequence still emits a store of the
+        // loaded value back to rs1; for I/O addresses below RAM, the device
+        // store handler has value-independent side effects (flips the panic
+        // flag, extends the output buffer), so a failed SC into the I/O
+        // region would diverge from native SC semantics and let a malicious
+        // prover mutate the proof's public I/O.
+        let v_ram_start = allocator.allocate();
+        asm.emit_u::<LUI>(*v_ram_start, RAM_START_ADDRESS);
+        asm.emit_b::<VirtualAssertLTE>(*v_ram_start, self.operands.rs1, 0);
+        drop(v_ram_start);
+
+        // Prover supplies success flag (1=success, 0=failure)
         let v_success = allocator.allocate();
         asm.emit_j::<VirtualAdvice>(*v_success, 0);
 
-        // 1-2: Constrain v_success ∈ {0, 1}
+        // Constrain v_success ∈ {0, 1}
         let v_one = allocator.allocate();
         asm.emit_i::<ADDI>(*v_one, 0, 1);
         asm.emit_b::<VirtualAssertLTE>(*v_success, *v_one, 0);
         drop(v_one);
 
-        // 3-5: success → reservation must match
+        // success → reservation must match
         let v_addr_diff = allocator.allocate();
         asm.emit_r::<SUB>(*v_addr_diff, v_reservation, self.operands.rs1);
         asm.emit_r::<MUL>(*v_addr_diff, *v_success, *v_addr_diff);
         asm.emit_b::<VirtualAssertEQ>(*v_addr_diff, 0, 0);
         drop(v_addr_diff);
 
-        // 6-10: Conditional store (VirtualLW/VirtualSW for 32-bit mode)
+        // Conditional store (VirtualLW/VirtualSW for 32-bit mode)
         let v_mem = allocator.allocate();
         asm.emit_i::<VirtualLW>(*v_mem, self.operands.rs1, 0);
 
@@ -145,6 +166,15 @@ impl SCW {
         let v_reservation = allocator.reservation_w_register();
         let v_reservation_d = allocator.reservation_d_register();
         let mut asm = InstrAssembler::new(self.address, self.is_compressed, Xlen::Bit64, allocator);
+
+        // Restrict SC.W to the RAM region (rs1 >= RAM_START_ADDRESS). See
+        // inline_sequence_32 for rationale: the unconditional store cycle on
+        // the failure path would otherwise mutate the device's public state
+        // (panic flag / output buffer) on stores below RAM.
+        let v_ram_start = allocator.allocate();
+        asm.emit_u::<LUI>(*v_ram_start, RAM_START_ADDRESS);
+        asm.emit_b::<VirtualAssertLTE>(*v_ram_start, self.operands.rs1, 0);
+        drop(v_ram_start);
 
         // 0: Prover supplies success flag (1=success, 0=failure)
         let v_success = allocator.allocate();
@@ -447,6 +477,34 @@ mod tests {
             loaded, 0xDEAD0001CDF4DCC0,
             "after sc.w (word store), ld should see init high + stored low; got 0x{loaded:016x}"
         );
+    }
+
+    /// FJ-ACT-H-03: SC.W to a non-RAM (I/O) address must be rejected by the
+    /// inline-sequence RAM-range constraint. Without this constraint, the
+    /// failure-path store would flip the device's panic flag via the
+    /// byte-level store handler, mutating the proof's public I/O.
+    #[test]
+    #[should_panic(expected = "assertion failed")]
+    fn test_scw_to_io_rejected() {
+        let mut cpu = setup_cpu();
+        let panic_addr = cpu
+            .get_mut_mmu()
+            .jolt_device
+            .as_ref()
+            .unwrap()
+            .memory_layout
+            .panic;
+
+        cpu.x[11] = panic_addr as i64; // rs1 points at the panic byte
+        cpu.x[12] = 0x12345678;
+
+        let decoded = Instruction::decode(encode_scw(13, 11, 12), 0x1000, false).unwrap();
+        let Instruction::SCW(scw) = decoded else {
+            panic!("Expected SCW");
+        };
+
+        let mut trace = Vec::new();
+        scw.trace(&mut cpu, Some(&mut trace));
     }
 
     /// Regression test: SC.W with rd=x0 must still succeed when a reservation

--- a/tracer/src/utils/virtual_registers.rs
+++ b/tracer/src/utils/virtual_registers.rs
@@ -226,6 +226,17 @@ impl Default for VirtualRegisterAllocator {
     }
 }
 
+/// Returns whether `csr_addr` maps to a CSR that Jolt models in its proof
+/// system. Used by `Instruction::decode` to reject unsupported CSR
+/// instructions before they reach the tracer's inline-sequence path, which
+/// would otherwise panic on unsupported CSRs.
+pub fn is_supported_csr(csr_addr: u16) -> bool {
+    matches!(
+        csr_addr,
+        CSR_MSTATUS | CSR_MTVEC | CSR_MSCRATCH | CSR_MEPC | CSR_MCAUSE | CSR_MTVAL
+    )
+}
+
 pub struct VirtualRegisterGuard {
     index: u8,
     allocator: VirtualRegisterAllocator,


### PR DESCRIPTION
Tried to address FJ-ACT-H-03 and FJ-ACT-M-07 from internal review