### PR TITLE
refactor: add precommitted polynomial reductions

### DIFF
--- a/jolt-core/src/poly/commitment/dory/commitment_scheme.rs
+++ b/jolt-core/src/poly/commitment/dory/commitment_scheme.rs
@@ -1,6 +1,6 @@
 //! Dory polynomial commitment scheme implementation
 
-use super::dory_globals::{DoryGlobals, DoryLayout};
+use super::dory_globals::DoryGlobals;
 use super::jolt_dory_routines::{JoltG1Routines, JoltG2Routines};
 use super::wrappers::{
     ark_to_jolt, jolt_to_ark, ArkDoryProof, ArkFr, ArkG1, ArkGT, ArkworksProverSetup,
@@ -44,6 +44,17 @@ impl DoryOpeningProofHint {
         }
     }
 
+    pub fn empty() -> Self {
+        Self {
+            row_commitments: Vec::new(),
+            commit_blind: <ArkFr as DoryField>::zero(),
+        }
+    }
+
+    pub fn rows(&self) -> &[ArkG1] {
+        &self.row_commitments
+    }
+
     fn into_parts(self) -> (Vec<ArkG1>, ArkFr) {
         (self.row_commitments, self.commit_blind)
     }
@@ -60,6 +71,18 @@ fn maybe_blind_commitment(setup: &ArkworksProverSetup, commitment: ArkGT) -> (Ar
     {
         let _ = setup;
         (commitment, <ArkFr as DoryField>::zero())
+    }
+}
+
+#[inline]
+fn canonical_setup_log_n(max_num_vars: usize) -> usize {
+    // Dory's generator count depends on ceil(max_log_n / 2), so odd/even pairs like
+    // 23 and 24 share the same generator bucket. Canonicalizing to the even bucket
+    // representative keeps those runs on a single URS file.
+    if max_num_vars.is_multiple_of(2) {
+        max_num_vars
+    } else {
+        max_num_vars + 1
     }
 }
 
