### PR TITLE
refactor: add modular foundation helpers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3089,6 +3089,7 @@ dependencies = [
  "rand_core 0.6.4",
  "rayon",
  "serde",
+ "thiserror 2.0.18",
  "tracing",
 ]
 

--- a/crates/jolt-field/src/arkworks/bn254.rs
+++ b/crates/jolt-field/src/arkworks/bn254.rs
@@ -358,7 +358,26 @@ impl ReducingBytes for Fr {
 impl TranscriptChallenge for Fr {
     #[inline]
     fn from_challenge_bytes(bytes: &[u8]) -> Self {
-        Fr::from_le_bytes_mod_order(bytes)
+        let mut buf = [0u8; 16];
+        let len = bytes.len().min(buf.len());
+        buf[..len].copy_from_slice(&bytes[..len]);
+        let value = u128::from_le_bytes(buf);
+        let low = value as u64;
+        let high = ((value >> 64) as u64) & (u64::MAX >> 3);
+        let Some(inner) = InnerFr::from_bigint_unchecked(ark_ff::BigInt::new([0, 0, low, high]))
+        else {
+            unreachable!("masked 125-bit shifted challenge fits in BN254 Fr")
+        };
+        Fr(inner)
+    }
+
+    #[inline]
+    fn from_scalar_challenge_bytes(bytes: &[u8]) -> Self {
+        let mut buf = bytes.to_vec();
+        // Scalar challenges match the legacy transcript convention: digest bytes
+        // are interpreted as a big-endian integer before reduction.
+        buf.reverse();
+        Fr::from_le_bytes_mod_order(&buf)
     }
 }
 

--- a/crates/jolt-field/src/arkworks/bn254.rs
+++ b/crates/jolt-field/src/arkworks/bn254.rs
@@ -363,6 +363,7 @@ impl TranscriptChallenge for Fr {
         buf[..len].copy_from_slice(&bytes[..len]);
         let value = u128::from_le_bytes(buf);
         let low = value as u64;
+        // Top 3 bits of high limb are zeroed to ensure value < BN254 modulus.
         let high = ((value >> 64) as u64) & (u64::MAX >> 3);
         let Some(inner) = InnerFr::from_bigint_unchecked(ark_ff::BigInt::new([0, 0, low, high]))
         else {

--- a/crates/jolt-field/src/ring_core.rs
+++ b/crates/jolt-field/src/ring_core.rs
@@ -30,4 +30,23 @@ pub trait RingCore:
     fn square(&self) -> Self {
         *self * *self
     }
+
+    #[inline]
+    fn pow2(exponent: usize) -> Self {
+        let mut result = Self::one();
+        let mut base = Self::one() + Self::one();
+        let mut remaining = exponent;
+
+        while remaining > 0 {
+            if remaining % 2 == 1 {
+                result *= base;
+            }
+            remaining /= 2;
+            if remaining > 0 {
+                base = base.square();
+            }
+        }
+
+        result
+    }
 }

--- a/crates/jolt-field/src/transcript_challenge.rs
+++ b/crates/jolt-field/src/transcript_challenge.rs
@@ -4,4 +4,9 @@ pub trait TranscriptChallenge:
 {
     /// Constructs a challenge from transcript bytes.
     fn from_challenge_bytes(bytes: &[u8]) -> Self;
+
+    /// Constructs a non-optimized scalar challenge from transcript bytes.
+    fn from_scalar_challenge_bytes(bytes: &[u8]) -> Self {
+        Self::from_challenge_bytes(bytes)
+    }
 }

--- a/crates/jolt-poly/Cargo.toml
+++ b/crates/jolt-poly/Cargo.toml
@@ -18,6 +18,7 @@ tracing.workspace = true
 rayon = { workspace = true, optional = true }
 rand_core = { workspace = true }
 num-traits = { workspace = true }
+thiserror = { workspace = true }
 
 [dev-dependencies]
 rand = { workspace = true }

--- a/crates/jolt-poly/src/eq.rs
+++ b/crates/jolt-poly/src/eq.rs
@@ -6,6 +6,7 @@ use jolt_field::Field;
 use serde::{Deserialize, Serialize};
 
 use crate::math::Math;
+use crate::mle::MleError;
 use crate::thread::unsafe_allocate_zero_vec;
 
 /// Equality polynomial $\widetilde{eq}(x, r) = \prod_{i=1}^{n}(r_i x_i + (1-r_i)(1-x_i))$.
@@ -114,6 +115,34 @@ impl<F: Field> EqPolynomial<F> {
                 acc * (r_i * p_i + (F::one() - r_i) * (F::one() - p_i))
             })
     }
+}
+
+pub fn try_eq_mle<F: Field>(left: &[F], right: &[F]) -> Result<F, MleError> {
+    if left.len() != right.len() {
+        return Err(MleError::EqualityArityMismatch {
+            left: left.len(),
+            right: right.len(),
+        });
+    }
+    Ok(EqPolynomial::<F>::mle(left, right))
+}
+
+pub fn eq_index_msb<F: Field>(point: &[F], index: usize) -> F {
+    let mut eq = F::one();
+    for (position, challenge) in point.iter().enumerate() {
+        let shift = point.len() - 1 - position;
+        let bit = if shift < usize::BITS as usize {
+            (index >> shift) & 1
+        } else {
+            0
+        };
+        if bit == 1 {
+            eq *= *challenge;
+        } else {
+            eq *= F::one() - *challenge;
+        }
+    }
+    eq
 }
 
 /// Static (point-free) evaluation methods for eq polynomial tables.

