### PR TITLE
Fix batched sumcheck padding for non-Boolean domains

### DIFF
--- a/crates/jolt-sumcheck/src/batched_verifier.rs
+++ b/crates/jolt-sumcheck/src/batched_verifier.rs
@@ -200,12 +200,14 @@ impl BatchedSumcheckVerifier {
         }
 
         let alpha: F = transcript.challenge();
+        let padding_scale = domain.padding_scale()?;
 
         // Running power of alpha: alpha^j for j = 0, 1, 2, …
         let mut alpha_pow = F::one();
         let mut combined_sum = F::zero();
         for claim in claims {
-            let scaled = claim.claimed_sum.mul_pow_2(max_num_vars - claim.num_vars);
+            let scaled =
+                claim.claimed_sum * pow_usize(padding_scale, max_num_vars - claim.num_vars);
             combined_sum += alpha_pow * scaled;
             alpha_pow *= alpha;
         }
@@ -383,4 +385,21 @@ impl BatchedSumcheckVerifier {
             .map(|_| transcript.challenge_scalar())
             .collect::<Vec<_>>()
     }
+}
+
+fn pow_usize<F>(mut base: F, mut exponent: usize) -> F
+where
+    F: SumcheckScalar,
+{
+    let mut result = F::one();
+    while exponent > 0 {
+        if exponent % 2 == 1 {
+            result *= base;
+        }
+        exponent /= 2;
+        if exponent > 0 {
+            base = base.square();
+        }
+    }
+    result
 }

--- a/crates/jolt-sumcheck/src/batched_verifier.rs
+++ b/crates/jolt-sumcheck/src/batched_verifier.rs
@@ -200,14 +200,12 @@ impl BatchedSumcheckVerifier {
         }
 
         let alpha: F = transcript.challenge();
-        let padding_scale = domain.padding_scale()?;
 
         // Running power of alpha: alpha^j for j = 0, 1, 2, …
         let mut alpha_pow = F::one();
         let mut combined_sum = F::zero();
         for claim in claims {
-            let scaled =
-                claim.claimed_sum * pow_usize(padding_scale, max_num_vars - claim.num_vars);
+            let scaled = domain.scale_padding(claim.claimed_sum, max_num_vars - claim.num_vars)?;
             combined_sum += alpha_pow * scaled;
             alpha_pow *= alpha;
         }
@@ -385,21 +383,4 @@ impl BatchedSumcheckVerifier {
             .map(|_| transcript.challenge_scalar())
             .collect::<Vec<_>>()
     }
-}
-
-fn pow_usize<F>(mut base: F, mut exponent: usize) -> F
-where
-    F: SumcheckScalar,
-{
-    let mut result = F::one();
-    while exponent > 0 {
-        if exponent % 2 == 1 {
-            result *= base;
-        }
-        exponent /= 2;
-        if exponent > 0 {
-            base = base.square();
-        }
-    }
-    result
 }

--- a/crates/jolt-sumcheck/src/domain.rs
+++ b/crates/jolt-sumcheck/src/domain.rs
@@ -8,6 +8,7 @@ use jolt_poly::lagrange::{centered_domain_start, centered_power_sums, CenteredIn
 pub trait SumcheckDomain<F: SumcheckScalar> {
     fn round_sum_coefficients(&self, degree: usize) -> Result<Vec<F>, SumcheckError<F>>;
 
+    #[inline]
     fn padding_scale(&self) -> Result<F, SumcheckError<F>> {
         let coefficients = self.round_sum_coefficients(0)?;
         match coefficients.as_slice() {
@@ -17,6 +18,14 @@ pub trait SumcheckDomain<F: SumcheckScalar> {
                 got: coefficients.len(),
             }),
         }
+    }
+
+    #[inline]
+    fn scale_padding(&self, value: F, padding_rounds: usize) -> Result<F, SumcheckError<F>> {
+        if padding_rounds == 0 {
+            return Ok(value);
+        }
+        Ok(value * pow_usize(self.padding_scale()?, padding_rounds))
     }
 
     fn check_round_sum<R>(
@@ -76,6 +85,26 @@ where
             }
         }
     }
+
+    #[inline]
+    fn padding_scale(&self) -> Result<F, SumcheckError<F>> {
+        match *self {
+            Self::BooleanHypercube => BooleanHypercube.padding_scale(),
+            Self::CenteredInteger { domain_size } => {
+                CenteredIntegerDomain::new(domain_size).padding_scale()
+            }
+        }
+    }
+
+    #[inline]
+    fn scale_padding(&self, value: F, padding_rounds: usize) -> Result<F, SumcheckError<F>> {
+        match *self {
+            Self::BooleanHypercube => BooleanHypercube.scale_padding(value, padding_rounds),
+            Self::CenteredInteger { domain_size } => {
+                CenteredIntegerDomain::new(domain_size).scale_padding(value, padding_rounds)
+            }
+        }
+    }
 }
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
@@ -89,6 +118,16 @@ where
         let mut coefficients = vec![F::one(); degree + 1];
         coefficients[0] = F::from_u64(2);
         Ok(coefficients)