@@ -105,13 +128,13 @@ impl CommitmentScheme for DoryCommitmentScheme {
 
     fn setup_prover(max_num_vars: usize) -> Self::ProverSetup {
         let _span = trace_span!("DoryCommitmentScheme::setup_prover").entered();
+        let canonical_max_num_vars = canonical_setup_log_n(max_num_vars);
         #[cfg(test)]
         DoryGlobals::configure_test_cache_root();
-
         #[cfg(not(target_arch = "wasm32"))]
-        let setup = ArkworksProverSetup::new_from_urs(max_num_vars);
+        let setup = ArkworksProverSetup::new_from_urs(canonical_max_num_vars);
         #[cfg(target_arch = "wasm32")]
-        let setup = ArkworksProverSetup::new(max_num_vars);
+        let setup = ArkworksProverSetup::new(canonical_max_num_vars);
 
         // The prepared-point cache in dory-pcs is global and can only be initialized once.
         // In unit tests, multiple setups with different sizes are created, so initializing the
@@ -194,8 +217,7 @@ impl CommitmentScheme for DoryCommitmentScheme {
         let sigma = num_cols.log_2();
         let nu = num_rows.log_2();
 
-        let reordered_point = reorder_opening_point_for_layout::<ark_bn254::Fr>(opening_point);
-        let ark_point: Vec<ArkFr> = reordered_point
+        let ark_point: Vec<ArkFr> = opening_point
             .iter()
             .rev()
             .map(|p| {
@@ -237,10 +259,8 @@ impl CommitmentScheme for DoryCommitmentScheme {
     ) -> Result<(), ProofVerifyError> {
         let _span = trace_span!("DoryCommitmentScheme::verify").entered();
 
-        let reordered_point = reorder_opening_point_for_layout::<ark_bn254::Fr>(opening_point);
-
         // Dory uses the opposite endian-ness as Jolt
-        let ark_point: Vec<ArkFr> = reordered_point
+        let ark_point: Vec<ArkFr> = opening_point
             .iter()
             .rev()
             .map(|p| {
@@ -270,7 +290,7 @@ impl CommitmentScheme for DoryCommitmentScheme {
             setup.clone().into_inner(),
             &mut dory_transcript,
         )
-        .map_err(|_| ProofVerifyError::InternalError)?;
+        .map_err(|err| ProofVerifyError::DoryError(format!("dory::verify failed: {err:?}")))?;
 
         Ok(())
     }
@@ -494,26 +514,5 @@ where
             .collect();
         let h1 = C::G1::from(setup.0.h1);
         Some((g1s, h1))
-    }
-}
-
-/// Reorders opening_point for AddressMajor layout.
-///
-/// For AddressMajor layout, reorders opening_point from [r_address, r_cycle] to [r_cycle, r_address].
-/// This ensures that after Dory's reversal and splitting:
-/// - Column (right) vector gets address variables (matching AddressMajor column indexing)
-/// - Row (left) vector gets cycle variables (matching AddressMajor row indexing)
-///
-/// For CycleMajor layout, returns the point unchanged.
-fn reorder_opening_point_for_layout<F: JoltField>(
-    opening_point: &[F::Challenge],
-) -> Vec<F::Challenge> {
-    if DoryGlobals::get_layout() == DoryLayout::AddressMajor {
-        let log_T = DoryGlobals::get_T().log_2();
-        let log_K = opening_point.len().saturating_sub(log_T);
-        let (r_address, r_cycle) = opening_point.split_at(log_K);
-        [r_cycle, r_address].concat()
-    } else {
-        opening_point.to_vec()
     }
 }

--- a/jolt-core/src/poly/commitment/dory/commitment_scheme.rs
+++ b/jolt-core/src/poly/commitment/dory/commitment_scheme.rs
@@ -44,17 +44,6 @@ impl DoryOpeningProofHint {
         }
     }
 
-    pub fn empty() -> Self {
-        Self {
-            row_commitments: Vec::new(),
-            commit_blind: <ArkFr as DoryField>::zero(),
-        }
-    }
-
-    pub fn rows(&self) -> &[ArkG1] {
-        &self.row_commitments
-    }
-
     fn into_parts(self) -> (Vec<ArkG1>, ArkFr) {
         (self.row_commitments, self.commit_blind)
     }

--- a/jolt-core/src/poly/commitment/dory/dory_globals.rs
+++ b/jolt-core/src/poly/commitment/dory/dory_globals.rs
@@ -4,7 +4,7 @@ use crate::utils::math::Math;
 use allocative::Allocative;
 use dory::backends::arkworks::{init_cache, ArkG1, ArkG2};
 use std::sync::{
-    atomic::{AtomicU8, Ordering},
+    atomic::{AtomicU8, AtomicUsize, Ordering},
     RwLock,
 };
 #[cfg(test)]
@@ -143,6 +143,7 @@ impl From<DoryLayout> for u8 {
 
 // Main polynomial globals
 static GLOBAL_T: RwLock<Option<usize>> = RwLock::new(None);
+static MAIN_K_CHUNK: RwLock<Option<usize>> = RwLock::new(None);
 static MAX_NUM_ROWS: RwLock<Option<usize>> = RwLock::new(None);
 static NUM_COLUMNS: RwLock<Option<usize>> = RwLock::new(None);
 
@@ -161,6 +162,8 @@ static CURRENT_CONTEXT: AtomicU8 = AtomicU8::new(0);
 
 // Layout tracking: 0=CycleMajor, 1=AddressMajor
 static CURRENT_LAYOUT: AtomicU8 = AtomicU8::new(0);
+// Largest Main log-embedding needed for precommitted/embed calculations.
+static MAIN_LOG_EMBEDDING: AtomicUsize = AtomicUsize::new(0);
 
 /// Dory commitment context - determines which set of global parameters to use
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -256,6 +259,22 @@ impl DoryGlobals {
         log_t.saturating_sub(sigma_main)
     }
 
+    #[inline]
+    pub fn get_main_log_embedding() -> usize {
+        let stored = MAIN_LOG_EMBEDDING.load(Ordering::SeqCst);
+        if stored > 0 {
+            stored
+        } else {
+            let main_cols = Self::configured_main_num_columns();
+            let main_rows = *MAX_NUM_ROWS
+                .read()
+                .unwrap()
+                .as_ref()
+                .expect("main max_num_rows not initialized");
+            main_cols.log_2() + main_rows.log_2()
+        }
+    }
+
     /// Get the current Dory context
     pub fn current_context() -> DoryContext {
         CURRENT_CONTEXT.load(Ordering::SeqCst).into()
@@ -288,11 +307,84 @@ impl DoryGlobals {
         (Self::get_max_num_rows(), Self::get_num_columns())
     }
 
+    #[inline]
+    pub(crate) fn main_k() -> usize {
+        *MAIN_K_CHUNK
+            .read()
+            .unwrap()
+            .as_ref()
+            .expect("main k not initialized")
+    }
+
+    #[inline]
+    pub(crate) fn main_t() -> usize {
+        *GLOBAL_T
+            .read()
+            .unwrap()
+            .as_ref()
+            .expect("main t not initialized")
+    }
+
+    #[inline]
+    pub(crate) fn configured_main_num_columns() -> usize {
+        *NUM_COLUMNS
+            .read()
+            .unwrap()
+            .as_ref()
+            .expect("main num_columns not initialized")
+    }
+
+    #[inline]
+    fn main_embedding_extra_vars() -> usize {
+        let main_total_vars = Self::main_k().log_2() + Self::get_T().log_2();
+        Self::get_main_log_embedding().saturating_sub(main_total_vars)
+    }
+
+    /// Column stride for one-hot embeddings in the current layout/context.
+    pub fn one_hot_stride() -> usize {
+        if Self::current_context() != DoryContext::Main
+            || Self::get_layout() != DoryLayout::AddressMajor
+        {
+            return 1;
+        }
+        1usize << Self::main_embedding_extra_vars()
+    }
+
+    /// Column stride for dense trace-domain embeddings in the current layout/context.
+    pub fn dense_stride() -> usize {
+        if Self::current_context() != DoryContext::Main
+            || Self::get_layout() != DoryLayout::AddressMajor
+        {
+            return 1;
+        }
+        let dense_stride_log = Self::main_embedding_extra_vars() + Self::main_k().log_2();
+        1usize << dense_stride_log
+    }
+
+    /// Returns the embedded cycle-domain size for the current Dory matrix.
+    pub fn get_embedded_t() -> usize {
+        let context = Self::current_context();
+        if context != DoryContext::Main {
+            return Self::get_T();
+        }
+
+        let k = Self::main_k();
+        let num_rows = Self::get_max_num_rows();
+        let num_cols = Self::get_num_columns();
+        let total = num_rows * num_cols;
+        debug_assert_eq!(
+            total % k,
+            0,
+            "Invalid Main DoryGlobals: num_rows*num_cols must be divisible by K"
+        );
+        total / k
+    }
+
     /// Returns the "K" used to initialize the *main* Dory matrix for OneHot polynomials.
-    ///
-    /// This is derived from the identity:
-    /// `K * T == num_rows * num_cols`  (all values are powers of two in our usage).
     pub fn k_from_matrix_shape() -> usize {
+        if Self::current_context() == DoryContext::Main {
+            return Self::main_k();
+        }
         let (num_rows, num_cols) = Self::matrix_shape();
         let t = Self::get_T();
         debug_assert_eq!(
@@ -305,18 +397,22 @@ impl DoryGlobals {
 
     /// For `AddressMajor`, each Dory matrix row corresponds to this many cycles.
     ///
-    /// Equivalent to `T / num_rows` and to `num_cols / K`.
+    /// Equivalent to `T / num_rows` and to `num_cols / dense_stride`.
     pub fn address_major_cycles_per_row() -> usize {
-        let (num_rows, num_cols) = Self::matrix_shape();
-        let k = Self::k_from_matrix_shape();
-        debug_assert!(k > 0);
-        debug_assert_eq!(num_cols % k, 0, "Expected num_cols to be divisible by K");
-        debug_assert_eq!(
-            Self::get_T() % num_rows,
+        let num_cols = Self::get_num_columns();
+        let dense_stride = Self::dense_stride();
+        assert!(dense_stride > 0, "Dense stride must be positive");
+        assert_eq!(
+            num_cols % dense_stride,
             0,
-            "Expected T to be divisible by num_rows"
+            "Expected num_cols to be divisible by dense stride"
         );
-        num_cols / k
+        let cycles_per_row = num_cols / dense_stride;
+        assert!(
+            cycles_per_row > 0,
+            "AddressMajor row must contain at least one cycle"
+        );
+        cycles_per_row
     }
 
     fn set_max_num_rows_for_context(max_num_rows: usize, context: DoryContext) {
@@ -363,6 +459,10 @@ impl DoryGlobals {
                 *UNTRUSTED_ADVICE_NUM_COLUMNS.write().unwrap() = Some(num_columns);
             }
         }
+    }
+
+    fn set_main_k(k: usize) {
+        *MAIN_K_CHUNK.write().unwrap() = Some(k);
     }
 
     pub fn get_num_columns() -> usize {
@@ -430,6 +530,20 @@ impl DoryGlobals {
         (num_columns, num_rows, T)
     }
 
+    fn initialize_context_common(
+        K: usize,
+        embedded_t: usize,
+        stored_t: usize,
+        context: DoryContext,
+    ) -> Option<()> {
+        let (num_columns, num_rows, _) = Self::calculate_dimensions(K, embedded_t);
+        Self::set_num_columns_for_context(num_columns, context);
+        Self::set_T_for_context(stored_t, context);
+        Self::set_max_num_rows_for_context(num_rows, context);
+
+        Some(())
+    }
+
     /// Initialize the globals for a specific Dory context
     ///
     /// # Arguments
@@ -452,19 +566,30 @@ impl DoryGlobals {
         #[cfg(test)]
         Self::configure_test_cache_root();
 
-        let (num_columns, num_rows, t) = Self::calculate_dimensions(K, T);
-        Self::set_num_columns_for_context(num_columns, context);
-        Self::set_T_for_context(t, context);
-        Self::set_max_num_rows_for_context(num_rows, context);
-
-        // For Main context, set layout (if provided) and ensure subsequent uses of `get_*` read from it
         if context == DoryContext::Main {
-            if let Some(l) = layout {
-                CURRENT_LAYOUT.store(l as u8, Ordering::SeqCst);
-            }
-            CURRENT_CONTEXT.store(DoryContext::Main as u8, Ordering::SeqCst);
+            return Self::initialize_main_with_log_embedding(K, T, K.log_2() + T.log_2(), layout);
         }
+        Self::initialize_context_common(K, T, T, context)?;
+        Some(())
+    }
 
+    /// Initialize Main context with execution `T` and explicit `main_log_embedding` for
+    /// global precommitted geometry.
+    pub fn initialize_main_with_log_embedding(
+        K: usize,
+        T: usize,
+        matrix_total_vars: usize,
+        layout: Option<DoryLayout>,
+    ) -> Option<()> {
+        let log_k = K.log_2();
+        let embedded_t = 1usize << matrix_total_vars.saturating_sub(log_k);
+        Self::initialize_context_common(K, embedded_t, T, DoryContext::Main)?;
+        Self::set_main_k(K);
+        if let Some(l) = layout {
+            CURRENT_LAYOUT.store(l as u8, Ordering::SeqCst);
+        }
+        CURRENT_CONTEXT.store(DoryContext::Main as u8, Ordering::SeqCst);
+        MAIN_LOG_EMBEDDING.store(matrix_total_vars, Ordering::SeqCst);
         Some(())
     }
 
@@ -475,6 +600,7 @@ impl DoryGlobals {
 
         // Reset main globals
         *GLOBAL_T.write().unwrap() = None;
+        *MAIN_K_CHUNK.write().unwrap() = None;
         *MAX_NUM_ROWS.write().unwrap() = None;
         *NUM_COLUMNS.write().unwrap() = None;
 
@@ -492,6 +618,7 @@ impl DoryGlobals {
         *UNTRUSTED_ADVICE_NUM_COLUMNS.write().unwrap() = None;
 
         CURRENT_CONTEXT.store(0, Ordering::SeqCst);
+        MAIN_LOG_EMBEDDING.store(0, Ordering::SeqCst);
     }
 
     /// Initialize the prepared point cache for faster pairing operations

--- a/jolt-core/src/poly/commitment/dory/dory_globals.rs
+++ b/jolt-core/src/poly/commitment/dory/dory_globals.rs
@@ -395,26 +395,6 @@ impl DoryGlobals {
         (num_rows * num_cols) / t
     }
 
-    /// For `AddressMajor`, each Dory matrix row corresponds to this many cycles.
-    ///
-    /// Equivalent to `T / num_rows` and to `num_cols / dense_stride`.
-    pub fn address_major_cycles_per_row() -> usize {
-        let num_cols = Self::get_num_columns();
-        let dense_stride = Self::dense_stride();
-        assert!(dense_stride > 0, "Dense stride must be positive");
-        assert_eq!(
-            num_cols % dense_stride,
-            0,
-            "Expected num_cols to be divisible by dense stride"
-        );
-        let cycles_per_row = num_cols / dense_stride;
-        assert!(
-            cycles_per_row > 0,
-            "AddressMajor row must contain at least one cycle"
-        );
-        cycles_per_row
-    }
-
     fn set_max_num_rows_for_context(max_num_rows: usize, context: DoryContext) {
         match context {
             DoryContext::Main => {
@@ -565,7 +545,6 @@ impl DoryGlobals {
     ) -> Option<()> {
         #[cfg(test)]
         Self::configure_test_cache_root();
-
         if context == DoryContext::Main {
             return Self::initialize_main_with_log_embedding(K, T, K.log_2() + T.log_2(), layout);
         }

--- a/jolt-core/src/poly/commitment/dory/tests.rs
+++ b/jolt-core/src/poly/commitment/dory/tests.rs
@@ -8,6 +8,7 @@ mod tests {
     use crate::poly::dense_mlpoly::DensePolynomial;
     use crate::poly::multilinear_polynomial::{MultilinearPolynomial, PolynomialEvaluation};
     use crate::transcripts::{Blake2bTranscript, Transcript};
+    use crate::utils::math::Math;
     use ark_ff::biginteger::S128;
     use ark_std::rand::{thread_rng, Rng};
     use ark_std::{UniformRand, Zero};
@@ -906,19 +907,26 @@ mod tests {
         let num_vars = one_hot_poly.get_num_vars();
         let poly = MultilinearPolynomial::OneHot(one_hot_poly);
 
-        let opening_point: Vec<<Fr as JoltField>::Challenge> = (0..num_vars)
+        // AddressMajor Dory opening points are consumed as [cycle vars || address vars],
+        // while OneHotPolynomial::evaluate expects [address vars || cycle vars].
+        let log_t = T.log_2();
+        let log_k = num_vars - log_t;
+        let r_cycle: Vec<<Fr as JoltField>::Challenge> = (0..log_t)
             .map(|_| <Fr as JoltField>::Challenge::random(&mut rng))
             .collect();
+        let r_address: Vec<<Fr as JoltField>::Challenge> = (0..log_k)
+            .map(|_| <Fr as JoltField>::Challenge::random(&mut rng))
+            .collect();
+        let opening_point = [r_cycle.clone(), r_address.clone()].concat();
+        let eval_point = [r_address, r_cycle].concat();
 
         let prover_setup = DoryCommitmentScheme::setup_prover(num_vars);
         let verifier_setup = DoryCommitmentScheme::setup_verifier(&prover_setup);
 
         let (commitment, row_commitments) = DoryCommitmentScheme::commit(&poly, &prover_setup);
 
-        let evaluation = <MultilinearPolynomial<Fr> as PolynomialEvaluation<Fr>>::evaluate(
-            &poly,
-            &opening_point,
-        );
+        let evaluation =
+            <MultilinearPolynomial<Fr> as PolynomialEvaluation<Fr>>::evaluate(&poly, &eval_point);
 
         let mut prove_transcript = Blake2bTranscript::new(b"dory_test");
         bind_opening_inputs::<Fr, _>(&mut prove_transcript, &opening_point, &evaluation);
@@ -1002,16 +1010,25 @@ mod tests {
         let vmp_result = rlc_poly.vector_matrix_product(&left_vec);
 
         let mut expected = vec![Fr::zero(); num_columns];
-        let cycles_per_row = DoryGlobals::address_major_cycles_per_row();
+        let dense_stride = DoryGlobals::dense_stride();
+        let cycles_per_row = num_columns / dense_stride;
 
         // Dense contribution for AddressMajor layout:
         // Dense coefficients occupy evenly-spaced columns (every K-th column).
         // Coefficient i maps to: row = i / cycles_per_row, col = (i % cycles_per_row) * K
         for (i, &coeff) in rlc_dense.iter().enumerate() {
-            let row = i / cycles_per_row;
-            let col = (i % cycles_per_row) * K;
-            if row < num_rows && col < num_columns {
-                expected[col] += left_vec[row] * coeff;
+            if let Some(row) = i.checked_div(cycles_per_row) {
+                let col = (i % cycles_per_row) * K;
+                if row < num_rows && col < num_columns {
+                    expected[col] += left_vec[row] * coeff;
+                }
+            } else {
+                let scaled_index = i * dense_stride;
+                let row = scaled_index / num_columns;
+                let col = scaled_index % num_columns;
+                if row < num_rows && col < num_columns {
+                    expected[col] += left_vec[row] * coeff;
+                }
             }
         }
 

--- a/jolt-core/src/poly/commitment/dory/wrappers.rs
+++ b/jolt-core/src/poly/commitment/dory/wrappers.rs
@@ -202,30 +202,112 @@ where
     let dory_context = DoryGlobals::current_context();
     let dory_layout = DoryGlobals::get_layout();
 
-    // Dense polynomials (all scalar variants except OneHot/RLC) are committed row-wise.
-    // Under AddressMajor, dense coefficients occupy evenly-spaced columns, so each row
-    // commitment uses `cycles_per_row` bases (one per occupied column).
-    let (dense_affine_bases, dense_chunk_size): (Vec<_>, usize) = match (dory_context, dory_layout)
-    {
-        (DoryContext::Main, DoryLayout::AddressMajor) => {
-            let cycles_per_row = DoryGlobals::address_major_cycles_per_row();
-            let bases: Vec<_> = g1_slice
+    let is_dense_poly = !matches!(
+        poly,
+        MultilinearPolynomial::OneHot(_) | MultilinearPolynomial::RLC(_)
+    );
+
+    let is_trace_dense_addr_major = matches!(dory_context, DoryContext::Main)
+        && dory_layout == DoryLayout::AddressMajor
+        && is_dense_poly;
+    debug_assert!(
+        !is_trace_dense_addr_major || poly.original_len() <= DoryGlobals::get_T(),
+        "Main+AddressMajor dense polynomial length exceeds trace T"
+    );
+
+    let (dense_affine_bases, dense_chunk_size, dense_sparse_row_terms): (
+        Vec<_>,
+        usize,
+        Option<Vec<Vec<(usize, Fr)>>>,
+    ) = if is_trace_dense_addr_major {
+        let stride = DoryGlobals::dense_stride();
+        let cycles_per_row = row_len / stride;
+        // This branch is taken when the AddressMajor trace-dense embedding stride exceeds
+        // the post-embedded Main row width (`row_len`), i.e. `row_len < stride`.
+        //
+        // With:
+        // - M = DoryGlobals::get_main_log_embedding() = total embedded Main vars
+        // - k = log2(main K)
+        // - t = log2(execution T)
+        // - e = embedding extra vars = M - (k + t)
+        //
+        // we have:
+        // - row_len = 2^sigma_main, where sigma_main = ceil(M/2)
+        //          = 2^ceil((e + k + t)/2)
+        // - stride  = 2^(main_embedding_extra_vars + k) = 2^(M - t) = 2^(e + k)
+        //
+        // so `cycles_per_row == 0` exactly when:
+        //   ceil(M/2) < (M - t)   <=>   t < floor(M/2).
+        if cycles_per_row == 0 {
+            let dense_len = poly.original_len();
+            let dense_affine_bases: Vec<_> = g1_slice
                 .par_iter()
                 .take(row_len)
-                .step_by(row_len / cycles_per_row)
                 .map(|g| g.0.into_affine())
                 .collect();
-            (bases, cycles_per_row)
+            let num_rows = DoryGlobals::get_max_num_rows();
+            let sparse_terms: Vec<(usize, usize, Fr)> = (0..dense_len)
+                .into_par_iter()
+                .filter_map(|cycle| {
+                    let coeff = poly.get_coeff(cycle);
+                    if coeff.is_zero() {
+                        return None;
+                    }
+                    let scaled_index = cycle.saturating_mul(stride);
+                    let row_index = scaled_index / row_len;
+                    let col_index = scaled_index % row_len;
+                    debug_assert!(row_index < num_rows);
+                    Some((row_index, col_index, coeff))
+                })
+                .collect();
+            let mut row_terms: Vec<Vec<(usize, Fr)>> = vec![Vec::new(); num_rows];
+            for (row_index, col_index, coeff) in sparse_terms {
+                row_terms[row_index].push((col_index, coeff));
+            }
+            (dense_affine_bases, 1, Some(row_terms))
+        } else {
+            let dense_affine_bases: Vec<_> = g1_slice
+                .par_iter()
+                .take(row_len)
+                .step_by(stride)
+                .map(|g| g.0.into_affine())
+                .collect();
+            (dense_affine_bases, cycles_per_row, None)
         }
-        _ => (
+    } else {
+        (
             g1_slice
                 .par_iter()
                 .take(row_len)
                 .map(|g| g.0.into_affine())
                 .collect(),
             row_len,
-        ),
+            None,
+        )
     };
+
+    if let Some(row_terms) = dense_sparse_row_terms {
+        let result: Vec<ArkG1> = row_terms
+            .into_par_iter()
+            .map(|terms| {
+                if terms.is_empty() {
+                    return ArkG1(ark_bn254::G1Projective::zero());
+                }
+                let mut bases = Vec::with_capacity(terms.len());
+                let mut scalars = Vec::with_capacity(terms.len());
+                for (col_index, scalar) in terms {
+                    bases.push(dense_affine_bases[col_index]);
+                    scalars.push(scalar);
+                }
+                ArkG1(VariableBaseMSM::msm_field_elements(&bases, &scalars).unwrap())
+            })
+            .collect();
+        // SAFETY: Vec<ArkG1> and Vec<E::G1> have the same memory layout when E = BN254.
+        #[allow(clippy::missing_transmute_annotations)]
+        unsafe {
+            return Ok(std::mem::transmute(result));
+        }
+    }
 
     let result: Vec<ArkG1> = match poly {
         MultilinearPolynomial::LargeScalars(poly) => poly

--- a/jolt-core/src/poly/commitment/dory/wrappers.rs
+++ b/jolt-core/src/poly/commitment/dory/wrappers.rs
@@ -28,6 +28,11 @@ pub use dory::backends::arkworks::{
 };
 
 pub type JoltFieldWrapper = ArkFr;
+type DenseTier1Setup = (
+    Vec<ark_bn254::G1Affine>,
+    usize,
+    Option<Vec<Vec<(usize, Fr)>>>,
+);
 
 #[inline]
 pub fn jolt_to_ark(f: &Fr) -> ArkFr {
@@ -215,76 +220,73 @@ where
         "Main+AddressMajor dense polynomial length exceeds trace T"
     );
 
-    let (dense_affine_bases, dense_chunk_size, dense_sparse_row_terms): (
-        Vec<_>,
-        usize,
-        Option<Vec<Vec<(usize, Fr)>>>,
-    ) = if is_trace_dense_addr_major {
-        let stride = DoryGlobals::dense_stride();
-        let cycles_per_row = row_len / stride;
-        // This branch is taken when the AddressMajor trace-dense embedding stride exceeds
-        // the post-embedded Main row width (`row_len`), i.e. `row_len < stride`.
-        //
-        // With:
-        // - M = DoryGlobals::get_main_log_embedding() = total embedded Main vars
-        // - k = log2(main K)
-        // - t = log2(execution T)
-        // - e = embedding extra vars = M - (k + t)
-        //
-        // we have:
-        // - row_len = 2^sigma_main, where sigma_main = ceil(M/2)
-        //          = 2^ceil((e + k + t)/2)
-        // - stride  = 2^(main_embedding_extra_vars + k) = 2^(M - t) = 2^(e + k)
-        //
-        // so `cycles_per_row == 0` exactly when:
-        //   ceil(M/2) < (M - t)   <=>   t < floor(M/2).
-        if cycles_per_row == 0 {
-            let dense_len = poly.original_len();
-            let dense_affine_bases: Vec<_> = g1_slice
-                .par_iter()
-                .take(row_len)
-                .map(|g| g.0.into_affine())
-                .collect();
-            let num_rows = DoryGlobals::get_max_num_rows();
-            let sparse_terms: Vec<(usize, usize, Fr)> = (0..dense_len)
-                .into_par_iter()
-                .filter_map(|cycle| {
-                    let coeff = poly.get_coeff(cycle);
-                    if coeff.is_zero() {
-                        return None;
-                    }
-                    let scaled_index = cycle.saturating_mul(stride);
-                    let row_index = scaled_index / row_len;
-                    let col_index = scaled_index % row_len;
-                    debug_assert!(row_index < num_rows);
-                    Some((row_index, col_index, coeff))
-                })
-                .collect();
-            let mut row_terms: Vec<Vec<(usize, Fr)>> = vec![Vec::new(); num_rows];
-            for (row_index, col_index, coeff) in sparse_terms {
-                row_terms[row_index].push((col_index, coeff));
+    let (dense_affine_bases, dense_chunk_size, dense_sparse_row_terms): DenseTier1Setup =
+        if is_trace_dense_addr_major {
+            let stride = DoryGlobals::dense_stride();
+            let cycles_per_row = row_len / stride;
+            // This branch is taken when the AddressMajor trace-dense embedding stride exceeds
+            // the post-embedded Main row width (`row_len`), i.e. `row_len < stride`.
+            //
+            // With:
+            // - M = DoryGlobals::get_main_log_embedding() = total embedded Main vars
+            // - k = log2(main K)
+            // - t = log2(execution T)
+            // - e = embedding extra vars = M - (k + t)
+            //
+            // we have:
+            // - row_len = 2^sigma_main, where sigma_main = ceil(M/2)
+            //          = 2^ceil((e + k + t)/2)
+            // - stride  = 2^(main_embedding_extra_vars + k) = 2^(M - t) = 2^(e + k)
+            //
+            // so `cycles_per_row == 0` exactly when:
+            //   ceil(M/2) < (M - t)   <=>   t < floor(M/2).
+            if cycles_per_row == 0 {
+                let dense_len = poly.original_len();
+                let dense_affine_bases: Vec<_> = g1_slice
+                    .par_iter()
+                    .take(row_len)
+                    .map(|g| g.0.into_affine())
+                    .collect();
+                let num_rows = DoryGlobals::get_max_num_rows();
+                let sparse_terms: Vec<(usize, usize, Fr)> = (0..dense_len)
+                    .into_par_iter()
+                    .filter_map(|cycle| {
+                        let coeff = poly.get_coeff(cycle);
+                        if coeff.is_zero() {
+                            return None;
+                        }
+                        let scaled_index = cycle.saturating_mul(stride);
+                        let row_index = scaled_index / row_len;
+                        let col_index = scaled_index % row_len;
+                        debug_assert!(row_index < num_rows);
+                        Some((row_index, col_index, coeff))
+                    })
+                    .collect();
+                let mut row_terms: Vec<Vec<(usize, Fr)>> = vec![Vec::new(); num_rows];
+                for (row_index, col_index, coeff) in sparse_terms {
+                    row_terms[row_index].push((col_index, coeff));
+                }
+                (dense_affine_bases, 1, Some(row_terms))
+            } else {
+                let dense_affine_bases: Vec<_> = g1_slice
+                    .par_iter()
+                    .take(row_len)
+                    .step_by(stride)
+                    .map(|g| g.0.into_affine())
+                    .collect();
+                (dense_affine_bases, cycles_per_row, None)
             }
-            (dense_affine_bases, 1, Some(row_terms))
         } else {
-            let dense_affine_bases: Vec<_> = g1_slice
-                .par_iter()
-                .take(row_len)
-                .step_by(stride)
-                .map(|g| g.0.into_affine())
-                .collect();
-            (dense_affine_bases, cycles_per_row, None)
-        }
-    } else {
-        (
-            g1_slice
-                .par_iter()
-                .take(row_len)
-                .map(|g| g.0.into_affine())
-                .collect(),
-            row_len,
-            None,
-        )
-    };
+            (
+                g1_slice
+                    .par_iter()
+                    .take(row_len)
+                    .map(|g| g.0.into_affine())
+                    .collect(),
+                row_len,
+                None,
+            )
+        };
 
     if let Some(row_terms) = dense_sparse_row_terms {
         let result: Vec<ArkG1> = row_terms

--- a/jolt-core/src/poly/commitment/dory/wrappers.rs
+++ b/jolt-core/src/poly/commitment/dory/wrappers.rs
@@ -28,11 +28,6 @@ pub use dory::backends::arkworks::{
 };
 
 pub type JoltFieldWrapper = ArkFr;
-type DenseTier1Setup = (
-    Vec<ark_bn254::G1Affine>,
-    usize,
-    Option<Vec<Vec<(usize, Fr)>>>,
-);
 
 #[inline]
 pub fn jolt_to_ark(f: &Fr) -> ArkFr {
@@ -220,7 +215,7 @@ where
         "Main+AddressMajor dense polynomial length exceeds trace T"
     );
 
-    let (dense_affine_bases, dense_chunk_size, dense_sparse_row_terms): DenseTier1Setup =
+    let (dense_affine_bases, dense_chunk_size, dense_sparse_row_terms) =
         if is_trace_dense_addr_major {
             let stride = DoryGlobals::dense_stride();
             let cycles_per_row = row_len / stride;

--- a/jolt-core/src/poly/one_hot_polynomial.rs
+++ b/jolt-core/src/poly/one_hot_polynomial.rs
@@ -56,9 +56,14 @@ impl<F: JoltField> OneHotPolynomial<F> {
     ///
     /// Note: the Dory matrix may be square or almost-square depending on `log2(K*T)`.
     pub fn num_rows(&self) -> usize {
-        let t = self.nonzero_indices.len();
+        let t = DoryGlobals::get_T();
         match DoryGlobals::get_layout() {
-            DoryLayout::AddressMajor => t.div_ceil(DoryGlobals::address_major_cycles_per_row()),
+            DoryLayout::AddressMajor => {
+                if t == 0 {
+                    return 0;
+                }
+                t.div_ceil(DoryGlobals::address_major_cycles_per_row())
+            }
             DoryLayout::CycleMajor => (t * self.K).div_ceil(DoryGlobals::get_num_columns()),
         }
     }
@@ -104,7 +109,7 @@ impl<F: JoltField> OneHotPolynomial<F> {
     }
 
     pub fn from_indices(nonzero_indices: Vec<Option<u8>>, K: usize) -> Self {
-        debug_assert_eq!(DoryGlobals::get_T(), nonzero_indices.len());
+        debug_assert!(nonzero_indices.len() <= DoryGlobals::get_T());
         assert!(K <= 1usize << u8::BITS, "K must be <= 256 for indices");
 
         Self {
@@ -120,9 +125,15 @@ impl<F: JoltField> OneHotPolynomial<F> {
         bases: &[G::Affine],
     ) -> Vec<G> {
         let layout = DoryGlobals::get_layout();
+        let one_hot_stride = DoryGlobals::one_hot_stride();
         let num_rows = self.num_rows();
         let row_len = DoryGlobals::get_num_columns();
         let t = self.nonzero_indices.len();
+        let effective_t = DoryGlobals::get_T();
+        debug_assert_eq!(
+            effective_t, t,
+            "one-hot polynomial length must match configured Main T"
+        );
 
         debug_assert!(
             bases.len() >= row_len,
@@ -172,11 +183,16 @@ impl<F: JoltField> OneHotPolynomial<F> {
 
         // General path: collect column indices for each row based on layout
         let mut row_indices: Vec<Vec<usize>> = vec![Vec::new(); num_rows];
+        let dense_stride = DoryGlobals::dense_stride();
         for (cycle, k) in self.nonzero_indices.iter().enumerate() {
             if let Some(k) = k {
-                let global_index = layout.address_cycle_to_index(*k as usize, cycle, self.K, t);
-                let row_index = global_index / row_len;
-                let col_index = global_index % row_len;
+                let scaled_index = if layout == DoryLayout::AddressMajor {
+                    cycle * dense_stride + (*k as usize) * one_hot_stride
+                } else {
+                    layout.address_cycle_to_index(*k as usize, cycle, self.K, effective_t)
+                };
+                let row_index = scaled_index / row_len;
+                let col_index = scaled_index % row_len;
                 if row_index < num_rows {
                     row_indices[row_index].push(col_index);
                 }
@@ -211,12 +227,13 @@ impl<F: JoltField> OneHotPolynomial<F> {
     pub fn vector_matrix_product(&self, left_vec: &[F], coeff: F, result: &mut [F]) {
         let layout = DoryGlobals::get_layout();
         let t = self.nonzero_indices.len();
+        let effective_t = DoryGlobals::get_T();
         let num_columns = DoryGlobals::get_num_columns();
         debug_assert_eq!(result.len(), num_columns);
 
         // CycleMajor optimization for T >= row_len (typical case where T >= K)
         if layout == DoryLayout::CycleMajor && t >= num_columns {
-            let rows_per_k = t / num_columns;
+            let rows_per_k = effective_t / num_columns;
             result
                 .par_iter_mut()
                 .enumerate()
@@ -234,11 +251,17 @@ impl<F: JoltField> OneHotPolynomial<F> {
         }
 
         // General path: iterate through nonzero indices and compute contributions
+        let dense_stride = DoryGlobals::dense_stride();
+        let one_hot_stride = DoryGlobals::one_hot_stride();
         for (cycle, k) in self.nonzero_indices.iter().enumerate() {
             if let Some(k) = k {
-                let global_index = layout.address_cycle_to_index(*k as usize, cycle, self.K, t);
-                let row_index = global_index / num_columns;
-                let col_index = global_index % num_columns;
+                let scaled_index = if layout == DoryLayout::AddressMajor {
+                    cycle * dense_stride + (*k as usize) * one_hot_stride
+                } else {
+                    layout.address_cycle_to_index(*k as usize, cycle, self.K, effective_t)
+                };
+                let row_index = scaled_index / num_columns;
+                let col_index = scaled_index % num_columns;
                 if row_index < left_vec.len() && col_index < result.len() {
                     result[col_index] += coeff * left_vec[row_index];
                 }

--- a/jolt-core/src/poly/one_hot_polynomial.rs
+++ b/jolt-core/src/poly/one_hot_polynomial.rs
@@ -56,15 +56,11 @@ impl<F: JoltField> OneHotPolynomial<F> {
     ///
     /// Note: the Dory matrix may be square or almost-square depending on `log2(K*T)`.
     pub fn num_rows(&self) -> usize {
-        let t = DoryGlobals::get_T();
         match DoryGlobals::get_layout() {
-            DoryLayout::AddressMajor => {
-                if t == 0 {
-                    return 0;
-                }
-                t.div_ceil(DoryGlobals::address_major_cycles_per_row())
+            DoryLayout::AddressMajor => DoryGlobals::get_max_num_rows(),
+            DoryLayout::CycleMajor => {
+                (DoryGlobals::get_T() * self.K).div_ceil(DoryGlobals::get_num_columns())
             }
-            DoryLayout::CycleMajor => (t * self.K).div_ceil(DoryGlobals::get_num_columns()),
         }
     }
 

--- a/jolt-core/src/poly/opening_proof.rs
+++ b/jolt-core/src/poly/opening_proof.rs
@@ -855,37 +855,37 @@ where
     }
 }
 
-/// Computes the Lagrange factor for embedding a smaller "advice" polynomial into the top-left
-/// block of the main Dory matrix.
+/// Computes the Lagrange factor for embedding a smaller polynomial into the top-left block of
+/// the main Dory matrix.
 ///
-/// Advice polynomials have fewer variables than main polynomials. To batch them together,
-/// we embed advice in the top-left corner of the larger matrix and multiply by a Lagrange
+/// Embedded polynomials can have fewer variables than main polynomials. To batch them together,
+/// we embed them in the top-left corner of the larger matrix and multiply by a Lagrange
 /// selector that is 1 on that block and 0 elsewhere:
 ///
 /// ```text
-/// Lagrange factor = ∏_{r ∈ opening_point, r ∉ advice_opening_point} (1 - r)
+/// Lagrange factor = ∏_{r ∈ opening_point, r ∉ embedded_opening_point} (1 - r)
 /// ```
 ///
 /// # Arguments
 /// - `opening_point`: The unified opening point for the Dory opening proof
-/// - `advice_opening_point`: The opening point for the advice polynomial
+/// - `embedded_opening_point`: The opening point for the embedded polynomial
 ///
 /// # Returns
 /// The Lagrange factor as a field element
-pub fn compute_advice_lagrange_factor<F: JoltField>(
+pub fn compute_lagrange_factor<F: JoltField>(
     opening_point: &[F::Challenge],
-    advice_opening_point: &[F::Challenge],
+    embedded_opening_point: &[F::Challenge],
 ) -> F {
     #[cfg(test)]
     {
-        for r in advice_opening_point.iter() {
+        for r in embedded_opening_point.iter() {
             assert!(opening_point.contains(r));
         }
     }
     opening_point
         .iter()
         .map(|r| {
-            if advice_opening_point.contains(r) {
+            if embedded_opening_point.contains(r) {
                 F::one()
             } else {
                 F::one() - r

--- a/jolt-core/src/poly/rlc_polynomial.rs
+++ b/jolt-core/src/poly/rlc_polynomial.rs
@@ -295,21 +295,31 @@ impl<F: JoltField> RLCPolynomial<F> {
                         });
                 }
                 DoryLayout::AddressMajor => {
-                    let cycles_per_row = DoryGlobals::address_major_cycles_per_row();
-                    dense_result
-                        .par_iter_mut()
-                        .step_by(num_columns / cycles_per_row)
+                    let dense_stride = DoryGlobals::dense_stride();
+                    dense_result = self
+                        .dense_rlc
+                        .par_iter()
                         .enumerate()
-                        .for_each(|(offset, dot_product_result)| {
-                            *dot_product_result = self
-                                .dense_rlc
-                                .par_iter()
-                                .skip(offset)
-                                .step_by(cycles_per_row)
-                                .zip(left_vec.par_iter())
-                                .map(|(&a, &b)| -> F { a * b })
-                                .sum::<F>();
-                        });
+                        .fold(
+                            || unsafe_allocate_zero_vec(num_columns),
+                            |mut acc, (cycle, coeff)| {
+                                let scaled_index = cycle.saturating_mul(dense_stride);
+                                let row_index = scaled_index / num_columns;
+                                if row_index >= left_vec.len() {
+                                    return acc;
+                                }
+                                let col_index = scaled_index % num_columns;
+                                acc[col_index] += *coeff * left_vec[row_index];
+                                acc
+                            },
+                        )
+                        .reduce(
+                            || unsafe_allocate_zero_vec(num_columns),
+                            |mut a, b| {
+                                a.iter_mut().zip(b.iter()).for_each(|(x, y)| *x += *y);
+                                a
+                            },
+                        );
                 }
             }
             dense_result
@@ -415,7 +425,7 @@ guardrail in gen_from_trace should ensure sigma_main >= sigma_a."
             return self.address_major_vector_matrix_product(left_vec, num_columns, &ctx);
         }
 
-        let T = DoryGlobals::get_T();
+        let T = DoryGlobals::get_embedded_t();
         match &ctx.trace_source {
             TraceSource::Materialized(trace) => {
                 self.materialized_vector_matrix_product(left_vec, num_columns, trace, &ctx, T)

--- a/jolt-core/src/zkvm/claim_reductions/advice.rs
+++ b/jolt-core/src/zkvm/claim_reductions/advice.rs
@@ -9,8 +9,8 @@ use crate::poly::multilinear_polynomial::MultilinearPolynomial;
 #[cfg(feature = "zk")]
 use crate::poly::opening_proof::OpeningId;
 use crate::poly::opening_proof::{
-    OpeningAccumulator, OpeningPoint, ProverOpeningAccumulator, SumcheckId,
-    VerifierOpeningAccumulator, BIG_ENDIAN, LITTLE_ENDIAN,
+    AbstractVerifierOpeningAccumulator, OpeningAccumulator, OpeningPoint, ProverOpeningAccumulator,
+    SumcheckId, VerifierOpeningAccumulator, BIG_ENDIAN, LITTLE_ENDIAN,
 };
 use crate::poly::unipoly::UniPoly;
 #[cfg(feature = "zk")]
@@ -443,8 +443,12 @@ impl<F: JoltField> AdviceClaimReductionVerifier<F> {
     }
 }
 
-impl<F: JoltField, T: Transcript> SumcheckInstanceVerifier<F, T>
+impl<F, T, A> SumcheckInstanceVerifier<F, T, A>
     for AdviceClaimReductionVerifier<F>
+where
+    F: JoltField,
+    T: Transcript,
+    A: AbstractVerifierOpeningAccumulator<F>,
 {
     fn get_params(&self) -> &dyn SumcheckInstanceParams<F> {
         unsafe { &*self.params.as_ptr() }
@@ -452,7 +456,7 @@ impl<F: JoltField, T: Transcript> SumcheckInstanceVerifier<F, T>
 
     fn expected_output_claim(
         &self,
-        accumulator: &VerifierOpeningAccumulator<F>,
+        accumulator: &A,
         sumcheck_challenges: &[F::Challenge],
     ) -> F {
         let params = self.params.borrow();
@@ -478,7 +482,7 @@ impl<F: JoltField, T: Transcript> SumcheckInstanceVerifier<F, T>
 
     fn cache_openings(
         &self,
-        accumulator: &mut VerifierOpeningAccumulator<F>,
+        accumulator: &mut A,
         sumcheck_challenges: &[F::Challenge],
     ) {
         let mut params = self.params.borrow_mut();

--- a/jolt-core/src/zkvm/claim_reductions/advice.rs
+++ b/jolt-core/src/zkvm/claim_reductions/advice.rs
@@ -1,7 +1,5 @@
 //! Two-phase advice claim reduction (Stage 6 cycle -> Stage 7 address).
 
-use std::cell::RefCell;
-
 use crate::field::JoltField;
 use crate::poly::commitment::dory::DoryGlobals;
 use crate::poly::eq_poly::EqPolynomial;
@@ -233,6 +231,18 @@ impl<F: JoltField> PrecommittedParams<F> for AdviceClaimReductionParams<F> {
     fn precommitted_mut(&mut self) -> &mut PrecommittedClaimReduction<F> {
         &mut self.precommitted
     }
+
+    fn get_cycle_challenges<A: AbstractVerifierOpeningAccumulator<F>>(
+        &self,
+        accumulator: &A,
+    ) -> Vec<F::Challenge> {
+        let (cycle_opening_point, _) = accumulator
+            .get_advice_opening(self.kind, SumcheckId::AdviceClaimReductionCyclePhase)
+            .expect("Cycle phase intermediate claim not found");
+        let opening_point_le: OpeningPoint<LITTLE_ENDIAN, F> =
+            cycle_opening_point.match_endianness();
+        opening_point_le.r
+    }
 }
 
 #[derive(Allocative)]
@@ -324,18 +334,17 @@ impl<F: JoltField, T: Transcript> SumcheckInstanceProver<F, T> for AdviceClaimRe
     ) {
         let params = self.core.params();
         let opening_point = params.normalize_opening_point(sumcheck_challenges);
-        if params.is_cycle_phase() {
+        if params.is_cycle_phase() && params.precommitted.num_address_phase_rounds() > 0 {
             let c_mid = self.core.cycle_intermediate_claim();
-
             match params.kind {
                 AdviceKind::Trusted => accumulator.append_trusted_advice(
                     SumcheckId::AdviceClaimReductionCyclePhase,
-                    OpeningPoint::<BIG_ENDIAN, F>::new(vec![]),
+                    opening_point.clone(),
                     c_mid,
                 ),
                 AdviceKind::Untrusted => accumulator.append_untrusted_advice(
                     SumcheckId::AdviceClaimReductionCyclePhase,
-                    OpeningPoint::<BIG_ENDIAN, F>::new(vec![]),
+                    opening_point.clone(),
                     c_mid,
                 ),
             }
@@ -364,7 +373,7 @@ impl<F: JoltField, T: Transcript> SumcheckInstanceProver<F, T> for AdviceClaimRe
 }
 
 pub struct AdviceClaimReductionVerifier<F: JoltField> {
-    pub params: RefCell<AdviceClaimReductionParams<F>>,
+    pub params: AdviceClaimReductionParams<F>,
 }
 
 impl<F: JoltField> AdviceClaimReductionVerifier<F> {
@@ -381,9 +390,7 @@ impl<F: JoltField> AdviceClaimReductionVerifier<F> {
             accumulator,
         );
 
-        Self {
-            params: RefCell::new(params),
-        }
+        Self { params }
     }
 }
 
@@ -391,11 +398,11 @@ impl<F: JoltField, T: Transcript, A: AbstractVerifierOpeningAccumulator<F>>
     SumcheckInstanceVerifier<F, T, A> for AdviceClaimReductionVerifier<F>
 {
     fn get_params(&self) -> &dyn SumcheckInstanceParams<F> {
-        unsafe { &*self.params.as_ptr() }
+        &self.params
     }
 
     fn expected_output_claim(&self, accumulator: &A, sumcheck_challenges: &[F::Challenge]) -> F {
-        let params = self.params.borrow();
+        let params = &self.params;
         match params.precommitted.phase {
             PrecommittedPhase::CycleVariables
                 if params.precommitted.num_address_phase_rounds() > 0 =>
@@ -418,23 +425,19 @@ impl<F: JoltField, T: Transcript, A: AbstractVerifierOpeningAccumulator<F>>
     }
 
     fn cache_openings(&self, accumulator: &mut A, sumcheck_challenges: &[F::Challenge]) {
-        let mut params = self.params.borrow_mut();
-        if params.is_cycle_phase() {
+        let params = &self.params;
+        if params.is_cycle_phase() && params.precommitted.num_address_phase_rounds() > 0 {
             let opening_point = params.normalize_opening_point(sumcheck_challenges);
             match params.kind {
                 AdviceKind::Trusted => accumulator.append_trusted_advice(
                     SumcheckId::AdviceClaimReductionCyclePhase,
-                    OpeningPoint::<BIG_ENDIAN, F>::new(vec![]),
+                    opening_point.clone(),
                 ),
                 AdviceKind::Untrusted => accumulator.append_untrusted_advice(
                     SumcheckId::AdviceClaimReductionCyclePhase,
-                    OpeningPoint::<BIG_ENDIAN, F>::new(vec![]),
+                    opening_point,
                 ),
             }
-            let opening_point_le: OpeningPoint<LITTLE_ENDIAN, F> = opening_point.match_endianness();
-            params
-                .precommitted
-                .set_cycle_var_challenges(opening_point_le.r);
         }
 
         if params.precommitted.num_address_phase_rounds() == 0 || !params.is_cycle_phase() {

--- a/jolt-core/src/zkvm/claim_reductions/advice.rs
+++ b/jolt-core/src/zkvm/claim_reductions/advice.rs
@@ -198,6 +198,72 @@ impl<F: JoltField> SumcheckInstanceParams<F> for AdviceClaimReductionParams<F> {
     }
 }
 
+impl<F: JoltField> AdviceClaimReductionParams<F> {
+    #[cfg(feature = "zk")]
+    fn final_advice_output_claim_constraint(&self) -> Option<OutputClaimConstraint> {
+        let advice_opening = match self.kind {
+            AdviceKind::Trusted => OpeningId::TrustedAdvice(SumcheckId::AdviceClaimReduction),
+            AdviceKind::Untrusted => OpeningId::UntrustedAdvice(SumcheckId::AdviceClaimReduction),
+        };
+        Some(OutputClaimConstraint::linear(vec![(
+            ValueSource::Challenge(0),
+            ValueSource::Opening(advice_opening),
+        )]))
+    }
+
+    fn final_advice_output_scale(&self, sumcheck_challenges: &[F::Challenge]) -> F {
+        let eq_eval = self.final_advice_eq_eval(sumcheck_challenges);
+        let scale = match self.phase {
+            PrecommittedPhase::CycleVariables => self.precommitted.cycle_phase_skip_scale(),
+            PrecommittedPhase::AddressVariables => {
+                precommitted_skip_round_scale(&self.precommitted)
+            }
+        };
+        eq_eval * scale
+    }
+
+    fn final_advice_eq_eval(&self, sumcheck_challenges: &[F::Challenge]) -> F {
+        let opening_point = OpeningPoint::<BIG_ENDIAN, F>::new(
+            self.precommitted
+                .poly_opening_round_permutation_be()
+                .iter()
+                .map(|&global_round| {
+                    self.challenge_for_global_round(global_round, sumcheck_challenges)
+                })
+                .collect(),
+        );
+        EqPolynomial::mle(&opening_point.r, &self.r_val.r)
+    }
+
+    fn challenge_for_global_round(
+        &self,
+        global_round: usize,
+        sumcheck_challenges: &[F::Challenge],
+    ) -> F::Challenge {
+        let cycle_rounds = self.precommitted.cycle_alignment_rounds();
+        if global_round < cycle_rounds {
+            return match self.phase {
+                PrecommittedPhase::CycleVariables => sumcheck_challenges[global_round],
+                PrecommittedPhase::AddressVariables => {
+                    let idx = self
+                        .precommitted
+                        .cycle_phase_rounds()
+                        .binary_search(&global_round)
+                        .expect("cycle round should be active for advice polynomial");
+                    self.precommitted.cycle_var_challenges[idx]
+                }
+            };
+        }
+
+        assert_eq!(
+            self.phase,
+            PrecommittedPhase::AddressVariables,
+            "cycle-phase final advice scale should not contain address rounds"
+        );
+        sumcheck_challenges[global_round - cycle_rounds]
+    }
+}
+
 impl<F: JoltField> PrecomittedParams<F> for AdviceClaimReductionParams<F> {
     fn is_cycle_phase(&self) -> bool {
         self.phase == PrecommittedPhase::CycleVariables
@@ -450,5 +516,75 @@ impl<F: JoltField, T: Transcript> SumcheckInstanceVerifier<F, T>
     fn round_offset(&self, max_num_rounds: usize) -> usize {
         let params = self.params.borrow();
         params.round_offset(max_num_rounds)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ark_bn254::Fr;
+
+    type Challenge = <Fr as JoltField>::Challenge;
+
+    #[test]
+    fn final_advice_output_scale_counts_leading_dummy_rounds_when_col_range_is_empty() {
+        let challenges = [0, 12, 13]
+            .map(|value| Challenge::from(value as u128))
+            .to_vec();
+        let active_opening_point =
+            OpeningPoint::<LITTLE_ENDIAN, Fr>::new(challenges[0..1].to_vec()).match_endianness();
+        let scheduling_reference = PrecommittedSchedulingReference {
+            main_total_vars: 3,
+            reference_total_vars: 3,
+            cycle_alignment_rounds: 3,
+            address_rounds: 0,
+            joint_col_vars: 0,
+        };
+        let params = AdviceClaimReductionParams {
+            kind: AdviceKind::Trusted,
+            phase: PrecommittedPhase::CycleVariables,
+            precommitted: PrecommittedClaimReduction::new(1, 0, scheduling_reference),
+            advice_col_vars: 0,
+            advice_row_vars: 1,
+            r_val: active_opening_point,
+        };
+
+        let two_inv = Fr::from_u64(2).inverse().unwrap();
+
+        assert_eq!(
+            params.final_advice_output_scale(&challenges),
+            two_inv * two_inv
+        );
+    }
+
+    #[test]
+    fn final_advice_output_scale_ignores_unrun_address_dummy_rounds() {
+        let challenges = [11, 12]
+            .map(|value| Challenge::from(value as u128))
+            .to_vec();
+        let r_val = OpeningPoint::<BIG_ENDIAN, Fr>::new(vec![Challenge::from(7)]);
+        let scheduling_reference = PrecommittedSchedulingReference {
+            main_total_vars: 4,
+            reference_total_vars: 4,
+            cycle_alignment_rounds: 2,
+            address_rounds: 2,
+            joint_col_vars: 0,
+        };
+        let params = AdviceClaimReductionParams {
+            kind: AdviceKind::Trusted,
+            phase: PrecommittedPhase::CycleVariables,
+            precommitted: PrecommittedClaimReduction::new(1, 0, scheduling_reference),
+            advice_col_vars: 0,
+            advice_row_vars: 1,
+            r_val,
+        };
+
+        let two_inv = Fr::from_u64(2).inverse().unwrap();
+        let expected_eq = EqPolynomial::mle(&[challenges[0]], &params.r_val.r);
+
+        assert_eq!(
+            params.final_advice_output_scale(&challenges),
+            expected_eq * two_inv
+        );
     }
 }

--- a/jolt-core/src/zkvm/claim_reductions/advice.rs
+++ b/jolt-core/src/zkvm/claim_reductions/advice.rs
@@ -261,6 +261,31 @@ impl<F: JoltField> AdviceClaimReductionProver<F> {
             core: PrecomittedProver::new(params, advice_poly, eq_poly),
         }
     }
+
+    pub fn from_bound_state(
+        params: AdviceClaimReductionParams<F>,
+        advice_coeffs: Vec<F>,
+        eq_coeffs: Vec<F>,
+    ) -> Self {
+        Self::from_bound_state_with_scale(params, advice_coeffs, eq_coeffs, F::one())
+    }
+
+    pub fn from_bound_state_with_scale(
+        params: AdviceClaimReductionParams<F>,
+        advice_coeffs: Vec<F>,
+        eq_coeffs: Vec<F>,
+        scale: F,
+    ) -> Self {
+        let mut prover = Self {
+            core: PrecomittedProver::new(
+                params,
+                MultilinearPolynomial::from(advice_coeffs),
+                MultilinearPolynomial::from(eq_coeffs),
+            ),
+        };
+        prover.core.set_scale(scale);
+        prover
+    }
 }
 
 impl<F: JoltField, T: Transcript> SumcheckInstanceProver<F, T> for AdviceClaimReductionProver<F> {

--- a/jolt-core/src/zkvm/claim_reductions/advice.rs
+++ b/jolt-core/src/zkvm/claim_reductions/advice.rs
@@ -199,18 +199,6 @@ impl<F: JoltField> SumcheckInstanceParams<F> for AdviceClaimReductionParams<F> {
 }
 
 impl<F: JoltField> AdviceClaimReductionParams<F> {
-    #[cfg(feature = "zk")]
-    fn final_advice_output_claim_constraint(&self) -> Option<OutputClaimConstraint> {
-        let advice_opening = match self.kind {
-            AdviceKind::Trusted => OpeningId::TrustedAdvice(SumcheckId::AdviceClaimReduction),
-            AdviceKind::Untrusted => OpeningId::UntrustedAdvice(SumcheckId::AdviceClaimReduction),
-        };
-        Some(OutputClaimConstraint::linear(vec![(
-            ValueSource::Challenge(0),
-            ValueSource::Opening(advice_opening),
-        )]))
-    }
-
     #[cfg(test)]
     fn final_advice_output_scale(&self, sumcheck_challenges: &[F::Challenge]) -> F {
         let eq_eval = self.final_advice_eq_eval(sumcheck_challenges);

--- a/jolt-core/src/zkvm/claim_reductions/advice.rs
+++ b/jolt-core/src/zkvm/claim_reductions/advice.rs
@@ -10,7 +10,7 @@ use crate::poly::multilinear_polynomial::MultilinearPolynomial;
 use crate::poly::opening_proof::OpeningId;
 use crate::poly::opening_proof::{
     AbstractVerifierOpeningAccumulator, OpeningAccumulator, OpeningPoint, ProverOpeningAccumulator,
-    SumcheckId, VerifierOpeningAccumulator, BIG_ENDIAN, LITTLE_ENDIAN,
+    SumcheckId, BIG_ENDIAN, LITTLE_ENDIAN,
 };
 use crate::poly::unipoly::UniPoly;
 #[cfg(feature = "zk")]

--- a/jolt-core/src/zkvm/claim_reductions/advice.rs
+++ b/jolt-core/src/zkvm/claim_reductions/advice.rs
@@ -443,8 +443,7 @@ impl<F: JoltField> AdviceClaimReductionVerifier<F> {
     }
 }
 
-impl<F, T, A> SumcheckInstanceVerifier<F, T, A>
-    for AdviceClaimReductionVerifier<F>
+impl<F, T, A> SumcheckInstanceVerifier<F, T, A> for AdviceClaimReductionVerifier<F>
 where
     F: JoltField,
     T: Transcript,
@@ -454,11 +453,7 @@ where
         unsafe { &*self.params.as_ptr() }
     }
 
-    fn expected_output_claim(
-        &self,
-        accumulator: &A,
-        sumcheck_challenges: &[F::Challenge],
-    ) -> F {
+    fn expected_output_claim(&self, accumulator: &A, sumcheck_challenges: &[F::Challenge]) -> F {
         let params = self.params.borrow();
         match params.phase {
             PrecommittedPhase::CycleVariables => {
@@ -480,11 +475,7 @@ where
         }
     }
 
-    fn cache_openings(
-        &self,
-        accumulator: &mut A,
-        sumcheck_challenges: &[F::Challenge],
-    ) {
+    fn cache_openings(&self, accumulator: &mut A, sumcheck_challenges: &[F::Challenge]) {
         let mut params = self.params.borrow_mut();
         if params.phase == PrecommittedPhase::CycleVariables {
             let opening_point = params.normalize_opening_point(sumcheck_challenges);

--- a/jolt-core/src/zkvm/claim_reductions/advice.rs
+++ b/jolt-core/src/zkvm/claim_reductions/advice.rs
@@ -427,7 +427,7 @@ impl<F: JoltField> AdviceClaimReductionVerifier<F> {
         advice_size_bytes: usize,
         trace_len: usize,
         scheduling_reference: PrecommittedSchedulingReference,
-        accumulator: &VerifierOpeningAccumulator<F>,
+        accumulator: &dyn OpeningAccumulator<F>,
     ) -> Self {
         let params = AdviceClaimReductionParams::new(
             kind,
@@ -547,7 +547,8 @@ mod tests {
         let params = AdviceClaimReductionParams {
             kind: AdviceKind::Trusted,
             phase: PrecommittedPhase::CycleVariables,
-            precommitted: PrecommittedClaimReduction::new(1, 0, scheduling_reference),
+            precommitted: PrecommittedClaimReduction::new(1, 1, 0, scheduling_reference),
+            log_t: 0,
             advice_col_vars: 0,
             advice_row_vars: 1,
             r_val: active_opening_point,
@@ -577,7 +578,8 @@ mod tests {
         let params = AdviceClaimReductionParams {
             kind: AdviceKind::Trusted,
             phase: PrecommittedPhase::CycleVariables,
-            precommitted: PrecommittedClaimReduction::new(1, 0, scheduling_reference),
+            precommitted: PrecommittedClaimReduction::new(1, 1, 0, scheduling_reference),
+            log_t: 0,
             advice_col_vars: 0,
             advice_row_vars: 1,
             r_val,

--- a/jolt-core/src/zkvm/claim_reductions/advice.rs
+++ b/jolt-core/src/zkvm/claim_reductions/advice.rs
@@ -18,13 +18,14 @@ use crate::subprotocols::blindfold::{InputClaimConstraint, OutputClaimConstraint
 use crate::subprotocols::sumcheck_prover::SumcheckInstanceProver;
 use crate::subprotocols::sumcheck_verifier::{SumcheckInstanceParams, SumcheckInstanceVerifier};
 use crate::transcripts::Transcript;
-use crate::utils::math::Math;
 use crate::zkvm::claim_reductions::{
     permute_precommitted_polys, precommitted_eq_evals_with_scaling, precommitted_skip_round_scale,
-    PrecomittedParams, PrecomittedProver, PrecommittedClaimReduction, PrecommittedPhase,
-    PrecommittedSchedulingReference, TWO_PHASE_DEGREE_BOUND,
+    PrecommittedClaimReduction, PrecommittedPhase, PrecommittedSchedulingReference,
+    TWO_PHASE_DEGREE_BOUND,
 };
 use allocative::Allocative;
+
+use super::precommitted::{PrecommittedParams, PrecommittedProver};
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Allocative)]
 pub enum AdviceKind {
@@ -35,9 +36,7 @@ pub enum AdviceKind {
 #[derive(Clone, Allocative)]
 pub struct AdviceClaimReductionParams<F: JoltField> {
     pub kind: AdviceKind,
-    pub phase: PrecommittedPhase,
     pub precommitted: PrecommittedClaimReduction<F>,
-    pub log_t: usize,
     pub advice_col_vars: usize,
     pub advice_row_vars: usize,
     pub r_val: OpeningPoint<BIG_ENDIAN, F>,
@@ -47,11 +46,9 @@ impl<F: JoltField> AdviceClaimReductionParams<F> {
     pub fn new(
         kind: AdviceKind,
         advice_size_bytes: usize,
-        trace_len: usize,
         scheduling_reference: PrecommittedSchedulingReference,
         accumulator: &dyn OpeningAccumulator<F>,
     ) -> Self {
-        let log_t = trace_len.log_2();
         let r_val = accumulator
             .get_advice_opening(kind, SumcheckId::RamValCheck)
             .map(|(p, _)| p)
@@ -59,44 +56,22 @@ impl<F: JoltField> AdviceClaimReductionParams<F> {
 
         let (advice_col_vars, advice_row_vars) =
             DoryGlobals::advice_sigma_nu_from_max_bytes(advice_size_bytes);
-        let total_vars = advice_row_vars + advice_col_vars;
-        let precommitted = PrecommittedClaimReduction::new(
-            total_vars,
-            advice_row_vars,
-            advice_col_vars,
-            scheduling_reference,
-        );
+        let precommitted =
+            PrecommittedClaimReduction::new(advice_row_vars, advice_col_vars, scheduling_reference);
 
         Self {
             kind,
-            phase: PrecommittedPhase::CycleVariables,
             precommitted,
             advice_col_vars,
             advice_row_vars,
-            log_t,
             r_val,
         }
-    }
-
-    pub fn num_address_phase_rounds(&self) -> usize {
-        self.precommitted.num_address_phase_rounds()
-    }
-
-    pub fn transition_to_address_phase(&mut self) {
-        self.phase = PrecommittedPhase::AddressVariables;
-    }
-
-    pub fn round_offset(&self, max_num_rounds: usize) -> usize {
-        self.precommitted.round_offset(
-            self.phase == PrecommittedPhase::CycleVariables,
-            max_num_rounds,
-        )
     }
 }
 
 impl<F: JoltField> SumcheckInstanceParams<F> for AdviceClaimReductionParams<F> {
     fn input_claim(&self, accumulator: &dyn OpeningAccumulator<F>) -> F {
-        match self.phase {
+        match self.precommitted.phase {
             PrecommittedPhase::CycleVariables => {
                 accumulator
                     .get_advice_opening(self.kind, SumcheckId::RamValCheck)
@@ -117,21 +92,16 @@ impl<F: JoltField> SumcheckInstanceParams<F> for AdviceClaimReductionParams<F> {
     }
 
     fn num_rounds(&self) -> usize {
-        self.precommitted
-            .num_rounds_for_phase(self.phase == PrecommittedPhase::CycleVariables)
+        self.precommitted.num_rounds_for_current_phase()
     }
 
     fn normalize_opening_point(&self, challenges: &[F::Challenge]) -> OpeningPoint<BIG_ENDIAN, F> {
-        self.precommitted.normalize_opening_point(
-            self.phase == PrecommittedPhase::CycleVariables,
-            challenges,
-            self.log_t,
-        )
+        self.precommitted.normalize_opening_point(challenges)
     }
 
     #[cfg(feature = "zk")]
     fn input_claim_constraint(&self) -> InputClaimConstraint {
-        let opening = match self.phase {
+        let opening = match self.precommitted.phase {
             PrecommittedPhase::CycleVariables => match self.kind {
                 AdviceKind::Trusted => OpeningId::TrustedAdvice(SumcheckId::RamValCheck),
                 AdviceKind::Untrusted => OpeningId::UntrustedAdvice(SumcheckId::RamValCheck),
@@ -155,54 +125,56 @@ impl<F: JoltField> SumcheckInstanceParams<F> for AdviceClaimReductionParams<F> {
 
     #[cfg(feature = "zk")]
     fn output_claim_constraint(&self) -> Option<OutputClaimConstraint> {
-        match self.phase {
+        match self.precommitted.phase {
             PrecommittedPhase::CycleVariables => {
-                let opening = match self.kind {
-                    AdviceKind::Trusted => {
-                        OpeningId::TrustedAdvice(SumcheckId::AdviceClaimReductionCyclePhase)
-                    }
-                    AdviceKind::Untrusted => {
-                        OpeningId::UntrustedAdvice(SumcheckId::AdviceClaimReductionCyclePhase)
-                    }
-                };
-                Some(OutputClaimConstraint::direct(opening))
+                if self.precommitted.num_address_phase_rounds() > 0 {
+                    let advice_opening = match self.kind {
+                        AdviceKind::Trusted => {
+                            OpeningId::TrustedAdvice(SumcheckId::AdviceClaimReductionCyclePhase)
+                        }
+                        AdviceKind::Untrusted => {
+                            OpeningId::UntrustedAdvice(SumcheckId::AdviceClaimReductionCyclePhase)
+                        }
+                    };
+                    return Some(OutputClaimConstraint::direct(advice_opening));
+                }
+                self.final_advice_output_claim_constraint()
             }
-            PrecommittedPhase::AddressVariables => {
-                let opening = match self.kind {
-                    AdviceKind::Trusted => {
-                        OpeningId::TrustedAdvice(SumcheckId::AdviceClaimReduction)
-                    }
-                    AdviceKind::Untrusted => {
-                        OpeningId::UntrustedAdvice(SumcheckId::AdviceClaimReduction)
-                    }
-                };
-                Some(OutputClaimConstraint::linear(vec![(
-                    ValueSource::Challenge(0),
-                    ValueSource::Opening(opening),
-                )]))
-            }
+            PrecommittedPhase::AddressVariables => self.final_advice_output_claim_constraint(),
         }
     }
 
     #[cfg(feature = "zk")]
     fn output_constraint_challenge_values(&self, sumcheck_challenges: &[F::Challenge]) -> Vec<F> {
-        match self.phase {
-            PrecommittedPhase::CycleVariables => vec![],
-            PrecommittedPhase::AddressVariables => {
-                let opening_point = self.normalize_opening_point(sumcheck_challenges);
-                let eq_eval = EqPolynomial::mle(&opening_point.r, &self.r_val.r);
-                let scale: F = precommitted_skip_round_scale(&self.precommitted);
-                vec![eq_eval * scale]
+        match self.precommitted.phase {
+            PrecommittedPhase::CycleVariables
+                if self.precommitted.num_address_phase_rounds() > 0 =>
+            {
+                vec![]
+            }
+            PrecommittedPhase::CycleVariables | PrecommittedPhase::AddressVariables => {
+                vec![self.final_advice_output_scale(sumcheck_challenges)]
             }
         }
     }
 }
 
 impl<F: JoltField> AdviceClaimReductionParams<F> {
-    #[cfg(test)]
+    #[cfg(feature = "zk")]
+    fn final_advice_output_claim_constraint(&self) -> Option<OutputClaimConstraint> {
+        let advice_opening = match self.kind {
+            AdviceKind::Trusted => OpeningId::TrustedAdvice(SumcheckId::AdviceClaimReduction),
+            AdviceKind::Untrusted => OpeningId::UntrustedAdvice(SumcheckId::AdviceClaimReduction),
+        };
+        Some(OutputClaimConstraint::linear(vec![(
+            ValueSource::Challenge(0),
+            ValueSource::Opening(advice_opening),
+        )]))
+    }
+
     fn final_advice_output_scale(&self, sumcheck_challenges: &[F::Challenge]) -> F {
         let eq_eval = self.final_advice_eq_eval(sumcheck_challenges);
-        let scale = match self.phase {
+        let scale = match self.precommitted.phase {
             PrecommittedPhase::CycleVariables => self.precommitted.cycle_phase_skip_scale(),
             PrecommittedPhase::AddressVariables => {
                 precommitted_skip_round_scale(&self.precommitted)
@@ -211,7 +183,6 @@ impl<F: JoltField> AdviceClaimReductionParams<F> {
         eq_eval * scale
     }
 
-    #[cfg(test)]
     fn final_advice_eq_eval(&self, sumcheck_challenges: &[F::Challenge]) -> F {
         let opening_point = OpeningPoint::<BIG_ENDIAN, F>::new(
             self.precommitted
@@ -225,7 +196,6 @@ impl<F: JoltField> AdviceClaimReductionParams<F> {
         EqPolynomial::mle(&opening_point.r, &self.r_val.r)
     }
 
-    #[cfg(test)]
     fn challenge_for_global_round(
         &self,
         global_round: usize,
@@ -233,7 +203,7 @@ impl<F: JoltField> AdviceClaimReductionParams<F> {
     ) -> F::Challenge {
         let cycle_rounds = self.precommitted.cycle_alignment_rounds();
         if global_round < cycle_rounds {
-            return match self.phase {
+            return match self.precommitted.phase {
                 PrecommittedPhase::CycleVariables => sumcheck_challenges[global_round],
                 PrecommittedPhase::AddressVariables => {
                     let idx = self
@@ -247,7 +217,7 @@ impl<F: JoltField> AdviceClaimReductionParams<F> {
         }
 
         assert_eq!(
-            self.phase,
+            self.precommitted.phase,
             PrecommittedPhase::AddressVariables,
             "cycle-phase final advice scale should not contain address rounds"
         );
@@ -255,35 +225,19 @@ impl<F: JoltField> AdviceClaimReductionParams<F> {
     }
 }
 
-impl<F: JoltField> PrecomittedParams<F> for AdviceClaimReductionParams<F> {
-    fn is_cycle_phase(&self) -> bool {
-        self.phase == PrecommittedPhase::CycleVariables
+impl<F: JoltField> PrecommittedParams<F> for AdviceClaimReductionParams<F> {
+    fn precommitted(&self) -> &PrecommittedClaimReduction<F> {
+        &self.precommitted
     }
 
-    fn is_cycle_phase_round(&self, round: usize) -> bool {
-        self.precommitted.is_cycle_phase_round(round)
-    }
-
-    fn is_address_phase_round(&self, round: usize) -> bool {
-        self.precommitted.is_address_phase_round(round)
-    }
-
-    fn cycle_alignment_rounds(&self) -> usize {
-        self.precommitted.cycle_alignment_rounds()
-    }
-
-    fn address_alignment_rounds(&self) -> usize {
-        self.precommitted.address_alignment_rounds()
-    }
-
-    fn record_cycle_challenge(&mut self, challenge: F::Challenge) {
-        self.precommitted.record_cycle_challenge(challenge);
+    fn precommitted_mut(&mut self) -> &mut PrecommittedClaimReduction<F> {
+        &mut self.precommitted
     }
 }
 
 #[derive(Allocative)]
 pub struct AdviceClaimReductionProver<F: JoltField> {
-    core: PrecomittedProver<F, AdviceClaimReductionParams<F>>,
+    core: PrecommittedProver<F, AdviceClaimReductionParams<F>>,
 }
 
 impl<F: JoltField> AdviceClaimReductionProver<F> {
@@ -292,7 +246,7 @@ impl<F: JoltField> AdviceClaimReductionProver<F> {
     }
 
     pub fn transition_to_address_phase(&mut self) {
-        self.core.params_mut().transition_to_address_phase();
+        self.core.transition_to_address_phase();
     }
 
     pub fn initialize(
@@ -315,7 +269,7 @@ impl<F: JoltField> AdviceClaimReductionProver<F> {
         };
 
         Self {
-            core: PrecomittedProver::new(params, advice_poly, eq_poly),
+            core: PrecommittedProver::new(params, advice_poly, eq_poly, None),
         }
     }
 
@@ -334,10 +288,11 @@ impl<F: JoltField> AdviceClaimReductionProver<F> {
         scale: F,
     ) -> Self {
         let mut prover = Self {
-            core: PrecomittedProver::new(
+            core: PrecommittedProver::new(
                 params,
                 MultilinearPolynomial::from(advice_coeffs),
                 MultilinearPolynomial::from(eq_coeffs),
+                None,
             ),
         };
         prover.core.set_scale(scale);
@@ -350,8 +305,8 @@ impl<F: JoltField, T: Transcript> SumcheckInstanceProver<F, T> for AdviceClaimRe
         self.core.params()
     }
 
-    fn round_offset(&self, max_num_rounds: usize) -> usize {
-        self.core.params().round_offset(max_num_rounds)
+    fn round_offset(&self, _max_num_rounds: usize) -> usize {
+        0
     }
 
     fn compute_message(&mut self, round: usize, previous_claim: F) -> UniPoly<F> {
@@ -369,7 +324,7 @@ impl<F: JoltField, T: Transcript> SumcheckInstanceProver<F, T> for AdviceClaimRe
     ) {
         let params = self.core.params();
         let opening_point = params.normalize_opening_point(sumcheck_challenges);
-        if params.phase == PrecommittedPhase::CycleVariables {
+        if params.is_cycle_phase() {
             let c_mid = self.core.cycle_intermediate_claim();
 
             match params.kind {
@@ -416,14 +371,12 @@ impl<F: JoltField> AdviceClaimReductionVerifier<F> {
     pub fn new(
         kind: AdviceKind,
         advice_size_bytes: usize,
-        trace_len: usize,
         scheduling_reference: PrecommittedSchedulingReference,
         accumulator: &dyn OpeningAccumulator<F>,
     ) -> Self {
         let params = AdviceClaimReductionParams::new(
             kind,
             advice_size_bytes,
-            trace_len,
             scheduling_reference,
             accumulator,
         );
@@ -434,11 +387,8 @@ impl<F: JoltField> AdviceClaimReductionVerifier<F> {
     }
 }
 
-impl<F, T, A> SumcheckInstanceVerifier<F, T, A> for AdviceClaimReductionVerifier<F>
-where
-    F: JoltField,
-    T: Transcript,
-    A: AbstractVerifierOpeningAccumulator<F>,
+impl<F: JoltField, T: Transcript, A: AbstractVerifierOpeningAccumulator<F>>
+    SumcheckInstanceVerifier<F, T, A> for AdviceClaimReductionVerifier<F>
 {
     fn get_params(&self) -> &dyn SumcheckInstanceParams<F> {
         unsafe { &*self.params.as_ptr() }
@@ -446,29 +396,30 @@ where
 
     fn expected_output_claim(&self, accumulator: &A, sumcheck_challenges: &[F::Challenge]) -> F {
         let params = self.params.borrow();
-        match params.phase {
-            PrecommittedPhase::CycleVariables => {
+        match params.precommitted.phase {
+            PrecommittedPhase::CycleVariables
+                if params.precommitted.num_address_phase_rounds() > 0 =>
+            {
                 accumulator
                     .get_advice_opening(params.kind, SumcheckId::AdviceClaimReductionCyclePhase)
                     .unwrap_or_else(|| panic!("Cycle phase intermediate claim not found"))
                     .1
             }
-            PrecommittedPhase::AddressVariables => {
-                let opening_point = params.normalize_opening_point(sumcheck_challenges);
+            PrecommittedPhase::CycleVariables | PrecommittedPhase::AddressVariables => {
                 let advice_claim = accumulator
                     .get_advice_opening(params.kind, SumcheckId::AdviceClaimReduction)
                     .expect("Final advice claim not found")
                     .1;
-                let eq_eval = EqPolynomial::mle(&opening_point.r, &params.r_val.r);
-                let scale: F = precommitted_skip_round_scale(&params.precommitted);
-                advice_claim * eq_eval * scale
+
+                // Account for Phase 1's internal dummy-gap traversal via constant scaling.
+                advice_claim * params.final_advice_output_scale(sumcheck_challenges)
             }
         }
     }
 
     fn cache_openings(&self, accumulator: &mut A, sumcheck_challenges: &[F::Challenge]) {
         let mut params = self.params.borrow_mut();
-        if params.phase == PrecommittedPhase::CycleVariables {
+        if params.is_cycle_phase() {
             let opening_point = params.normalize_opening_point(sumcheck_challenges);
             match params.kind {
                 AdviceKind::Trusted => accumulator.append_trusted_advice(
@@ -486,9 +437,7 @@ where
                 .set_cycle_var_challenges(opening_point_le.r);
         }
 
-        if params.num_address_phase_rounds() == 0
-            || params.phase == PrecommittedPhase::AddressVariables
-        {
+        if params.precommitted.num_address_phase_rounds() == 0 || !params.is_cycle_phase() {
             let opening_point = params.normalize_opening_point(sumcheck_challenges);
             match params.kind {
                 AdviceKind::Trusted => accumulator
@@ -499,9 +448,8 @@ where
         }
     }
 
-    fn round_offset(&self, max_num_rounds: usize) -> usize {
-        let params = self.params.borrow();
-        params.round_offset(max_num_rounds)
+    fn round_offset(&self, _max_num_rounds: usize) -> usize {
+        0
     }
 }
 
@@ -528,9 +476,7 @@ mod tests {
         };
         let params = AdviceClaimReductionParams {
             kind: AdviceKind::Trusted,
-            phase: PrecommittedPhase::CycleVariables,
-            precommitted: PrecommittedClaimReduction::new(1, 1, 0, scheduling_reference),
-            log_t: 0,
+            precommitted: PrecommittedClaimReduction::new(1, 0, scheduling_reference),
             advice_col_vars: 0,
             advice_row_vars: 1,
             r_val: active_opening_point,
@@ -559,9 +505,7 @@ mod tests {
         };
         let params = AdviceClaimReductionParams {
             kind: AdviceKind::Trusted,
-            phase: PrecommittedPhase::CycleVariables,
-            precommitted: PrecommittedClaimReduction::new(1, 1, 0, scheduling_reference),
-            log_t: 0,
+            precommitted: PrecommittedClaimReduction::new(1, 0, scheduling_reference),
             advice_col_vars: 0,
             advice_row_vars: 1,
             r_val,

--- a/jolt-core/src/zkvm/claim_reductions/advice.rs
+++ b/jolt-core/src/zkvm/claim_reductions/advice.rs
@@ -211,6 +211,7 @@ impl<F: JoltField> AdviceClaimReductionParams<F> {
         )]))
     }
 
+    #[cfg(test)]
     fn final_advice_output_scale(&self, sumcheck_challenges: &[F::Challenge]) -> F {
         let eq_eval = self.final_advice_eq_eval(sumcheck_challenges);
         let scale = match self.phase {
@@ -222,6 +223,7 @@ impl<F: JoltField> AdviceClaimReductionParams<F> {
         eq_eval * scale
     }
 
+    #[cfg(test)]
     fn final_advice_eq_eval(&self, sumcheck_challenges: &[F::Challenge]) -> F {
         let opening_point = OpeningPoint::<BIG_ENDIAN, F>::new(
             self.precommitted
@@ -235,6 +237,7 @@ impl<F: JoltField> AdviceClaimReductionParams<F> {
         EqPolynomial::mle(&opening_point.r, &self.r_val.r)
     }
 
+    #[cfg(test)]
     fn challenge_for_global_round(
         &self,
         global_round: usize,

--- a/jolt-core/src/zkvm/claim_reductions/advice.rs
+++ b/jolt-core/src/zkvm/claim_reductions/advice.rs
@@ -1,47 +1,16 @@
-//! Two-phase advice claim reduction (Stage 6 cycle → Stage 7 address)
-//!
-//! This module generalizes the previous single-phase `AdviceClaimReduction` so that trusted and
-//! untrusted advice can be committed as an arbitrary Dory matrix `2^{nu_a} x 2^{sigma_a}` (balanced
-//! by default), while still keeping a **single Stage 8 Dory opening** at the unified Dory point.
-//!
-//! For an advice matrix embedded as the **top-left block** `2^{nu_a} x 2^{sigma_a}`, the *native*
-//! advice evaluation point (in Dory order, LSB-first) is:
-//! - `advice_cols = col_coords[0..sigma_a]`
-//! - `advice_rows = row_coords[0..nu_a]`
-//! - `advice_point = [advice_cols || advice_rows]`
-//!
-//! In our current pipeline, `cycle` coordinates come from Stage 6 and `addr` coordinates come from
-//! Stage 7.
-//! - **Phase 1 (Stage 6)**: bind the cycle-derived advice coordinates and output an intermediate
-//!   scalar claim `C_mid`.
-//! - **Phase 2 (Stage 7)**: resume from `C_mid`, bind the address-derived advice coordinates, and
-//!   cache the final advice opening `AdviceMLE(advice_point)` for batching into Stage 8.
-//!
-//! ## Dummy-gap scaling (within Stage 6)
-//! With cycle-major order, there may be a gap during the cycle phase where the cycle variables
-//! being bound in the batched sumcheck do not appear in the advice polynommial.
-//!
-//! We handle this without modifying the generic batched sumcheck by treating those intervening
-//! rounds as **dummy internal rounds** (constant univariates), and maintaining a running scaling
-//! factor `2^{-dummy_done}` so the per-round univariates remain consistent.
-//!
-//! Trusted and untrusted advice run as **separate** sumcheck instances (each may have different
-//! dimensions).
-//!
+//! Two-phase advice claim reduction (Stage 6 cycle -> Stage 7 address).
 
 use std::cell::RefCell;
-use std::cmp::{min, Ordering};
-use std::ops::Range;
 
 use crate::field::JoltField;
-use crate::poly::commitment::dory::{DoryGlobals, DoryLayout};
+use crate::poly::commitment::dory::DoryGlobals;
 use crate::poly::eq_poly::EqPolynomial;
-use crate::poly::multilinear_polynomial::{BindingOrder, MultilinearPolynomial, PolynomialBinding};
+use crate::poly::multilinear_polynomial::MultilinearPolynomial;
 #[cfg(feature = "zk")]
 use crate::poly::opening_proof::OpeningId;
 use crate::poly::opening_proof::{
-    AbstractVerifierOpeningAccumulator, OpeningAccumulator, OpeningPoint, ProverOpeningAccumulator,
-    SumcheckId, BIG_ENDIAN, LITTLE_ENDIAN,
+    OpeningAccumulator, OpeningPoint, ProverOpeningAccumulator, SumcheckId,
+    VerifierOpeningAccumulator, BIG_ENDIAN, LITTLE_ENDIAN,
 };
 use crate::poly::unipoly::UniPoly;
 #[cfg(feature = "zk")]
@@ -50,12 +19,12 @@ use crate::subprotocols::sumcheck_prover::SumcheckInstanceProver;
 use crate::subprotocols::sumcheck_verifier::{SumcheckInstanceParams, SumcheckInstanceVerifier};
 use crate::transcripts::Transcript;
 use crate::utils::math::Math;
-use crate::zkvm::config::OneHotConfig;
+use crate::zkvm::claim_reductions::{
+    permute_precommitted_polys, precommitted_eq_evals_with_scaling, precommitted_skip_round_scale,
+    PrecomittedParams, PrecomittedProver, PrecommittedClaimReduction, PrecommittedPhase,
+    PrecommittedSchedulingReference, TWO_PHASE_DEGREE_BOUND,
+};
 use allocative::Allocative;
-use common::jolt_device::MemoryLayout;
-use rayon::prelude::*;
-
-const DEGREE_BOUND: usize = 2;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Allocative)]
 pub enum AdviceKind {
@@ -63,134 +32,78 @@ pub enum AdviceKind {
     Untrusted,
 }
 
-#[derive(Debug, Clone, Allocative, PartialEq, Eq)]
-pub enum ReductionPhase {
-    CycleVariables,
-    AddressVariables,
-}
-
 #[derive(Clone, Allocative)]
 pub struct AdviceClaimReductionParams<F: JoltField> {
     pub kind: AdviceKind,
-    pub phase: ReductionPhase,
-    pub log_k_chunk: usize,
+    pub phase: PrecommittedPhase,
+    pub precommitted: PrecommittedClaimReduction<F>,
     pub log_t: usize,
     pub advice_col_vars: usize,
     pub advice_row_vars: usize,
-    /// Number of column variables in the main Dory matrix
-    pub main_col_vars: usize,
-    /// Number of row variables in the main Dory matrix
-    pub main_row_vars: usize,
-    #[allocative(skip)]
-    pub cycle_phase_row_rounds: Range<usize>,
-    #[allocative(skip)]
-    pub cycle_phase_col_rounds: Range<usize>,
     pub r_val: OpeningPoint<BIG_ENDIAN, F>,
-    /// (little-endian) challenges for the cycle phase variables
-    pub cycle_var_challenges: Vec<F::Challenge>,
-}
-
-fn cycle_phase_round_schedule(
-    log_T: usize,
-    log_k_chunk: usize,
-    main_col_vars: usize,
-    advice_row_vars: usize,
-    advice_col_vars: usize,
-) -> (Range<usize>, Range<usize>) {
-    match DoryGlobals::get_layout() {
-        DoryLayout::CycleMajor => {
-            // Low-order cycle variables correspond to the low-order bits of the
-            // column index
-            let col_binding_rounds = 0..min(log_T, advice_col_vars);
-            // High-order cycle variables correspond to the low-order bits of the
-            // rows index
-            let row_binding_rounds =
-                min(log_T, main_col_vars)..min(log_T, main_col_vars + advice_row_vars);
-            (col_binding_rounds, row_binding_rounds)
-        }
-        DoryLayout::AddressMajor => {
-            // Low-order cycle variables correspond to the high-order bits of the
-            // column index
-            let col_binding_rounds = 0..advice_col_vars.saturating_sub(log_k_chunk);
-            // High-order cycle variables correspond to the bits of the row index
-            let row_binding_rounds = main_col_vars.saturating_sub(log_k_chunk)
-                ..min(
-                    log_T,
-                    main_col_vars.saturating_sub(log_k_chunk) + advice_row_vars,
-                );
-            (col_binding_rounds, row_binding_rounds)
-        }
-    }
 }
 
 impl<F: JoltField> AdviceClaimReductionParams<F> {
     pub fn new(
         kind: AdviceKind,
-        memory_layout: &MemoryLayout,
+        advice_size_bytes: usize,
         trace_len: usize,
+        scheduling_reference: PrecommittedSchedulingReference,
         accumulator: &dyn OpeningAccumulator<F>,
     ) -> Self {
-        let max_advice_size_bytes = match kind {
-            AdviceKind::Trusted => memory_layout.max_trusted_advice_size as usize,
-            AdviceKind::Untrusted => memory_layout.max_untrusted_advice_size as usize,
-        };
-
         let log_t = trace_len.log_2();
-        let log_k_chunk = OneHotConfig::new(log_t).log_k_chunk as usize;
-        let (main_col_vars, main_row_vars) = DoryGlobals::main_sigma_nu(log_k_chunk, log_t);
-
         let r_val = accumulator
             .get_advice_opening(kind, SumcheckId::RamValCheck)
             .map(|(p, _)| p)
             .unwrap();
 
         let (advice_col_vars, advice_row_vars) =
-            DoryGlobals::advice_sigma_nu_from_max_bytes(max_advice_size_bytes);
-        let (col_binding_rounds, row_binding_rounds) = cycle_phase_round_schedule(
-            log_t,
-            log_k_chunk,
-            main_col_vars,
+            DoryGlobals::advice_sigma_nu_from_max_bytes(advice_size_bytes);
+        let total_vars = advice_row_vars + advice_col_vars;
+        let precommitted = PrecommittedClaimReduction::new(
+            total_vars,
             advice_row_vars,
             advice_col_vars,
+            scheduling_reference,
         );
 
         Self {
             kind,
-            phase: ReductionPhase::CycleVariables,
+            phase: PrecommittedPhase::CycleVariables,
+            precommitted,
             advice_col_vars,
             advice_row_vars,
-            log_k_chunk,
             log_t,
-            main_col_vars,
-            main_row_vars,
-            cycle_phase_row_rounds: row_binding_rounds,
-            cycle_phase_col_rounds: col_binding_rounds,
             r_val,
-            cycle_var_challenges: vec![],
         }
     }
 
-    /// (Total # advice variables) - (# variables bound during cycle phase)
     pub fn num_address_phase_rounds(&self) -> usize {
-        (self.advice_col_vars + self.advice_row_vars)
-            - (self.cycle_phase_col_rounds.len() + self.cycle_phase_row_rounds.len())
+        self.precommitted.num_address_phase_rounds()
+    }
+
+    pub fn transition_to_address_phase(&mut self) {
+        self.phase = PrecommittedPhase::AddressVariables;
+    }
+
+    pub fn round_offset(&self, max_num_rounds: usize) -> usize {
+        self.precommitted.round_offset(
+            self.phase == PrecommittedPhase::CycleVariables,
+            max_num_rounds,
+        )
     }
 }
 
 impl<F: JoltField> SumcheckInstanceParams<F> for AdviceClaimReductionParams<F> {
     fn input_claim(&self, accumulator: &dyn OpeningAccumulator<F>) -> F {
         match self.phase {
-            ReductionPhase::CycleVariables => {
-                let mut claim = F::zero();
-                if let Some((_, eval)) =
-                    accumulator.get_advice_opening(self.kind, SumcheckId::RamValCheck)
-                {
-                    claim += eval;
-                }
-                claim
+            PrecommittedPhase::CycleVariables => {
+                accumulator
+                    .get_advice_opening(self.kind, SumcheckId::RamValCheck)
+                    .expect("RamValCheck advice opening missing")
+                    .1
             }
-            ReductionPhase::AddressVariables => {
-                // Address phase starts from the cycle phase intermediate claim.
+            PrecommittedPhase::AddressVariables => {
                 accumulator
                     .get_advice_opening(self.kind, SumcheckId::AdviceClaimReductionCyclePhase)
                     .expect("Cycle phase intermediate claim not found")
@@ -200,77 +113,39 @@ impl<F: JoltField> SumcheckInstanceParams<F> for AdviceClaimReductionParams<F> {
     }
 
     fn degree(&self) -> usize {
-        DEGREE_BOUND
+        TWO_PHASE_DEGREE_BOUND
     }
 
     fn num_rounds(&self) -> usize {
-        match self.phase {
-            ReductionPhase::CycleVariables => {
-                if !self.cycle_phase_row_rounds.is_empty() {
-                    self.cycle_phase_row_rounds.end - self.cycle_phase_col_rounds.start
-                } else {
-                    self.cycle_phase_col_rounds.len()
-                }
-            }
-            ReductionPhase::AddressVariables => {
-                let first_phase_rounds =
-                    self.cycle_phase_row_rounds.len() + self.cycle_phase_col_rounds.len();
-                // Total advice variables, minus the variables bound during the cycle phase
-                (self.advice_col_vars + self.advice_row_vars) - first_phase_rounds
-            }
-        }
+        self.precommitted
+            .num_rounds_for_phase(self.phase == PrecommittedPhase::CycleVariables)
     }
 
-    /// Rearrange the opening point so that it is big-endian with respect to the original,
-    /// unpermuted advice/EQ polynomials.
-    fn normalize_opening_point(
-        &self,
-        challenges: &[<F as JoltField>::Challenge],
-    ) -> OpeningPoint<BIG_ENDIAN, F> {
-        if self.phase == ReductionPhase::CycleVariables {
-            let advice_vars = self.advice_col_vars + self.advice_row_vars;
-            let mut advice_var_challenges: Vec<F::Challenge> = Vec::with_capacity(advice_vars);
-            advice_var_challenges
-                .extend_from_slice(&challenges[self.cycle_phase_col_rounds.clone()]);
-            advice_var_challenges
-                .extend_from_slice(&challenges[self.cycle_phase_row_rounds.clone()]);
-            return OpeningPoint::<LITTLE_ENDIAN, F>::new(advice_var_challenges).match_endianness();
-        }
-
-        match DoryGlobals::get_layout() {
-            DoryLayout::CycleMajor => OpeningPoint::<LITTLE_ENDIAN, F>::new(
-                [self.cycle_var_challenges.as_slice(), challenges].concat(),
-            )
-            .match_endianness(),
-            DoryLayout::AddressMajor => OpeningPoint::<LITTLE_ENDIAN, F>::new(
-                [challenges, self.cycle_var_challenges.as_slice()].concat(),
-            )
-            .match_endianness(),
-        }
+    fn normalize_opening_point(&self, challenges: &[F::Challenge]) -> OpeningPoint<BIG_ENDIAN, F> {
+        self.precommitted.normalize_opening_point(
+            self.phase == PrecommittedPhase::CycleVariables,
+            challenges,
+            self.log_t,
+        )
     }
 
     #[cfg(feature = "zk")]
     fn input_claim_constraint(&self) -> InputClaimConstraint {
-        match self.phase {
-            ReductionPhase::CycleVariables => {
-                let val_opening = match self.kind {
-                    AdviceKind::Trusted => OpeningId::TrustedAdvice(SumcheckId::RamValCheck),
-                    AdviceKind::Untrusted => OpeningId::UntrustedAdvice(SumcheckId::RamValCheck),
-                };
-                InputClaimConstraint::direct(val_opening)
-            }
-            ReductionPhase::AddressVariables => {
-                let cycle_phase_opening = match self.kind {
-                    AdviceKind::Trusted => {
-                        OpeningId::TrustedAdvice(SumcheckId::AdviceClaimReductionCyclePhase)
-                    }
-                    AdviceKind::Untrusted => {
-                        OpeningId::UntrustedAdvice(SumcheckId::AdviceClaimReductionCyclePhase)
-                    }
-                };
-                InputClaimConstraint::direct(cycle_phase_opening)
-            }
-        }
+        let opening = match self.phase {
+            PrecommittedPhase::CycleVariables => match self.kind {
+                AdviceKind::Trusted => OpeningId::TrustedAdvice(SumcheckId::RamValCheck),
+                AdviceKind::Untrusted => OpeningId::UntrustedAdvice(SumcheckId::RamValCheck),
+            },
+            PrecommittedPhase::AddressVariables => match self.kind {
+                AdviceKind::Trusted => {
+                    OpeningId::TrustedAdvice(SumcheckId::AdviceClaimReductionCyclePhase)
+                }
+                AdviceKind::Untrusted => {
+                    OpeningId::UntrustedAdvice(SumcheckId::AdviceClaimReductionCyclePhase)
+                }
+            },
+        };
+        InputClaimConstraint::direct(opening)
     }
 
     #[cfg(feature = "zk")]
@@ -281,236 +156,128 @@ impl<F: JoltField> SumcheckInstanceParams<F> for AdviceClaimReductionParams<F> {
     #[cfg(feature = "zk")]
     fn output_claim_constraint(&self) -> Option<OutputClaimConstraint> {
         match self.phase {
-            ReductionPhase::CycleVariables => {
-                if self.num_address_phase_rounds() > 0 {
-                    let advice_opening = match self.kind {
-                        AdviceKind::Trusted => {
-                            OpeningId::TrustedAdvice(SumcheckId::AdviceClaimReductionCyclePhase)
-                        }
-                        AdviceKind::Untrusted => {
-                            OpeningId::UntrustedAdvice(SumcheckId::AdviceClaimReductionCyclePhase)
-                        }
-                    };
-                    return Some(OutputClaimConstraint::direct(advice_opening));
-                }
-                self.final_advice_output_claim_constraint()
+            PrecommittedPhase::CycleVariables => {
+                let opening = match self.kind {
+                    AdviceKind::Trusted => {
+                        OpeningId::TrustedAdvice(SumcheckId::AdviceClaimReductionCyclePhase)
+                    }
+                    AdviceKind::Untrusted => {
+                        OpeningId::UntrustedAdvice(SumcheckId::AdviceClaimReductionCyclePhase)
+                    }
+                };
+                Some(OutputClaimConstraint::direct(opening))
             }
-            ReductionPhase::AddressVariables => self.final_advice_output_claim_constraint(),
+            PrecommittedPhase::AddressVariables => {
+                let opening = match self.kind {
+                    AdviceKind::Trusted => {
+                        OpeningId::TrustedAdvice(SumcheckId::AdviceClaimReduction)
+                    }
+                    AdviceKind::Untrusted => {
+                        OpeningId::UntrustedAdvice(SumcheckId::AdviceClaimReduction)
+                    }
+                };
+                Some(OutputClaimConstraint::linear(vec![(
+                    ValueSource::Challenge(0),
+                    ValueSource::Opening(opening),
+                )]))
+            }
         }
     }
 
     #[cfg(feature = "zk")]
     fn output_constraint_challenge_values(&self, sumcheck_challenges: &[F::Challenge]) -> Vec<F> {
         match self.phase {
-            ReductionPhase::CycleVariables if self.num_address_phase_rounds() > 0 => vec![],
-            ReductionPhase::CycleVariables | ReductionPhase::AddressVariables => {
-                vec![self.final_advice_output_scale(sumcheck_challenges)]
+            PrecommittedPhase::CycleVariables => vec![],
+            PrecommittedPhase::AddressVariables => {
+                let opening_point = self.normalize_opening_point(sumcheck_challenges);
+                let eq_eval = EqPolynomial::mle(&opening_point.r, &self.r_val.r);
+                let scale: F = precommitted_skip_round_scale(&self.precommitted);
+                vec![eq_eval * scale]
             }
         }
     }
 }
 
-impl<F: JoltField> AdviceClaimReductionParams<F> {
-    #[cfg(feature = "zk")]
-    fn final_advice_output_claim_constraint(&self) -> Option<OutputClaimConstraint> {
-        let advice_opening = match self.kind {
-            AdviceKind::Trusted => OpeningId::TrustedAdvice(SumcheckId::AdviceClaimReduction),
-            AdviceKind::Untrusted => OpeningId::UntrustedAdvice(SumcheckId::AdviceClaimReduction),
-        };
-        // output = (eq_combined * scale) * advice_claim
-        // Challenge(0) holds eq_combined * scale (computed in output_constraint_challenge_values)
-        Some(OutputClaimConstraint::linear(vec![(
-            ValueSource::Challenge(0),
-            ValueSource::Opening(advice_opening),
-        )]))
+impl<F: JoltField> PrecomittedParams<F> for AdviceClaimReductionParams<F> {
+    fn is_cycle_phase(&self) -> bool {
+        self.phase == PrecommittedPhase::CycleVariables
     }
 
-    fn final_advice_output_scale(&self, sumcheck_challenges: &[F::Challenge]) -> F {
-        let opening_point = self.normalize_opening_point(sumcheck_challenges);
-        let eq_eval = EqPolynomial::mle(&opening_point.r, &self.r_val.r);
+    fn is_cycle_phase_round(&self, round: usize) -> bool {
+        self.precommitted.is_cycle_phase_round(round)
+    }
 
-        let total_cycle_phase_rounds = if !self.cycle_phase_row_rounds.is_empty() {
-            self.cycle_phase_row_rounds.end - self.cycle_phase_col_rounds.start
-        } else {
-            self.cycle_phase_col_rounds.len()
-        };
-        let active_cycle_phase_rounds =
-            self.cycle_phase_col_rounds.len() + self.cycle_phase_row_rounds.len();
-        let dummy_rounds = total_cycle_phase_rounds.saturating_sub(active_cycle_phase_rounds);
+    fn is_address_phase_round(&self, round: usize) -> bool {
+        self.precommitted.is_address_phase_round(round)
+    }
 
-        let two_inv = F::from_u64(2).inverse().unwrap();
-        let scale = (0..dummy_rounds).fold(F::one(), |acc, _| acc * two_inv);
+    fn cycle_alignment_rounds(&self) -> usize {
+        self.precommitted.cycle_alignment_rounds()
+    }
 
-        eq_eval * scale
+    fn address_alignment_rounds(&self) -> usize {
+        self.precommitted.address_alignment_rounds()
+    }
+
+    fn record_cycle_challenge(&mut self, challenge: F::Challenge) {
+        self.precommitted.record_cycle_challenge(challenge);
     }
 }
 
 #[derive(Allocative)]
 pub struct AdviceClaimReductionProver<F: JoltField> {
-    pub params: AdviceClaimReductionParams<F>,
-    advice_poly: MultilinearPolynomial<F>,
-    eq_poly: MultilinearPolynomial<F>,
-    /// Maintains the running internal scaling factor 2^{-dummy_done}.
-    scale: F,
+    core: PrecomittedProver<F, AdviceClaimReductionParams<F>>,
 }
 
 impl<F: JoltField> AdviceClaimReductionProver<F> {
+    pub fn params(&self) -> &AdviceClaimReductionParams<F> {
+        self.core.params()
+    }
+
+    pub fn transition_to_address_phase(&mut self) {
+        self.core.params_mut().transition_to_address_phase();
+    }
+
     pub fn initialize(
         params: AdviceClaimReductionParams<F>,
         advice_poly: MultilinearPolynomial<F>,
     ) -> Self {
-        let eq_evals = EqPolynomial::evals(&params.r_val.r);
-
-        let main_cols = 1 << params.main_col_vars;
-        // Maps a (row, col) position in the Dory matrix layout to its
-        // implied (address, cycle).
-        let row_col_to_address_cycle = |row: usize, col: usize| -> (usize, usize) {
-            match DoryGlobals::get_layout() {
-                DoryLayout::CycleMajor => {
-                    let global_index = row as u128 * main_cols + col as u128;
-                    let address = global_index / (1 << params.log_t);
-                    let cycle = global_index % (1 << params.log_t);
-                    (address as usize, cycle as usize)
-                }
-                DoryLayout::AddressMajor => {
-                    let global_index = row as u128 * main_cols + col as u128;
-                    let address = global_index % (1 << params.log_k_chunk);
-                    let cycle = global_index / (1 << params.log_k_chunk);
-                    (address as usize, cycle as usize)
-                }
-            }
+        let eq_evals =
+            precommitted_eq_evals_with_scaling(&params.r_val.r, None, &params.precommitted);
+        let (advice_poly, eq_poly): (MultilinearPolynomial<F>, MultilinearPolynomial<F>) = {
+            let MultilinearPolynomial::U64Scalars(poly) = advice_poly else {
+                panic!("Advice should have u64 coefficients");
+            };
+            let mut permuted =
+                permute_precommitted_polys(vec![poly.coeffs], &params.precommitted).into_iter();
+            let advice_poly = permuted
+                .next()
+                .expect("expected one permuted advice polynomial");
+            let eq_poly = eq_evals.into();
+            (advice_poly, eq_poly)
         };
-
-        let advice_cols = 1 << params.advice_col_vars;
-        // Maps an index in the advice vector to its implied (address, cycle), based
-        // on the position the index maps to in the Dory matrix layout.
-        let advice_index_to_address_cycle = |index: usize| -> (usize, usize) {
-            let row = index / advice_cols;
-            let col = index % advice_cols;
-            row_col_to_address_cycle(row, col)
-        };
-
-        let mut permuted_coeffs: Vec<(usize, (u64, F))> = match advice_poly {
-            MultilinearPolynomial::U64Scalars(poly) => poly
-                .coeffs
-                .into_par_iter()
-                .zip(eq_evals.into_par_iter())
-                .enumerate()
-                .collect(),
-            _ => panic!("Advice should have u64 coefficients"),
-        };
-        // Sort the advice and EQ polynomial coefficients by (address, cycle).
-        // By sorting this way, binding the resulting polynomials in low-to-high
-        // order is equivalent to binding the original polynomials' "cycle" variables
-        // low-to-high, then their "address" variables low-to-high.
-        permuted_coeffs.par_sort_by(|&(index_a, _), &(index_b, _)| {
-            let (address_a, cycle_a) = advice_index_to_address_cycle(index_a);
-            let (address_b, cycle_b) = advice_index_to_address_cycle(index_b);
-            match address_a.cmp(&address_b) {
-                Ordering::Less => Ordering::Less,
-                Ordering::Greater => Ordering::Greater,
-                Ordering::Equal => cycle_a.cmp(&cycle_b),
-            }
-        });
-
-        let (advice_coeffs, eq_coeffs): (Vec<_>, Vec<_>) = permuted_coeffs
-            .into_par_iter()
-            .map(|(_, coeffs)| coeffs)
-            .unzip();
-        let advice_poly = advice_coeffs.into();
-        let eq_poly = eq_coeffs.into();
 
         Self {
-            params,
-            advice_poly,
-            eq_poly,
-            scale: F::one(),
+            core: PrecomittedProver::new(params, advice_poly, eq_poly),
         }
-    }
-
-    fn compute_message_unscaled(&mut self, previous_claim_unscaled: F) -> UniPoly<F> {
-        let half = self.advice_poly.len() / 2;
-        let evals: [F; DEGREE_BOUND] = (0..half)
-            .into_par_iter()
-            .map(|j| {
-                let a_evals = self
-                    .advice_poly
-                    .sumcheck_evals_array::<DEGREE_BOUND>(j, BindingOrder::LowToHigh);
-                let eq_evals = self
-                    .eq_poly
-                    .sumcheck_evals_array::<DEGREE_BOUND>(j, BindingOrder::LowToHigh);
-
-                let mut out = [F::zero(); DEGREE_BOUND];
-                for i in 0..DEGREE_BOUND {
-                    out[i] = a_evals[i] * eq_evals[i];
-                }
-                out
-            })
-            .reduce(
-                || [F::zero(); DEGREE_BOUND],
-                |mut acc, arr| {
-                    acc.par_iter_mut()
-                        .zip(arr.par_iter())
-                        .for_each(|(a, b)| *a += *b);
-                    acc
-                },
-            );
-        UniPoly::from_evals_and_hint(previous_claim_unscaled, &evals)
     }
 }
 
 impl<F: JoltField, T: Transcript> SumcheckInstanceProver<F, T> for AdviceClaimReductionProver<F> {
     fn get_params(&self) -> &dyn SumcheckInstanceParams<F> {
-        &self.params
+        self.core.params()
+    }
+
+    fn round_offset(&self, max_num_rounds: usize) -> usize {
+        self.core.params().round_offset(max_num_rounds)
     }
 
     fn compute_message(&mut self, round: usize, previous_claim: F) -> UniPoly<F> {
-        if self.params.phase == ReductionPhase::CycleVariables
-            && !self.params.cycle_phase_col_rounds.contains(&round)
-            && !self.params.cycle_phase_row_rounds.contains(&round)
-        {
-            // Current sumcheck variable does not appear in advice polynomial, so we
-            // can simply send a constant polynomial equal to the previous claim divided by 2
-            UniPoly::from_coeff(vec![previous_claim * F::from_u64(2).inverse().unwrap()])
-        } else {
-            // Account for (1) internal dummy rounds already traversed and
-            // (2) trailing dummy rounds after this instance's active window in the batched sumcheck.
-            let num_trailing_variables = match self.params.phase {
-                ReductionPhase::CycleVariables => {
-                    self.params.log_t.saturating_sub(self.params.num_rounds())
-                }
-                ReductionPhase::AddressVariables => self
-                    .params
-                    .log_k_chunk
-                    .saturating_sub(self.params.num_rounds()),
-            };
-            let scaling_factor = self.scale * F::one().mul_pow_2(num_trailing_variables);
-            let prev_unscaled = previous_claim * scaling_factor.inverse().unwrap();
-            let poly_unscaled = self.compute_message_unscaled(prev_unscaled);
-            poly_unscaled * scaling_factor
-        }
+        self.core.compute_message(round, previous_claim)
     }
 
     fn ingest_challenge(&mut self, r_j: F::Challenge, round: usize) {
-        match self.params.phase {
-            ReductionPhase::CycleVariables => {
-                if !self.params.cycle_phase_col_rounds.contains(&round)
-                    && !self.params.cycle_phase_row_rounds.contains(&round)
-                {
-                    // Each dummy internal round halves the running claim; equivalently, we multiply the
-                    // scaling factor by 1/2.
-                    self.scale *= F::from_u64(2).inverse().unwrap();
-                } else {
-                    self.advice_poly.bind_parallel(r_j, BindingOrder::LowToHigh);
-                    self.eq_poly.bind_parallel(r_j, BindingOrder::LowToHigh);
-                    self.params.cycle_var_challenges.push(r_j);
-                }
-            }
-            ReductionPhase::AddressVariables => {
-                self.advice_poly.bind_parallel(r_j, BindingOrder::LowToHigh);
-                self.eq_poly.bind_parallel(r_j, BindingOrder::LowToHigh);
-            }
-        }
+        self.core.ingest_challenge(r_j, round);
     }
 
     fn cache_openings(
@@ -518,43 +285,27 @@ impl<F: JoltField, T: Transcript> SumcheckInstanceProver<F, T> for AdviceClaimRe
         accumulator: &mut ProverOpeningAccumulator<F>,
         sumcheck_challenges: &[F::Challenge],
     ) {
-        let opening_point = self.params.normalize_opening_point(sumcheck_challenges);
-        if self.params.phase == ReductionPhase::CycleVariables {
-            // Compute the intermediate claim C_mid = (2^{-gap}) * Σ_y advice(y) * eq(y),
-            // where y are the remaining (address-derived) advice row variables.
-            let len = self.advice_poly.len();
-            debug_assert_eq!(len, self.eq_poly.len());
+        let params = self.core.params();
+        let opening_point = params.normalize_opening_point(sumcheck_challenges);
+        if params.phase == PrecommittedPhase::CycleVariables {
+            let c_mid = self.core.cycle_intermediate_claim();
 
-            let mut sum = F::zero();
-            for i in 0..len {
-                sum += self.advice_poly.get_bound_coeff(i) * self.eq_poly.get_bound_coeff(i);
-            }
-            let c_mid = sum * self.scale;
-
-            match self.params.kind {
+            match params.kind {
                 AdviceKind::Trusted => accumulator.append_trusted_advice(
                     SumcheckId::AdviceClaimReductionCyclePhase,
-                    // This is a phase-boundary intermediate reduction claim (c_mid), not an advice
-                    // polynomial opening. Store it without an opening point so it can't be deduped
-                    // against the final advice opening.
                     OpeningPoint::<BIG_ENDIAN, F>::new(vec![]),
                     c_mid,
                 ),
                 AdviceKind::Untrusted => accumulator.append_untrusted_advice(
                     SumcheckId::AdviceClaimReductionCyclePhase,
-                    // This is a phase-boundary intermediate reduction claim (c_mid), not an advice
-                    // polynomial opening. Store it without an opening point so it can't be deduped
-                    // against the final advice opening.
                     OpeningPoint::<BIG_ENDIAN, F>::new(vec![]),
                     c_mid,
                 ),
             }
         }
 
-        // If we're done binding advice variables, cache the final advice opening
-        if self.advice_poly.len() == 1 {
-            let advice_claim = self.advice_poly.final_sumcheck_claim();
-            match self.params.kind {
+        if let Some(advice_claim) = self.core.final_claim_if_ready() {
+            match params.kind {
                 AdviceKind::Trusted => accumulator.append_trusted_advice(
                     SumcheckId::AdviceClaimReduction,
                     opening_point,
@@ -567,10 +318,6 @@ impl<F: JoltField, T: Transcript> SumcheckInstanceProver<F, T> for AdviceClaimRe
                 ),
             }
         }
-    }
-
-    fn round_offset(&self, _max_num_rounds: usize) -> usize {
-        0
     }
 
     #[cfg(feature = "allocative")]
@@ -586,11 +333,18 @@ pub struct AdviceClaimReductionVerifier<F: JoltField> {
 impl<F: JoltField> AdviceClaimReductionVerifier<F> {
     pub fn new(
         kind: AdviceKind,
-        memory_layout: &MemoryLayout,
+        advice_size_bytes: usize,
         trace_len: usize,
-        accumulator: &dyn OpeningAccumulator<F>,
+        scheduling_reference: PrecommittedSchedulingReference,
+        accumulator: &VerifierOpeningAccumulator<F>,
     ) -> Self {
-        let params = AdviceClaimReductionParams::new(kind, memory_layout, trace_len, accumulator);
+        let params = AdviceClaimReductionParams::new(
+            kind,
+            advice_size_bytes,
+            trace_len,
+            scheduling_reference,
+            accumulator,
+        );
 
         Self {
             params: RefCell::new(params),
@@ -598,60 +352,65 @@ impl<F: JoltField> AdviceClaimReductionVerifier<F> {
     }
 }
 
-impl<F: JoltField, T: Transcript, A: AbstractVerifierOpeningAccumulator<F>>
-    SumcheckInstanceVerifier<F, T, A> for AdviceClaimReductionVerifier<F>
+impl<F: JoltField, T: Transcript> SumcheckInstanceVerifier<F, T>
+    for AdviceClaimReductionVerifier<F>
 {
     fn get_params(&self) -> &dyn SumcheckInstanceParams<F> {
         unsafe { &*self.params.as_ptr() }
     }
 
-    fn expected_output_claim(&self, accumulator: &A, sumcheck_challenges: &[F::Challenge]) -> F {
+    fn expected_output_claim(
+        &self,
+        accumulator: &VerifierOpeningAccumulator<F>,
+        sumcheck_challenges: &[F::Challenge],
+    ) -> F {
         let params = self.params.borrow();
         match params.phase {
-            ReductionPhase::CycleVariables if params.num_address_phase_rounds() > 0 => {
+            PrecommittedPhase::CycleVariables => {
                 accumulator
                     .get_advice_opening(params.kind, SumcheckId::AdviceClaimReductionCyclePhase)
-                    .unwrap_or_else(|| panic!("Cycle phase intermediate claim not found",))
+                    .unwrap_or_else(|| panic!("Cycle phase intermediate claim not found"))
                     .1
             }
-            ReductionPhase::CycleVariables | ReductionPhase::AddressVariables => {
+            PrecommittedPhase::AddressVariables => {
+                let opening_point = params.normalize_opening_point(sumcheck_challenges);
                 let advice_claim = accumulator
                     .get_advice_opening(params.kind, SumcheckId::AdviceClaimReduction)
                     .expect("Final advice claim not found")
                     .1;
-
-                // Account for Phase 1's internal dummy-gap traversal via constant scaling.
-                advice_claim * params.final_advice_output_scale(sumcheck_challenges)
+                let eq_eval = EqPolynomial::mle(&opening_point.r, &params.r_val.r);
+                let scale: F = precommitted_skip_round_scale(&params.precommitted);
+                advice_claim * eq_eval * scale
             }
         }
     }
 
-    fn cache_openings(&self, accumulator: &mut A, sumcheck_challenges: &[F::Challenge]) {
+    fn cache_openings(
+        &self,
+        accumulator: &mut VerifierOpeningAccumulator<F>,
+        sumcheck_challenges: &[F::Challenge],
+    ) {
         let mut params = self.params.borrow_mut();
-        if params.phase == ReductionPhase::CycleVariables {
+        if params.phase == PrecommittedPhase::CycleVariables {
             let opening_point = params.normalize_opening_point(sumcheck_challenges);
             match params.kind {
                 AdviceKind::Trusted => accumulator.append_trusted_advice(
                     SumcheckId::AdviceClaimReductionCyclePhase,
-                    // This is a phase-boundary intermediate reduction claim (c_mid), not an advice
-                    // polynomial opening. Store it without an opening point so it can't be deduped
-                    // against the final advice opening.
                     OpeningPoint::<BIG_ENDIAN, F>::new(vec![]),
                 ),
                 AdviceKind::Untrusted => accumulator.append_untrusted_advice(
                     SumcheckId::AdviceClaimReductionCyclePhase,
-                    // This is a phase-boundary intermediate reduction claim (c_mid), not an advice
-                    // polynomial opening. Store it without an opening point so it can't be deduped
-                    // against the final advice opening.
                     OpeningPoint::<BIG_ENDIAN, F>::new(vec![]),
                 ),
             }
             let opening_point_le: OpeningPoint<LITTLE_ENDIAN, F> = opening_point.match_endianness();
-            params.cycle_var_challenges = opening_point_le.r;
+            params
+                .precommitted
+                .set_cycle_var_challenges(opening_point_le.r);
         }
 
         if params.num_address_phase_rounds() == 0
-            || params.phase == ReductionPhase::AddressVariables
+            || params.phase == PrecommittedPhase::AddressVariables
         {
             let opening_point = params.normalize_opening_point(sumcheck_challenges);
             match params.kind {
@@ -663,45 +422,8 @@ impl<F: JoltField, T: Transcript, A: AbstractVerifierOpeningAccumulator<F>>
         }
     }
 
-    fn round_offset(&self, _max_num_rounds: usize) -> usize {
-        0
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use ark_bn254::Fr;
-
-    type Challenge = <Fr as JoltField>::Challenge;
-
-    #[test]
-    fn final_advice_output_scale_counts_leading_dummy_rounds_when_col_range_is_empty() {
-        let challenges = [11, 12, 0]
-            .map(|value| Challenge::from(value as u128))
-            .to_vec();
-        let active_opening_point =
-            OpeningPoint::<LITTLE_ENDIAN, Fr>::new(challenges[2..3].to_vec()).match_endianness();
-        let params = AdviceClaimReductionParams {
-            kind: AdviceKind::Trusted,
-            phase: ReductionPhase::CycleVariables,
-            log_k_chunk: 2,
-            log_t: 6,
-            advice_col_vars: 1,
-            advice_row_vars: 1,
-            main_col_vars: 4,
-            main_row_vars: 4,
-            cycle_phase_col_rounds: 0..0,
-            cycle_phase_row_rounds: 2..3,
-            r_val: active_opening_point,
-            cycle_var_challenges: vec![],
-        };
-
-        let two_inv = Fr::from_u64(2).inverse().unwrap();
-
-        assert_eq!(
-            params.final_advice_output_scale(&challenges),
-            two_inv * two_inv
-        );
+    fn round_offset(&self, max_num_rounds: usize) -> usize {
+        let params = self.params.borrow();
+        params.round_offset(max_num_rounds)
     }
 }

--- a/jolt-core/src/zkvm/claim_reductions/mod.rs
+++ b/jolt-core/src/zkvm/claim_reductions/mod.rs
@@ -2,6 +2,7 @@ pub mod advice;
 pub mod hamming_weight;
 pub mod increments;
 pub mod instruction_lookups;
+mod precommitted;
 pub mod ram_ra;
 pub mod registers;
 
@@ -20,6 +21,11 @@ pub use increments::{
 pub use instruction_lookups::{
     InstructionLookupsClaimReductionSumcheckParams, InstructionLookupsClaimReductionSumcheckProver,
     InstructionLookupsClaimReductionSumcheckVerifier,
+};
+pub use precommitted::{
+    permute_precommitted_polys, precommitted_eq_evals_with_scaling, precommitted_skip_round_scale,
+    PrecomittedParams, PrecomittedProver, PrecommittedClaimReduction, PrecommittedEmbeddingMode,
+    PrecommittedPhase, PrecommittedSchedulingReference, TWO_PHASE_DEGREE_BOUND,
 };
 pub use ram_ra::{
     RaReductionParams, RamRaClaimReductionSumcheckProver, RamRaClaimReductionSumcheckVerifier,

--- a/jolt-core/src/zkvm/claim_reductions/mod.rs
+++ b/jolt-core/src/zkvm/claim_reductions/mod.rs
@@ -8,7 +8,7 @@ pub mod registers;
 
 pub use advice::{
     AdviceClaimReductionParams, AdviceClaimReductionProver, AdviceClaimReductionVerifier,
-    AdviceKind, ReductionPhase,
+    AdviceKind,
 };
 pub use hamming_weight::{
     HammingWeightClaimReductionParams, HammingWeightClaimReductionProver,

--- a/jolt-core/src/zkvm/claim_reductions/mod.rs
+++ b/jolt-core/src/zkvm/claim_reductions/mod.rs
@@ -24,8 +24,8 @@ pub use instruction_lookups::{
 };
 pub use precommitted::{
     permute_precommitted_polys, precommitted_eq_evals_with_scaling, precommitted_skip_round_scale,
-    PrecomittedParams, PrecomittedProver, PrecommittedClaimReduction, PrecommittedEmbeddingMode,
-    PrecommittedPhase, PrecommittedSchedulingReference, TWO_PHASE_DEGREE_BOUND,
+    precommitted_sumcheck_inverse_index_permutation, PrecommittedClaimReduction, PrecommittedPhase,
+    PrecommittedSchedulingReference, TWO_PHASE_DEGREE_BOUND,
 };
 pub use ram_ra::{
     RaReductionParams, RamRaClaimReductionSumcheckProver, RamRaClaimReductionSumcheckVerifier,

--- a/jolt-core/src/zkvm/claim_reductions/mod.rs
+++ b/jolt-core/src/zkvm/claim_reductions/mod.rs
@@ -24,8 +24,8 @@ pub use instruction_lookups::{
 };
 pub use precommitted::{
     permute_precommitted_polys, precommitted_eq_evals_with_scaling, precommitted_skip_round_scale,
-    precommitted_sumcheck_inverse_index_permutation, PrecommittedClaimReduction, PrecommittedPhase,
-    PrecommittedSchedulingReference, TWO_PHASE_DEGREE_BOUND,
+    precommitted_sumcheck_inverse_index_permutation, PrecommittedClaimReduction,
+    PrecommittedParams, PrecommittedPhase, PrecommittedSchedulingReference, TWO_PHASE_DEGREE_BOUND,
 };
 pub use ram_ra::{
     RaReductionParams, RamRaClaimReductionSumcheckProver, RamRaClaimReductionSumcheckVerifier,

--- a/jolt-core/src/zkvm/claim_reductions/precommitted.rs
+++ b/jolt-core/src/zkvm/claim_reductions/precommitted.rs
@@ -1,0 +1,615 @@
+use allocative::Allocative;
+use rayon::prelude::*;
+
+use crate::field::JoltField;
+use crate::poly::commitment::dory::{DoryGlobals, DoryLayout};
+use crate::poly::eq_poly::EqPolynomial;
+use crate::poly::multilinear_polynomial::{BindingOrder, MultilinearPolynomial, PolynomialBinding};
+use crate::poly::opening_proof::{OpeningPoint, BIG_ENDIAN, LITTLE_ENDIAN};
+use crate::poly::unipoly::UniPoly;
+use crate::subprotocols::sumcheck_verifier::SumcheckInstanceParams;
+use crate::utils::math::Math;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Allocative)]
+pub enum PrecommittedEmbeddingMode {
+    DominantPrecommitted,
+    EmbeddedPrecommitted,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Allocative)]
+pub enum PrecommittedPhase {
+    CycleVariables,
+    AddressVariables,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Allocative)]
+pub struct PrecommittedSchedulingReference {
+    pub main_total_vars: usize,
+    pub reference_total_vars: usize,
+    pub cycle_alignment_rounds: usize,
+    pub address_rounds: usize,
+    pub joint_col_vars: usize,
+}
+
+#[derive(Debug, Clone, Allocative)]
+pub struct PrecommittedClaimReduction<F: JoltField> {
+    pub scheduling_reference: PrecommittedSchedulingReference,
+    pub embedding_mode: PrecommittedEmbeddingMode,
+    pub cycle_var_challenges: Vec<F::Challenge>,
+    dory_opening_round_permutation_be: Vec<usize>,
+    poly_opening_round_permutation_be: Vec<usize>,
+    cycle_phase_rounds: Vec<usize>,
+    cycle_phase_total_rounds: usize,
+    address_phase_rounds: Vec<usize>,
+    address_phase_total_rounds: usize,
+}
+
+impl<F: JoltField> PrecommittedClaimReduction<F> {
+    /// Compute shared scheduling dimensions from Main and precommitted candidates.
+    ///
+    /// `reference_total_vars` is the largest total var count across Main and candidates.
+    pub fn scheduling_reference(
+        main_total_vars: usize,
+        candidates: &[usize],
+    ) -> PrecommittedSchedulingReference {
+        let address_rounds = DoryGlobals::main_k().log_2();
+        let max_precommitted = candidates.iter().copied().max().unwrap_or(0);
+        let reference_total_vars = std::cmp::max(main_total_vars, max_precommitted);
+        let cycle_alignment_rounds = reference_total_vars.saturating_sub(address_rounds);
+        let (reference_sigma, _) = DoryGlobals::balanced_sigma_nu(reference_total_vars);
+        let joint_col_vars = std::cmp::max(
+            DoryGlobals::configured_main_num_columns().log_2(),
+            reference_sigma,
+        );
+        PrecommittedSchedulingReference {
+            main_total_vars,
+            reference_total_vars,
+            cycle_alignment_rounds,
+            address_rounds,
+            joint_col_vars,
+        }
+    }
+
+    #[inline]
+    pub fn new(
+        poly_total_vars: usize,
+        poly_row_vars: usize,
+        poly_col_vars: usize,
+        scheduling_reference: PrecommittedSchedulingReference,
+    ) -> Self {
+        let has_precommitted_dominance =
+            scheduling_reference.reference_total_vars > scheduling_reference.main_total_vars;
+        let embedding_mode = Self::embedding_mode_for_poly(poly_total_vars, &scheduling_reference);
+        let dory_opening_round_permutation_be = Self::reference_dory_opening_round_permutation_be(
+            &scheduling_reference,
+            has_precommitted_dominance,
+            DoryGlobals::main_t().log_2(),
+        );
+        let poly_opening_round_permutation_be = Self::project_dory_round_permutation_for_poly(
+            &dory_opening_round_permutation_be,
+            &scheduling_reference,
+            poly_row_vars,
+            poly_col_vars,
+        );
+        let (cycle_phase_rounds, address_phase_rounds) = Self::active_rounds_from_poly_permutation(
+            &poly_opening_round_permutation_be,
+            scheduling_reference.cycle_alignment_rounds,
+        );
+        Self {
+            scheduling_reference,
+            embedding_mode,
+            cycle_var_challenges: vec![],
+            dory_opening_round_permutation_be,
+            poly_opening_round_permutation_be,
+            cycle_phase_rounds,
+            cycle_phase_total_rounds: scheduling_reference.cycle_alignment_rounds,
+            address_phase_rounds,
+            address_phase_total_rounds: scheduling_reference.address_rounds,
+        }
+    }
+
+    #[inline]
+    fn embedding_mode_for_poly(
+        poly_total_vars: usize,
+        reference: &PrecommittedSchedulingReference,
+    ) -> PrecommittedEmbeddingMode {
+        let has_precommitted_dominance = reference.reference_total_vars > reference.main_total_vars;
+        let embedding_mode =
+            if has_precommitted_dominance && poly_total_vars == reference.reference_total_vars {
+                PrecommittedEmbeddingMode::DominantPrecommitted
+            } else {
+                PrecommittedEmbeddingMode::EmbeddedPrecommitted
+            };
+        if embedding_mode == PrecommittedEmbeddingMode::DominantPrecommitted {
+            assert_eq!(poly_total_vars, reference.reference_total_vars);
+        }
+        embedding_mode
+    }
+
+    fn reference_dory_opening_round_permutation_be(
+        reference: &PrecommittedSchedulingReference,
+        has_precommitted_dominance: bool,
+        dense_cycle_prefix_rounds: usize,
+    ) -> Vec<usize> {
+        let cycle_rounds = reference.cycle_alignment_rounds;
+        let address_rounds = reference.address_rounds;
+        let total_rounds = cycle_rounds + address_rounds;
+        if has_precommitted_dominance {
+            let address_rev = (cycle_rounds..total_rounds).rev();
+            match DoryGlobals::get_layout() {
+                DoryLayout::CycleMajor => {
+                    let t = dense_cycle_prefix_rounds.min(cycle_rounds);
+                    let prefix_rev = (0..cycle_rounds.saturating_sub(t)).rev();
+                    let dense_rev = (cycle_rounds.saturating_sub(t)..cycle_rounds).rev();
+                    return prefix_rev.chain(address_rev).chain(dense_rev).collect();
+                }
+                DoryLayout::AddressMajor => {
+                    let t = dense_cycle_prefix_rounds.min(cycle_rounds);
+                    let prefix_rev = (0..cycle_rounds.saturating_sub(t)).rev();
+                    let dense_rev = (cycle_rounds.saturating_sub(t)..cycle_rounds).rev();
+                    return dense_rev.chain(address_rev).chain(prefix_rev).collect();
+                }
+            }
+        }
+
+        match DoryGlobals::get_layout() {
+            DoryLayout::CycleMajor => (0..total_rounds).rev().collect(),
+            DoryLayout::AddressMajor => {
+                let cycle_rev = (0..cycle_rounds).rev();
+                let address_rev = (cycle_rounds..total_rounds).rev();
+                cycle_rev.chain(address_rev).collect()
+            }
+        }
+    }
+
+    fn project_dory_round_permutation_for_poly(
+        dory_opening_round_permutation_be: &[usize],
+        reference: &PrecommittedSchedulingReference,
+        poly_row_vars: usize,
+        poly_col_vars: usize,
+    ) -> Vec<usize> {
+        let total_full = reference.reference_total_vars;
+        let sigma_full = reference.joint_col_vars;
+        let nu_full = total_full.saturating_sub(sigma_full);
+        assert_eq!(
+            dory_opening_round_permutation_be.len(),
+            total_full,
+            "reference dory round permutation length mismatch",
+        );
+        assert!(
+            poly_row_vars <= nu_full && poly_col_vars <= sigma_full,
+            "top-left projection requires poly dims <= full dims (poly row/col vars={poly_row_vars}/{poly_col_vars}, full row/col vars={nu_full}/{sigma_full})"
+        );
+        let row_be = &dory_opening_round_permutation_be[..nu_full];
+        let col_be = &dory_opening_round_permutation_be[nu_full..nu_full + sigma_full];
+        let row_tail = &row_be[nu_full - poly_row_vars..];
+        let col_tail = &col_be[sigma_full - poly_col_vars..];
+        [row_tail, col_tail].concat()
+    }
+
+    fn active_rounds_from_poly_permutation(
+        poly_opening_round_permutation_be: &[usize],
+        cycle_alignment_rounds: usize,
+    ) -> (Vec<usize>, Vec<usize>) {
+        let mut cycle_phase_rounds = Vec::new();
+        let mut address_phase_rounds = Vec::new();
+        for &global_round in poly_opening_round_permutation_be.iter() {
+            if global_round < cycle_alignment_rounds {
+                cycle_phase_rounds.push(global_round);
+            } else {
+                address_phase_rounds.push(global_round - cycle_alignment_rounds);
+            }
+        }
+        cycle_phase_rounds.sort_unstable();
+        cycle_phase_rounds.dedup();
+        address_phase_rounds.sort_unstable();
+        address_phase_rounds.dedup();
+        (cycle_phase_rounds, address_phase_rounds)
+    }
+
+    #[inline]
+    pub fn num_address_phase_rounds(&self) -> usize {
+        self.address_phase_rounds.len()
+    }
+
+    #[inline]
+    pub fn is_cycle_phase_round(&self, round: usize) -> bool {
+        self.cycle_phase_rounds
+            .iter()
+            .any(|&scheduled| scheduled == round)
+    }
+
+    #[inline]
+    pub fn is_address_phase_round(&self, round: usize) -> bool {
+        self.address_phase_rounds
+            .iter()
+            .any(|&scheduled| scheduled == round)
+    }
+
+    #[inline]
+    pub fn cycle_alignment_rounds(&self) -> usize {
+        self.scheduling_reference.cycle_alignment_rounds
+    }
+
+    #[inline]
+    pub fn address_alignment_rounds(&self) -> usize {
+        self.scheduling_reference.address_rounds
+    }
+
+    #[inline]
+    pub fn num_rounds_for_phase(&self, is_cycle_phase: bool) -> usize {
+        if is_cycle_phase {
+            self.cycle_phase_total_rounds
+        } else {
+            self.address_phase_total_rounds
+        }
+    }
+
+    pub fn round_offset(&self, is_cycle_phase: bool, max_num_rounds: usize) -> usize {
+        let _ = (is_cycle_phase, max_num_rounds);
+        0
+    }
+
+    fn cycle_challenge_for_round(&self, round: usize) -> F::Challenge {
+        let idx = self
+            .cycle_phase_rounds
+            .iter()
+            .position(|&scheduled_round| scheduled_round == round)
+            .unwrap_or_else(|| {
+                panic!(
+                    "missing recorded cycle challenge for round={} (active rounds={:?})",
+                    round, self.cycle_phase_rounds
+                )
+            });
+        assert!(
+            idx < self.cycle_var_challenges.len(),
+            "cycle challenge vector too short: idx={} len={}",
+            idx,
+            self.cycle_var_challenges.len()
+        );
+        self.cycle_var_challenges[idx]
+    }
+
+    pub fn normalize_opening_point(
+        &self,
+        is_cycle_phase: bool,
+        challenges: &[F::Challenge],
+        dense_cycle_prefix_rounds: usize,
+    ) -> OpeningPoint<BIG_ENDIAN, F> {
+        let _ = dense_cycle_prefix_rounds;
+        if is_cycle_phase {
+            let local_cycle_challenges: Vec<F::Challenge> = self
+                .cycle_phase_rounds
+                .iter()
+                .map(|&round| {
+                    assert!(
+                        round < challenges.len(),
+                        "cycle round index out of local bounds: round={} local_len={}",
+                        round,
+                        challenges.len()
+                    );
+                    challenges[round]
+                })
+                .collect();
+            return OpeningPoint::<LITTLE_ENDIAN, F>::new(local_cycle_challenges)
+                .match_endianness();
+        }
+
+        debug_assert_eq!(
+            self.dory_opening_round_permutation_be.len(),
+            self.scheduling_reference.reference_total_vars
+        );
+        let cycle_round_limit = self.cycle_alignment_rounds();
+        let opening_rounds = &self.poly_opening_round_permutation_be;
+        let mut opening_point_be = Vec::with_capacity(opening_rounds.len());
+        for &global_round in opening_rounds.iter() {
+            if global_round < cycle_round_limit {
+                opening_point_be.push(self.cycle_challenge_for_round(global_round));
+            } else {
+                let address_round = global_round - cycle_round_limit;
+                assert!(
+                    address_round < challenges.len(),
+                    "address round index out of local bounds: round={} local_len={}",
+                    address_round,
+                    challenges.len()
+                );
+                opening_point_be.push(challenges[address_round]);
+            }
+        }
+        OpeningPoint::<BIG_ENDIAN, F>::new(opening_point_be)
+    }
+
+    #[inline]
+    pub fn record_cycle_challenge(&mut self, challenge: F::Challenge) {
+        self.cycle_var_challenges.push(challenge);
+    }
+
+    #[inline]
+    pub fn set_cycle_var_challenges(&mut self, challenges: Vec<F::Challenge>) {
+        self.cycle_var_challenges = challenges;
+    }
+}
+
+pub fn permute_precommitted_polys<V: Copy + Send + Sync, F: JoltField>(
+    coeffs_by_poly: Vec<Vec<V>>,
+    precommitted: &PrecommittedClaimReduction<F>,
+) -> Vec<MultilinearPolynomial<F>>
+where
+    MultilinearPolynomial<F>: From<Vec<V>>,
+{
+    if coeffs_by_poly.is_empty() {
+        return Vec::new();
+    }
+    let coeffs_len = coeffs_by_poly[0].len();
+    assert!(
+        coeffs_by_poly
+            .iter()
+            .all(|coeffs| coeffs.len() == coeffs_len),
+        "all precommitted polynomials must have equal coefficient lengths",
+    );
+    let inverse_permutation = precommitted_sumcheck_inverse_index_permutation(
+        coeffs_len,
+        &precommitted.poly_opening_round_permutation_be,
+    );
+    let permuted_coeffs_by_poly: Vec<Vec<V>> =
+        if let Some(inverse_permutation) = inverse_permutation {
+            coeffs_by_poly
+                .into_iter()
+                .map(|coeffs| {
+                    (0..coeffs_len)
+                        .into_par_iter()
+                        .map(|new_idx| {
+                            let old_idx = inverse_permutation[new_idx];
+                            coeffs[old_idx]
+                        })
+                        .collect()
+                })
+                .collect()
+        } else {
+            coeffs_by_poly
+        };
+    permuted_coeffs_by_poly
+        .into_iter()
+        .map(Into::into)
+        .collect()
+}
+
+pub fn precommitted_eq_evals_with_scaling<F: JoltField>(
+    challenges_be: &[F::Challenge],
+    scaling_factor: Option<F>,
+    precommitted: &PrecommittedClaimReduction<F>,
+) -> Vec<F>
+where
+    F: std::ops::Mul<F::Challenge, Output = F> + std::ops::SubAssign<F>,
+{
+    let permuted_challenges = precommitted_permute_eq_challenges(
+        challenges_be,
+        &precommitted.poly_opening_round_permutation_be,
+    );
+    if let Some(permuted_challenges) = permuted_challenges {
+        EqPolynomial::evals_with_scaling(&permuted_challenges, scaling_factor)
+    } else {
+        EqPolynomial::evals_with_scaling(challenges_be, scaling_factor)
+    }
+}
+
+fn precommitted_permute_eq_challenges<C: Copy>(
+    challenges_be: &[C],
+    poly_opening_round_permutation_be: &[usize],
+) -> Option<Vec<C>> {
+    let old_lsb_to_new_lsb =
+        precommitted_sumcheck_lsb_permutation(poly_opening_round_permutation_be)?;
+    assert_eq!(
+        challenges_be.len(),
+        old_lsb_to_new_lsb.len(),
+        "challenge vector length mismatch for precommitted eq permutation",
+    );
+    let num_vars = challenges_be.len();
+    let mut permuted_challenges = challenges_be.to_vec();
+    for old_be in 0..num_vars {
+        let old_lsb = num_vars - 1 - old_be;
+        let new_lsb = old_lsb_to_new_lsb[old_lsb];
+        let new_be = num_vars - 1 - new_lsb;
+        permuted_challenges[new_be] = challenges_be[old_be];
+    }
+    Some(permuted_challenges)
+}
+
+fn precommitted_sumcheck_lsb_permutation(
+    poly_opening_round_permutation_be: &[usize],
+) -> Option<Vec<usize>> {
+    let num_vars = poly_opening_round_permutation_be.len();
+    let mut be_var_by_round: Vec<usize> = (0..num_vars).collect();
+    be_var_by_round.sort_unstable_by_key(|&be_idx| poly_opening_round_permutation_be[be_idx]);
+
+    let mut old_lsb_to_new_lsb = vec![0usize; num_vars];
+    for (new_lsb, be_var_idx) in be_var_by_round.into_iter().enumerate() {
+        let old_lsb = num_vars - 1 - be_var_idx;
+        old_lsb_to_new_lsb[old_lsb] = new_lsb;
+    }
+
+    if old_lsb_to_new_lsb
+        .iter()
+        .enumerate()
+        .all(|(old_lsb, &new_lsb)| old_lsb == new_lsb)
+    {
+        return None;
+    }
+    Some(old_lsb_to_new_lsb)
+}
+
+fn precommitted_sumcheck_inverse_index_permutation(
+    coeffs_len: usize,
+    poly_opening_round_permutation_be: &[usize],
+) -> Option<Vec<usize>> {
+    let num_vars = poly_opening_round_permutation_be.len();
+    assert_eq!(
+        coeffs_len,
+        1usize << num_vars,
+        "precommitted coeff vector length mismatch: len={} expected=2^{}",
+        coeffs_len,
+        num_vars
+    );
+    let old_lsb_to_new_lsb =
+        precommitted_sumcheck_lsb_permutation(poly_opening_round_permutation_be)?;
+
+    let mut new_lsb_to_old_lsb = vec![0usize; num_vars];
+    for (old_lsb, &new_lsb) in old_lsb_to_new_lsb.iter().enumerate() {
+        new_lsb_to_old_lsb[new_lsb] = old_lsb;
+    }
+
+    let inverse_permutation: Vec<usize> = (0..coeffs_len)
+        .into_par_iter()
+        .map(|new_idx| {
+            let mut old_idx = 0usize;
+            for new_lsb in 0..num_vars {
+                let bit = (new_idx >> new_lsb) & 1usize;
+                let old_lsb = new_lsb_to_old_lsb[new_lsb];
+                old_idx |= bit << old_lsb;
+            }
+            old_idx
+        })
+        .collect();
+    Some(inverse_permutation)
+}
+
+pub const TWO_PHASE_DEGREE_BOUND: usize = 2;
+
+pub trait PrecomittedParams<F: JoltField>: SumcheckInstanceParams<F> {
+    fn is_cycle_phase(&self) -> bool;
+    fn is_cycle_phase_round(&self, round: usize) -> bool;
+    fn is_address_phase_round(&self, round: usize) -> bool;
+    fn cycle_alignment_rounds(&self) -> usize;
+    fn address_alignment_rounds(&self) -> usize;
+    fn record_cycle_challenge(&mut self, challenge: F::Challenge);
+}
+
+#[derive(Allocative)]
+pub struct PrecomittedProver<F: JoltField, P: PrecomittedParams<F>> {
+    params: P,
+    value_poly: MultilinearPolynomial<F>,
+    eq_poly: MultilinearPolynomial<F>,
+    scale: F,
+}
+
+impl<F: JoltField, P: PrecomittedParams<F>> PrecomittedProver<F, P> {
+    pub fn new(
+        params: P,
+        value_poly: MultilinearPolynomial<F>,
+        eq_poly: MultilinearPolynomial<F>,
+    ) -> Self {
+        Self {
+            params,
+            value_poly,
+            eq_poly,
+            scale: F::one(),
+        }
+    }
+
+    pub fn params(&self) -> &P {
+        &self.params
+    }
+
+    pub fn params_mut(&mut self) -> &mut P {
+        &mut self.params
+    }
+
+    fn compute_message_unscaled(&self, previous_claim_unscaled: F) -> UniPoly<F> {
+        let half = self.value_poly.len() / 2;
+        let value_poly = &self.value_poly;
+        let eq_poly = &self.eq_poly;
+        let evals: [F; TWO_PHASE_DEGREE_BOUND] = (0..half)
+            .into_par_iter()
+            .map(|j| {
+                let value_evals = value_poly
+                    .sumcheck_evals_array::<TWO_PHASE_DEGREE_BOUND>(j, BindingOrder::LowToHigh);
+                let eq_evals = eq_poly
+                    .sumcheck_evals_array::<TWO_PHASE_DEGREE_BOUND>(j, BindingOrder::LowToHigh);
+
+                let mut out = [F::zero(); TWO_PHASE_DEGREE_BOUND];
+                for i in 0..TWO_PHASE_DEGREE_BOUND {
+                    out[i] = value_evals[i] * eq_evals[i];
+                }
+                out
+            })
+            .reduce(
+                || [F::zero(); TWO_PHASE_DEGREE_BOUND],
+                |mut acc, arr| {
+                    acc.iter_mut().zip(arr.iter()).for_each(|(a, b)| *a += *b);
+                    acc
+                },
+            );
+        UniPoly::from_evals_and_hint(previous_claim_unscaled, &evals)
+    }
+
+    pub fn compute_message(&mut self, round: usize, previous_claim: F) -> UniPoly<F> {
+        let is_active_round = if self.params.is_cycle_phase() {
+            self.params.is_cycle_phase_round(round)
+        } else {
+            self.params.is_address_phase_round(round)
+        };
+        if !is_active_round {
+            return UniPoly::from_coeff(vec![previous_claim * F::from_u64(2).inverse().unwrap()]);
+        }
+
+        let trailing_cap = if self.params.is_cycle_phase() {
+            self.params.cycle_alignment_rounds()
+        } else {
+            self.params.address_alignment_rounds()
+        };
+        let num_trailing_variables = trailing_cap.saturating_sub(self.params.num_rounds());
+        let scaling_factor = self.scale * F::one().mul_pow_2(num_trailing_variables);
+        let prev_unscaled = previous_claim * scaling_factor.inverse().unwrap();
+        let poly_unscaled = self.compute_message_unscaled(prev_unscaled);
+        poly_unscaled * scaling_factor
+    }
+
+    pub fn ingest_challenge(&mut self, r_j: F::Challenge, round: usize) {
+        let is_active_round = if self.params.is_cycle_phase() {
+            self.params.is_cycle_phase_round(round)
+        } else {
+            self.params.is_address_phase_round(round)
+        };
+        if !is_active_round {
+            self.scale *= F::from_u64(2).inverse().unwrap();
+            return;
+        }
+
+        self.value_poly.bind_parallel(r_j, BindingOrder::LowToHigh);
+        self.eq_poly.bind_parallel(r_j, BindingOrder::LowToHigh);
+        if self.params.is_cycle_phase() {
+            self.params.record_cycle_challenge(r_j);
+        }
+    }
+
+    pub fn cycle_intermediate_claim(&self) -> F {
+        let len = self.value_poly.len();
+        assert_eq!(len, self.eq_poly.len());
+
+        let mut sum = F::zero();
+        for i in 0..len {
+            sum += self.value_poly.get_bound_coeff(i) * self.eq_poly.get_bound_coeff(i);
+        }
+        sum * self.scale
+    }
+
+    pub fn final_claim_if_ready(&self) -> Option<F> {
+        if self.value_poly.len() == 1 {
+            Some(self.value_poly.get_bound_coeff(0))
+        } else {
+            None
+        }
+    }
+}
+
+pub fn precommitted_skip_round_scale<F: JoltField>(
+    precommitted: &PrecommittedClaimReduction<F>,
+) -> F {
+    let cycle_gap_len =
+        precommitted.cycle_phase_total_rounds - precommitted.cycle_phase_rounds.len();
+    let address_gap_len =
+        precommitted.address_phase_total_rounds - precommitted.address_phase_rounds.len();
+    let gap_len = cycle_gap_len + address_gap_len;
+    let two_inv = F::from_u64(2).inverse().unwrap();
+    (0..gap_len).fold(F::one(), |acc, _| acc * two_inv)
+}

--- a/jolt-core/src/zkvm/claim_reductions/precommitted.rs
+++ b/jolt-core/src/zkvm/claim_reductions/precommitted.rs
@@ -80,10 +80,15 @@ impl<F: JoltField> PrecommittedClaimReduction<F> {
         let has_precommitted_dominance =
             scheduling_reference.reference_total_vars > scheduling_reference.main_total_vars;
         let embedding_mode = Self::embedding_mode_for_poly(poly_total_vars, &scheduling_reference);
+        let dense_cycle_prefix_rounds = if has_precommitted_dominance {
+            DoryGlobals::main_t().log_2()
+        } else {
+            0
+        };
         let dory_opening_round_permutation_be = Self::reference_dory_opening_round_permutation_be(
             &scheduling_reference,
             has_precommitted_dominance,
-            DoryGlobals::main_t().log_2(),
+            dense_cycle_prefix_rounds,
         );
         let poly_opening_round_permutation_be = Self::project_dory_round_permutation_for_poly(
             &dory_opening_round_permutation_be,

--- a/jolt-core/src/zkvm/claim_reductions/precommitted.rs
+++ b/jolt-core/src/zkvm/claim_reductions/precommitted.rs
@@ -11,12 +11,6 @@ use crate::subprotocols::sumcheck_verifier::SumcheckInstanceParams;
 use crate::utils::math::Math;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Allocative)]
-pub enum PrecommittedEmbeddingMode {
-    DominantPrecommitted,
-    EmbeddedPrecommitted,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Allocative)]
 pub enum PrecommittedPhase {
     CycleVariables,
     AddressVariables,
@@ -34,9 +28,8 @@ pub struct PrecommittedSchedulingReference {
 #[derive(Debug, Clone, Allocative)]
 pub struct PrecommittedClaimReduction<F: JoltField> {
     pub scheduling_reference: PrecommittedSchedulingReference,
-    pub embedding_mode: PrecommittedEmbeddingMode,
     pub cycle_var_challenges: Vec<F::Challenge>,
-    dory_opening_round_permutation_be: Vec<usize>,
+    pub phase: PrecommittedPhase,
     poly_opening_round_permutation_be: Vec<usize>,
     cycle_phase_rounds: Vec<usize>,
     cycle_phase_total_rounds: usize,
@@ -72,14 +65,12 @@ impl<F: JoltField> PrecommittedClaimReduction<F> {
 
     #[inline]
     pub fn new(
-        poly_total_vars: usize,
         poly_row_vars: usize,
         poly_col_vars: usize,
         scheduling_reference: PrecommittedSchedulingReference,
     ) -> Self {
         let has_precommitted_dominance =
             scheduling_reference.reference_total_vars > scheduling_reference.main_total_vars;
-        let embedding_mode = Self::embedding_mode_for_poly(poly_total_vars, &scheduling_reference);
         let dense_cycle_prefix_rounds = if has_precommitted_dominance {
             DoryGlobals::main_t().log_2()
         } else {
@@ -102,33 +93,14 @@ impl<F: JoltField> PrecommittedClaimReduction<F> {
         );
         Self {
             scheduling_reference,
-            embedding_mode,
             cycle_var_challenges: vec![],
-            dory_opening_round_permutation_be,
+            phase: PrecommittedPhase::CycleVariables,
             poly_opening_round_permutation_be,
             cycle_phase_rounds,
             cycle_phase_total_rounds: scheduling_reference.cycle_alignment_rounds,
             address_phase_rounds,
             address_phase_total_rounds: scheduling_reference.address_rounds,
         }
-    }
-
-    #[inline]
-    fn embedding_mode_for_poly(
-        poly_total_vars: usize,
-        reference: &PrecommittedSchedulingReference,
-    ) -> PrecommittedEmbeddingMode {
-        let has_precommitted_dominance = reference.reference_total_vars > reference.main_total_vars;
-        let embedding_mode =
-            if has_precommitted_dominance && poly_total_vars == reference.reference_total_vars {
-                PrecommittedEmbeddingMode::DominantPrecommitted
-            } else {
-                PrecommittedEmbeddingMode::EmbeddedPrecommitted
-            };
-        if embedding_mode == PrecommittedEmbeddingMode::DominantPrecommitted {
-            assert_eq!(poly_total_vars, reference.reference_total_vars);
-        }
-        embedding_mode
     }
 
     fn reference_dory_opening_round_permutation_be(
@@ -213,6 +185,16 @@ impl<F: JoltField> PrecommittedClaimReduction<F> {
     }
 
     #[inline]
+    pub fn is_cycle_phase(&self) -> bool {
+        self.phase == PrecommittedPhase::CycleVariables
+    }
+
+    #[inline]
+    pub fn transition_to_address_phase(&mut self) {
+        self.phase = PrecommittedPhase::AddressVariables;
+    }
+
+    #[inline]
     pub fn num_address_phase_rounds(&self) -> usize {
         self.address_phase_rounds.len()
     }
@@ -222,26 +204,40 @@ impl<F: JoltField> PrecommittedClaimReduction<F> {
         self.cycle_phase_rounds.contains(&round)
     }
 
-    pub fn cycle_phase_rounds_debug(&self) -> &[usize] {
-        &self.cycle_phase_rounds
-    }
-
+    /// Indices of the cycle-phase rounds that this poly actively participates
+    /// in (i.e. rounds where the verifier evaluates the poly rather than
+    /// scaling by 1/2). The vector is sorted ascending and deduplicated.
     pub fn cycle_phase_rounds(&self) -> &[usize] {
         &self.cycle_phase_rounds
     }
 
-    pub fn address_phase_rounds_debug(&self) -> &[usize] {
-        &self.address_phase_rounds
-    }
-
+    /// Indices of the address-phase rounds that this poly actively
+    /// participates in. Same conventions as [`Self::cycle_phase_rounds`].
     pub fn address_phase_rounds(&self) -> &[usize] {
         &self.address_phase_rounds
     }
 
+    /// Big-endian round-permutation projected onto this poly's
+    /// `(poly_row_vars, poly_col_vars)` rectangle.
+    ///
+    /// The slice is `poly_row_vars + poly_col_vars` long: the first
+    /// `poly_row_vars` entries describe the row-side rounds, the rest the
+    /// column-side rounds. Pair this with
+    /// [`precommitted_sumcheck_inverse_index_permutation`] to permute a
+    /// length-`2^len` coefficient vector into opening order, instead of
+    /// re-deriving it from `scheduling_reference`.
     pub fn poly_opening_round_permutation_be(&self) -> &[usize] {
         &self.poly_opening_round_permutation_be
     }
 
+    /// The `(1/2)^cycle_gap` factor that "non-active" cycle-phase rounds
+    /// contribute to the running scale. Returns `F::one()` when there are
+    /// no inactive cycle-phase rounds.
+    ///
+    /// This is the cycle-only counterpart of
+    /// [`precommitted_skip_round_scale`], intended for callers that need
+    /// the scale strictly at the cycle-to-address handoff (e.g. when
+    /// constructing the address-phase prover).
     #[inline]
     pub fn cycle_phase_skip_scale(&self) -> F {
         let cycle_gap_len = self.cycle_phase_total_rounds - self.cycle_phase_rounds.len();
@@ -250,10 +246,6 @@ impl<F: JoltField> PrecommittedClaimReduction<F> {
         }
         let two_inv = F::from_u64(2).inverse().unwrap();
         (0..cycle_gap_len).fold(F::one(), |acc, _| acc * two_inv)
-    }
-
-    pub fn is_address_phase_active_round(&self, round: usize) -> bool {
-        self.address_phase_rounds.contains(&round)
     }
 
     #[inline]
@@ -272,17 +264,12 @@ impl<F: JoltField> PrecommittedClaimReduction<F> {
     }
 
     #[inline]
-    pub fn num_rounds_for_phase(&self, is_cycle_phase: bool) -> usize {
-        if is_cycle_phase {
+    pub fn num_rounds_for_current_phase(&self) -> usize {
+        if self.is_cycle_phase() {
             self.cycle_phase_total_rounds
         } else {
             self.address_phase_total_rounds
         }
-    }
-
-    pub fn round_offset(&self, is_cycle_phase: bool, max_num_rounds: usize) -> usize {
-        let _ = (is_cycle_phase, max_num_rounds);
-        0
     }
 
     fn cycle_challenge_for_round(&self, round: usize) -> F::Challenge {
@@ -307,12 +294,9 @@ impl<F: JoltField> PrecommittedClaimReduction<F> {
 
     pub fn normalize_opening_point(
         &self,
-        is_cycle_phase: bool,
         challenges: &[F::Challenge],
-        dense_cycle_prefix_rounds: usize,
     ) -> OpeningPoint<BIG_ENDIAN, F> {
-        let _ = dense_cycle_prefix_rounds;
-        if is_cycle_phase {
+        if self.is_cycle_phase() {
             let local_cycle_challenges: Vec<F::Challenge> = self
                 .cycle_phase_rounds
                 .iter()
@@ -330,10 +314,6 @@ impl<F: JoltField> PrecommittedClaimReduction<F> {
                 .match_endianness();
         }
 
-        debug_assert_eq!(
-            self.dory_opening_round_permutation_be.len(),
-            self.scheduling_reference.reference_total_vars
-        );
         let cycle_round_limit = self.cycle_alignment_rounds();
         let opening_rounds = &self.poly_opening_round_permutation_be;
         let mut opening_point_be = Vec::with_capacity(opening_rounds.len());
@@ -409,13 +389,14 @@ where
         .collect()
 }
 
-pub fn precommitted_eq_evals_with_scaling<F>(
-    challenges_be: &[F::Challenge],
+pub fn precommitted_eq_evals_with_scaling<F, C>(
+    challenges_be: &[C],
     scaling_factor: Option<F>,
     precommitted: &PrecommittedClaimReduction<F>,
 ) -> Vec<F>
 where
-    F: JoltField + std::ops::Mul<F::Challenge, Output = F> + std::ops::SubAssign<F>,
+    C: Copy + Send + Sync + Into<F>,
+    F: JoltField + std::ops::Mul<C, Output = F> + std::ops::SubAssign<F>,
 {
     let permuted_challenges = precommitted_permute_eq_challenges(
         challenges_be,
@@ -473,7 +454,17 @@ fn precommitted_sumcheck_lsb_permutation(
     Some(old_lsb_to_new_lsb)
 }
 
-fn precommitted_sumcheck_inverse_index_permutation(
+/// Inverse index permutation for permuting a precommitted polynomial's
+/// coefficient vector into the order implied by `poly_opening_round_permutation_be`.
+///
+/// Returns `Some(perm)` such that `perm[new_idx] = old_idx`, suitable for
+/// driving an out-of-place permute of a length-`coeffs_len` vector. Returns
+/// `None` when the requested permutation is the identity, so callers can
+/// short-circuit and skip the permute entirely.
+///
+/// `coeffs_len` must equal `1 << poly_opening_round_permutation_be.len()`;
+/// asserts otherwise.
+pub fn precommitted_sumcheck_inverse_index_permutation(
     coeffs_len: usize,
     poly_opening_round_permutation_be: &[usize],
 ) -> Option<Vec<usize>> {
@@ -510,33 +501,36 @@ fn precommitted_sumcheck_inverse_index_permutation(
 
 pub const TWO_PHASE_DEGREE_BOUND: usize = 2;
 
-pub trait PrecomittedParams<F: JoltField>: SumcheckInstanceParams<F> {
-    fn is_cycle_phase(&self) -> bool;
-    fn is_cycle_phase_round(&self, round: usize) -> bool;
-    fn is_address_phase_round(&self, round: usize) -> bool;
-    fn cycle_alignment_rounds(&self) -> usize;
-    fn address_alignment_rounds(&self) -> usize;
-    fn record_cycle_challenge(&mut self, challenge: F::Challenge);
+pub trait PrecommittedParams<F: JoltField>: SumcheckInstanceParams<F> {
+    fn precommitted(&self) -> &PrecommittedClaimReduction<F>;
+    fn precommitted_mut(&mut self) -> &mut PrecommittedClaimReduction<F>;
+
+    fn is_cycle_phase(&self) -> bool {
+        self.precommitted().is_cycle_phase()
+    }
 }
 
 #[derive(Allocative)]
-pub struct PrecomittedProver<F: JoltField, P: PrecomittedParams<F>> {
+pub struct PrecommittedProver<F: JoltField, P: PrecommittedParams<F>> {
     params: P,
     value_poly: MultilinearPolynomial<F>,
     eq_poly: MultilinearPolynomial<F>,
+    aux_polys: Vec<MultilinearPolynomial<F>>,
     scale: F,
 }
 
-impl<F: JoltField, P: PrecomittedParams<F>> PrecomittedProver<F, P> {
+impl<F: JoltField, P: PrecommittedParams<F>> PrecommittedProver<F, P> {
     pub fn new(
         params: P,
         value_poly: MultilinearPolynomial<F>,
         eq_poly: MultilinearPolynomial<F>,
+        aux_polys: Option<Vec<MultilinearPolynomial<F>>>,
     ) -> Self {
         Self {
             params,
             value_poly,
             eq_poly,
+            aux_polys: aux_polys.unwrap_or_default(),
             scale: F::one(),
         }
     }
@@ -545,16 +539,17 @@ impl<F: JoltField, P: PrecomittedParams<F>> PrecomittedProver<F, P> {
         &self.params
     }
 
-    pub fn params_mut(&mut self) -> &mut P {
-        &mut self.params
+    pub fn transition_to_address_phase(&mut self) {
+        self.params.precommitted_mut().transition_to_address_phase();
     }
 
     pub fn set_scale(&mut self, scale: F) {
         self.scale = scale;
     }
 
-    pub fn scale(&self) -> F {
-        self.scale
+    #[expect(dead_code)]
+    pub fn aux_polys(&self) -> &[MultilinearPolynomial<F>] {
+        &self.aux_polys
     }
 
     fn compute_message_unscaled(&self, previous_claim_unscaled: F) -> UniPoly<F> {
@@ -586,19 +581,20 @@ impl<F: JoltField, P: PrecomittedParams<F>> PrecomittedProver<F, P> {
     }
 
     pub fn compute_message(&mut self, round: usize, previous_claim: F) -> UniPoly<F> {
+        let precommitted = self.params.precommitted();
         let is_active_round = if self.params.is_cycle_phase() {
-            self.params.is_cycle_phase_round(round)
+            precommitted.is_cycle_phase_round(round)
         } else {
-            self.params.is_address_phase_round(round)
+            precommitted.is_address_phase_round(round)
         };
         if !is_active_round {
             return UniPoly::from_coeff(vec![previous_claim * F::from_u64(2).inverse().unwrap()]);
         }
 
         let trailing_cap = if self.params.is_cycle_phase() {
-            self.params.cycle_alignment_rounds()
+            precommitted.cycle_alignment_rounds()
         } else {
-            self.params.address_alignment_rounds()
+            precommitted.address_alignment_rounds()
         };
         let num_trailing_variables = trailing_cap.saturating_sub(self.params.num_rounds());
         let scaling_factor = self.scale * F::one().mul_pow_2(num_trailing_variables);
@@ -609,19 +605,24 @@ impl<F: JoltField, P: PrecomittedParams<F>> PrecomittedProver<F, P> {
 
     pub fn ingest_challenge(&mut self, r_j: F::Challenge, round: usize) {
         let is_active_round = if self.params.is_cycle_phase() {
-            self.params.is_cycle_phase_round(round)
+            let precommitted = self.params.precommitted();
+            precommitted.is_cycle_phase_round(round)
         } else {
-            self.params.is_address_phase_round(round)
+            let precommitted = self.params.precommitted();
+            precommitted.is_address_phase_round(round)
         };
         if !is_active_round {
             self.scale *= F::from_u64(2).inverse().unwrap();
             return;
         }
+        if self.params.is_cycle_phase() {
+            self.params.precommitted_mut().record_cycle_challenge(r_j);
+        }
 
         self.value_poly.bind_parallel(r_j, BindingOrder::LowToHigh);
         self.eq_poly.bind_parallel(r_j, BindingOrder::LowToHigh);
-        if self.params.is_cycle_phase() {
-            self.params.record_cycle_challenge(r_j);
+        for aux_poly in self.aux_polys.iter_mut() {
+            aux_poly.bind_parallel(r_j, BindingOrder::LowToHigh);
         }
     }
 
@@ -655,4 +656,117 @@ pub fn precommitted_skip_round_scale<F: JoltField>(
     let gap_len = cycle_gap_len + address_gap_len;
     let two_inv = F::from_u64(2).inverse().unwrap();
     (0..gap_len).fold(F::one(), |acc, _| acc * two_inv)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::field::JoltField;
+    use ark_bn254::Fr;
+    use num_traits::One;
+
+    fn make_reduction(
+        poly_opening_round_permutation_be: Vec<usize>,
+        cycle_phase_rounds: Vec<usize>,
+        cycle_phase_total_rounds: usize,
+        address_phase_rounds: Vec<usize>,
+        address_phase_total_rounds: usize,
+    ) -> PrecommittedClaimReduction<Fr> {
+        let scheduling_reference = PrecommittedSchedulingReference {
+            main_total_vars: cycle_phase_total_rounds + address_phase_total_rounds,
+            reference_total_vars: cycle_phase_total_rounds + address_phase_total_rounds,
+            cycle_alignment_rounds: cycle_phase_total_rounds,
+            address_rounds: address_phase_total_rounds,
+            joint_col_vars: 0,
+        };
+        PrecommittedClaimReduction {
+            scheduling_reference,
+            cycle_var_challenges: vec![],
+            phase: PrecommittedPhase::CycleVariables,
+            poly_opening_round_permutation_be,
+            cycle_phase_rounds,
+            cycle_phase_total_rounds,
+            address_phase_rounds,
+            address_phase_total_rounds,
+        }
+    }
+
+    #[test]
+    fn poly_opening_round_permutation_be_returns_stored_field() {
+        let perm = vec![3usize, 0, 1, 2];
+        let r = make_reduction(perm.clone(), vec![0, 1], 2, vec![0, 1], 2);
+        assert_eq!(r.poly_opening_round_permutation_be(), perm.as_slice());
+    }
+
+    #[test]
+    fn cycle_and_address_phase_rounds_accessors_match_internal_storage() {
+        let cycle = vec![0usize, 2, 3];
+        let address = vec![1usize];
+        let r = make_reduction(vec![0, 1, 2, 3], cycle.clone(), 4, address.clone(), 2);
+        assert_eq!(r.cycle_phase_rounds(), cycle.as_slice());
+        assert_eq!(r.address_phase_rounds(), address.as_slice());
+    }
+
+    #[test]
+    fn cycle_phase_skip_scale_is_one_when_no_gap() {
+        let r = make_reduction(vec![0, 1], vec![0, 1], 2, vec![], 0);
+        assert_eq!(r.cycle_phase_skip_scale(), Fr::one());
+    }
+
+    #[test]
+    fn cycle_phase_skip_scale_is_two_inverse_per_inactive_round() {
+        let two_inv = Fr::from_u64(2).inverse().unwrap();
+        // 1 inactive cycle round
+        let r1 = make_reduction(vec![0], vec![0], 2, vec![], 0);
+        assert_eq!(r1.cycle_phase_skip_scale(), two_inv);
+        // 3 inactive cycle rounds
+        let r3 = make_reduction(vec![0], vec![0], 4, vec![], 0);
+        assert_eq!(r3.cycle_phase_skip_scale(), two_inv * two_inv * two_inv);
+        // address-phase gap must NOT contribute (this is the cycle-only flavour)
+        let r_ignore = make_reduction(vec![0], vec![0], 1, vec![], 5);
+        assert_eq!(r_ignore.cycle_phase_skip_scale(), Fr::one());
+    }
+
+    #[test]
+    fn cycle_phase_skip_scale_agrees_with_full_skip_when_address_gap_is_zero() {
+        let r = make_reduction(vec![0, 1], vec![0], 3, vec![0, 1], 2);
+        // cycle_gap = 3 - 1 = 2, address_gap = 2 - 2 = 0
+        // full = (1/2)^2; cycle_only = (1/2)^2; they should agree.
+        let full = precommitted_skip_round_scale(&r);
+        assert_eq!(r.cycle_phase_skip_scale(), full);
+    }
+
+    #[test]
+    fn inverse_index_permutation_returns_none_for_identity() {
+        // BE descending = identity LSB permutation (no reordering).
+        let identity_be: Vec<usize> = (0..4).rev().collect();
+        let perm = precommitted_sumcheck_inverse_index_permutation(1 << 4, &identity_be);
+        assert!(
+            perm.is_none(),
+            "identity permutation should be reported as None, got Some(len={})",
+            perm.map(|p| p.len()).unwrap_or(0),
+        );
+    }
+
+    #[test]
+    fn inverse_index_permutation_is_a_genuine_permutation_when_nontrivial() {
+        // Swap the two LSBs by reversing the BE round order partially.
+        let poly_perm_be: Vec<usize> = vec![0, 1, 3, 2];
+        let coeffs_len = 1usize << poly_perm_be.len();
+        let perm = precommitted_sumcheck_inverse_index_permutation(coeffs_len, &poly_perm_be)
+            .expect("non-identity permutation expected for this input");
+        assert_eq!(perm.len(), coeffs_len);
+        let mut seen = vec![false; coeffs_len];
+        for (new_idx, &old_idx) in perm.iter().enumerate() {
+            assert!(
+                old_idx < coeffs_len,
+                "perm[{new_idx}] = {old_idx} is out of bounds for coeffs_len={coeffs_len}",
+            );
+            assert!(
+                !seen[old_idx],
+                "perm contains duplicate old_idx={old_idx} (at new_idx={new_idx})",
+            );
+            seen[old_idx] = true;
+        }
+    }
 }

--- a/jolt-core/src/zkvm/claim_reductions/precommitted.rs
+++ b/jolt-core/src/zkvm/claim_reductions/precommitted.rs
@@ -228,8 +228,30 @@ impl<F: JoltField> PrecommittedClaimReduction<F> {
         &self.cycle_phase_rounds
     }
 
+    pub fn cycle_phase_rounds(&self) -> &[usize] {
+        &self.cycle_phase_rounds
+    }
+
     pub fn address_phase_rounds_debug(&self) -> &[usize] {
         &self.address_phase_rounds
+    }
+
+    pub fn address_phase_rounds(&self) -> &[usize] {
+        &self.address_phase_rounds
+    }
+
+    pub fn poly_opening_round_permutation_be(&self) -> &[usize] {
+        &self.poly_opening_round_permutation_be
+    }
+
+    #[inline]
+    pub fn cycle_phase_skip_scale(&self) -> F {
+        let cycle_gap_len = self.cycle_phase_total_rounds - self.cycle_phase_rounds.len();
+        if cycle_gap_len == 0 {
+            return F::one();
+        }
+        let two_inv = F::from_u64(2).inverse().unwrap();
+        (0..cycle_gap_len).fold(F::one(), |acc, _| acc * two_inv)
     }
 
     pub fn is_address_phase_active_round(&self, round: usize) -> bool {

--- a/jolt-core/src/zkvm/claim_reductions/precommitted.rs
+++ b/jolt-core/src/zkvm/claim_reductions/precommitted.rs
@@ -219,6 +219,18 @@ impl<F: JoltField> PrecommittedClaimReduction<F> {
             .any(|&scheduled| scheduled == round)
     }
 
+    pub fn cycle_phase_rounds_debug(&self) -> &[usize] {
+        &self.cycle_phase_rounds
+    }
+
+    pub fn address_phase_rounds_debug(&self) -> &[usize] {
+        &self.address_phase_rounds
+    }
+
+    pub fn is_address_phase_active_round(&self, round: usize) -> bool {
+        self.address_phase_rounds.contains(&round)
+    }
+
     #[inline]
     pub fn is_address_phase_round(&self, round: usize) -> bool {
         self.address_phase_rounds
@@ -512,6 +524,14 @@ impl<F: JoltField, P: PrecomittedParams<F>> PrecomittedProver<F, P> {
 
     pub fn params_mut(&mut self) -> &mut P {
         &mut self.params
+    }
+
+    pub fn set_scale(&mut self, scale: F) {
+        self.scale = scale;
+    }
+
+    pub fn scale(&self) -> F {
+        self.scale
     }
 
     fn compute_message_unscaled(&self, previous_claim_unscaled: F) -> UniPoly<F> {

--- a/jolt-core/src/zkvm/claim_reductions/precommitted.rs
+++ b/jolt-core/src/zkvm/claim_reductions/precommitted.rs
@@ -219,9 +219,7 @@ impl<F: JoltField> PrecommittedClaimReduction<F> {
 
     #[inline]
     pub fn is_cycle_phase_round(&self, round: usize) -> bool {
-        self.cycle_phase_rounds
-            .iter()
-            .any(|&scheduled| scheduled == round)
+        self.cycle_phase_rounds.contains(&round)
     }
 
     pub fn cycle_phase_rounds_debug(&self) -> &[usize] {
@@ -260,9 +258,7 @@ impl<F: JoltField> PrecommittedClaimReduction<F> {
 
     #[inline]
     pub fn is_address_phase_round(&self, round: usize) -> bool {
-        self.address_phase_rounds
-            .iter()
-            .any(|&scheduled| scheduled == round)
+        self.address_phase_rounds.contains(&round)
     }
 
     #[inline]
@@ -413,13 +409,13 @@ where
         .collect()
 }
 
-pub fn precommitted_eq_evals_with_scaling<F: JoltField>(
+pub fn precommitted_eq_evals_with_scaling<F>(
     challenges_be: &[F::Challenge],
     scaling_factor: Option<F>,
     precommitted: &PrecommittedClaimReduction<F>,
 ) -> Vec<F>
 where
-    F: std::ops::Mul<F::Challenge, Output = F> + std::ops::SubAssign<F>,
+    F: JoltField + std::ops::Mul<F::Challenge, Output = F> + std::ops::SubAssign<F>,
 {
     let permuted_challenges = precommitted_permute_eq_challenges(
         challenges_be,

--- a/jolt-core/src/zkvm/claim_reductions/precommitted.rs
+++ b/jolt-core/src/zkvm/claim_reductions/precommitted.rs
@@ -5,7 +5,9 @@ use crate::field::JoltField;
 use crate::poly::commitment::dory::{DoryGlobals, DoryLayout};
 use crate::poly::eq_poly::EqPolynomial;
 use crate::poly::multilinear_polynomial::{BindingOrder, MultilinearPolynomial, PolynomialBinding};
-use crate::poly::opening_proof::{OpeningPoint, BIG_ENDIAN, LITTLE_ENDIAN};
+use crate::poly::opening_proof::{
+    AbstractVerifierOpeningAccumulator, OpeningPoint, BIG_ENDIAN, LITTLE_ENDIAN,
+};
 use crate::poly::unipoly::UniPoly;
 use crate::subprotocols::sumcheck_verifier::SumcheckInstanceParams;
 use crate::utils::math::Math;
@@ -190,11 +192,6 @@ impl<F: JoltField> PrecommittedClaimReduction<F> {
     }
 
     #[inline]
-    pub fn transition_to_address_phase(&mut self) {
-        self.phase = PrecommittedPhase::AddressVariables;
-    }
-
-    #[inline]
     pub fn num_address_phase_rounds(&self) -> usize {
         self.address_phase_rounds.len()
     }
@@ -337,11 +334,6 @@ impl<F: JoltField> PrecommittedClaimReduction<F> {
     #[inline]
     pub fn record_cycle_challenge(&mut self, challenge: F::Challenge) {
         self.cycle_var_challenges.push(challenge);
-    }
-
-    #[inline]
-    pub fn set_cycle_var_challenges(&mut self, challenges: Vec<F::Challenge>) {
-        self.cycle_var_challenges = challenges;
     }
 }
 
@@ -508,6 +500,27 @@ pub trait PrecommittedParams<F: JoltField>: SumcheckInstanceParams<F> {
     fn is_cycle_phase(&self) -> bool {
         self.precommitted().is_cycle_phase()
     }
+
+    fn get_cycle_challenges<A: AbstractVerifierOpeningAccumulator<F>>(
+        &self,
+        accumulator: &A,
+    ) -> Vec<F::Challenge>;
+
+    fn transition_to_address_phase<A: AbstractVerifierOpeningAccumulator<F>>(
+        &mut self,
+        accumulator: &A,
+    ) {
+        let cycle_challenges = if self.precommitted().num_address_phase_rounds() > 0 {
+            Some(self.get_cycle_challenges(accumulator))
+        } else {
+            None
+        };
+        let precommitted = self.precommitted_mut();
+        if let Some(cycle_challenges) = cycle_challenges {
+            precommitted.cycle_var_challenges = cycle_challenges;
+        }
+        precommitted.phase = PrecommittedPhase::AddressVariables;
+    }
 }
 
 #[derive(Allocative)]
@@ -540,7 +553,7 @@ impl<F: JoltField, P: PrecommittedParams<F>> PrecommittedProver<F, P> {
     }
 
     pub fn transition_to_address_phase(&mut self) {
-        self.params.precommitted_mut().transition_to_address_phase();
+        self.params.precommitted_mut().phase = PrecommittedPhase::AddressVariables;
     }
 
     pub fn set_scale(&mut self, scale: F) {

--- a/jolt-core/src/zkvm/mod.rs
+++ b/jolt-core/src/zkvm/mod.rs
@@ -7,11 +7,12 @@ use crate::{
     field::JoltField,
     poly::commitment::commitment_scheme::CommitmentScheme,
     poly::commitment::dory::{DoryCommitmentScheme, DoryLayout},
-    poly::opening_proof::{
-        OpeningAccumulator, OpeningId, OpeningPoint, ProverOpeningAccumulator, SumcheckId,
-        BIG_ENDIAN,
-    },
+    poly::opening_proof::{OpeningId, ProverOpeningAccumulator, SumcheckId},
     transcripts::Transcript,
+};
+#[cfg(feature = "prover")]
+use crate::{
+    poly::opening_proof::{OpeningAccumulator, OpeningPoint, BIG_ENDIAN},
     utils::errors::ProofVerifyError,
     zkvm::claim_reductions::AdviceKind,
 };
@@ -112,6 +113,7 @@ pub(crate) fn stage8_opening_ids(
     opening_ids
 }
 
+#[cfg(feature = "prover")]
 pub(crate) fn compute_final_opening_point<F: JoltField>(
     opening_accumulator: &impl OpeningAccumulator<F>,
     native_main_vars: usize,

--- a/jolt-core/src/zkvm/mod.rs
+++ b/jolt-core/src/zkvm/mod.rs
@@ -7,12 +7,11 @@ use crate::{
     field::JoltField,
     poly::commitment::commitment_scheme::CommitmentScheme,
     poly::commitment::dory::{DoryCommitmentScheme, DoryLayout},
-    poly::opening_proof::{OpeningId, ProverOpeningAccumulator, SumcheckId},
+    poly::opening_proof::{
+        OpeningAccumulator, OpeningId, OpeningPoint, ProverOpeningAccumulator, SumcheckId,
+        BIG_ENDIAN,
+    },
     transcripts::Transcript,
-};
-#[cfg(feature = "prover")]
-use crate::{
-    poly::opening_proof::{OpeningAccumulator, OpeningPoint, BIG_ENDIAN},
     utils::errors::ProofVerifyError,
     zkvm::claim_reductions::AdviceKind,
 };
@@ -113,7 +112,6 @@ pub(crate) fn stage8_opening_ids(
     opening_ids
 }
 
-#[cfg(feature = "prover")]
 pub(crate) fn compute_final_opening_point<F: JoltField>(
     opening_accumulator: &impl OpeningAccumulator<F>,
     native_main_vars: usize,

--- a/jolt-core/src/zkvm/mod.rs
+++ b/jolt-core/src/zkvm/mod.rs
@@ -7,9 +7,13 @@ use crate::{
     field::JoltField,
     poly::commitment::commitment_scheme::CommitmentScheme,
     poly::commitment::dory::{DoryCommitmentScheme, DoryLayout},
-    poly::opening_proof::ProverOpeningAccumulator,
-    poly::opening_proof::{OpeningId, SumcheckId},
+    poly::opening_proof::{
+        OpeningAccumulator, OpeningId, OpeningPoint, ProverOpeningAccumulator, SumcheckId,
+        BIG_ENDIAN,
+    },
     transcripts::Transcript,
+    utils::errors::ProofVerifyError,
+    zkvm::claim_reductions::AdviceKind,
 };
 
 // Compile-time error if multiple transcript features are enabled
@@ -106,6 +110,86 @@ pub(crate) fn stage8_opening_ids(
     }
 
     opening_ids
+}
+
+pub(crate) fn compute_final_opening_point<F: JoltField>(
+    opening_accumulator: &impl OpeningAccumulator<F>,
+    native_main_vars: usize,
+    log_k_chunk: usize,
+    layout: DoryLayout,
+) -> Result<OpeningPoint<BIG_ENDIAN, F>, ProofVerifyError> {
+    let mut opening_candidates: Vec<(&str, OpeningPoint<BIG_ENDIAN, F>)> = Vec::new();
+    if let Some((point, _)) = opening_accumulator
+        .get_advice_opening(AdviceKind::Trusted, SumcheckId::AdviceClaimReduction)
+    {
+        opening_candidates.push(("trusted_advice", point));
+    }
+    if let Some((point, _)) = opening_accumulator
+        .get_advice_opening(AdviceKind::Untrusted, SumcheckId::AdviceClaimReduction)
+    {
+        opening_candidates.push(("untrusted_advice", point));
+    }
+
+    let (hamming_point, _) = opening_accumulator.get_committed_polynomial_opening(
+        CommittedPolynomial::InstructionRa(0),
+        SumcheckId::HammingWeightClaimReduction,
+    );
+    let (r_cycle_stage6, _) = opening_accumulator.get_committed_polynomial_opening(
+        CommittedPolynomial::RamInc,
+        SumcheckId::IncClaimReduction,
+    );
+
+    let max_len = opening_candidates
+        .iter()
+        .map(|(_, point)| point.r.len())
+        .max()
+        .unwrap_or(0);
+    if max_len > native_main_vars {
+        let dominant = opening_candidates
+            .iter()
+            .find(|(_, point)| point.r.len() == max_len)
+            .expect("at least one dominant precommitted candidate expected");
+        for (name, point) in opening_candidates
+            .iter()
+            .filter(|(_, point)| point.r.len() == max_len)
+        {
+            if point.r != dominant.1.r {
+                return Err(ProofVerifyError::DoryError(format!(
+                    "incompatible dominant precommitted anchors: {} and {} have equal dimensionality {} but different opening points",
+                    dominant.0, name, max_len
+                )));
+            }
+        }
+        Ok(OpeningPoint::<BIG_ENDIAN, F>::new(dominant.1.r.clone()))
+    } else {
+        let r_address_stage7 = hamming_point.r[..log_k_chunk].to_vec();
+
+        match layout {
+            DoryLayout::AddressMajor => Ok(OpeningPoint::<BIG_ENDIAN, F>::new(
+                [r_cycle_stage6.r.as_slice(), r_address_stage7.as_slice()].concat(),
+            )),
+            DoryLayout::CycleMajor => {
+                let native_cycle = &hamming_point.r[log_k_chunk..];
+                if r_cycle_stage6.r.len() < native_cycle.len() {
+                    return Err(ProofVerifyError::DoryError(
+                        "stage6 cycle challenges shorter than native cycle vars".to_string(),
+                    ));
+                }
+                if r_cycle_stage6.r[..native_cycle.len()] != *native_cycle {
+                    return Err(ProofVerifyError::DoryError(format!(
+                        "cycle-major Stage-8 expects stage6 cycle prefix to equal native cycle vars \
+                         (cycle_full_len={}, native_len={})",
+                        r_cycle_stage6.r.len(),
+                        native_cycle.len()
+                    )));
+                }
+                let cycle_extra = &r_cycle_stage6.r[native_cycle.len()..];
+                let cycle_extra_and_anchor =
+                    [cycle_extra, r_address_stage7.as_slice(), native_cycle].concat();
+                Ok(OpeningPoint::<BIG_ENDIAN, F>::new(cycle_extra_and_anchor))
+            }
+        }
+    }
 }
 
 // Scoped CPU profiler for performance analysis. Feature-gated by "pprof".

--- a/jolt-core/src/zkvm/prover.rs
+++ b/jolt-core/src/zkvm/prover.rs
@@ -348,12 +348,43 @@ impl<
             }
             OpeningPoint::<BIG_ENDIAN, F>::new(dominant.1.r.clone())
         } else {
-            self.opening_accumulator
+            let (hamming_point, _) = self.opening_accumulator.get_committed_polynomial_opening(
+                CommittedPolynomial::InstructionRa(0),
+                SumcheckId::HammingWeightClaimReduction,
+            );
+            let r_address_stage7 = hamming_point.r[..self.one_hot_params.log_k_chunk].to_vec();
+            let r_cycle_stage6 = self
+                .opening_accumulator
                 .get_committed_polynomial_opening(
-                    CommittedPolynomial::InstructionRa(0),
-                    SumcheckId::HammingWeightClaimReduction,
+                    CommittedPolynomial::RamInc,
+                    SumcheckId::IncClaimReduction,
                 )
                 .0
+                .r;
+
+            match DoryGlobals::get_layout() {
+                DoryLayout::AddressMajor => OpeningPoint::<BIG_ENDIAN, F>::new(
+                    [r_cycle_stage6.as_slice(), r_address_stage7.as_slice()].concat(),
+                ),
+                DoryLayout::CycleMajor => {
+                    let native_cycle = &hamming_point.r[self.one_hot_params.log_k_chunk..];
+                    assert!(
+                        r_cycle_stage6.len() >= native_cycle.len(),
+                        "stage6 cycle challenges shorter than native cycle vars"
+                    );
+                    assert!(
+                        r_cycle_stage6[..native_cycle.len()] == *native_cycle,
+                        "cycle-major Stage-8 expects stage6 cycle prefix to equal native cycle vars \
+                         (cycle_full_len={}, native_len={})",
+                        r_cycle_stage6.len(),
+                        native_cycle.len()
+                    );
+                    let cycle_extra = &r_cycle_stage6[native_cycle.len()..];
+                    let cycle_extra_and_anchor =
+                        [cycle_extra, r_address_stage7.as_slice(), native_cycle].concat();
+                    OpeningPoint::<BIG_ENDIAN, F>::new(cycle_extra_and_anchor)
+                }
+            }
         }
     }
 

--- a/jolt-core/src/zkvm/prover.rs
+++ b/jolt-core/src/zkvm/prover.rs
@@ -2,7 +2,6 @@
 use crate::poly::opening_proof::OpeningId;
 #[cfg(feature = "zk")]
 use crate::zkvm::stage8_opening_ids;
-use crate::zkvm::{claim_reductions::advice::ReductionPhase, config::OneHotConfig};
 #[cfg(not(target_arch = "wasm32"))]
 use std::time::Instant;
 use std::{
@@ -37,11 +36,10 @@ use crate::{
             commitment_scheme::{StreamingCommitmentScheme, ZkEvalCommitment},
             dory::{DoryGlobals, DoryLayout},
         },
-        eq_poly::EqPolynomial,
         multilinear_polynomial::MultilinearPolynomial,
         opening_proof::{
-            compute_advice_lagrange_factor, DoryOpeningState, OpeningAccumulator,
-            ProverOpeningAccumulator, SumcheckId,
+            compute_lagrange_factor, DoryOpeningState, OpeningAccumulator, OpeningPoint,
+            ProverOpeningAccumulator, SumcheckId, BIG_ENDIAN,
         },
         rlc_polynomial::{RLCStreamingData, TraceSource},
     },
@@ -65,9 +63,9 @@ use crate::{
             HammingWeightClaimReductionParams, HammingWeightClaimReductionProver,
             IncClaimReductionSumcheckParams, IncClaimReductionSumcheckProver,
             InstructionLookupsClaimReductionSumcheckParams,
-            InstructionLookupsClaimReductionSumcheckProver, RaReductionParams,
-            RamRaClaimReductionSumcheckProver, RegistersClaimReductionSumcheckParams,
-            RegistersClaimReductionSumcheckProver,
+            InstructionLookupsClaimReductionSumcheckProver, PrecommittedClaimReduction,
+            RaReductionParams, RamRaClaimReductionSumcheckProver,
+            RegistersClaimReductionSumcheckParams, RegistersClaimReductionSumcheckProver,
         },
         config::OneHotParams,
         instruction_lookups::{
@@ -282,81 +280,81 @@ impl<
         )
     }
 
-    /// Adjusts the padded trace length to ensure the main Dory matrix is large enough
-    /// to embed advice polynomials as the top-left block.
-    ///
-    /// Returns the adjusted padded_trace_len that satisfies:
-    /// - `sigma_main >= max_sigma_a`
-    /// - `nu_main >= max_nu_a`
-    ///
-    /// Panics if `max_padded_trace_length` is too small for the configured advice sizes.
-    fn adjust_trace_length_for_advice(
-        mut padded_trace_len: usize,
-        max_padded_trace_length: usize,
-        max_trusted_advice_size: u64,
-        max_untrusted_advice_size: u64,
-        has_trusted_advice: bool,
-        has_untrusted_advice: bool,
-    ) -> usize {
-        // Canonical advice shape policy (balanced):
-        // - advice_vars = log2(advice_len)
-        // - sigma_a = ceil(advice_vars/2)
-        // - nu_a    = advice_vars - sigma_a
-        let mut max_sigma_a = 0usize;
-        let mut max_nu_a = 0usize;
-
-        if has_trusted_advice {
-            let (sigma_a, nu_a) =
-                DoryGlobals::advice_sigma_nu_from_max_bytes(max_trusted_advice_size as usize);
-            max_sigma_a = max_sigma_a.max(sigma_a);
-            max_nu_a = max_nu_a.max(nu_a);
+    #[inline]
+    fn main_total_vars(&self) -> usize {
+        let trace_log_t = self.trace.len().log_2();
+        let log_k_chunk = self.one_hot_params.log_k_chunk;
+        let mut max_total_vars = trace_log_t + log_k_chunk;
+        for total_vars in self.precommitted_candidate_total_vars() {
+            max_total_vars = max_total_vars.max(total_vars);
         }
-        if has_untrusted_advice {
-            let (sigma_a, nu_a) =
-                DoryGlobals::advice_sigma_nu_from_max_bytes(max_untrusted_advice_size as usize);
-            max_sigma_a = max_sigma_a.max(sigma_a);
-            max_nu_a = max_nu_a.max(nu_a);
+        max_total_vars
+    }
+
+    #[inline]
+    fn precommitted_candidate_total_vars(&self) -> Vec<usize> {
+        let mut candidates = Vec::new();
+        if !self.program_io.trusted_advice.is_empty() {
+            let (sigma, nu) = DoryGlobals::advice_sigma_nu_from_max_bytes(
+                self.program_io.memory_layout.max_trusted_advice_size as usize,
+            );
+            candidates.push(sigma + nu);
         }
 
-        if max_sigma_a == 0 && max_nu_a == 0 {
-            return padded_trace_len;
+        if !self.program_io.untrusted_advice.is_empty() {
+            let (sigma, nu) = DoryGlobals::advice_sigma_nu_from_max_bytes(
+                self.program_io.memory_layout.max_untrusted_advice_size as usize,
+            );
+            candidates.push(sigma + nu);
+        }
+        candidates
+    }
+
+    fn stage8_opening_point(&self) -> OpeningPoint<BIG_ENDIAN, F> {
+        let native_main_vars = self.trace.len().log_2() + self.one_hot_params.log_k_chunk;
+        let mut opening_candidates: Vec<(&str, OpeningPoint<BIG_ENDIAN, F>)> = Vec::new();
+        if let Some((point, _)) = self
+            .opening_accumulator
+            .get_advice_opening(AdviceKind::Trusted, SumcheckId::AdviceClaimReduction)
+        {
+            opening_candidates.push(("trusted_advice", point));
+        }
+        if let Some((point, _)) = self
+            .opening_accumulator
+            .get_advice_opening(AdviceKind::Untrusted, SumcheckId::AdviceClaimReduction)
+        {
+            opening_candidates.push(("untrusted_advice", point));
         }
 
-        // Require main matrix dimensions to be large enough to embed advice as the top-left
-        // block: sigma_main >= sigma_a and nu_main >= nu_a.
-        //
-        // This loop doubles padded_trace_len until the main Dory matrix is large enough.
-        // Each doubling increases log_t by 1, which increases total_vars by 1 (since
-        // log_k_chunk stays constant for a given log_t range), increasing both sigma_main
-        // and nu_main by roughly 0.5 each iteration.
-        while {
-            let log_t = padded_trace_len.log_2();
-            let log_k_chunk = OneHotConfig::new(log_t).log_k_chunk as usize;
-            let (sigma_main, nu_main) = DoryGlobals::main_sigma_nu(log_k_chunk, log_t);
-            sigma_main < max_sigma_a || nu_main < max_nu_a
-        } {
-            if padded_trace_len >= max_padded_trace_length {
-                // This is a configuration error: the preprocessing was set up with
-                // max_padded_trace_length too small for the configured advice sizes.
-                // Cannot recover at runtime - user must fix their configuration.
-                let log_t = padded_trace_len.log_2();
-                let log_k_chunk = OneHotConfig::new(log_t).log_k_chunk as usize;
-                let total_vars = log_k_chunk + log_t;
-                let (sigma_main, nu_main) = DoryGlobals::main_sigma_nu(log_k_chunk, log_t);
-                panic!(
-                    "Configuration error: trace too small to embed advice into Dory batch opening.\n\
-                    Current: (sigma_main={sigma_main}, nu_main={nu_main}) from total_vars={total_vars} (log_t={log_t}, log_k_chunk={log_k_chunk})\n\
-                    Required: (sigma_a={max_sigma_a}, nu_a={max_nu_a}) for advice embedding\n\
-                    Solutions:\n\
-                    1. Increase max_trace_length in preprocessing (currently {max_padded_trace_length})\n\
-                    2. Reduce max_trusted_advice_size or max_untrusted_advice_size\n\
-                    3. Run a program with more cycles"
+        let max_len = opening_candidates
+            .iter()
+            .map(|(_, p)| p.r.len())
+            .max()
+            .unwrap_or(0);
+        if max_len > native_main_vars {
+            let dominant = opening_candidates
+                .iter()
+                .find(|(_, p)| p.r.len() == max_len)
+                .expect("at least one dominant precommitted candidate expected");
+            for (name, point) in opening_candidates
+                .iter()
+                .filter(|(_, p)| p.r.len() == max_len)
+            {
+                assert_eq!(
+                    point.r, dominant.1.r,
+                    "incompatible dominant precommitted anchors: {} and {} have equal dimensionality {} but different opening points",
+                    dominant.0, name, max_len
                 );
             }
-            padded_trace_len = (padded_trace_len * 2).min(max_padded_trace_length);
+            OpeningPoint::<BIG_ENDIAN, F>::new(dominant.1.r.clone())
+        } else {
+            self.opening_accumulator
+                .get_committed_polynomial_opening(
+                    CommittedPolynomial::InstructionRa(0),
+                    SumcheckId::HammingWeightClaimReduction,
+                )
+                .0
         }
-
-        padded_trace_len
     }
 
     pub fn gen_from_trace(
@@ -393,20 +391,6 @@ impl<
                 Increase max_trace_length to at least {padded_trace_len}."
             );
         }
-
-        // We may need extra padding so the main Dory matrix has enough (row, col) variables
-        // to embed advice commitments committed in their own preprocessing-only contexts.
-        let has_trusted_advice = !program_io.trusted_advice.is_empty();
-        let has_untrusted_advice = !program_io.untrusted_advice.is_empty();
-
-        let padded_trace_len = Self::adjust_trace_length_for_advice(
-            padded_trace_len,
-            preprocessing.shared.max_padded_trace_length,
-            preprocessing.shared.memory_layout.max_trusted_advice_size,
-            preprocessing.shared.memory_layout.max_untrusted_advice_size,
-            has_trusted_advice,
-            has_untrusted_advice,
-        );
 
         trace.resize(padded_trace_len, Cycle::NoOp);
 
@@ -682,29 +666,27 @@ impl<
         Vec<PCS::Commitment>,
         HashMap<CommittedPolynomial, PCS::OpeningProofHint>,
     ) {
-        let _guard = DoryGlobals::initialize_context(
+        let main_total_vars = self.main_total_vars();
+        let trace = Arc::clone(&self.trace);
+        let _guard = DoryGlobals::initialize_main_with_log_embedding(
             1 << self.one_hot_params.log_k_chunk,
-            self.padded_trace_len,
-            DoryContext::Main,
+            trace.len(),
+            main_total_vars,
             Some(DoryGlobals::get_layout()),
         );
 
         let polys = all_committed_polynomials(&self.one_hot_params);
-        let T = DoryGlobals::get_T();
+        let T = DoryGlobals::get_embedded_t();
 
-        // For AddressMajor, use non-streaming commit path since streaming assumes CycleMajor layout
-        let (commitments, hint_map) = if DoryGlobals::get_layout() == DoryLayout::AddressMajor {
+        // AddressMajor uses non-streaming commit path, and we also use non-streaming when
+        // Stage 6/8 embedding domain exceeds the trace domain.
+        let use_materialized_commit =
+            DoryGlobals::get_layout() == DoryLayout::AddressMajor || self.trace.len() != T;
+        let (commitments, hint_map) = if use_materialized_commit {
             tracing::debug!(
-                "Using non-streaming commit path for AddressMajor layout with {} polynomials",
+                "Using non-streaming commit path with {} polynomials",
                 polys.len()
             );
-
-            // Materialize the trace for non-streaming commit
-            let trace: Vec<Cycle> = self
-                .lazy_trace
-                .clone()
-                .pad_using(T, |_| Cycle::NoOp)
-                .collect();
 
             // Generate witnesses and commit using the regular (non-streaming) path
             let (commitments, hints): (Vec<_>, Vec<_>) = polys
@@ -1327,12 +1309,21 @@ impl<
             &mut self.transcript,
         );
 
+        let main_total_vars = self.trace.len().log_2() + self.one_hot_params.log_k_chunk;
+        let precommitted_candidates = self.precommitted_candidate_total_vars();
+        let precommitted_scheduling_reference =
+            PrecommittedClaimReduction::<F>::scheduling_reference(
+                main_total_vars,
+                &precommitted_candidates,
+            );
+
         // Advice claim reduction (Phase 1 in Stage 6b): trusted and untrusted are separate instances.
         if self.advice.trusted_advice_polynomial.is_some() {
             let trusted_advice_params = AdviceClaimReductionParams::new(
                 AdviceKind::Trusted,
-                &self.program_io.memory_layout,
+                self.program_io.memory_layout.max_trusted_advice_size as usize,
                 self.trace.len(),
+                precommitted_scheduling_reference,
                 &self.opening_accumulator,
             );
             // Note: We clone the advice polynomial here because Stage 8 needs the original polynomial
@@ -1353,8 +1344,9 @@ impl<
         if self.advice.untrusted_advice_polynomial.is_some() {
             let untrusted_advice_params = AdviceClaimReductionParams::new(
                 AdviceKind::Untrusted,
-                &self.program_io.memory_layout,
+                self.program_io.memory_layout.max_untrusted_advice_size as usize,
                 self.trace.len(),
+                precommitted_scheduling_reference,
                 &self.opening_accumulator,
             );
             // Note: We clone the advice polynomial here because Stage 8 needs the original polynomial
@@ -1960,12 +1952,12 @@ impl<
             self.advice_reduction_prover_trusted.take()
         {
             if advice_reduction_prover_trusted
-                .params
+                .params()
                 .num_address_phase_rounds()
                 > 0
             {
                 // Transition phase
-                advice_reduction_prover_trusted.params.phase = ReductionPhase::AddressVariables;
+                advice_reduction_prover_trusted.transition_to_address_phase();
                 instances.push(Box::new(advice_reduction_prover_trusted));
             }
         }
@@ -1973,12 +1965,12 @@ impl<
             self.advice_reduction_prover_untrusted.take()
         {
             if advice_reduction_prover_untrusted
-                .params
+                .params()
                 .num_address_phase_rounds()
                 > 0
             {
                 // Transition phase
-                advice_reduction_prover_untrusted.params.phase = ReductionPhase::AddressVariables;
+                advice_reduction_prover_untrusted.transition_to_address_phase();
                 instances.push(Box::new(advice_reduction_prover_untrusted));
             }
         }
@@ -2005,70 +1997,60 @@ impl<
     ) -> PCS::Proof {
         tracing::info!("Stage 8 proving (Dory batch opening)");
 
-        let _guard = DoryGlobals::initialize_context(
-            self.one_hot_params.k_chunk,
-            self.padded_trace_len,
-            DoryContext::Main,
-            Some(DoryGlobals::get_layout()),
-        );
-
-        // Get the unified opening point from HammingWeightClaimReduction
-        // This contains (r_address_stage7 || r_cycle_stage6) in big-endian
-        let (opening_point, _) = self.opening_accumulator.get_committed_polynomial_opening(
-            CommittedPolynomial::InstructionRa(0),
-            SumcheckId::HammingWeightClaimReduction,
-        );
-
-        let log_k_chunk = self.one_hot_params.log_k_chunk;
-        let r_address_stage7 = &opening_point.r[..log_k_chunk];
+        let opening_point = self.stage8_opening_point();
 
         let mut polynomial_claims = Vec::new();
         let mut scaling_factors = Vec::new();
 
-        // Dense polynomials: RamInc and RdInc (from IncClaimReduction in Stage 6)
-        // at r_cycle_stage6 only (length log_T)
-        let (_, ram_inc_claim) = self.opening_accumulator.get_committed_polynomial_opening(
-            CommittedPolynomial::RamInc,
-            SumcheckId::IncClaimReduction,
-        );
-        let (_, rd_inc_claim) = self.opening_accumulator.get_committed_polynomial_opening(
-            CommittedPolynomial::RdInc,
-            SumcheckId::IncClaimReduction,
-        );
+        let (ram_inc_point, ram_inc_claim) =
+            self.opening_accumulator.get_committed_polynomial_opening(
+                CommittedPolynomial::RamInc,
+                SumcheckId::IncClaimReduction,
+            );
+        let (rd_inc_point, rd_inc_claim) =
+            self.opening_accumulator.get_committed_polynomial_opening(
+                CommittedPolynomial::RdInc,
+                SumcheckId::IncClaimReduction,
+            );
 
-        // Dense polynomials are zero-padded in the Dory matrix, so their evaluation
-        // includes a factor eq(r_addr, 0) = ∏(1 − r_addr_i).
-        let lagrange_factor: F = EqPolynomial::zero_selector(r_address_stage7);
-        polynomial_claims.push((CommittedPolynomial::RamInc, ram_inc_claim * lagrange_factor));
-        scaling_factors.push(lagrange_factor);
-        polynomial_claims.push((CommittedPolynomial::RdInc, rd_inc_claim * lagrange_factor));
-        scaling_factors.push(lagrange_factor);
+        let ram_inc_lagrange = compute_lagrange_factor::<F>(&opening_point.r, &ram_inc_point.r);
+        let rd_inc_lagrange = compute_lagrange_factor::<F>(&opening_point.r, &rd_inc_point.r);
+        polynomial_claims.push((
+            CommittedPolynomial::RamInc,
+            ram_inc_claim * ram_inc_lagrange,
+        ));
+        scaling_factors.push(ram_inc_lagrange);
+        polynomial_claims.push((CommittedPolynomial::RdInc, rd_inc_claim * rd_inc_lagrange));
+        scaling_factors.push(rd_inc_lagrange);
 
         // Sparse polynomials: all RA polys (from HammingWeightClaimReduction)
         // These are at (r_address_stage7, r_cycle_stage6)
         for i in 0..self.one_hot_params.instruction_d {
-            let (_, claim) = self.opening_accumulator.get_committed_polynomial_opening(
+            let (ra_point, claim) = self.opening_accumulator.get_committed_polynomial_opening(
                 CommittedPolynomial::InstructionRa(i),
                 SumcheckId::HammingWeightClaimReduction,
             );
-            polynomial_claims.push((CommittedPolynomial::InstructionRa(i), claim));
-            scaling_factors.push(F::one());
+            let lagrange = compute_lagrange_factor::<F>(&opening_point.r, &ra_point.r);
+            polynomial_claims.push((CommittedPolynomial::InstructionRa(i), claim * lagrange));
+            scaling_factors.push(lagrange);
         }
         for i in 0..self.one_hot_params.bytecode_d {
-            let (_, claim) = self.opening_accumulator.get_committed_polynomial_opening(
+            let (ra_point, claim) = self.opening_accumulator.get_committed_polynomial_opening(
                 CommittedPolynomial::BytecodeRa(i),
                 SumcheckId::HammingWeightClaimReduction,
             );
-            polynomial_claims.push((CommittedPolynomial::BytecodeRa(i), claim));
-            scaling_factors.push(F::one());
+            let lagrange = compute_lagrange_factor::<F>(&opening_point.r, &ra_point.r);
+            polynomial_claims.push((CommittedPolynomial::BytecodeRa(i), claim * lagrange));
+            scaling_factors.push(lagrange);
         }
         for i in 0..self.one_hot_params.ram_d {
-            let (_, claim) = self.opening_accumulator.get_committed_polynomial_opening(
+            let (ra_point, claim) = self.opening_accumulator.get_committed_polynomial_opening(
                 CommittedPolynomial::RamRa(i),
                 SumcheckId::HammingWeightClaimReduction,
             );
-            polynomial_claims.push((CommittedPolynomial::RamRa(i), claim));
-            scaling_factors.push(F::one());
+            let lagrange = compute_lagrange_factor::<F>(&opening_point.r, &ra_point.r);
+            polynomial_claims.push((CommittedPolynomial::RamRa(i), claim * lagrange));
+            scaling_factors.push(lagrange);
         }
 
         // Advice polynomials: TrustedAdvice and UntrustedAdvice (from AdviceClaimReduction in Stage 6)
@@ -2083,8 +2065,7 @@ impl<
             .opening_accumulator
             .get_advice_opening(AdviceKind::Trusted, SumcheckId::AdviceClaimReduction)
         {
-            let lagrange_factor =
-                compute_advice_lagrange_factor::<F>(&opening_point.r, &advice_point.r);
+            let lagrange_factor = compute_lagrange_factor::<F>(&opening_point.r, &advice_point.r);
             polynomial_claims.push((
                 CommittedPolynomial::TrustedAdvice,
                 advice_claim * lagrange_factor,
@@ -2100,8 +2081,7 @@ impl<
             .opening_accumulator
             .get_advice_opening(AdviceKind::Untrusted, SumcheckId::AdviceClaimReduction)
         {
-            let lagrange_factor =
-                compute_advice_lagrange_factor::<F>(&opening_point.r, &advice_point.r);
+            let lagrange_factor = compute_lagrange_factor::<F>(&opening_point.r, &advice_point.r);
             polynomial_claims.push((
                 CommittedPolynomial::UntrustedAdvice,
                 advice_claim * lagrange_factor,

--- a/jolt-core/src/zkvm/prover.rs
+++ b/jolt-core/src/zkvm/prover.rs
@@ -1322,7 +1322,6 @@ impl<
             let trusted_advice_params = AdviceClaimReductionParams::new(
                 AdviceKind::Trusted,
                 self.program_io.memory_layout.max_trusted_advice_size as usize,
-                self.trace.len(),
                 precommitted_scheduling_reference,
                 &self.opening_accumulator,
             );
@@ -1345,7 +1344,6 @@ impl<
             let untrusted_advice_params = AdviceClaimReductionParams::new(
                 AdviceKind::Untrusted,
                 self.program_io.memory_layout.max_untrusted_advice_size as usize,
-                self.trace.len(),
                 precommitted_scheduling_reference,
                 &self.opening_accumulator,
             );
@@ -1953,6 +1951,7 @@ impl<
         {
             if advice_reduction_prover_trusted
                 .params()
+                .precommitted
                 .num_address_phase_rounds()
                 > 0
             {
@@ -1966,6 +1965,7 @@ impl<
         {
             if advice_reduction_prover_untrusted
                 .params()
+                .precommitted
                 .num_address_phase_rounds()
                 > 0
             {

--- a/jolt-core/src/zkvm/prover.rs
+++ b/jolt-core/src/zkvm/prover.rs
@@ -103,7 +103,7 @@ use crate::{
         bytecode::read_raf_checking::{
             BytecodeReadRafAddressSumcheckProver, BytecodeReadRafCycleSumcheckProver,
         },
-        fiat_shamir_preamble,
+        compute_final_opening_point, fiat_shamir_preamble,
         instruction_lookups::{
             ra_virtual::InstructionRaSumcheckProver as LookupsRaSumcheckProver,
             read_raf_checking::InstructionReadRafSumcheckProver,
@@ -312,80 +312,13 @@ impl<
 
     fn stage8_opening_point(&self) -> OpeningPoint<BIG_ENDIAN, F> {
         let native_main_vars = self.trace.len().log_2() + self.one_hot_params.log_k_chunk;
-        let mut opening_candidates: Vec<(&str, OpeningPoint<BIG_ENDIAN, F>)> = Vec::new();
-        if let Some((point, _)) = self
-            .opening_accumulator
-            .get_advice_opening(AdviceKind::Trusted, SumcheckId::AdviceClaimReduction)
-        {
-            opening_candidates.push(("trusted_advice", point));
-        }
-        if let Some((point, _)) = self
-            .opening_accumulator
-            .get_advice_opening(AdviceKind::Untrusted, SumcheckId::AdviceClaimReduction)
-        {
-            opening_candidates.push(("untrusted_advice", point));
-        }
-
-        let max_len = opening_candidates
-            .iter()
-            .map(|(_, p)| p.r.len())
-            .max()
-            .unwrap_or(0);
-        if max_len > native_main_vars {
-            let dominant = opening_candidates
-                .iter()
-                .find(|(_, p)| p.r.len() == max_len)
-                .expect("at least one dominant precommitted candidate expected");
-            for (name, point) in opening_candidates
-                .iter()
-                .filter(|(_, p)| p.r.len() == max_len)
-            {
-                assert_eq!(
-                    point.r, dominant.1.r,
-                    "incompatible dominant precommitted anchors: {} and {} have equal dimensionality {} but different opening points",
-                    dominant.0, name, max_len
-                );
-            }
-            OpeningPoint::<BIG_ENDIAN, F>::new(dominant.1.r.clone())
-        } else {
-            let (hamming_point, _) = self.opening_accumulator.get_committed_polynomial_opening(
-                CommittedPolynomial::InstructionRa(0),
-                SumcheckId::HammingWeightClaimReduction,
-            );
-            let r_address_stage7 = hamming_point.r[..self.one_hot_params.log_k_chunk].to_vec();
-            let r_cycle_stage6 = self
-                .opening_accumulator
-                .get_committed_polynomial_opening(
-                    CommittedPolynomial::RamInc,
-                    SumcheckId::IncClaimReduction,
-                )
-                .0
-                .r;
-
-            match DoryGlobals::get_layout() {
-                DoryLayout::AddressMajor => OpeningPoint::<BIG_ENDIAN, F>::new(
-                    [r_cycle_stage6.as_slice(), r_address_stage7.as_slice()].concat(),
-                ),
-                DoryLayout::CycleMajor => {
-                    let native_cycle = &hamming_point.r[self.one_hot_params.log_k_chunk..];
-                    assert!(
-                        r_cycle_stage6.len() >= native_cycle.len(),
-                        "stage6 cycle challenges shorter than native cycle vars"
-                    );
-                    assert!(
-                        r_cycle_stage6[..native_cycle.len()] == *native_cycle,
-                        "cycle-major Stage-8 expects stage6 cycle prefix to equal native cycle vars \
-                         (cycle_full_len={}, native_len={})",
-                        r_cycle_stage6.len(),
-                        native_cycle.len()
-                    );
-                    let cycle_extra = &r_cycle_stage6[native_cycle.len()..];
-                    let cycle_extra_and_anchor =
-                        [cycle_extra, r_address_stage7.as_slice(), native_cycle].concat();
-                    OpeningPoint::<BIG_ENDIAN, F>::new(cycle_extra_and_anchor)
-                }
-            }
-        }
+        compute_final_opening_point(
+            &self.opening_accumulator,
+            native_main_vars,
+            self.one_hot_params.log_k_chunk,
+            DoryGlobals::get_layout(),
+        )
+        .expect("invalid prover Stage-8 opening point")
     }
 
     pub fn gen_from_trace(

--- a/jolt-core/src/zkvm/prover.rs
+++ b/jolt-core/src/zkvm/prover.rs
@@ -38,8 +38,8 @@ use crate::{
         },
         multilinear_polynomial::MultilinearPolynomial,
         opening_proof::{
-            compute_lagrange_factor, DoryOpeningState, OpeningAccumulator, OpeningPoint,
-            ProverOpeningAccumulator, SumcheckId, BIG_ENDIAN,
+            compute_lagrange_factor, DoryOpeningState, OpeningAccumulator,
+            ProverOpeningAccumulator, SumcheckId,
         },
         rlc_polynomial::{RLCStreamingData, TraceSource},
     },

--- a/jolt-core/src/zkvm/prover.rs
+++ b/jolt-core/src/zkvm/prover.rs
@@ -310,17 +310,6 @@ impl<
         candidates
     }
 
-    fn stage8_opening_point(&self) -> OpeningPoint<BIG_ENDIAN, F> {
-        let native_main_vars = self.trace.len().log_2() + self.one_hot_params.log_k_chunk;
-        compute_final_opening_point(
-            &self.opening_accumulator,
-            native_main_vars,
-            self.one_hot_params.log_k_chunk,
-            DoryGlobals::get_layout(),
-        )
-        .expect("invalid prover Stage-8 opening point")
-    }
-
     pub fn gen_from_trace(
         preprocessing: &'a JoltProverPreprocessing<F, C, PCS>,
         lazy_trace: LazyTraceIterator,
@@ -1961,7 +1950,14 @@ impl<
     ) -> PCS::Proof {
         tracing::info!("Stage 8 proving (Dory batch opening)");
 
-        let opening_point = self.stage8_opening_point();
+        let native_main_vars = self.trace.len().log_2() + self.one_hot_params.log_k_chunk;
+        let opening_point = compute_final_opening_point(
+            &self.opening_accumulator,
+            native_main_vars,
+            self.one_hot_params.log_k_chunk,
+            DoryGlobals::get_layout(),
+        )
+        .expect("invalid prover Stage-8 opening point");
 
         let mut polynomial_claims = Vec::new();
         let mut scaling_factors = Vec::new();

--- a/jolt-core/src/zkvm/transpilable_verifier.rs
+++ b/jolt-core/src/zkvm/transpilable_verifier.rs
@@ -41,12 +41,13 @@
 
 use crate::curve::JoltCurve;
 use crate::poly::commitment::commitment_scheme::CommitmentScheme;
+use crate::poly::commitment::dory::DoryGlobals;
 #[cfg(not(feature = "zk"))]
 use crate::poly::opening_proof::{OpeningPoint, BIG_ENDIAN};
 use crate::subprotocols::sumcheck::{BatchedSumcheck, ClearSumcheckProof, SumcheckInstanceProof};
 use crate::zkvm::claim_reductions::{
-    AdviceClaimReductionVerifier, AdviceKind, HammingWeightClaimReductionVerifier, ReductionPhase,
-    RegistersClaimReductionSumcheckVerifier,
+    AdviceClaimReductionVerifier, AdviceKind, HammingWeightClaimReductionVerifier,
+    PrecommittedClaimReduction, RegistersClaimReductionSumcheckVerifier,
 };
 use crate::zkvm::config::OneHotParams;
 use crate::zkvm::{
@@ -152,6 +153,36 @@ impl<
         A: AbstractVerifierOpeningAccumulator<F>,
     > TranspilableVerifier<'a, F, C, PCS, ProofTranscript, A>
 {
+    #[inline]
+    fn main_total_vars(&self) -> usize {
+        let trace_log_t = self.proof.trace_length.log_2();
+        let log_k_chunk = self.one_hot_params.log_k_chunk;
+        let mut max_total_vars = trace_log_t + log_k_chunk;
+        for total_vars in self.precommitted_candidate_total_vars() {
+            max_total_vars = max_total_vars.max(total_vars);
+        }
+        max_total_vars
+    }
+
+    #[inline]
+    fn precommitted_candidate_total_vars(&self) -> Vec<usize> {
+        let mut candidates = Vec::new();
+        if self.trusted_advice_commitment.is_some() {
+            let (sigma, nu) = DoryGlobals::advice_sigma_nu_from_max_bytes(
+                self.program_io.memory_layout.max_trusted_advice_size as usize,
+            );
+            candidates.push(sigma + nu);
+        }
+
+        if self.proof.untrusted_advice_commitment.is_some() {
+            let (sigma, nu) = DoryGlobals::advice_sigma_nu_from_max_bytes(
+                self.program_io.memory_layout.max_untrusted_advice_size as usize,
+            );
+            candidates.push(sigma + nu);
+        }
+        candidates
+    }
+
     /// Create a TranspilableVerifier for real verification.
     ///
     /// This constructor creates a new `VerifierOpeningAccumulator` and populates
@@ -560,6 +591,12 @@ impl<
     }
 
     fn verify_stage6(&mut self) -> Result<(), ProofVerifyError> {
+        let _ = DoryGlobals::initialize_main_with_log_embedding(
+            self.one_hot_params.k_chunk,
+            self.proof.trace_length,
+            self.main_total_vars(),
+            Some(self.proof.dory_layout),
+        );
         let (bytecode_read_raf_params, booleanity_params) = self.verify_stage6a()?;
         self.verify_stage6b(bytecode_read_raf_params, booleanity_params)
     }
@@ -631,20 +668,30 @@ impl<
             &mut self.transcript,
         );
 
+        let main_total_vars = self.proof.trace_length.log_2() + self.one_hot_params.log_k_chunk;
+        let precommitted_candidates = self.precommitted_candidate_total_vars();
+        let precommitted_scheduling_reference =
+            PrecommittedClaimReduction::<F>::scheduling_reference(
+                main_total_vars,
+                &precommitted_candidates,
+            );
+
         // Advice claim reduction (Phase 1 in Stage 6b): trusted and untrusted are separate instances.
         if self.trusted_advice_commitment.is_some() {
             self.advice_reduction_verifier_trusted = Some(AdviceClaimReductionVerifier::new(
                 AdviceKind::Trusted,
-                &self.program_io.memory_layout,
+                self.program_io.memory_layout.max_trusted_advice_size as usize,
                 self.proof.trace_length,
+                precommitted_scheduling_reference,
                 &self.opening_accumulator,
             ));
         }
         if self.proof.untrusted_advice_commitment.is_some() {
             self.advice_reduction_verifier_untrusted = Some(AdviceClaimReductionVerifier::new(
                 AdviceKind::Untrusted,
-                &self.program_io.memory_layout,
+                self.program_io.memory_layout.max_untrusted_advice_size as usize,
                 self.proof.trace_length,
+                precommitted_scheduling_reference,
                 &self.opening_accumulator,
             ));
         }

--- a/jolt-core/src/zkvm/transpilable_verifier.rs
+++ b/jolt-core/src/zkvm/transpilable_verifier.rs
@@ -681,7 +681,6 @@ impl<
             self.advice_reduction_verifier_trusted = Some(AdviceClaimReductionVerifier::new(
                 AdviceKind::Trusted,
                 self.program_io.memory_layout.max_trusted_advice_size as usize,
-                self.proof.trace_length,
                 precommitted_scheduling_reference,
                 &self.opening_accumulator,
             ));
@@ -690,7 +689,6 @@ impl<
             self.advice_reduction_verifier_untrusted = Some(AdviceClaimReductionVerifier::new(
                 AdviceKind::Untrusted,
                 self.program_io.memory_layout.max_untrusted_advice_size as usize,
-                self.proof.trace_length,
                 precommitted_scheduling_reference,
                 &self.opening_accumulator,
             ));
@@ -741,8 +739,8 @@ impl<
             self.advice_reduction_verifier_trusted.as_mut()
         {
             let mut params = advice_reduction_verifier_trusted.params.borrow_mut();
-            if params.num_address_phase_rounds() > 0 {
-                params.transition_to_address_phase();
+            if params.precommitted.num_address_phase_rounds() > 0 {
+                params.precommitted.transition_to_address_phase();
                 instances.push(advice_reduction_verifier_trusted);
             }
         }
@@ -750,8 +748,8 @@ impl<
             self.advice_reduction_verifier_untrusted.as_mut()
         {
             let mut params = advice_reduction_verifier_untrusted.params.borrow_mut();
-            if params.num_address_phase_rounds() > 0 {
-                params.transition_to_address_phase();
+            if params.precommitted.num_address_phase_rounds() > 0 {
+                params.precommitted.transition_to_address_phase();
                 instances.push(advice_reduction_verifier_untrusted);
             }
         }

--- a/jolt-core/src/zkvm/transpilable_verifier.rs
+++ b/jolt-core/src/zkvm/transpilable_verifier.rs
@@ -47,7 +47,7 @@ use crate::poly::opening_proof::{OpeningPoint, BIG_ENDIAN};
 use crate::subprotocols::sumcheck::{BatchedSumcheck, ClearSumcheckProof, SumcheckInstanceProof};
 use crate::zkvm::claim_reductions::{
     AdviceClaimReductionVerifier, AdviceKind, HammingWeightClaimReductionVerifier,
-    PrecommittedClaimReduction, RegistersClaimReductionSumcheckVerifier,
+    PrecommittedClaimReduction, PrecommittedParams, RegistersClaimReductionSumcheckVerifier,
 };
 use crate::zkvm::config::OneHotParams;
 use crate::zkvm::{
@@ -283,9 +283,9 @@ impl<
             .map_err(ProofVerifyError::InvalidReadWriteConfig)?;
 
         // Construct full params from the validated config
-        let bytecode_K = preprocessing.shared.bytecode.code_size;
+        let bytecode_len = preprocessing.shared.bytecode.code_size;
         let one_hot_params =
-            OneHotParams::from_config(&proof.one_hot_config, bytecode_K, proof.ram_K);
+            OneHotParams::from_config(&proof.one_hot_config, bytecode_len, proof.ram_K);
 
         Ok(TranspilableVerifier {
             trusted_advice_commitment,
@@ -314,9 +314,9 @@ impl<
         opening_accumulator: A,
     ) -> Self {
         let spartan_key = UniformSpartanKey::new(proof.trace_length.next_power_of_two());
-        let bytecode_K = preprocessing.shared.bytecode.code_size;
+        let bytecode_len = preprocessing.shared.bytecode.code_size;
         let one_hot_params =
-            OneHotParams::from_config(&proof.one_hot_config, bytecode_K, proof.ram_K);
+            OneHotParams::from_config(&proof.one_hot_config, bytecode_len, proof.ram_K);
 
         Self {
             trusted_advice_commitment,
@@ -738,18 +738,30 @@ impl<
         if let Some(advice_reduction_verifier_trusted) =
             self.advice_reduction_verifier_trusted.as_mut()
         {
-            let mut params = advice_reduction_verifier_trusted.params.borrow_mut();
-            if params.precommitted.num_address_phase_rounds() > 0 {
-                params.precommitted.transition_to_address_phase();
+            if advice_reduction_verifier_trusted
+                .params
+                .precommitted
+                .num_address_phase_rounds()
+                > 0
+            {
+                advice_reduction_verifier_trusted
+                    .params
+                    .transition_to_address_phase(&self.opening_accumulator);
                 instances.push(advice_reduction_verifier_trusted);
             }
         }
         if let Some(advice_reduction_verifier_untrusted) =
             self.advice_reduction_verifier_untrusted.as_mut()
         {
-            let mut params = advice_reduction_verifier_untrusted.params.borrow_mut();
-            if params.precommitted.num_address_phase_rounds() > 0 {
-                params.precommitted.transition_to_address_phase();
+            if advice_reduction_verifier_untrusted
+                .params
+                .precommitted
+                .num_address_phase_rounds()
+                > 0
+            {
+                advice_reduction_verifier_untrusted
+                    .params
+                    .transition_to_address_phase(&self.opening_accumulator);
                 instances.push(advice_reduction_verifier_untrusted);
             }
         }

--- a/jolt-core/src/zkvm/transpilable_verifier.rs
+++ b/jolt-core/src/zkvm/transpilable_verifier.rs
@@ -742,7 +742,7 @@ impl<
         {
             let mut params = advice_reduction_verifier_trusted.params.borrow_mut();
             if params.num_address_phase_rounds() > 0 {
-                params.phase = ReductionPhase::AddressVariables;
+                params.transition_to_address_phase();
                 instances.push(advice_reduction_verifier_trusted);
             }
         }
@@ -751,7 +751,7 @@ impl<
         {
             let mut params = advice_reduction_verifier_untrusted.params.borrow_mut();
             if params.num_address_phase_rounds() > 0 {
-                params.phase = ReductionPhase::AddressVariables;
+                params.transition_to_address_phase();
                 instances.push(advice_reduction_verifier_untrusted);
             }
         }

--- a/jolt-core/src/zkvm/verifier.rs
+++ b/jolt-core/src/zkvm/verifier.rs
@@ -8,7 +8,7 @@ use crate::curve::JoltCurve;
 use crate::poly::commitment::commitment_scheme::{CommitmentScheme, ZkEvalCommitment};
 #[cfg(feature = "zk")]
 use crate::poly::commitment::dory::bind_opening_inputs_zk;
-use crate::poly::commitment::dory::{bind_opening_inputs, DoryContext, DoryGlobals};
+use crate::poly::commitment::dory::{bind_opening_inputs, DoryContext, DoryGlobals, DoryLayout};
 use crate::poly::commitment::pedersen::PedersenGenerators;
 #[cfg(feature = "zk")]
 use crate::poly::lagrange_poly::LagrangeHelper;
@@ -328,13 +328,48 @@ impl<
             }
             Ok(OpeningPoint::<BIG_ENDIAN, F>::new(dominant.1.r.clone()))
         } else {
-            Ok(self
+            let (hamming_point, _) = self.opening_accumulator.get_committed_polynomial_opening(
+                CommittedPolynomial::InstructionRa(0),
+                SumcheckId::HammingWeightClaimReduction,
+            );
+            let r_address_stage7 = hamming_point.r[..self.one_hot_params.log_k_chunk].to_vec();
+            let r_cycle_stage6 = self
                 .opening_accumulator
                 .get_committed_polynomial_opening(
-                    CommittedPolynomial::InstructionRa(0),
-                    SumcheckId::HammingWeightClaimReduction,
+                    CommittedPolynomial::RamInc,
+                    SumcheckId::IncClaimReduction,
                 )
-                .0)
+                .0
+                .r;
+
+            match self.proof.dory_layout {
+                DoryLayout::AddressMajor => Ok(OpeningPoint::<BIG_ENDIAN, F>::new(
+                    [r_cycle_stage6.as_slice(), r_address_stage7.as_slice()].concat(),
+                )),
+                DoryLayout::CycleMajor => {
+                    let native_cycle = &hamming_point.r[self.one_hot_params.log_k_chunk..];
+                    if r_cycle_stage6.len() < native_cycle.len() {
+                        return Err(ProofVerifyError::DoryError(format!(
+                            "stage6 cycle challenges shorter than native cycle vars \
+                             (cycle_full_len={}, native_len={})",
+                            r_cycle_stage6.len(),
+                            native_cycle.len()
+                        )));
+                    }
+                    if r_cycle_stage6[..native_cycle.len()] != *native_cycle {
+                        return Err(ProofVerifyError::DoryError(format!(
+                            "cycle-major Stage-8 expects stage6 cycle prefix to equal native cycle vars \
+                             (cycle_full_len={}, native_len={})",
+                            r_cycle_stage6.len(),
+                            native_cycle.len()
+                        )));
+                    }
+                    let cycle_extra = &r_cycle_stage6[native_cycle.len()..];
+                    let cycle_extra_and_anchor =
+                        [cycle_extra, r_address_stage7.as_slice(), native_cycle].concat();
+                    Ok(OpeningPoint::<BIG_ENDIAN, F>::new(cycle_extra_and_anchor))
+                }
+            }
         }
     }
 

--- a/jolt-core/src/zkvm/verifier.rs
+++ b/jolt-core/src/zkvm/verifier.rs
@@ -1251,7 +1251,6 @@ impl<
             self.advice_reduction_verifier_trusted = Some(AdviceClaimReductionVerifier::new(
                 AdviceKind::Trusted,
                 self.program_io.memory_layout.max_trusted_advice_size as usize,
-                self.proof.trace_length,
                 precommitted_scheduling_reference,
                 &self.opening_accumulator,
             ));
@@ -1260,7 +1259,6 @@ impl<
             self.advice_reduction_verifier_untrusted = Some(AdviceClaimReductionVerifier::new(
                 AdviceKind::Untrusted,
                 self.program_io.memory_layout.max_untrusted_advice_size as usize,
-                self.proof.trace_length,
                 precommitted_scheduling_reference,
                 &self.opening_accumulator,
             ));
@@ -1629,9 +1627,9 @@ impl<
             self.advice_reduction_verifier_trusted.as_mut()
         {
             let mut params = advice_reduction_verifier_trusted.params.borrow_mut();
-            if params.num_address_phase_rounds() > 0 {
+            if params.precommitted.num_address_phase_rounds() > 0 {
                 // Transition phase
-                params.transition_to_address_phase();
+                params.precommitted.transition_to_address_phase();
                 instances.push(advice_reduction_verifier_trusted);
             }
         }
@@ -1639,9 +1637,9 @@ impl<
             self.advice_reduction_verifier_untrusted.as_mut()
         {
             let mut params = advice_reduction_verifier_untrusted.params.borrow_mut();
-            if params.num_address_phase_rounds() > 0 {
+            if params.precommitted.num_address_phase_rounds() > 0 {
                 // Transition phase
-                params.transition_to_address_phase();
+                params.precommitted.transition_to_address_phase();
                 instances.push(advice_reduction_verifier_untrusted);
             }
         }

--- a/jolt-core/src/zkvm/verifier.rs
+++ b/jolt-core/src/zkvm/verifier.rs
@@ -8,7 +8,7 @@ use crate::curve::JoltCurve;
 use crate::poly::commitment::commitment_scheme::{CommitmentScheme, ZkEvalCommitment};
 #[cfg(feature = "zk")]
 use crate::poly::commitment::dory::bind_opening_inputs_zk;
-use crate::poly::commitment::dory::{bind_opening_inputs, DoryContext, DoryGlobals, DoryLayout};
+use crate::poly::commitment::dory::{bind_opening_inputs, DoryContext, DoryGlobals};
 use crate::poly::commitment::pedersen::PedersenGenerators;
 #[cfg(feature = "zk")]
 use crate::poly::lagrange_poly::LagrangeHelper;
@@ -50,7 +50,7 @@ use crate::zkvm::{
         IncClaimReductionSumcheckVerifier, InstructionLookupsClaimReductionSumcheckVerifier,
         PrecommittedClaimReduction, PrecommittedParams, RamRaClaimReductionSumcheckVerifier,
     },
-    fiat_shamir_preamble,
+    compute_final_opening_point, fiat_shamir_preamble,
     instruction_lookups::{
         ra_virtual::RaSumcheckVerifier as LookupsRaSumcheckVerifier,
         read_raf_checking::InstructionReadRafSumcheckVerifier,
@@ -79,8 +79,8 @@ use crate::zkvm::{
 use crate::{
     field::JoltField,
     poly::opening_proof::{
-        compute_lagrange_factor, DoryOpeningState, OpeningAccumulator, OpeningId, OpeningPoint,
-        SumcheckId, VerifierOpeningAccumulator, BIG_ENDIAN,
+        compute_lagrange_factor, DoryOpeningState, OpeningAccumulator, OpeningId, SumcheckId,
+        VerifierOpeningAccumulator,
     },
     pprof_scope,
     subprotocols::{
@@ -287,87 +287,6 @@ impl<
             candidates.push(sigma + nu);
         }
         candidates
-    }
-
-    fn stage8_opening_point(&self) -> Result<OpeningPoint<BIG_ENDIAN, F>, ProofVerifyError> {
-        let native_main_vars = self.proof.trace_length.log_2() + self.one_hot_params.log_k_chunk;
-        let mut opening_candidates: Vec<(&str, OpeningPoint<BIG_ENDIAN, F>)> = Vec::new();
-        if let Some((point, _)) = self
-            .opening_accumulator
-            .get_advice_opening(AdviceKind::Trusted, SumcheckId::AdviceClaimReduction)
-        {
-            opening_candidates.push(("trusted_advice", point));
-        }
-        if let Some((point, _)) = self
-            .opening_accumulator
-            .get_advice_opening(AdviceKind::Untrusted, SumcheckId::AdviceClaimReduction)
-        {
-            opening_candidates.push(("untrusted_advice", point));
-        }
-
-        let max_len = opening_candidates
-            .iter()
-            .map(|(_, p)| p.r.len())
-            .max()
-            .unwrap_or(0);
-        if max_len > native_main_vars {
-            let dominant = opening_candidates
-                .iter()
-                .find(|(_, p)| p.r.len() == max_len)
-                .expect("at least one dominant precommitted candidate expected");
-            for (name, point) in opening_candidates
-                .iter()
-                .filter(|(_, p)| p.r.len() == max_len)
-            {
-                if point.r != dominant.1.r {
-                    return Err(ProofVerifyError::DoryError(format!(
-                        "incompatible dominant precommitted anchors: {} and {} have equal dimensionality {} but different opening points",
-                        dominant.0, name, max_len
-                    )));
-                }
-            }
-            Ok(OpeningPoint::<BIG_ENDIAN, F>::new(dominant.1.r.clone()))
-        } else {
-            let (hamming_point, _) = self.opening_accumulator.get_committed_polynomial_opening(
-                CommittedPolynomial::InstructionRa(0),
-                SumcheckId::HammingWeightClaimReduction,
-            );
-            let r_address_stage7 = hamming_point.r[..self.one_hot_params.log_k_chunk].to_vec();
-            let r_cycle_stage6 = self
-                .opening_accumulator
-                .get_committed_polynomial_opening(
-                    CommittedPolynomial::RamInc,
-                    SumcheckId::IncClaimReduction,
-                )
-                .0
-                .r;
-
-            match self.proof.dory_layout {
-                DoryLayout::AddressMajor => Ok(OpeningPoint::<BIG_ENDIAN, F>::new(
-                    [r_cycle_stage6.as_slice(), r_address_stage7.as_slice()].concat(),
-                )),
-                DoryLayout::CycleMajor => {
-                    let native_cycle = &hamming_point.r[self.one_hot_params.log_k_chunk..];
-                    if r_cycle_stage6.len() < native_cycle.len() {
-                        return Err(ProofVerifyError::DoryError(
-                            "stage6 cycle challenges shorter than native cycle vars".to_string(),
-                        ));
-                    }
-                    if r_cycle_stage6[..native_cycle.len()] != *native_cycle {
-                        return Err(ProofVerifyError::DoryError(format!(
-                            "cycle-major Stage-8 expects stage6 cycle prefix to equal native cycle vars \
-                             (cycle_full_len={}, native_len={})",
-                            r_cycle_stage6.len(),
-                            native_cycle.len()
-                        )));
-                    }
-                    let cycle_extra = &r_cycle_stage6[native_cycle.len()..];
-                    let cycle_extra_and_anchor =
-                        [cycle_extra, r_address_stage7.as_slice(), native_cycle].concat();
-                    Ok(OpeningPoint::<BIG_ENDIAN, F>::new(cycle_extra_and_anchor))
-                }
-            }
-        }
     }
 
     pub fn new(
@@ -1736,7 +1655,13 @@ impl<
 
     /// Stage 8: Dory batch opening verification.
     fn verify_stage8(&mut self) -> Result<Stage8VerifyData<F>, ProofVerifyError> {
-        let opening_point = self.stage8_opening_point()?;
+        let native_main_vars = self.proof.trace_length.log_2() + self.one_hot_params.log_k_chunk;
+        let opening_point = compute_final_opening_point(
+            &self.opening_accumulator,
+            native_main_vars,
+            self.one_hot_params.log_k_chunk,
+            self.proof.dory_layout,
+        )?;
 
         // 1. Collect all (polynomial, claim) pairs
         let mut polynomial_claims = Vec::new();

--- a/jolt-core/src/zkvm/verifier.rs
+++ b/jolt-core/src/zkvm/verifier.rs
@@ -8,7 +8,7 @@ use crate::curve::JoltCurve;
 use crate::poly::commitment::commitment_scheme::{CommitmentScheme, ZkEvalCommitment};
 #[cfg(feature = "zk")]
 use crate::poly::commitment::dory::bind_opening_inputs_zk;
-use crate::poly::commitment::dory::{bind_opening_inputs, DoryContext, DoryGlobals};
+use crate::poly::commitment::dory::{bind_opening_inputs, DoryGlobals};
 use crate::poly::commitment::pedersen::PedersenGenerators;
 #[cfg(feature = "zk")]
 use crate::poly::lagrange_poly::LagrangeHelper;
@@ -28,7 +28,6 @@ use crate::subprotocols::sumcheck_verifier::SumcheckInstanceParams;
 #[cfg(feature = "zk")]
 use crate::subprotocols::univariate_skip::UniSkipFirstRoundProofVariant;
 use crate::zkvm::bytecode::{BytecodePreprocessing, PreprocessingError};
-use crate::zkvm::claim_reductions::advice::ReductionPhase;
 use crate::zkvm::claim_reductions::RegistersClaimReductionSumcheckVerifier;
 use crate::zkvm::config::OneHotParams;
 #[cfg(feature = "prover")]
@@ -49,7 +48,7 @@ use crate::zkvm::{
     claim_reductions::{
         AdviceClaimReductionVerifier, AdviceKind, HammingWeightClaimReductionVerifier,
         IncClaimReductionSumcheckVerifier, InstructionLookupsClaimReductionSumcheckVerifier,
-        RamRaClaimReductionSumcheckVerifier,
+        PrecommittedClaimReduction, RamRaClaimReductionSumcheckVerifier,
     },
     fiat_shamir_preamble,
     instruction_lookups::{
@@ -79,12 +78,9 @@ use crate::zkvm::{
 };
 use crate::{
     field::JoltField,
-    poly::{
-        eq_poly::EqPolynomial,
-        opening_proof::{
-            compute_advice_lagrange_factor, DoryOpeningState, OpeningAccumulator, OpeningId,
-            SumcheckId, VerifierOpeningAccumulator,
-        },
+    poly::opening_proof::{
+        compute_lagrange_factor, DoryOpeningState, OpeningAccumulator, OpeningId, OpeningPoint,
+        SumcheckId, VerifierOpeningAccumulator, BIG_ENDIAN,
     },
     pprof_scope,
     subprotocols::{
@@ -263,6 +259,85 @@ impl<
         ProofTranscript: Transcript,
     > JoltVerifier<'a, F, C, PCS, ProofTranscript>
 {
+    #[inline]
+    fn main_total_vars(&self) -> usize {
+        let trace_log_t = self.proof.trace_length.log_2();
+        let log_k_chunk = self.one_hot_params.log_k_chunk;
+        let mut max_total_vars = trace_log_t + log_k_chunk;
+        for total_vars in self.precommitted_candidate_total_vars() {
+            max_total_vars = max_total_vars.max(total_vars);
+        }
+        max_total_vars
+    }
+
+    #[inline]
+    fn precommitted_candidate_total_vars(&self) -> Vec<usize> {
+        let mut candidates = Vec::new();
+        if self.trusted_advice_commitment.is_some() {
+            let (sigma, nu) = DoryGlobals::advice_sigma_nu_from_max_bytes(
+                self.program_io.memory_layout.max_trusted_advice_size as usize,
+            );
+            candidates.push(sigma + nu);
+        }
+
+        if self.proof.untrusted_advice_commitment.is_some() {
+            let (sigma, nu) = DoryGlobals::advice_sigma_nu_from_max_bytes(
+                self.program_io.memory_layout.max_untrusted_advice_size as usize,
+            );
+            candidates.push(sigma + nu);
+        }
+        candidates
+    }
+
+    fn stage8_opening_point(&self) -> Result<OpeningPoint<BIG_ENDIAN, F>, ProofVerifyError> {
+        let native_main_vars = self.proof.trace_length.log_2() + self.one_hot_params.log_k_chunk;
+        let mut opening_candidates: Vec<(&str, OpeningPoint<BIG_ENDIAN, F>)> = Vec::new();
+        if let Some((point, _)) = self
+            .opening_accumulator
+            .get_advice_opening(AdviceKind::Trusted, SumcheckId::AdviceClaimReduction)
+        {
+            opening_candidates.push(("trusted_advice", point));
+        }
+        if let Some((point, _)) = self
+            .opening_accumulator
+            .get_advice_opening(AdviceKind::Untrusted, SumcheckId::AdviceClaimReduction)
+        {
+            opening_candidates.push(("untrusted_advice", point));
+        }
+
+        let max_len = opening_candidates
+            .iter()
+            .map(|(_, p)| p.r.len())
+            .max()
+            .unwrap_or(0);
+        if max_len > native_main_vars {
+            let dominant = opening_candidates
+                .iter()
+                .find(|(_, p)| p.r.len() == max_len)
+                .expect("at least one dominant precommitted candidate expected");
+            for (name, point) in opening_candidates
+                .iter()
+                .filter(|(_, p)| p.r.len() == max_len)
+            {
+                if point.r != dominant.1.r {
+                    return Err(ProofVerifyError::DoryError(format!(
+                        "incompatible dominant precommitted anchors: {} and {} have equal dimensionality {} but different opening points",
+                        dominant.0, name, max_len
+                    )));
+                }
+            }
+            Ok(OpeningPoint::<BIG_ENDIAN, F>::new(dominant.1.r.clone()))
+        } else {
+            Ok(self
+                .opening_accumulator
+                .get_committed_polynomial_opening(
+                    CommittedPolynomial::InstructionRa(0),
+                    SumcheckId::HammingWeightClaimReduction,
+                )
+                .0)
+        }
+    }
+
     pub fn new(
         preprocessing: &'a JoltVerifierPreprocessing<F, C, PCS>,
         proof: JoltProof<F, C, PCS, ProofTranscript>,
@@ -1035,6 +1110,12 @@ impl<
     fn verify_stage6(
         &mut self,
     ) -> Result<(StageVerifyResult<F>, StageVerifyResult<F>), ProofVerifyError> {
+        let _ = DoryGlobals::initialize_main_with_log_embedding(
+            self.one_hot_params.k_chunk,
+            self.proof.trace_length,
+            self.main_total_vars(),
+            Some(self.proof.dory_layout),
+        );
         let (bytecode_read_raf_params, booleanity_params, stage6a_result) =
             self.verify_stage6a()?;
         let stage6b_result = self.verify_stage6b(bytecode_read_raf_params, booleanity_params)?;
@@ -1157,20 +1238,30 @@ impl<
             &mut self.transcript,
         );
 
+        let main_total_vars = self.proof.trace_length.log_2() + self.one_hot_params.log_k_chunk;
+        let precommitted_candidates = self.precommitted_candidate_total_vars();
+        let precommitted_scheduling_reference =
+            PrecommittedClaimReduction::<F>::scheduling_reference(
+                main_total_vars,
+                &precommitted_candidates,
+            );
+
         // Advice claim reduction (Phase 1 in Stage 6b): trusted and untrusted are separate instances.
         if self.trusted_advice_commitment.is_some() {
             self.advice_reduction_verifier_trusted = Some(AdviceClaimReductionVerifier::new(
                 AdviceKind::Trusted,
-                &self.program_io.memory_layout,
+                self.program_io.memory_layout.max_trusted_advice_size as usize,
                 self.proof.trace_length,
+                precommitted_scheduling_reference,
                 &self.opening_accumulator,
             ));
         }
         if self.proof.untrusted_advice_commitment.is_some() {
             self.advice_reduction_verifier_untrusted = Some(AdviceClaimReductionVerifier::new(
                 AdviceKind::Untrusted,
-                &self.program_io.memory_layout,
+                self.program_io.memory_layout.max_untrusted_advice_size as usize,
                 self.proof.trace_length,
+                precommitted_scheduling_reference,
                 &self.opening_accumulator,
             ));
         }
@@ -1540,7 +1631,7 @@ impl<
             let mut params = advice_reduction_verifier_trusted.params.borrow_mut();
             if params.num_address_phase_rounds() > 0 {
                 // Transition phase
-                params.phase = ReductionPhase::AddressVariables;
+                params.transition_to_address_phase();
                 instances.push(advice_reduction_verifier_trusted);
             }
         }
@@ -1550,7 +1641,7 @@ impl<
             let mut params = advice_reduction_verifier_untrusted.params.borrow_mut();
             if params.num_address_phase_rounds() > 0 {
                 // Transition phase
-                params.phase = ReductionPhase::AddressVariables;
+                params.transition_to_address_phase();
                 instances.push(advice_reduction_verifier_untrusted);
             }
         }
@@ -1603,61 +1694,60 @@ impl<
 
     /// Stage 8: Dory batch opening verification.
     fn verify_stage8(&mut self) -> Result<Stage8VerifyData<F>, ProofVerifyError> {
-        // Get the unified opening point from HammingWeightClaimReduction
-        // This contains (r_address_stage7 || r_cycle_stage6) in big-endian
-        let (opening_point, _) = self.opening_accumulator.get_committed_polynomial_opening(
-            CommittedPolynomial::InstructionRa(0),
-            SumcheckId::HammingWeightClaimReduction,
-        );
-        let log_k_chunk = self.one_hot_params.log_k_chunk;
-        let r_address_stage7 = &opening_point.r[..log_k_chunk];
+        let opening_point = self.stage8_opening_point()?;
 
         // 1. Collect all (polynomial, claim) pairs
         let mut polynomial_claims = Vec::new();
         let mut scaling_factors = Vec::new();
 
         // Dense polynomials: RamInc and RdInc (from IncClaimReduction in Stage 6)
-        let (_, ram_inc_claim) = self.opening_accumulator.get_committed_polynomial_opening(
+        let (ram_inc_point, ram_inc_claim) =
+            self.opening_accumulator.get_committed_polynomial_opening(
+                CommittedPolynomial::RamInc,
+                SumcheckId::IncClaimReduction,
+            );
+        let (rd_inc_point, rd_inc_claim) =
+            self.opening_accumulator.get_committed_polynomial_opening(
+                CommittedPolynomial::RdInc,
+                SumcheckId::IncClaimReduction,
+            );
+        let ram_inc_lagrange = compute_lagrange_factor::<F>(&opening_point.r, &ram_inc_point.r);
+        let rd_inc_lagrange = compute_lagrange_factor::<F>(&opening_point.r, &rd_inc_point.r);
+        polynomial_claims.push((
             CommittedPolynomial::RamInc,
-            SumcheckId::IncClaimReduction,
-        );
-        let (_, rd_inc_claim) = self.opening_accumulator.get_committed_polynomial_opening(
-            CommittedPolynomial::RdInc,
-            SumcheckId::IncClaimReduction,
-        );
-
-        // Dense polynomials are zero-padded in the Dory matrix, so their evaluation
-        // includes a factor eq(r_addr, 0) = ∏(1 − r_addr_i).
-        let lagrange_factor: F = EqPolynomial::zero_selector(r_address_stage7);
-        polynomial_claims.push((CommittedPolynomial::RamInc, ram_inc_claim * lagrange_factor));
-        scaling_factors.push(lagrange_factor);
-        polynomial_claims.push((CommittedPolynomial::RdInc, rd_inc_claim * lagrange_factor));
-        scaling_factors.push(lagrange_factor);
+            ram_inc_claim * ram_inc_lagrange,
+        ));
+        scaling_factors.push(ram_inc_lagrange);
+        polynomial_claims.push((CommittedPolynomial::RdInc, rd_inc_claim * rd_inc_lagrange));
+        scaling_factors.push(rd_inc_lagrange);
 
         // Sparse polynomials: all RA polys (from HammingWeightClaimReduction)
         for i in 0..self.one_hot_params.instruction_d {
-            let (_, claim) = self.opening_accumulator.get_committed_polynomial_opening(
+            let (ra_point, claim) = self.opening_accumulator.get_committed_polynomial_opening(
                 CommittedPolynomial::InstructionRa(i),
                 SumcheckId::HammingWeightClaimReduction,
             );
-            polynomial_claims.push((CommittedPolynomial::InstructionRa(i), claim));
-            scaling_factors.push(F::one());
+            let lagrange = compute_lagrange_factor::<F>(&opening_point.r, &ra_point.r);
+            polynomial_claims.push((CommittedPolynomial::InstructionRa(i), claim * lagrange));
+            scaling_factors.push(lagrange);
         }
         for i in 0..self.one_hot_params.bytecode_d {
-            let (_, claim) = self.opening_accumulator.get_committed_polynomial_opening(
+            let (ra_point, claim) = self.opening_accumulator.get_committed_polynomial_opening(
                 CommittedPolynomial::BytecodeRa(i),
                 SumcheckId::HammingWeightClaimReduction,
             );
-            polynomial_claims.push((CommittedPolynomial::BytecodeRa(i), claim));
-            scaling_factors.push(F::one());
+            let lagrange = compute_lagrange_factor::<F>(&opening_point.r, &ra_point.r);
+            polynomial_claims.push((CommittedPolynomial::BytecodeRa(i), claim * lagrange));
+            scaling_factors.push(lagrange);
         }
         for i in 0..self.one_hot_params.ram_d {
-            let (_, claim) = self.opening_accumulator.get_committed_polynomial_opening(
+            let (ra_point, claim) = self.opening_accumulator.get_committed_polynomial_opening(
                 CommittedPolynomial::RamRa(i),
                 SumcheckId::HammingWeightClaimReduction,
             );
-            polynomial_claims.push((CommittedPolynomial::RamRa(i), claim));
-            scaling_factors.push(F::one());
+            let lagrange = compute_lagrange_factor::<F>(&opening_point.r, &ra_point.r);
+            polynomial_claims.push((CommittedPolynomial::RamRa(i), claim * lagrange));
+            scaling_factors.push(lagrange);
         }
 
         // Advice polynomials: TrustedAdvice and UntrustedAdvice (from AdviceClaimReduction in Stage 6)
@@ -1670,8 +1760,7 @@ impl<
             .opening_accumulator
             .get_advice_opening(AdviceKind::Trusted, SumcheckId::AdviceClaimReduction)
         {
-            let lagrange_factor =
-                compute_advice_lagrange_factor::<F>(&opening_point.r, &advice_point.r);
+            let lagrange_factor = compute_lagrange_factor::<F>(&opening_point.r, &advice_point.r);
             polynomial_claims.push((
                 CommittedPolynomial::TrustedAdvice,
                 advice_claim * lagrange_factor,
@@ -1684,8 +1773,7 @@ impl<
             .opening_accumulator
             .get_advice_opening(AdviceKind::Untrusted, SumcheckId::AdviceClaimReduction)
         {
-            let lagrange_factor =
-                compute_advice_lagrange_factor::<F>(&opening_point.r, &advice_point.r);
+            let lagrange_factor = compute_lagrange_factor::<F>(&opening_point.r, &advice_point.r);
             polynomial_claims.push((
                 CommittedPolynomial::UntrustedAdvice,
                 advice_claim * lagrange_factor,

--- a/jolt-core/src/zkvm/verifier.rs
+++ b/jolt-core/src/zkvm/verifier.rs
@@ -8,7 +8,7 @@ use crate::curve::JoltCurve;
 use crate::poly::commitment::commitment_scheme::{CommitmentScheme, ZkEvalCommitment};
 #[cfg(feature = "zk")]
 use crate::poly::commitment::dory::bind_opening_inputs_zk;
-use crate::poly::commitment::dory::{bind_opening_inputs, DoryGlobals};
+use crate::poly::commitment::dory::{bind_opening_inputs, DoryContext, DoryGlobals};
 use crate::poly::commitment::pedersen::PedersenGenerators;
 #[cfg(feature = "zk")]
 use crate::poly::lagrange_poly::LagrangeHelper;

--- a/jolt-core/src/zkvm/verifier.rs
+++ b/jolt-core/src/zkvm/verifier.rs
@@ -8,7 +8,7 @@ use crate::curve::JoltCurve;
 use crate::poly::commitment::commitment_scheme::{CommitmentScheme, ZkEvalCommitment};
 #[cfg(feature = "zk")]
 use crate::poly::commitment::dory::bind_opening_inputs_zk;
-use crate::poly::commitment::dory::{bind_opening_inputs, DoryContext, DoryGlobals};
+use crate::poly::commitment::dory::{bind_opening_inputs, DoryContext, DoryGlobals, DoryLayout};
 use crate::poly::commitment::pedersen::PedersenGenerators;
 #[cfg(feature = "zk")]
 use crate::poly::lagrange_poly::LagrangeHelper;
@@ -48,9 +48,9 @@ use crate::zkvm::{
     claim_reductions::{
         AdviceClaimReductionVerifier, AdviceKind, HammingWeightClaimReductionVerifier,
         IncClaimReductionSumcheckVerifier, InstructionLookupsClaimReductionSumcheckVerifier,
-        PrecommittedClaimReduction, RamRaClaimReductionSumcheckVerifier,
+        PrecommittedClaimReduction, PrecommittedParams, RamRaClaimReductionSumcheckVerifier,
     },
-    compute_final_opening_point, fiat_shamir_preamble,
+    fiat_shamir_preamble,
     instruction_lookups::{
         ra_virtual::RaSumcheckVerifier as LookupsRaSumcheckVerifier,
         read_raf_checking::InstructionReadRafSumcheckVerifier,
@@ -79,8 +79,8 @@ use crate::zkvm::{
 use crate::{
     field::JoltField,
     poly::opening_proof::{
-        compute_lagrange_factor, DoryOpeningState, OpeningAccumulator, OpeningId, SumcheckId,
-        VerifierOpeningAccumulator,
+        compute_lagrange_factor, DoryOpeningState, OpeningAccumulator, OpeningId, OpeningPoint,
+        SumcheckId, VerifierOpeningAccumulator, BIG_ENDIAN,
     },
     pprof_scope,
     subprotocols::{
@@ -289,6 +289,87 @@ impl<
         candidates
     }
 
+    fn stage8_opening_point(&self) -> Result<OpeningPoint<BIG_ENDIAN, F>, ProofVerifyError> {
+        let native_main_vars = self.proof.trace_length.log_2() + self.one_hot_params.log_k_chunk;
+        let mut opening_candidates: Vec<(&str, OpeningPoint<BIG_ENDIAN, F>)> = Vec::new();
+        if let Some((point, _)) = self
+            .opening_accumulator
+            .get_advice_opening(AdviceKind::Trusted, SumcheckId::AdviceClaimReduction)
+        {
+            opening_candidates.push(("trusted_advice", point));
+        }
+        if let Some((point, _)) = self
+            .opening_accumulator
+            .get_advice_opening(AdviceKind::Untrusted, SumcheckId::AdviceClaimReduction)
+        {
+            opening_candidates.push(("untrusted_advice", point));
+        }
+
+        let max_len = opening_candidates
+            .iter()
+            .map(|(_, p)| p.r.len())
+            .max()
+            .unwrap_or(0);
+        if max_len > native_main_vars {
+            let dominant = opening_candidates
+                .iter()
+                .find(|(_, p)| p.r.len() == max_len)
+                .expect("at least one dominant precommitted candidate expected");
+            for (name, point) in opening_candidates
+                .iter()
+                .filter(|(_, p)| p.r.len() == max_len)
+            {
+                if point.r != dominant.1.r {
+                    return Err(ProofVerifyError::DoryError(format!(
+                        "incompatible dominant precommitted anchors: {} and {} have equal dimensionality {} but different opening points",
+                        dominant.0, name, max_len
+                    )));
+                }
+            }
+            Ok(OpeningPoint::<BIG_ENDIAN, F>::new(dominant.1.r.clone()))
+        } else {
+            let (hamming_point, _) = self.opening_accumulator.get_committed_polynomial_opening(
+                CommittedPolynomial::InstructionRa(0),
+                SumcheckId::HammingWeightClaimReduction,
+            );
+            let r_address_stage7 = hamming_point.r[..self.one_hot_params.log_k_chunk].to_vec();
+            let r_cycle_stage6 = self
+                .opening_accumulator
+                .get_committed_polynomial_opening(
+                    CommittedPolynomial::RamInc,
+                    SumcheckId::IncClaimReduction,
+                )
+                .0
+                .r;
+
+            match self.proof.dory_layout {
+                DoryLayout::AddressMajor => Ok(OpeningPoint::<BIG_ENDIAN, F>::new(
+                    [r_cycle_stage6.as_slice(), r_address_stage7.as_slice()].concat(),
+                )),
+                DoryLayout::CycleMajor => {
+                    let native_cycle = &hamming_point.r[self.one_hot_params.log_k_chunk..];
+                    if r_cycle_stage6.len() < native_cycle.len() {
+                        return Err(ProofVerifyError::DoryError(
+                            "stage6 cycle challenges shorter than native cycle vars".to_string(),
+                        ));
+                    }
+                    if r_cycle_stage6[..native_cycle.len()] != *native_cycle {
+                        return Err(ProofVerifyError::DoryError(format!(
+                            "cycle-major Stage-8 expects stage6 cycle prefix to equal native cycle vars \
+                             (cycle_full_len={}, native_len={})",
+                            r_cycle_stage6.len(),
+                            native_cycle.len()
+                        )));
+                    }
+                    let cycle_extra = &r_cycle_stage6[native_cycle.len()..];
+                    let cycle_extra_and_anchor =
+                        [cycle_extra, r_address_stage7.as_slice(), native_cycle].concat();
+                    Ok(OpeningPoint::<BIG_ENDIAN, F>::new(cycle_extra_and_anchor))
+                }
+            }
+        }
+    }
+
     pub fn new(
         preprocessing: &'a JoltVerifierPreprocessing<F, C, PCS>,
         proof: JoltProof<F, C, PCS, ProofTranscript>,
@@ -391,9 +472,9 @@ impl<
             .map_err(ProofVerifyError::InvalidReadWriteConfig)?;
 
         // Construct full params from the validated config.
-        let bytecode_K = preprocessing.shared.bytecode.code_size;
+        let bytecode_len = preprocessing.shared.bytecode.code_size;
         let one_hot_params =
-            OneHotParams::from_config(&proof.one_hot_config, bytecode_K, proof.ram_K);
+            OneHotParams::from_config(&proof.one_hot_config, bytecode_len, proof.ram_K);
 
         Ok(Self {
             trusted_advice_commitment,
@@ -1577,20 +1658,32 @@ impl<
         if let Some(advice_reduction_verifier_trusted) =
             self.advice_reduction_verifier_trusted.as_mut()
         {
-            let mut params = advice_reduction_verifier_trusted.params.borrow_mut();
-            if params.precommitted.num_address_phase_rounds() > 0 {
+            if advice_reduction_verifier_trusted
+                .params
+                .precommitted
+                .num_address_phase_rounds()
+                > 0
+            {
                 // Transition phase
-                params.precommitted.transition_to_address_phase();
+                advice_reduction_verifier_trusted
+                    .params
+                    .transition_to_address_phase(&self.opening_accumulator);
                 instances.push(advice_reduction_verifier_trusted);
             }
         }
         if let Some(advice_reduction_verifier_untrusted) =
             self.advice_reduction_verifier_untrusted.as_mut()
         {
-            let mut params = advice_reduction_verifier_untrusted.params.borrow_mut();
-            if params.precommitted.num_address_phase_rounds() > 0 {
+            if advice_reduction_verifier_untrusted
+                .params
+                .precommitted
+                .num_address_phase_rounds()
+                > 0
+            {
                 // Transition phase
-                params.precommitted.transition_to_address_phase();
+                advice_reduction_verifier_untrusted
+                    .params
+                    .transition_to_address_phase(&self.opening_accumulator);
                 instances.push(advice_reduction_verifier_untrusted);
             }
         }
@@ -1643,13 +1736,7 @@ impl<
 
     /// Stage 8: Dory batch opening verification.
     fn verify_stage8(&mut self) -> Result<Stage8VerifyData<F>, ProofVerifyError> {
-        let native_main_vars = self.proof.trace_length.log_2() + self.one_hot_params.log_k_chunk;
-        let opening_point = compute_final_opening_point(
-            &self.opening_accumulator,
-            native_main_vars,
-            self.one_hot_params.log_k_chunk,
-            self.proof.dory_layout,
-        )?;
+        let opening_point = self.stage8_opening_point()?;
 
         // 1. Collect all (polynomial, claim) pairs
         let mut polynomial_claims = Vec::new();

--- a/jolt-core/src/zkvm/verifier.rs
+++ b/jolt-core/src/zkvm/verifier.rs
@@ -349,12 +349,9 @@ impl<
                 DoryLayout::CycleMajor => {
                     let native_cycle = &hamming_point.r[self.one_hot_params.log_k_chunk..];
                     if r_cycle_stage6.len() < native_cycle.len() {
-                        return Err(ProofVerifyError::DoryError(format!(
-                            "stage6 cycle challenges shorter than native cycle vars \
-                             (cycle_full_len={}, native_len={})",
-                            r_cycle_stage6.len(),
-                            native_cycle.len()
-                        )));
+                        return Err(ProofVerifyError::DoryError(
+                            "stage6 cycle challenges shorter than native cycle vars".to_string(),
+                        ));
                     }
                     if r_cycle_stage6[..native_cycle.len()] != *native_cycle {
                         return Err(ProofVerifyError::DoryError(format!(

--- a/jolt-core/src/zkvm/verifier.rs
+++ b/jolt-core/src/zkvm/verifier.rs
@@ -8,7 +8,7 @@ use crate::curve::JoltCurve;
 use crate::poly::commitment::commitment_scheme::{CommitmentScheme, ZkEvalCommitment};
 #[cfg(feature = "zk")]
 use crate::poly::commitment::dory::bind_opening_inputs_zk;
-use crate::poly::commitment::dory::{bind_opening_inputs, DoryContext, DoryGlobals, DoryLayout};
+use crate::poly::commitment::dory::{bind_opening_inputs, DoryContext, DoryGlobals};
 use crate::poly::commitment::pedersen::PedersenGenerators;
 #[cfg(feature = "zk")]
 use crate::poly::lagrange_poly::LagrangeHelper;
@@ -50,7 +50,7 @@ use crate::zkvm::{
         IncClaimReductionSumcheckVerifier, InstructionLookupsClaimReductionSumcheckVerifier,
         PrecommittedClaimReduction, RamRaClaimReductionSumcheckVerifier,
     },
-    fiat_shamir_preamble,
+    compute_final_opening_point, fiat_shamir_preamble,
     instruction_lookups::{
         ra_virtual::RaSumcheckVerifier as LookupsRaSumcheckVerifier,
         read_raf_checking::InstructionReadRafSumcheckVerifier,
@@ -79,8 +79,8 @@ use crate::zkvm::{
 use crate::{
     field::JoltField,
     poly::opening_proof::{
-        compute_lagrange_factor, DoryOpeningState, OpeningAccumulator, OpeningId, OpeningPoint,
-        SumcheckId, VerifierOpeningAccumulator, BIG_ENDIAN,
+        compute_lagrange_factor, DoryOpeningState, OpeningAccumulator, OpeningId, SumcheckId,
+        VerifierOpeningAccumulator,
     },
     pprof_scope,
     subprotocols::{
@@ -287,87 +287,6 @@ impl<
             candidates.push(sigma + nu);
         }
         candidates
-    }
-
-    fn stage8_opening_point(&self) -> Result<OpeningPoint<BIG_ENDIAN, F>, ProofVerifyError> {
-        let native_main_vars = self.proof.trace_length.log_2() + self.one_hot_params.log_k_chunk;
-        let mut opening_candidates: Vec<(&str, OpeningPoint<BIG_ENDIAN, F>)> = Vec::new();
-        if let Some((point, _)) = self
-            .opening_accumulator
-            .get_advice_opening(AdviceKind::Trusted, SumcheckId::AdviceClaimReduction)
-        {
-            opening_candidates.push(("trusted_advice", point));
-        }
-        if let Some((point, _)) = self
-            .opening_accumulator
-            .get_advice_opening(AdviceKind::Untrusted, SumcheckId::AdviceClaimReduction)
-        {
-            opening_candidates.push(("untrusted_advice", point));
-        }
-
-        let max_len = opening_candidates
-            .iter()
-            .map(|(_, p)| p.r.len())
-            .max()
-            .unwrap_or(0);
-        if max_len > native_main_vars {
-            let dominant = opening_candidates
-                .iter()
-                .find(|(_, p)| p.r.len() == max_len)
-                .expect("at least one dominant precommitted candidate expected");
-            for (name, point) in opening_candidates
-                .iter()
-                .filter(|(_, p)| p.r.len() == max_len)
-            {
-                if point.r != dominant.1.r {
-                    return Err(ProofVerifyError::DoryError(format!(
-                        "incompatible dominant precommitted anchors: {} and {} have equal dimensionality {} but different opening points",
-                        dominant.0, name, max_len
-                    )));
-                }
-            }
-            Ok(OpeningPoint::<BIG_ENDIAN, F>::new(dominant.1.r.clone()))
-        } else {
-            let (hamming_point, _) = self.opening_accumulator.get_committed_polynomial_opening(
-                CommittedPolynomial::InstructionRa(0),
-                SumcheckId::HammingWeightClaimReduction,
-            );
-            let r_address_stage7 = hamming_point.r[..self.one_hot_params.log_k_chunk].to_vec();
-            let r_cycle_stage6 = self
-                .opening_accumulator
-                .get_committed_polynomial_opening(
-                    CommittedPolynomial::RamInc,
-                    SumcheckId::IncClaimReduction,
-                )
-                .0
-                .r;
-
-            match self.proof.dory_layout {
-                DoryLayout::AddressMajor => Ok(OpeningPoint::<BIG_ENDIAN, F>::new(
-                    [r_cycle_stage6.as_slice(), r_address_stage7.as_slice()].concat(),
-                )),
-                DoryLayout::CycleMajor => {
-                    let native_cycle = &hamming_point.r[self.one_hot_params.log_k_chunk..];
-                    if r_cycle_stage6.len() < native_cycle.len() {
-                        return Err(ProofVerifyError::DoryError(
-                            "stage6 cycle challenges shorter than native cycle vars".to_string(),
-                        ));
-                    }
-                    if r_cycle_stage6[..native_cycle.len()] != *native_cycle {
-                        return Err(ProofVerifyError::DoryError(format!(
-                            "cycle-major Stage-8 expects stage6 cycle prefix to equal native cycle vars \
-                             (cycle_full_len={}, native_len={})",
-                            r_cycle_stage6.len(),
-                            native_cycle.len()
-                        )));
-                    }
-                    let cycle_extra = &r_cycle_stage6[native_cycle.len()..];
-                    let cycle_extra_and_anchor =
-                        [cycle_extra, r_address_stage7.as_slice(), native_cycle].concat();
-                    Ok(OpeningPoint::<BIG_ENDIAN, F>::new(cycle_extra_and_anchor))
-                }
-            }
-        }
     }
 
     pub fn new(
@@ -1724,7 +1643,13 @@ impl<
 
     /// Stage 8: Dory batch opening verification.
     fn verify_stage8(&mut self) -> Result<Stage8VerifyData<F>, ProofVerifyError> {
-        let opening_point = self.stage8_opening_point()?;
+        let native_main_vars = self.proof.trace_length.log_2() + self.one_hot_params.log_k_chunk;
+        let opening_point = compute_final_opening_point(
+            &self.opening_accumulator,
+            native_main_vars,
+            self.one_hot_params.log_k_chunk,
+            self.proof.dory_layout,
+        )?;
 
         // 1. Collect all (polynomial, claim) pairs
         let mut polynomial_claims = Vec::new();


### PR DESCRIPTION
Generated stack PR from `amir/bytecode-commitment-merged`.

Stack position: `02`
Base branch: `a16z/main`
Head branch: `LayerZero-Research:amir/bytecode-stack/02-precommitted`

This follows the merged Stage 6 split PR.

Owned paths:
```text
jolt-core/src/zkvm/claim_reductions/precommitted.rs
jolt-core/src/zkvm/claim_reductions/advice.rs
jolt-core/src/zkvm/claim_reductions/mod.rs
jolt-core/src/poly/commitment/dory/
jolt-core/src/poly/one_hot_polynomial.rs
jolt-core/src/poly/opening_proof.rs
jolt-core/src/poly/rlc_polynomial.rs
jolt-core/src/zkvm/prover.rs
jolt-core/src/zkvm/transpilable_verifier.rs
jolt-core/src/zkvm/verifier.rs
```

## Test plan
- Full local CI was run on this PR branch before the previous stack push.
- Branch was rebased onto current `a16z/main` after PR01 merged.

Made with [Cursor](https://cursor.com)