--- a/crates/jolt-poly/src/identity.rs
+++ b/crates/jolt-poly/src/identity.rs
@@ -3,6 +3,63 @@
 use jolt_field::Field;
 use serde::{Deserialize, Serialize};
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum OperandSide {
+    Left,
+    Right,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct OperandPolynomial {
+    num_vars: usize,
+    side: OperandSide,
+}
+
+impl OperandPolynomial {
+    pub const fn new(num_vars: usize, side: OperandSide) -> Self {
+        Self { num_vars, side }
+    }
+
+    pub const fn num_vars(&self) -> usize {
+        self.num_vars
+    }
+
+    pub const fn side(&self) -> OperandSide {
+        self.side
+    }
+}
+
+impl<F: Field> crate::MultilinearEvaluation<F> for OperandPolynomial {
+    fn num_vars(&self) -> usize {
+        self.num_vars
+    }
+
+    fn len(&self) -> usize {
+        1 << self.num_vars
+    }
+
+    fn evaluate(&self, point: &[F]) -> F {
+        assert_eq!(
+            point.len(),
+            self.num_vars,
+            "point dimension must match num_vars"
+        );
+        assert!(
+            self.num_vars.is_multiple_of(2),
+            "operand polynomial requires an even number of variables"
+        );
+
+        let offset = match self.side {
+            OperandSide::Left => 0,
+            OperandSide::Right => 1,
+        };
+        let bits = self.num_vars / 2;
+        (0..bits).fold(F::zero(), |acc, bit_index| {
+            acc + point[2 * bit_index + offset].mul_pow_2(bits - 1 - bit_index)
+        })
+    }
+}
+
 /// Identity polynomial: $\widetilde{I}(x) = \sum_{i=0}^{2^n - 1} i \cdot \widetilde{eq}(x, i)$.
 ///
 /// At each Boolean hypercube point $b \in \{0,1\}^n$, this polynomial evaluates to the
@@ -23,12 +80,18 @@ impl IdentityPolynomial {
     pub fn num_vars(&self) -> usize {
         self.num_vars
     }
+}
 
-    /// Evaluates $\widetilde{I}(r) = \sum_{i=1}^{n} r_i \cdot 2^{n-i}$.
-    ///
-    /// Time: $O(n)$. No heap allocation.
-    #[inline]
-    pub fn evaluate<F: Field>(&self, point: &[F]) -> F {
+impl<F: Field> crate::MultilinearEvaluation<F> for IdentityPolynomial {
+    fn num_vars(&self) -> usize {
+        self.num_vars
+    }
+
+    fn len(&self) -> usize {
+        1 << self.num_vars
+    }
+
+    fn evaluate(&self, point: &[F]) -> F {
         assert_eq!(
             point.len(),
             self.num_vars,
@@ -42,23 +105,10 @@ impl IdentityPolynomial {
     }
 }
 
-impl<F: Field> crate::MultilinearEvaluation<F> for IdentityPolynomial {
-    fn num_vars(&self) -> usize {
-        self.num_vars
-    }
-
-    fn len(&self) -> usize {
-        1 << self.num_vars
-    }
-
-    fn evaluate(&self, point: &[F]) -> F {
-        IdentityPolynomial::evaluate(self, point)
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::MultilinearEvaluation;
     use jolt_field::Fr;
     use jolt_field::FromPrimitiveInt;
     use num_traits::{One, Zero};
@@ -89,7 +139,9 @@ mod tests {
     #[test]
     fn zero_vars() {
         let id = IdentityPolynomial::new(0);
-        assert!(id.evaluate::<Fr>(&[]).is_zero());
+        assert!(
+            <IdentityPolynomial as crate::MultilinearEvaluation<Fr>>::evaluate(&id, &[]).is_zero()
+        );
     }
 
     #[test]
@@ -97,5 +149,26 @@ mod tests {
         let id = IdentityPolynomial::new(1);
         assert!(id.evaluate(&[Fr::zero()]).is_zero());
         assert_eq!(id.evaluate(&[Fr::one()]), Fr::one());
+    }
+
+    #[test]
+    fn operand_polynomial_splits_interleaved_left_and_right_bits() {
+        let point = [
+            Fr::from_u64(1),
+            Fr::from_u64(0),
+            Fr::from_u64(0),
+            Fr::from_u64(1),
+            Fr::from_u64(1),
+            Fr::from_u64(1),
+        ];
+
+        assert_eq!(
+            OperandPolynomial::new(6, OperandSide::Left).evaluate(&point),
+            Fr::from_u64(5)
+        );
+        assert_eq!(
+            OperandPolynomial::new(6, OperandSide::Right).evaluate(&point),
+            Fr::from_u64(3)
+        );
     }
 }

--- a/crates/jolt-poly/src/identity.rs
+++ b/crates/jolt-poly/src/identity.rs
@@ -20,10 +20,6 @@ impl OperandPolynomial {
         Self { num_vars, side }
     }
 
-    pub const fn num_vars(&self) -> usize {
-        self.num_vars
-    }
-
     pub const fn side(&self) -> OperandSide {
         self.side
     }

--- a/crates/jolt-poly/src/lagrange.rs
+++ b/crates/jolt-poly/src/lagrange.rs
@@ -4,6 +4,8 @@
 //! protocols. All functions are generic over [`Field`] and operate on
 //! integer-indexed domains (symmetric or arbitrary).
 
+use std::fmt;
+
 use jolt_field::Field;
 
 /// Evaluates all Lagrange basis polynomials $L_0(r), \ldots, L_{N-1}(r)$ over
@@ -61,6 +63,46 @@ pub fn lagrange_evals<F: Field>(domain_start: i64, domain_size: usize, r: F) -> 
     result
 }
 
+/// Evaluates all Lagrange basis polynomials over the centered consecutive
+/// integer domain used by univariate-skip protocols.
+pub fn centered_lagrange_evals<F: Field>(
+    domain_size: usize,
+    r: F,
+) -> Result<Vec<F>, CenteredIntegerDomainError> {
+    Ok(lagrange_evals(
+        centered_domain_start(domain_size)?,
+        domain_size,
+        r,
+    ))
+}
+
+pub fn centered_lagrange_evals_array<F: Field, const N: usize>(
+    r: F,
+) -> Result<[F; N], CenteredIntegerDomainError> {
+    let evals = centered_lagrange_evals(N, r)?;
+    let mut result = [F::zero(); N];
+    for (dst, src) in result.iter_mut().zip(evals) {
+        *dst = src;
+    }
+    Ok(result)
+}
+
+/// Computes `sum_i L_i(x) * L_i(y)` over the centered consecutive integer
+/// domain used by univariate-skip protocols.
+pub fn centered_lagrange_kernel<F: Field>(
+    domain_size: usize,
+    x: F,
+    y: F,
+) -> Result<F, CenteredIntegerDomainError> {
+    let x_evals = centered_lagrange_evals(domain_size, x)?;
+    let y_evals = centered_lagrange_evals(domain_size, y)?;
+    Ok(x_evals
+        .into_iter()
+        .zip(y_evals)
+        .map(|(left, right)| left * right)
+        .sum())
+}
+
 /// Computes power sums $S_k = \sum_{t=-D}^{D} t^k$ for $k = 0, 1, \ldots, \text{num\_powers}-1$
 /// over the symmetric integer domain $\{-D, \ldots, D\}$ of size $2D+1$.
 ///
@@ -78,6 +120,90 @@ pub fn symmetric_power_sums(half_width: i64, num_powers: usize) -> Vec<i128> {
         }
     }
     sums
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum CenteredIntegerDomainError {
+    EmptyDomain,
+    DomainTooLarge { domain_size: usize },
+    PowerSumOverflow { domain_size: usize, power: usize },
+}
+
+impl fmt::Display for CenteredIntegerDomainError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::EmptyDomain => write!(f, "centered integer domain must be non-empty"),
+            Self::DomainTooLarge { domain_size } => {
+                write!(
+                    f,
+                    "centered integer domain size {domain_size} exceeds i64::MAX"
+                )
+            }
+            Self::PowerSumOverflow { domain_size, power } => write!(
+                f,
+                "centered integer domain size {domain_size} overflowed i128 at power {power}"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for CenteredIntegerDomainError {}
+
+/// Start of the centered consecutive-integer domain used by core univariate skip.
+///
+/// The domain has `domain_size` consecutive integer points
+/// `{start, start + 1, ..., start + domain_size - 1}` where
+/// `start = -floor((domain_size - 1) / 2)`.
+pub fn centered_domain_start(domain_size: usize) -> Result<i64, CenteredIntegerDomainError> {
+    if domain_size == 0 {
+        return Err(CenteredIntegerDomainError::EmptyDomain);
+    }
+    if domain_size > i64::MAX as usize {
+        return Err(CenteredIntegerDomainError::DomainTooLarge { domain_size });
+    }
+    Ok(-(((domain_size - 1) / 2) as i64))
+}
+
+/// Computes `S_k = sum_t t^k` over the centered consecutive-integer domain.
+///
+/// This matches core's univariate-skip window convention for both odd and even
+/// domain sizes. For example, size `3` is `{-1, 0, 1}` and size `4` is
+/// `{-1, 0, 1, 2}`.
+pub fn centered_power_sums(
+    domain_size: usize,
+    num_powers: usize,
+) -> Result<Vec<i128>, CenteredIntegerDomainError> {
+    let start = centered_domain_start(domain_size)?;
+    let mut sums = vec![0i128; num_powers];
+    if num_powers == 0 {
+        return Ok(sums);
+    }
+
+    for offset in 0..domain_size {
+        let offset = i64::try_from(offset)
+            .map_err(|_| CenteredIntegerDomainError::DomainTooLarge { domain_size })?;
+        let t = i128::from(
+            start
+                .checked_add(offset)
+                .ok_or(CenteredIntegerDomainError::DomainTooLarge { domain_size })?,
+        );
+        let mut pow = 1i128;
+        for (power, sum) in sums.iter_mut().enumerate() {
+            *sum = sum
+                .checked_add(pow)
+                .ok_or(CenteredIntegerDomainError::PowerSumOverflow { domain_size, power })?;
+            if power + 1 < num_powers {
+                pow = pow
+                    .checked_mul(t)
+                    .ok_or(CenteredIntegerDomainError::PowerSumOverflow {
+                        domain_size,
+                        power: power + 1,
+                    })?;
+            }
+        }
+    }
+
+    Ok(sums)
 }
 
 /// Polynomial multiplication in coefficient form.
@@ -155,6 +281,7 @@ pub fn interpolate_to_coeffs<F: Field>(domain_start: i64, values: &[F]) -> Vec<F
 }
 
 #[cfg(test)]
+#[expect(clippy::unwrap_used, reason = "tests should fail loudly")]
 mod tests {
     use super::*;
     use jolt_field::{Fr, FromPrimitiveInt};
@@ -223,6 +350,50 @@ mod tests {
         assert_eq!(sums[0], 5);
         assert_eq!(sums[1], 0);
         assert_eq!(sums[2], 10); // 4 + 1 + 0 + 1 + 4
+    }
+
+    #[test]
+    fn centered_domain_start_matches_core_uniskip_convention() {
+        assert_eq!(centered_domain_start(1), Ok(0));
+        assert_eq!(centered_domain_start(3), Ok(-1));
+        assert_eq!(centered_domain_start(4), Ok(-1));
+        assert_eq!(centered_domain_start(10), Ok(-4));
+    }
+
+    #[test]
+    fn centered_lagrange_helpers_match_centered_domain() {
+        let r = Fr::from_u64(7);
+        let evals = centered_lagrange_evals(5, r).unwrap();
+        let evals_array = centered_lagrange_evals_array::<_, 5>(r).unwrap();
+
+        assert_eq!(evals, lagrange_evals(-2, 5, r));
+        assert_eq!(evals_array.as_slice(), evals.as_slice());
+        assert_eq!(
+            centered_lagrange_kernel(5, Fr::from_i64(-1), Fr::from_i64(-1)),
+            Ok(Fr::one())
+        );
+        assert_eq!(
+            centered_lagrange_kernel(5, Fr::from_i64(-1), Fr::from_i64(2)),
+            Ok(Fr::zero())
+        );
+    }
+
+    #[test]
+    fn centered_power_sums_handle_even_and_odd_windows() {
+        assert_eq!(centered_power_sums(3, 4), Ok(vec![3, 0, 2, 0]));
+        assert_eq!(centered_power_sums(4, 4), Ok(vec![4, 2, 6, 8]));
+    }
+
+    #[test]
+    fn centered_power_sums_reject_invalid_or_overflowing_inputs() {
+        assert_eq!(
+            centered_power_sums(0, 2),
+            Err(CenteredIntegerDomainError::EmptyDomain)
+        );
+        assert!(matches!(
+            centered_power_sums(10, 100),
+            Err(CenteredIntegerDomainError::PowerSumOverflow { .. })
+        ));
     }
 
     #[test]

--- a/crates/jolt-poly/src/lib.rs
+++ b/crates/jolt-poly/src/lib.rs
@@ -38,8 +38,8 @@
 //!
 //! # Utility Modules
 //!
-//! - [`lagrange`]: Lagrange interpolation, symmetric power sums, polynomial multiplication,
-//!   Newton-form interpolation over integer domains
+//! - [`lagrange`]: Lagrange interpolation, integer-domain power sums, polynomial
+//!   multiplication, Newton-form interpolation over integer domains
 //! - [`math`]: Bit-manipulation utilities on `usize` via the `Math` trait (`pow2`, `log_2`)
 //! - [`thread`]: `drop_in_background_thread` (rayon) and `unsafe_allocate_zero_vec` (zero-init allocation)
 
@@ -52,18 +52,24 @@ mod identity;
 pub mod lagrange;
 mod lt;
 pub mod math;
+mod mle;
 mod multilinear;
 mod one_hot;
+mod point;
 pub mod thread;
 mod univariate;
 
 pub use binding::BindingOrder;
 pub use compressed_univariate::CompressedPoly;
 pub use dense::Polynomial;
-pub use eq::EqPolynomial;
+pub use eq::{eq_index_msb, try_eq_mle, EqPolynomial};
 pub use eq_plus_one::{EqPlusOnePolynomial, EqPlusOnePrefixSuffix};
-pub use identity::IdentityPolynomial;
+pub use identity::{IdentityPolynomial, OperandPolynomial, OperandSide};
 pub use lt::LtPolynomial;
+pub use mle::{
+    block_selector_mle_msb, range_mask_mle_msb, sparse_mle_msb, sparse_segments_mle_msb, MleError,
+};
 pub use multilinear::{MultilinearBinding, MultilinearEvaluation, MultilinearPoly, RlcSource};
 pub use one_hot::OneHotPolynomial;
+pub use point::Point;
 pub use univariate::{UnivariatePoly, UnivariatePolynomial};

--- a/crates/jolt-poly/src/lib.rs
+++ b/crates/jolt-poly/src/lib.rs
@@ -71,5 +71,5 @@ pub use mle::{
 };
 pub use multilinear::{MultilinearBinding, MultilinearEvaluation, MultilinearPoly, RlcSource};
 pub use one_hot::OneHotPolynomial;
-pub use point::Point;
+pub use point::{Endianness, Point, HIGH_TO_LOW, LOW_TO_HIGH};
 pub use univariate::{UnivariatePoly, UnivariatePolynomial};

--- a/crates/jolt-poly/src/mle.rs
+++ b/crates/jolt-poly/src/mle.rs
@@ -1,0 +1,286 @@
+use jolt_field::Field;
+use thiserror::Error;
+
+use crate::eq_index_msb;
+
+#[derive(Clone, Debug, Error, PartialEq, Eq)]
+pub enum MleError {
+    #[error("equality polynomial arity mismatch: left {left}, right {right}")]
+    EqualityArityMismatch { left: usize, right: usize },
+    #[error("invalid MLE range [{start}, {end})")]
+    InvalidRange { start: u128, end: u128 },
+    #[error("MLE arity {arity} exceeds u128 capacity")]
+    DomainTooLarge { arity: usize },
+    #[error("MLE range end {end} exceeds domain size {domain_size}")]
+    RangeEndOutOfDomain { end: u128, domain_size: u128 },
+    #[error("MLE block has {block_vars} variables but point has arity {arity}")]
+    BlockVariablesExceedArity { block_vars: usize, arity: usize },
+    #[error("MLE block start {start_index} is not aligned to block size {block_size}")]
+    BlockStartUnaligned {
+        start_index: usize,
+        block_size: u128,
+    },
+    #[error("MLE block end {end} exceeds domain size {domain_size}")]
+    BlockEndOutOfDomain { end: u128, domain_size: u128 },
+}
+
+pub fn sparse_mle_msb<F: Field>(start_index: usize, values: &[u64], point: &[F]) -> F {
+    values
+        .iter()
+        .enumerate()
+        .map(|(offset, value)| F::from_u64(*value) * eq_index_msb(point, start_index + offset))
+        .sum()
+}
+
+pub fn sparse_segments_mle_msb<'a, F, I>(segments: I, point: &[F]) -> F
+where
+    F: Field,
+    I: IntoIterator<Item = (usize, &'a [u64])>,
+{
+    segments
+        .into_iter()
+        .map(|(start_index, values)| sparse_mle_msb(start_index, values, point))
+        .sum()
+}
+
+pub fn block_selector_mle_msb<F: Field>(
+    start_index: usize,
+    block_num_vars: usize,
+    point: &[F],
+) -> Result<F, MleError> {
+    if block_num_vars > point.len() {
+        return Err(MleError::BlockVariablesExceedArity {
+            block_vars: block_num_vars,
+            arity: point.len(),
+        });
+    }
+    if block_num_vars >= usize::BITS as usize {
+        return Err(MleError::DomainTooLarge {
+            arity: block_num_vars,
+        });
+    }
+
+    let block_size = 1u128
+        .checked_shl(block_num_vars as u32)
+        .ok_or(MleError::DomainTooLarge {
+            arity: block_num_vars,
+        })?;
+    let domain_size = 1u128
+        .checked_shl(point.len() as u32)
+        .ok_or(MleError::DomainTooLarge { arity: point.len() })?;
+    let start = start_index as u128;
+    if !start.is_multiple_of(block_size) {
+        return Err(MleError::BlockStartUnaligned {
+            start_index,
+            block_size,
+        });
+    }
+    let end = start
+        .checked_add(block_size)
+        .ok_or(MleError::DomainTooLarge { arity: point.len() })?;
+    if end > domain_size {
+        return Err(MleError::BlockEndOutOfDomain { end, domain_size });
+    }
+
+    let selector_point_len = point.len() - block_num_vars;
+    let block_index = usize::try_from(start / block_size)
+        .map_err(|_| MleError::DomainTooLarge { arity: point.len() })?;
+    Ok(eq_index_msb(&point[..selector_point_len], block_index))
+}
+
+pub fn range_mask_mle_msb<F: Field>(
+    range_start: u128,
+    range_end: u128,
+    point: &[F],
+) -> Result<F, MleError> {
+    if range_start >= range_end {
+        return Err(MleError::InvalidRange {
+            start: range_start,
+            end: range_end,
+        });
+    }
+    let domain_size = 1u128
+        .checked_shl(point.len() as u32)
+        .ok_or(MleError::DomainTooLarge { arity: point.len() })?;
+    if range_end > domain_size {
+        return Err(MleError::RangeEndOutOfDomain {
+            end: range_end,
+            domain_size,
+        });
+    }
+
+    Ok(less_than_mle_msb(range_end, point) - less_than_mle_msb(range_start, point))
+}
+
+fn less_than_mle_msb<F: Field>(bound: u128, point: &[F]) -> F {
+    if Some(bound) == 1u128.checked_shl(point.len() as u32) {
+        return F::one();
+    }
+    let mut lt_bound = F::zero();
+    let mut eq_bound = F::one();
+    for (index, challenge) in point.iter().enumerate() {
+        if msb_bit(bound, point.len(), index) == 1 {
+            lt_bound += eq_bound * (F::one() - *challenge);
+            eq_bound *= *challenge;
+        } else {
+            eq_bound *= F::one() - *challenge;
+        }
+    }
+    lt_bound
+}
+
+const fn msb_bit(value: u128, len: usize, position: usize) -> u8 {
+    let shift = len - 1 - position;
+    if shift < u128::BITS as usize {
+        ((value >> shift) & 1) as u8
+    } else {
+        0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![expect(clippy::panic, reason = "tests fail loudly on unexpected errors")]
+
+    use super::*;
+    use crate::{eq_index_msb, try_eq_mle};
+    use jolt_field::{Fr, FromPrimitiveInt};
+    use num_traits::{One, Zero};
+
+    #[test]
+    fn eq_index_uses_msb_order() {
+        let point = [Fr::from_u64(2), Fr::from_u64(3), Fr::from_u64(5)];
+
+        assert_eq!(
+            eq_index_msb(&point, 0b101),
+            point[0] * (Fr::one() - point[1]) * point[2]
+        );
+        assert_eq!(
+            eq_index_msb(&point, 0b010),
+            (Fr::one() - point[0]) * point[1] * (Fr::one() - point[2])
+        );
+    }
+
+    #[test]
+    fn checked_eq_mle_rejects_arity_mismatch() {
+        assert_eq!(
+            try_eq_mle::<Fr>(&[Fr::from_u64(1)], &[Fr::from_u64(1), Fr::from_u64(0)]),
+            Err(MleError::EqualityArityMismatch { left: 1, right: 2 })
+        );
+    }
+
+    #[test]
+    fn sparse_mle_matches_explicit_sum() {
+        let point = [Fr::from_u64(2), Fr::from_u64(3)];
+        let values = [7, 11];
+
+        assert_eq!(
+            sparse_mle_msb(1, &values, &point),
+            Fr::from_u64(7) * eq_index_msb(&point, 1) + Fr::from_u64(11) * eq_index_msb(&point, 2)
+        );
+    }
+
+    #[test]
+    fn sparse_segments_mle_sums_segments() {
+        let point = [Fr::from_u64(2), Fr::from_u64(3)];
+        let left = [7];
+        let right = [11];
+
+        assert_eq!(
+            sparse_segments_mle_msb([(1, left.as_slice()), (2, right.as_slice())], &point),
+            sparse_mle_msb(1, &left, &point) + sparse_mle_msb(2, &right, &point)
+        );
+    }
+
+    #[test]
+    fn block_selector_evaluates_aligned_prefix() {
+        let point = [Fr::from_u64(2), Fr::from_u64(3), Fr::from_u64(5)];
+
+        assert_eq!(
+            block_selector_mle_msb(0b100, 1, &point)
+                .unwrap_or_else(|error| panic!("selector should evaluate: {error}")),
+            eq_index_msb(&point[..2], 0b10)
+        );
+        assert_eq!(
+            block_selector_mle_msb(0, 3, &point)
+                .unwrap_or_else(|error| panic!("whole-domain selector should evaluate: {error}")),
+            Fr::one()
+        );
+    }
+
+    #[test]
+    fn block_selector_rejects_invalid_blocks() {
+        assert_eq!(
+            block_selector_mle_msb::<Fr>(0, 3, &[Fr::zero(), Fr::zero()]),
+            Err(MleError::BlockVariablesExceedArity {
+                block_vars: 3,
+                arity: 2
+            })
+        );
+        assert_eq!(
+            block_selector_mle_msb::<Fr>(1, 1, &[Fr::zero(), Fr::zero()]),
+            Err(MleError::BlockStartUnaligned {
+                start_index: 1,
+                block_size: 2
+            })
+        );
+        assert_eq!(
+            block_selector_mle_msb::<Fr>(4, 1, &[Fr::zero(), Fr::zero()]),
+            Err(MleError::BlockEndOutOfDomain {
+                end: 6,
+                domain_size: 4
+            })
+        );
+        assert_eq!(
+            block_selector_mle_msb::<Fr>(
+                0,
+                usize::BITS as usize,
+                &vec![Fr::zero(); usize::BITS as usize]
+            ),
+            Err(MleError::DomainTooLarge {
+                arity: usize::BITS as usize
+            })
+        );
+    }
+
+    #[test]
+    fn range_mask_matches_vertex_membership() {
+        for index in 0..8 {
+            let point = [
+                Fr::from_u64(((index >> 2) & 1) as u64),
+                Fr::from_u64(((index >> 1) & 1) as u64),
+                Fr::from_u64((index & 1) as u64),
+            ];
+            let expected = if (2..5).contains(&index) {
+                Fr::one()
+            } else {
+                Fr::zero()
+            };
+            assert_eq!(
+                range_mask_mle_msb(2, 5, &point)
+                    .unwrap_or_else(|error| panic!("range mask should evaluate: {error}")),
+                expected
+            );
+        }
+    }
+
+    #[test]
+    fn range_mask_rejects_invalid_ranges() {
+        assert_eq!(
+            range_mask_mle_msb::<Fr>(3, 3, &[Fr::zero(), Fr::zero()]),
+            Err(MleError::InvalidRange { start: 3, end: 3 })
+        );
+        assert_eq!(
+            range_mask_mle_msb(0, 4, &[Fr::from_u64(7), Fr::from_u64(11)])
+                .unwrap_or_else(|error| panic!("full-domain range should evaluate: {error}")),
+            Fr::one()
+        );
+        assert_eq!(
+            range_mask_mle_msb::<Fr>(0, 5, &[Fr::zero(), Fr::zero()]),
+            Err(MleError::RangeEndOutOfDomain {
+                end: 5,
+                domain_size: 4
+            })
+        );
+    }
+}

--- a/crates/jolt-poly/src/point.rs
+++ b/crates/jolt-poly/src/point.rs
@@ -1,0 +1,98 @@
+use std::ops::Deref;
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct Point<F> {
+    coords: Vec<F>,
+}
+
+impl<F> Point<F> {
+    pub fn high_to_low(coords: impl Into<Vec<F>>) -> Self {
+        Self {
+            coords: coords.into(),
+        }
+    }
+
+    pub fn low_to_high(coords: impl Into<Vec<F>>) -> Self {
+        let mut coords = coords.into();
+        coords.reverse();
+        Self { coords }
+    }
+
+    pub fn concat(points: impl IntoIterator<Item = Self>) -> Self {
+        let mut coords = Vec::new();
+        for point in points {
+            coords.extend(point.coords);
+        }
+        Self { coords }
+    }
+
+    pub fn as_slice(&self) -> &[F] {
+        &self.coords
+    }
+
+    pub fn into_vec(self) -> Vec<F> {
+        self.coords
+    }
+
+    pub fn len(&self) -> usize {
+        self.coords.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.coords.is_empty()
+    }
+}
+
+impl<F> From<Vec<F>> for Point<F> {
+    fn from(coords: Vec<F>) -> Self {
+        Self::high_to_low(coords)
+    }
+}
+
+impl<F> From<Point<F>> for Vec<F> {
+    fn from(point: Point<F>) -> Self {
+        point.coords
+    }
+}
+
+impl<F> AsRef<[F]> for Point<F> {
+    fn as_ref(&self) -> &[F] {
+        self.as_slice()
+    }
+}
+
+impl<F> Deref for Point<F> {
+    type Target = [F];
+
+    fn deref(&self) -> &Self::Target {
+        self.as_slice()
+    }
+}
+
+impl<F: PartialEq> PartialEq<Vec<F>> for Point<F> {
+    fn eq(&self, other: &Vec<F>) -> bool {
+        self.as_slice() == other.as_slice()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Point;
+
+    #[test]
+    fn low_to_high_reverses_to_canonical_order() {
+        assert_eq!(Point::low_to_high(vec![1, 2, 3]).into_vec(), vec![3, 2, 1]);
+    }
+
+    #[test]
+    fn concat_preserves_canonical_part_order() {
+        let point = Point::concat([
+            Point::high_to_low(vec![1, 2]),
+            Point::low_to_high(vec![3, 4]),
+        ]);
+
+        assert_eq!(point.into_vec(), vec![1, 2, 4, 3]);
+    }
+}

--- a/crates/jolt-poly/src/point.rs
+++ b/crates/jolt-poly/src/point.rs
@@ -2,22 +2,31 @@ use std::ops::Deref;
 
 use serde::{Deserialize, Serialize};
 
+pub type Endianness = bool;
+pub const HIGH_TO_LOW: Endianness = false;
+pub const LOW_TO_HIGH: Endianness = true;
+
 #[derive(Clone, Debug, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
-pub struct Point<F> {
+pub struct Point<const E: Endianness, F> {
     coords: Vec<F>,
 }
 
-impl<F> Point<F> {
-    pub fn high_to_low(coords: impl Into<Vec<F>>) -> Self {
+impl<const E: Endianness, F> Point<E, F> {
+    pub fn new(coords: impl Into<Vec<F>>) -> Self {
         Self {
             coords: coords.into(),
         }
     }
 
-    pub fn low_to_high(coords: impl Into<Vec<F>>) -> Self {
-        let mut coords = coords.into();
-        coords.reverse();
-        Self { coords }
+    pub fn match_endianness<const TARGET: Endianness>(&self) -> Point<TARGET, F>
+    where
+        F: Clone,
+    {
+        let mut coords = self.coords.clone();
+        if E != TARGET {
+            coords.reverse();
+        }
+        Point::<TARGET, F>::new(coords)
     }
 
     pub fn concat(points: impl IntoIterator<Item = Self>) -> Self {
@@ -45,25 +54,37 @@ impl<F> Point<F> {
     }
 }
 
-impl<F> From<Vec<F>> for Point<F> {
-    fn from(coords: Vec<F>) -> Self {
-        Self::high_to_low(coords)
+impl<F> Point<HIGH_TO_LOW, F> {
+    pub fn high_to_low(coords: impl Into<Vec<F>>) -> Self {
+        Self::new(coords)
     }
 }
 
-impl<F> From<Point<F>> for Vec<F> {
-    fn from(point: Point<F>) -> Self {
+impl<F> Point<LOW_TO_HIGH, F> {
+    pub fn low_to_high(coords: impl Into<Vec<F>>) -> Self {
+        Self::new(coords)
+    }
+}
+
+impl<const E: Endianness, F> From<Vec<F>> for Point<E, F> {
+    fn from(coords: Vec<F>) -> Self {
+        Self::new(coords)
+    }
+}
+
+impl<const E: Endianness, F> From<Point<E, F>> for Vec<F> {
+    fn from(point: Point<E, F>) -> Self {
         point.coords
     }
 }
 
-impl<F> AsRef<[F]> for Point<F> {
+impl<const E: Endianness, F> AsRef<[F]> for Point<E, F> {
     fn as_ref(&self) -> &[F] {
         self.as_slice()
     }
 }
 
-impl<F> Deref for Point<F> {
+impl<const E: Endianness, F> Deref for Point<E, F> {
     type Target = [F];
 
     fn deref(&self) -> &Self::Target {
@@ -71,7 +92,7 @@ impl<F> Deref for Point<F> {
     }
 }
 
-impl<F: PartialEq> PartialEq<Vec<F>> for Point<F> {
+impl<const E: Endianness, F: PartialEq> PartialEq<Vec<F>> for Point<E, F> {
     fn eq(&self, other: &Vec<F>) -> bool {
         self.as_slice() == other.as_slice()
     }
@@ -79,18 +100,29 @@ impl<F: PartialEq> PartialEq<Vec<F>> for Point<F> {
 
 #[cfg(test)]
 mod tests {
-    use super::Point;
+    use super::{Point, HIGH_TO_LOW, LOW_TO_HIGH};
 
     #[test]
-    fn low_to_high_reverses_to_canonical_order() {
-        assert_eq!(Point::low_to_high(vec![1, 2, 3]).into_vec(), vec![3, 2, 1]);
+    fn match_endianness_reverses_when_order_changes() {
+        let point = Point::<LOW_TO_HIGH, _>::low_to_high(vec![1, 2, 3]);
+        let canonical = point.match_endianness::<HIGH_TO_LOW>();
+
+        assert_eq!(canonical.into_vec(), vec![3, 2, 1]);
     }
 
     #[test]
-    fn concat_preserves_canonical_part_order() {
-        let point = Point::concat([
-            Point::high_to_low(vec![1, 2]),
-            Point::low_to_high(vec![3, 4]),
+    fn match_endianness_preserves_matching_order() {
+        let point = Point::<HIGH_TO_LOW, _>::high_to_low(vec![1, 2, 3]);
+        let canonical = point.match_endianness::<HIGH_TO_LOW>();
+
+        assert_eq!(canonical.into_vec(), vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn concat_preserves_point_order() {
+        let point = Point::<HIGH_TO_LOW, _>::concat([
+            Point::<HIGH_TO_LOW, _>::high_to_low(vec![1, 2]),
+            Point::<LOW_TO_HIGH, _>::low_to_high(vec![3, 4]).match_endianness::<HIGH_TO_LOW>(),
         ]);
 
         assert_eq!(point.into_vec(), vec![1, 2, 4, 3]);

--- a/crates/jolt-poly/tests/integration.rs
+++ b/crates/jolt-poly/tests/integration.rs
@@ -7,7 +7,8 @@
 
 use jolt_field::{Fr, FromPrimitiveInt, RandomSampling};
 use jolt_poly::{
-    EqPolynomial, IdentityPolynomial, MultilinearPoly, Polynomial, RlcSource, UnivariatePoly,
+    EqPolynomial, IdentityPolynomial, MultilinearEvaluation, MultilinearPoly, Polynomial,
+    RlcSource, UnivariatePoly,
 };
 use rand_chacha::ChaCha20Rng;
 use rand_core::SeedableRng;
@@ -179,7 +180,7 @@ fn identity_polynomial_boolean_indexing() {
                 }
             })
             .collect();
-        let eval = id.evaluate::<Fr>(&bits);
+        let eval = id.evaluate(&bits);
         assert_eq!(eval, Fr::from_u64(idx as u64), "identity at index {idx}");
     }
 }
@@ -192,7 +193,7 @@ fn identity_polynomial_random_point() {
     let id = IdentityPolynomial::new(nv);
     let point: Vec<Fr> = (0..nv).map(|_| Fr::random(&mut rng)).collect();
 
-    let eval = id.evaluate::<Fr>(&point);
+    let eval = id.evaluate(&point);
 
     // Manual: sum_i r_i * 2^(n-1-i)
     let expected: Fr = point

--- a/crates/jolt-riscv/src/flags.rs
+++ b/crates/jolt-riscv/src/flags.rs
@@ -15,6 +15,10 @@ use strum::EnumCount;
 ///
 /// Note: the flags below deviate somewhat from those described in Appendix A.1
 /// of the Jolt paper.
+#[cfg_attr(
+    feature = "serialization",
+    derive(serde::Serialize, serde::Deserialize)
+)]
 #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, EnumCount)]
 #[repr(u8)]
 pub enum CircuitFlags {
@@ -51,9 +55,30 @@ pub enum CircuitFlags {
 /// Number of circuit flags.
 pub const NUM_CIRCUIT_FLAGS: usize = CircuitFlags::COUNT;
 
+pub const CIRCUIT_FLAGS: [CircuitFlags; NUM_CIRCUIT_FLAGS] = [
+    CircuitFlags::AddOperands,
+    CircuitFlags::SubtractOperands,
+    CircuitFlags::MultiplyOperands,
+    CircuitFlags::Load,
+    CircuitFlags::Store,
+    CircuitFlags::Jump,
+    CircuitFlags::WriteLookupOutputToRD,
+    CircuitFlags::VirtualInstruction,
+    CircuitFlags::Assert,
+    CircuitFlags::DoNotUpdateUnexpandedPC,
+    CircuitFlags::Advice,
+    CircuitFlags::IsCompressed,
+    CircuitFlags::IsFirstInSequence,
+    CircuitFlags::IsLastInSequence,
+];
+
 /// Boolean flags that are NOT part of Jolt's R1CS constraints.
 ///
 /// These control witness generation, operand routing, and auxiliary prover logic.
+#[cfg_attr(
+    feature = "serialization",
+    derive(serde::Serialize, serde::Deserialize)
+)]
 #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, EnumCount)]
 #[repr(u8)]
 pub enum InstructionFlags {

--- a/crates/jolt-riscv/src/lib.rs
+++ b/crates/jolt-riscv/src/lib.rs
@@ -239,7 +239,7 @@ macro_rules! for_each_jolt_instruction_kind {
 
 pub use flags::{
     CircuitFlagSet, CircuitFlags, Flags, InstructionFlagSet, InstructionFlags,
-    InterleavedBitsMarker, NUM_CIRCUIT_FLAGS, NUM_INSTRUCTION_FLAGS,
+    InterleavedBitsMarker, CIRCUIT_FLAGS, NUM_CIRCUIT_FLAGS, NUM_INSTRUCTION_FLAGS,
 };
 pub use instructions::{JoltInstruction, SourceInstruction};
 pub use kind::{

--- a/crates/jolt-transcript/src/digest.rs
+++ b/crates/jolt-transcript/src/digest.rs
@@ -19,6 +19,11 @@ struct TestState {
 ///
 /// Generic over the hash function `D` and field type `F`. Challenges are
 /// produced as field elements through `F::from_challenge_bytes`.
+///
+/// The byte layout intentionally matches `jolt-core`'s hash transcripts:
+/// appends hash `state || round || payload`, squeezes hash `state || round`,
+/// and optimized scalar challenges use the same 125-bit Montgomery-friendly
+/// decoding path as `jolt-core`.
 pub struct DigestTranscript<D: Digest<OutputSize = U32> + 'static, F> {
     state: [u8; 32],
     n_rounds: u32,
@@ -97,11 +102,7 @@ where
 
     #[inline]
     fn challenge_bytes32(&mut self, out: &mut [u8; 32]) {
-        let hash: [u8; 32] = self
-            .hasher()
-            .chain_update([0x01]) // squeeze domain tag
-            .finalize()
-            .into();
+        let hash: [u8; 32] = self.hasher().finalize().into();
         out.copy_from_slice(&hash);
         self.update_state(hash);
     }
@@ -155,12 +156,7 @@ where
     }
 
     fn append_bytes(&mut self, bytes: &[u8]) {
-        let hash: [u8; 32] = self
-            .hasher()
-            .chain_update([0x00]) // absorb domain tag
-            .chain_update(bytes)
-            .finalize()
-            .into();
+        let hash: [u8; 32] = self.hasher().chain_update(bytes).finalize().into();
         self.update_state(hash);
     }
 
@@ -168,6 +164,12 @@ where
         let mut buf = [0u8; 16];
         self.challenge_bytes(&mut buf);
         F::from_challenge_bytes(&buf)
+    }
+
+    fn challenge_scalar(&mut self) -> F {
+        let mut buf = [0u8; 16];
+        self.challenge_bytes(&mut buf);
+        F::from_scalar_challenge_bytes(&buf)
     }
 
     #[inline]

--- a/crates/jolt-transcript/src/digest.rs
+++ b/crates/jolt-transcript/src/digest.rs
@@ -22,8 +22,8 @@ struct TestState {
 ///
 /// The byte layout intentionally matches `jolt-core`'s hash transcripts:
 /// appends hash `state || round || payload`, squeezes hash `state || round`,
-/// and optimized scalar challenges use the same 125-bit Montgomery-friendly
-/// decoding path as `jolt-core`.
+/// and standard challenges use the same 125-bit Montgomery-friendly decoding
+/// path as `jolt-core`.
 pub struct DigestTranscript<D: Digest<OutputSize = U32> + 'static, F> {
     state: [u8; 32],
     n_rounds: u32,
@@ -167,7 +167,7 @@ where
     }
 
     fn challenge_scalar(&mut self) -> F {
-        let mut buf = [0u8; 16];
+        let mut buf = [0u8; 32];
         self.challenge_bytes(&mut buf);
         F::from_scalar_challenge_bytes(&buf)
     }
@@ -180,5 +180,38 @@ where
     #[cfg(test)]
     fn compare_to(&mut self, other: &Self) {
         self.test_state.expected_state_history = Some(other.test_state.state_history.clone());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use blake2::{digest::consts::U32, Blake2b};
+    use jolt_field::TranscriptChallenge;
+
+    use super::DigestTranscript;
+    use crate::Transcript;
+
+    #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
+    struct ChallengeByteLen(usize);
+
+    impl TranscriptChallenge for ChallengeByteLen {
+        fn from_challenge_bytes(bytes: &[u8]) -> Self {
+            Self(bytes.len())
+        }
+
+        fn from_scalar_challenge_bytes(bytes: &[u8]) -> Self {
+            Self(bytes.len())
+        }
+    }
+
+    type TestTranscript = DigestTranscript<Blake2b<U32>, ChallengeByteLen>;
+
+    #[test]
+    fn scalar_challenge_uses_full_digest_width() {
+        let mut transcript = TestTranscript::new(b"challenge-width");
+        assert_eq!(transcript.challenge(), ChallengeByteLen(16));
+
+        let mut transcript = TestTranscript::new(b"challenge-width");
+        assert_eq!(transcript.challenge_scalar(), ChallengeByteLen(32));
     }
 }

--- a/crates/jolt-transcript/src/transcript.rs
+++ b/crates/jolt-transcript/src/transcript.rs
@@ -3,6 +3,9 @@
 //! This module provides the [`Transcript`] trait for building Fiat-Shamir transcripts
 //! and the [`AppendToTranscript`] trait for types that can be absorbed into a transcript.
 
+use crate::domain::Label;
+use jolt_field::{Field, FromPrimitiveInt};
+
 /// Fiat-Shamir transcript for non-interactive proofs.
 ///
 /// A transcript absorbs data and produces deterministic challenges. Both prover
@@ -44,16 +47,46 @@ pub trait Transcript: Default + Clone + Sync + Send + 'static {
         value.append_to_transcript(self);
     }
 
+    /// Absorbs a domain label followed by a value.
+    ///
+    /// Jolt's core proof transcript commonly absorbs scalar payloads as
+    /// `label || payload`; this method makes that pattern explicit at the
+    /// transcript API boundary.
+    fn append_labeled<A: AppendToTranscript>(&mut self, label: &'static [u8], value: &A) {
+        self.append(&Label(label));
+        self.append(value);
+    }
+
     /// Squeezes a challenge from the transcript.
     ///
     /// Each call produces a new challenge and advances the transcript state.
     #[must_use]
     fn challenge(&mut self) -> Self::Challenge;
 
+    /// Squeezes a non-optimized scalar challenge from the transcript.
+    #[must_use]
+    fn challenge_scalar(&mut self) -> Self::Challenge {
+        self.challenge()
+    }
+
     /// Squeezes multiple challenges from the transcript.
     #[must_use]
     fn challenge_vector(&mut self, len: usize) -> Vec<Self::Challenge> {
         (0..len).map(|_| self.challenge()).collect()
+    }
+
+    /// Squeezes one scalar challenge and returns its powers `[1, gamma, gamma^2, ...]`.
+    #[must_use]
+    fn challenge_scalar_powers(&mut self, len: usize) -> Vec<Self::Challenge>
+    where
+        Self::Challenge: Field,
+    {
+        let gamma = self.challenge_scalar();
+        let mut powers = vec![Self::Challenge::from_u64(1); len];
+        for index in 1..len {
+            powers[index] = powers[index - 1] * gamma;
+        }
+        powers
     }
 
     /// Returns the current 256-bit transcript state.
@@ -78,4 +111,13 @@ pub const MAX_LABEL_LEN: usize = 32;
 pub trait AppendToTranscript {
     /// Absorbs this value into the transcript.
     fn append_to_transcript<T: Transcript>(&self, transcript: &mut T);
+
+    /// Byte length of the payload absorbed by [`append_to_transcript`].
+    ///
+    /// Types that need to match `jolt-core`'s variable-length labeled
+    /// transcript methods should override this so callers can prepend the same
+    /// packed label/length word before absorbing the payload.
+    fn transcript_payload_len(&self) -> Option<u64> {
+        None
+    }
 }


### PR DESCRIPTION
## Summary
- Rebase the foundation helper stack branch onto main after #1541 was accidentally merged into stack/00.
- Keep the already-merged stack automation changes out of this PR.
- Include the review feedback fixes from #1541.

## Testing
- cargo fmt -q
- cargo clippy --all --features host -q --all-targets -- -D warnings
- cargo clippy --all --features host,zk -q --all-targets -- -D warnings
- cargo nextest run -p jolt-core muldiv --cargo-quiet --features host
- cargo nextest run -p jolt-core muldiv --cargo-quiet --features host,zk

Follow-up for #1541.