+    }
+
+    #[inline]
+    fn padding_scale(&self) -> Result<F, SumcheckError<F>> {
+        Ok(F::from_u64(2))
+    }
+
+    #[inline]
+    fn scale_padding(&self, value: F, padding_rounds: usize) -> Result<F, SumcheckError<F>> {
+        Ok(value.mul_pow_2(padding_rounds))
     }
 }
 
@@ -126,4 +165,32 @@ where
             })
             .map(|power_sums| power_sums.into_iter().map(F::from_i128).collect())
     }
+
+    #[inline]
+    fn padding_scale(&self) -> Result<F, SumcheckError<F>> {
+        if self.domain_size == 0 || self.domain_size > i64::MAX as usize {
+            return Err(SumcheckError::InvalidIntegerDomain {
+                domain_size: self.domain_size,
+            });
+        }
+        Ok(F::from_u64(self.domain_size as u64))
+    }
+}
+
+#[inline]
+fn pow_usize<F>(mut base: F, mut exponent: usize) -> F
+where
+    F: SumcheckScalar,
+{
+    let mut result = F::one();
+    while exponent > 0 {
+        if exponent % 2 == 1 {
+            result *= base;
+        }
+        exponent /= 2;
+        if exponent > 0 {
+            base = base.square();
+        }
+    }
+    result
 }

