### PR TITLE
test(ci): enable test-utils for integration tests

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -239,7 +239,12 @@ jobs:
         run: |
           set -euo pipefail
           for pkg in ${{ steps.discover.outputs.pkgs }}; do
-            cargo nextest run -p "$pkg" --no-tests=pass
+            features=()
+            if cargo metadata --format-version=1 --no-deps \
+                 | jq -e --arg pkg "$pkg" '.packages[] | select(.name == $pkg) | .features | has("test-utils")' >/dev/null; then
+              features=(--features test-utils)
+            fi
+            cargo nextest run -p "$pkg" "${features[@]}" --no-tests=pass
           done
 
   test-inlines:
@@ -297,7 +302,7 @@ jobs:
       - name: Install nextest
         uses: taiki-e/install-action@nextest
       - name: Run tracer tests
-        run: cargo nextest run --release -p tracer
+        run: cargo nextest run --release -p tracer --features test-utils
 
   zklean-extractor-tests:
     name: ZkLean extractor tests

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ For faster incremental builds, use the `build-fast` profile:
 
 Unit and end-to-end tests for `jolt-core` can be run using the following command:
 
-```cargo test -p jolt-core```
+```cargo nextest run -p jolt-core --features host```
 
 Examples in the [`examples`](./examples/) directory can be run using e.g.
 

--- a/crates/jolt-openings/tests/reduction.rs
+++ b/crates/jolt-openings/tests/reduction.rs
@@ -1,7 +1,7 @@
 //! Integration tests for the opening reduction pipeline.
 //!
-//! These tests exercise the public API only — no internal imports.
-//! They verify that the full reduce → open → verify pipeline works
+//! These tests exercise the public API only -- no internal imports.
+//! They verify that the full reduce -> open -> verify pipeline works
 //! end-to-end with MockCommitmentScheme across both transcript backends.
 //!
 //! Requires: `cargo nextest run -p jolt-openings --features test-utils`
@@ -13,7 +13,7 @@
     reason = "tests may panic on assertion failures"
 )]
 
-use jolt_field::{Fr, FromPrimitiveInt, RandomSampling, ReducingBytes};
+use jolt_field::{Fr, FromPrimitiveInt, RandomSampling};
 use jolt_openings::mock::MockCommitmentScheme;
 use jolt_openings::{reduce_prover, reduce_verifier, CommitmentScheme, ProverClaim, VerifierClaim};
 use jolt_poly::Polynomial;
@@ -23,7 +23,6 @@ use rand_core::SeedableRng;
 
 type MockPCS = MockCommitmentScheme<Fr>;
 
-/// Full reduce → open → verify pipeline.
 fn reduce_open_verify<T: Transcript<Challenge = Fr>>(
     polys: &[Polynomial<Fr>],
     points: &[Vec<Fr>],
@@ -49,7 +48,6 @@ fn reduce_open_verify<T: Transcript<Challenge = Fr>>(
         });
     }
 
-    // Prover side
     let mut transcript_p = T::new(label);
     let reduced_p = reduce_prover(prover_claims, &mut transcript_p);
     let proofs: Vec<_> = reduced_p
@@ -66,7 +64,6 @@ fn reduce_open_verify<T: Transcript<Challenge = Fr>>(
         })
         .collect();
 
-    // Verifier side
     let mut transcript_v = T::new(label);
     let reduced_v = reduce_verifier::<MockPCS, _>(verifier_claims, &mut transcript_v)
         .expect("reduction should succeed");
@@ -200,7 +197,7 @@ fn tampered_eval_detected() {
         VerifierClaim {
             commitment: com_b,
             point: point.clone(),
-            eval: eval_b + Fr::from_u64(1), // tampered
+            eval: eval_b + Fr::from_u64(1),
         },
     ];
 


### PR DESCRIPTION
## Summary
- Restores the `jolt-openings` reduction integration tests behind the crate's `test-utils` feature.
- Updates CI test invocations so crates that declare `test-utils` run with that feature enabled.
- Updates the README test example to use `cargo nextest` instead of `cargo test`.

## Changes
- The modular-crate CI loop now detects `test-utils` in package metadata and passes `--features test-utils` only for those crates.
- Tracer tests run with `--features test-utils` to exercise its public helper feature.
- The `jolt-openings` reduction integration test stays under `tests/` and drops an unused import so `RUSTFLAGS=-D warnings` passes.

## Testing
- `cargo fmt -q`
- `cargo metadata --format-version=1 --no-deps >/dev/null`
- `taplo fmt --check`
- `git diff --check --cached`
- `RUSTFLAGS='-D warnings' cargo nextest run -p jolt-openings --features test-utils --cargo-quiet`
- `RUSTFLAGS='-D warnings' cargo nextest run -p jolt-openings --cargo-quiet`
- `RUSTFLAGS='-D warnings' cargo nextest run -p tracer --features test-utils --cargo-quiet`
- `RUSTFLAGS='-D warnings' cargo check -p tracer --tests --features test-utils --quiet`
- `RUSTFLAGS='-D warnings' cargo check -p jolt-core --tests --features host --quiet`
- `RUSTFLAGS='-D warnings' cargo check -p jolt-core --tests --features zk --quiet`
- `RUSTFLAGS='-D warnings' cargo check -p jolt-sdk --tests --features host --quiet`
- pre-commit hook: typos, `cargo fmt`, clippy
