### PR TITLE
fix(dory): reject mixed-mode opening proofs

### DIFF
--- a/crates/jolt-dory/src/scheme.rs
+++ b/crates/jolt-dory/src/scheme.rs
@@ -216,6 +216,15 @@ impl CommitmentScheme for DoryScheme {
         let ark_commitment = jolt_gt_to_ark(&commitment.0);
         let mut dory_transcript = JoltToDoryTranscript::new(transcript);
 
+        if proof.0.e2.is_some()
+            || proof.0.y_com.is_some()
+            || proof.0.sigma1_proof.is_some()
+            || proof.0.sigma2_proof.is_some()
+            || proof.0.scalar_product_proof.is_some()
+        {
+            return Err(OpeningsError::VerificationFailed);
+        }
+
         dory::verify::<ArkFr, InnerBN254, G1Routines, G2Routines, _>(
             ark_commitment,
             ark_eval,

--- a/crates/jolt-dory/tests/commit_open_verify.rs
+++ b/crates/jolt-dory/tests/commit_open_verify.rs
@@ -377,6 +377,33 @@ fn zk_round_trip_both_transcripts() {
 }
 
 #[test]
+fn transparent_verify_rejects_zk_opening_proof() {
+    let num_vars = 4;
+    let mut rng = ChaCha20Rng::seed_from_u64(1301);
+
+    let prover_setup = DoryScheme::setup_prover(num_vars);
+    let verifier_setup = DoryScheme::setup_verifier(num_vars);
+    let poly = Polynomial::<Fr>::random(num_vars, &mut rng);
+    let point: Vec<Fr> = (0..num_vars)
+        .map(|_| <Fr as RandomSampling>::random(&mut rng))
+        .collect();
+    let eval = poly.evaluate(&point);
+    let (commitment, hint) =
+        <DoryScheme as ZkOpeningScheme>::commit_zk(poly.evaluations(), &prover_setup);
+
+    let mut pt = Blake2bTranscript::new(b"zk-proof-transparent-verify");
+    let (proof, _eval_com, _blind) =
+        DoryScheme::open_zk(&poly, &point, eval, &prover_setup, hint, &mut pt);
+
+    let mut vt = Blake2bTranscript::new(b"zk-proof-transparent-verify");
+    let result = DoryScheme::verify(&commitment, &point, eval, &proof, &verifier_setup, &mut vt);
+    assert!(
+        result.is_err(),
+        "transparent verification must reject ZK opening proofs"
+    );
+}
+
+#[test]
 fn zk_wrong_commitment_rejected() {
     let num_vars = 3;
     let mut rng = ChaCha20Rng::seed_from_u64(1400);

--- a/jolt-core/src/poly/commitment/dory/commitment_scheme.rs
+++ b/jolt-core/src/poly/commitment/dory/commitment_scheme.rs
@@ -252,6 +252,16 @@ impl CommitmentScheme for DoryCommitmentScheme {
 
         let mut dory_transcript = JoltToDoryTranscript::<ProofTranscript>::new(transcript);
 
+        #[cfg(not(feature = "zk"))]
+        if proof.e2.is_some()
+            || proof.y_com.is_some()
+            || proof.sigma1_proof.is_some()
+            || proof.sigma2_proof.is_some()
+            || proof.scalar_product_proof.is_some()
+        {
+            return Err(ProofVerifyError::InvalidOpeningProof);
+        }
+
         dory::verify::<ArkFr, BN254, JoltG1Routines, JoltG2Routines, _>(
             *commitment,
             ark_eval,


### PR DESCRIPTION
## Credits
Thanks to Sunghyeon Jo from QED Audit for reporting this vulnerability.

## Summary
- Reject Dory proofs carrying ZK-only opening fields on transparent verifier paths.
- Cover the standalone Dory API with a regression test for transparent verification of a ZK opening proof.

## Changes
- Added a transparent-mode guard in `jolt-core` Dory verification before calling into `dory::verify`.
- Added the same guard in `crates/jolt-dory` for the public `DoryScheme::verify` API.
- Added `transparent_verify_rejects_zk_opening_proof` to lock the boundary.

## Testing
- `cargo fmt -q`
- `cargo clippy -p jolt-dory -q --all-targets -- -D warnings`
- `cargo clippy -p jolt-core --features host -q --all-targets -- -D warnings`
- `cargo clippy -p jolt-core --features host,zk -q --all-targets -- -D warnings`
- `cargo nextest run -p jolt-dory transparent_verify_rejects_zk_opening_proof --cargo-quiet`
- `cargo nextest run -p jolt-core muldiv --cargo-quiet --features host`
- `cargo nextest run -p jolt-core muldiv --cargo-quiet --features host,zk`
- `git diff --check`