--- a/crates/jolt-sumcheck/src/domain.rs
+++ b/crates/jolt-sumcheck/src/domain.rs
@@ -8,6 +8,17 @@ use jolt_poly::lagrange::{centered_domain_start, centered_power_sums, CenteredIn
 pub trait SumcheckDomain<F: SumcheckScalar> {
     fn round_sum_coefficients(&self, degree: usize) -> Result<Vec<F>, SumcheckError<F>>;
 
+    fn padding_scale(&self) -> Result<F, SumcheckError<F>> {
+        let coefficients = self.round_sum_coefficients(0)?;
+        match coefficients.as_slice() {
+            [scale] => Ok(*scale),
+            _ => Err(SumcheckError::PaddingScaleCoefficientCountMismatch {
+                expected: 1,
+                got: coefficients.len(),
+            }),
+        }
+    }
+
     fn check_round_sum<R>(
         &self,
         round_index: usize,

--- a/crates/jolt-sumcheck/src/domain.rs
+++ b/crates/jolt-sumcheck/src/domain.rs
@@ -13,7 +13,8 @@ pub trait SumcheckDomain<F: SumcheckScalar> {
         let coefficients = self.round_sum_coefficients(0)?;
         match coefficients.as_slice() {
             [scale] => Ok(*scale),
-            _ => Err(SumcheckError::PaddingScaleCoefficientCountMismatch {
+            _ => Err(SumcheckError::RoundSumCoefficientCountMismatch {
+                round: 0,
                 expected: 1,
                 got: coefficients.len(),
             }),

--- a/crates/jolt-sumcheck/src/error.rs
+++ b/crates/jolt-sumcheck/src/error.rs
@@ -110,4 +110,14 @@ pub enum SumcheckError<F: FieldCore> {
         /// Total number of available batched challenges.
         total: usize,
     },
+
+    /// The domain did not provide exactly one coefficient for summing a
+    /// constant padding round.
+    #[error("expected {expected} padding-scale coefficients, got {got}")]
+    PaddingScaleCoefficientCountMismatch {
+        /// Expected number of coefficients for a degree-0 round sum.
+        expected: usize,
+        /// Actual number of coefficients supplied by the domain.
+        got: usize,
+    },
 }

--- a/crates/jolt-sumcheck/src/error.rs
+++ b/crates/jolt-sumcheck/src/error.rs
@@ -110,14 +110,4 @@ pub enum SumcheckError<F: FieldCore> {
         /// Total number of available batched challenges.
         total: usize,
     },
-
-    /// The domain did not provide exactly one coefficient for summing a
-    /// constant padding round.
-    #[error("expected {expected} padding-scale coefficients, got {got}")]
-    PaddingScaleCoefficientCountMismatch {
-        /// Expected number of coefficients for a degree-0 round sum.
-        expected: usize,
-        /// Actual number of coefficients supplied by the domain.
-        got: usize,
-    },
 }

--- a/crates/jolt-sumcheck/src/tests.rs
+++ b/crates/jolt-sumcheck/src/tests.rs
@@ -814,6 +814,45 @@ fn batched_verify_different_sizes() {
 }
 
 #[test]
+fn batched_verify_uses_domain_padding_scale() {
+    let sum_a = F::from_u64(0);
+    let sum_b = F::from_u64(1);
+    let claims = vec![
+        SumcheckClaim {
+            num_vars: 1,
+            degree: 1,
+            claimed_sum: sum_a,
+        },
+        SumcheckClaim {
+            num_vars: 0,
+            degree: 1,
+            claimed_sum: sum_b,
+        },
+    ];
+
+    let mut pt = Blake2bTranscript::new(b"sumcheck-test");
+    sum_a.append_to_transcript(&mut pt);
+    sum_b.append_to_transcript(&mut pt);
+    let alpha: F = pt.challenge();
+
+    let proof = ClearSumcheckProof {
+        round_polynomials: vec![UnivariatePoly::new(vec![alpha])],
+    };
+
+    let mut vt = Blake2bTranscript::new(b"sumcheck-test");
+    let result = BatchedSumcheckVerifier::verify(
+        &claims,
+        &proof.round_polynomials,
+        CenteredIntegerDomain::new(3),
+        &mut vt,
+    )
+    .unwrap();
+
+    assert_eq!(result.value, alpha);
+    assert_eq!(result.point.len(), 1);
+}
+
+#[test]
 fn batched_single_claim_matches_single_verify() {
     let evals: Vec<F> = (1..=8).map(F::from_u64).collect();
     let sum = compute_sum(&evals);


### PR DESCRIPTION
## Summary

- Derive batched sumcheck front-padding scale from the active `SumcheckDomain` instead of assuming Boolean-hypercube scaling.
- Add domain-level padding helpers so `BooleanHypercube` keeps the original `mul_pow_2` fast path while non-Boolean domains use their own constant-round scale.
- Add a regression covering a heterogeneous batched proof over `CenteredIntegerDomain::new(3)`.

## Bug Context

PR #1547 generalized `BatchedSumcheckVerifier::verify` to accept any `D: SumcheckDomain`, but the combined input claim still scaled shorter instances with `2^(max_num_vars - claim.num_vars)`. That factor is correct for the Boolean hypercube because each front-padding variable ranges over two points.

For a non-Boolean domain, the padding multiplier must be the domain's constant-round sum raised to the number of inactive front-padding rounds. For example, over `CenteredIntegerDomain::new(3)`, a zero-variable claim with value `1` embedded into a one-round batch contributes `3 * alpha`, not `2 * alpha`. With the old code, an honest constant round polynomial over that three-point domain is rejected with `RoundCheckFailed` because the verifier computes the wrong combined claimed sum before checking the round.

## Fix

This PR adds `SumcheckDomain::padding_scale()` and `SumcheckDomain::scale_padding()`. The batched clear verifier now delegates front-padding scaling to the domain instead of doing the scaling inline.

The performance-sensitive Boolean path is restored by overriding `BooleanHypercube::scale_padding()` to call the previous `value.mul_pow_2(padding_rounds)` implementation directly. `CenteredIntegerDomain` overrides `padding_scale()` to return its validated domain size without allocating or computing all power sums. The default implementation remains available for future domains.

The compressed batched verifier remains Boolean-specific and continues using its existing Boolean-hypercube path.

## Validation

- `cargo nextest run -p jolt-sumcheck batched_verify_uses_domain_padding_scale --cargo-quiet`
- `cargo nextest run -p jolt-sumcheck --cargo-quiet`
- `cargo nextest run -p jolt-sumcheck --features r1cs --cargo-quiet`
- `cargo clippy -p jolt-sumcheck --features r1cs -q --all-targets -- -D warnings`
- `cargo clippy --all --features host -q --all-targets -- -D warnings`
- `cargo clippy --all --features host,zk -q --all-targets -- -D warnings`
- `cargo nextest run -p jolt-core muldiv --cargo-quiet --features host`
- `cargo nextest run -p jolt-core muldiv --cargo-quiet --features host,zk`
- `git diff --check`

After the performance follow-up:

- `cargo nextest run -p jolt-sumcheck batched_verify_uses_domain_padding_scale --cargo-quiet`
- `cargo nextest run -p jolt-sumcheck --cargo-quiet`
- `cargo nextest run -p jolt-sumcheck --features r1cs --cargo-quiet`
- `cargo clippy -p jolt-sumcheck --features r1cs -q --all-targets -- -D warnings`
- `git diff --check`

## Attribution

Posted by the assistant on behalf of Quang Dao. AI-authored by Codex (GPT-5).
