### PR TITLE
bench(jolt-sumcheck): add criterion benchmarks for verifier paths

### DIFF
--- a/.github/workflows/bench-crates.yml
+++ b/.github/workflows/bench-crates.yml
@@ -36,6 +36,7 @@ jobs:
           -p jolt-crypto
           -p jolt-field
           -p jolt-poly
+          -p jolt-sumcheck
           -p jolt-transcript
           --bench '*'
           -- --save-baseline main_run
@@ -66,6 +67,7 @@ jobs:
           -p jolt-crypto
           -p jolt-field
           -p jolt-poly
+          -p jolt-sumcheck
           -p jolt-transcript
           --bench '*'
           -- --save-baseline pr_run

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3104,10 +3104,12 @@ dependencies = [
 name = "jolt-sumcheck"
 version = "0.1.0"
 dependencies = [
+ "criterion",
  "jolt-field",
  "jolt-poly",
  "jolt-transcript",
  "num-traits",
+ "rand_chacha 0.3.1",
  "rand_core 0.6.4",
  "serde",
  "thiserror 2.0.18",

--- a/crates/jolt-sumcheck/Cargo.toml
+++ b/crates/jolt-sumcheck/Cargo.toml
@@ -19,3 +19,9 @@ thiserror.workspace = true
 [dev-dependencies]
 num-traits = { workspace = true }
 rand_core = { workspace = true }
+rand_chacha = { workspace = true }
+criterion = { workspace = true }
+
+[[bench]]
+name = "sumcheck_verifier"
+harness = false

--- a/crates/jolt-sumcheck/benches/sumcheck_verifier.rs
+++ b/crates/jolt-sumcheck/benches/sumcheck_verifier.rs
@@ -1,0 +1,162 @@
+#![expect(unused_results)]
+
+use std::hint::black_box;
+
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use jolt_field::{Fr, RandomSampling};
+use jolt_poly::UnivariatePoly;
+use jolt_sumcheck::{BatchedSumcheckVerifier, SumcheckClaim, SumcheckProof, SumcheckVerifier};
+use jolt_transcript::{AppendToTranscript, Blake2bTranscript, Transcript};
+use num_traits::One;
+use rand_chacha::ChaCha20Rng;
+use rand_core::SeedableRng;
+
+type F = Fr;
+
+/// Build an honest sumcheck proof for a multilinear polynomial over `{0,1}^num_vars`
+/// by running a minimal reference prover. The proof has degree-1 round polynomials.
+///
+/// Mirrors the `honest_prove` helper from the crate's unit tests so the verifier
+/// is benchmarked against valid proofs that exercise every round, including the
+/// final claim comparison and Fiat-Shamir absorption path.
+fn honest_prove(
+    evals: &[F],
+    num_vars: usize,
+    transcript: &mut Blake2bTranscript,
+) -> SumcheckProof<F> {
+    let mut buf = evals.to_vec();
+    let mut round_polys = Vec::with_capacity(num_vars);
+
+    for _round in 0..num_vars {
+        let half = buf.len() / 2;
+        let mut eval_0 = F::default();
+        let mut eval_1 = F::default();
+        for i in 0..half {
+            eval_0 += buf[i];
+            eval_1 += buf[i + half];
+        }
+
+        let c0 = eval_0;
+        let c1 = eval_1 - eval_0;
+        let round_poly = UnivariatePoly::new(vec![c0, c1]);
+
+        for coeff in round_poly.coefficients() {
+            coeff.append_to_transcript(transcript);
+        }
+
+        let r: F = transcript.challenge();
+        round_polys.push(round_poly);
+
+        for i in 0..half {
+            buf[i] = buf[i] + r * (buf[i + half] - buf[i]);
+        }
+        buf.truncate(half);
+    }
+
+    SumcheckProof {
+        round_polynomials: round_polys,
+    }
+}
+
+fn random_evals(num_vars: usize, seed: u64) -> Vec<F> {
+    let mut rng = ChaCha20Rng::seed_from_u64(seed);
+    (0..(1usize << num_vars))
+        .map(|_| F::random(&mut rng))
+        .collect()
+}
+
+fn make_proof(num_vars: usize, seed: u64) -> (SumcheckClaim<F>, SumcheckProof<F>) {
+    let evals = random_evals(num_vars, seed);
+    let claimed_sum: F = evals.iter().copied().sum();
+    let mut transcript = Blake2bTranscript::new(b"jolt-sumcheck-bench");
+    let proof = honest_prove(&evals, num_vars, &mut transcript);
+    let claim = SumcheckClaim {
+        num_vars,
+        degree: 1,
+        claimed_sum,
+    };
+    (claim, proof)
+}
+
+fn bench_single_verifier(c: &mut Criterion) {
+    let mut group = c.benchmark_group("SumcheckVerifier::verify");
+    for num_vars in [8, 14, 18, 22] {
+        let (claim, proof) = make_proof(num_vars, 1000 + num_vars as u64);
+
+        group.bench_with_input(
+            BenchmarkId::from_parameter(num_vars),
+            &num_vars,
+            |bench, _| {
+                bench.iter(|| {
+                    let mut transcript = Blake2bTranscript::new(b"jolt-sumcheck-bench");
+                    let result = SumcheckVerifier::verify(
+                        black_box(&claim),
+                        black_box(&proof.round_polynomials),
+                        &mut transcript,
+                    );
+                    assert!(result.is_ok());
+                });
+            },
+        );
+    }
+    group.finish();
+}
+
+fn bench_batched_verifier_same_size(c: &mut Criterion) {
+    let mut group = c.benchmark_group("BatchedSumcheckVerifier::verify/same_size");
+
+    for &(num_vars, n_claims) in &[(14usize, 2usize), (14, 4), (18, 2), (18, 4)] {
+        let evals_per_claim: Vec<Vec<F>> = (0..n_claims)
+            .map(|i| random_evals(num_vars, 2000 + i as u64 + num_vars as u64))
+            .collect();
+        let sums: Vec<F> = evals_per_claim
+            .iter()
+            .map(|evals| evals.iter().copied().sum())
+            .collect();
+
+        let mut prover_transcript = Blake2bTranscript::new(b"jolt-sumcheck-batched-bench");
+        for s in &sums {
+            s.append_to_transcript(&mut prover_transcript);
+        }
+        let alpha: F = prover_transcript.challenge();
+        let mut alpha_pow = F::one();
+        let mut combined = vec![F::default(); 1usize << num_vars];
+        for evals in &evals_per_claim {
+            for (slot, e) in combined.iter_mut().zip(evals) {
+                *slot += alpha_pow * *e;
+            }
+            alpha_pow *= alpha;
+        }
+        let proof = honest_prove(&combined, num_vars, &mut prover_transcript);
+
+        let claims: Vec<SumcheckClaim<F>> = sums
+            .iter()
+            .map(|&s| SumcheckClaim {
+                num_vars,
+                degree: 1,
+                claimed_sum: s,
+            })
+            .collect();
+
+        let label = format!("n_vars={num_vars}/n_claims={n_claims}");
+        group.bench_with_input(BenchmarkId::from_parameter(label), &num_vars, |bench, _| {
+            bench.iter(|| {
+                let mut transcript = Blake2bTranscript::new(b"jolt-sumcheck-batched-bench");
+                let result = BatchedSumcheckVerifier::verify(
+                    black_box(&claims),
+                    black_box(&proof.round_polynomials),
+                    &mut transcript,
+                );
+                assert!(result.is_ok());
+            });
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_single_verifier,
+    bench_batched_verifier_same_size
+);
+criterion_main!(benches);


### PR DESCRIPTION
## Summary

`jolt-sumcheck` is the only modular crate with fuzz coverage but no
criterion benchmarks (the four crates already in
`bench-crates.yml` — `jolt-crypto`, `jolt-field`, `jolt-poly`,
`jolt-transcript` — all publish baselines). This PR adds a
`benches/sumcheck_verifier.rs` covering both verifier entry points and
wires the crate into the existing matrix so future regressions show up
on PR via the critcmp diff against the `main` baseline.

## Benches

- `SumcheckVerifier::verify/{8,14,18,22}` — single-instance honest-proof
  verification across realistic round counts.
- `BatchedSumcheckVerifier::verify/same_size/{n_vars=14,18}/{n_claims=2,4}`
  — front-loaded RLC batching path.

Each bench builds an honest proof with a minimal in-bench reference
prover (mirroring the `honest_prove` helper from
`crates/jolt-sumcheck/src/tests.rs`) so the verifier exercises the
full Fiat-Shamir loop end-to-end, not just round-0 rejection.

## Local numbers

apple-darwin (M1), `--warm-up-time 1 --measurement-time 3 --sample-size 10`:

| Bench | Time (median) |
| --- | --- |
| `SumcheckVerifier::verify/8` | 3.32 µs |
| `SumcheckVerifier::verify/14` | 5.68 µs |
| `SumcheckVerifier::verify/18` | 7.32 µs |
| `SumcheckVerifier::verify/22` | 8.89 µs |
| `BatchedSumcheckVerifier::verify/n_vars=14/n_claims=2` | 6.10 µs |
| `BatchedSumcheckVerifier::verify/n_vars=14/n_claims=4` | 6.39 µs |
| `BatchedSumcheckVerifier::verify/n_vars=18/n_claims=2` | 7.73 µs |
| `BatchedSumcheckVerifier::verify/n_vars=18/n_claims=4` | 7.99 µs |

## CI

Adds `jolt-sumcheck` to both the baseline (`push` to main) and PR
runs in `.github/workflows/bench-crates.yml`, mirroring the existing
four-crate matrix.

## Test plan

- [x] `cargo fmt -q`
- [x] `cargo clippy -p jolt-sumcheck --all-targets -- -D warnings`
- [x] `cargo clippy -p jolt-core --features host --all-targets -- -D warnings`
- [x] `cargo clippy -p jolt-core --features host,zk --all-targets -- -D warnings`
- [x] `cargo nextest run -p jolt-sumcheck` — 42/42 pass
- [x] `cargo nextest run -p jolt-core muldiv --features host` — pass
- [x] `cargo nextest run -p jolt-core muldiv --features host,zk` — pass
- [x] `cargo bench -p jolt-sumcheck --bench sumcheck_verifier -- --warm-up-time 1 --measurement-time 3 --sample-size 10` — numbers above
