### PR TITLE
Fix verifier branch code-review findings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3169,7 +3169,6 @@ dependencies = [
  "jolt-claims",
  "jolt-field",
  "jolt-poly",
- "jolt-sumcheck",
  "num-traits",
  "rand_chacha 0.3.1",
  "rand_core 0.6.4",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3170,7 +3170,6 @@ dependencies = [
  "jolt-field",
  "jolt-poly",
  "jolt-sumcheck",
- "num-bigint",
  "num-traits",
  "rand_chacha 0.3.1",
  "rand_core 0.6.4",

--- a/crates/jolt-r1cs/Cargo.toml
+++ b/crates/jolt-r1cs/Cargo.toml
@@ -20,7 +20,6 @@ tracing = { workspace = true }
 
 [dev-dependencies]
 jolt-field = { path = "../jolt-field", features = ["bn254"] }
-jolt-sumcheck = { workspace = true, features = ["r1cs"] }
 rand_chacha = { workspace = true }
 rand_core = { workspace = true }
 

--- a/crates/jolt-r1cs/Cargo.toml
+++ b/crates/jolt-r1cs/Cargo.toml
@@ -12,7 +12,6 @@ workspace = true
 jolt-claims.workspace = true
 jolt-field = { path = "../jolt-field" }
 jolt-poly = { path = "../jolt-poly" }
-num-bigint.workspace = true
 num-traits.workspace = true
 rayon = { workspace = true, optional = true }
 serde = { workspace = true, features = ["derive"] }

--- a/crates/jolt-verifier/src/compat/audit.rs
+++ b/crates/jolt-verifier/src/compat/audit.rs
@@ -8,7 +8,6 @@ use jolt_openings::{AdditivelyHomomorphic, CommitmentScheme, ZkOpeningScheme};
 use jolt_transcript::{AppendToTranscript, Transcript};
 
 use crate::{
-    config::{validate_proof_config, JoltProtocolConfig},
     preprocessing::JoltVerifierPreprocessing,
     proof::JoltProof,
     stages::{
@@ -65,9 +64,6 @@ where
     VC::Output: Copy + HomomorphicCommitment<F> + AppendToTranscript,
     T: Transcript<Challenge = F>,
 {
-    let config = JoltProtocolConfig::for_zk(true);
-    validate_proof_config(&config, proof)?;
-
     let checked = validate_inputs(
         preprocessing,
         public_io,

--- a/crates/jolt-verifier/src/compat/convert.rs
+++ b/crates/jolt-verifier/src/compat/convert.rs
@@ -29,6 +29,7 @@ use jolt_sumcheck::{
     ClearProof, ClearSumcheckProof, CommittedOutputClaims, CommittedRound, CommittedSumcheckProof,
     CompressedSumcheckProof, SumcheckProof,
 };
+use serde::Deserialize;
 
 #[cfg(feature = "zk")]
 use jolt_blindfold::BlindFoldProof as ModularBlindFoldProof;
@@ -88,7 +89,7 @@ where
 
     fn commitment_into_verifier(
         commitment: Self::Commitment,
-    ) -> <Self::VerifierPcs as ModularCommitment>::Output;
+    ) -> Result<<Self::VerifierPcs as ModularCommitment>::Output, VerifierError>;
 
     fn proof_into_verifier(
         proof: Self::Proof,
@@ -98,8 +99,10 @@ where
 impl CorePcsBridge<ark_bn254::Fr> for CoreDoryCommitmentScheme {
     type VerifierPcs = DoryScheme;
 
-    fn commitment_into_verifier(commitment: Self::Commitment) -> DoryCommitment {
-        DoryCommitment(core_dory_commitment_into_verifier(&commitment))
+    fn commitment_into_verifier(
+        commitment: Self::Commitment,
+    ) -> Result<DoryCommitment, VerifierError> {
+        core_dory_commitment_into_verifier(&commitment).map(DoryCommitment)
     }
 
     fn proof_into_verifier(proof: Self::Proof) -> DoryProof {
@@ -189,7 +192,7 @@ where
     let commitments = commitments
         .into_iter()
         .map(PCS::commitment_into_verifier)
-        .collect::<Vec<_>>();
+        .collect::<Result<Vec<_>, _>>()?;
 
     commitments_from_proof_payload_order(commitments, instruction_ra_count, ram_ra_count)
 }
@@ -280,11 +283,12 @@ where
             joint_opening_proof: PCS::proof_into_verifier(proof.joint_opening_proof),
             untrusted_advice_commitment: proof
                 .untrusted_advice_commitment
-                .map(PCS::commitment_into_verifier),
+                .map(PCS::commitment_into_verifier)
+                .transpose()?,
             claims: JoltProofClaims::Clear(convert_opening_claims(
                 proof.opening_claims,
                 proof.trace_length,
-            )),
+            )?),
             trace_length: proof.trace_length,
             ram_K: proof.ram_K,
             rw_config: convert_read_write_config(proof.rw_config),
@@ -332,7 +336,8 @@ where
             joint_opening_proof: PCS::proof_into_verifier(proof.joint_opening_proof),
             untrusted_advice_commitment: proof
                 .untrusted_advice_commitment
-                .map(PCS::commitment_into_verifier),
+                .map(PCS::commitment_into_verifier)
+                .transpose()?,
             claims: JoltProofClaims::Zk {
                 blindfold_proof: legacy_blindfold_proof_into_modular::<F, C>(
                     &proof.blindfold_proof,
@@ -456,10 +461,24 @@ where
         .collect()
 }
 
-fn core_dory_commitment_into_verifier(commitment: &CoreDoryCommitment) -> Bn254GT {
-    // SAFETY: `jolt-core` Dory and modular `jolt-dory` use thin wrappers
-    // over the same arkworks `Fq12` target-group element.
-    unsafe { std::mem::transmute_copy(commitment) }
+fn core_dory_commitment_into_verifier(
+    commitment: &CoreDoryCommitment,
+) -> Result<Bn254GT, VerifierError> {
+    use ark_serialize::CanonicalSerialize;
+
+    let mut bytes = Vec::with_capacity(commitment.0.compressed_size());
+    commitment
+        .0
+        .serialize_compressed(&mut bytes)
+        .map_err(|error| VerifierError::CommitmentConversionFailed {
+            reason: error.to_string(),
+        })?;
+
+    let deserializer =
+        serde::de::value::SeqDeserializer::<_, serde::de::value::Error>::new(bytes.into_iter());
+    Bn254GT::deserialize(deserializer).map_err(|error| VerifierError::CommitmentConversionFailed {
+        reason: error.to_string(),
+    })
 }
 
 #[cfg(feature = "zk")]
@@ -569,15 +588,10 @@ where
         .collect()
 }
 
-#[cfg(not(feature = "zk"))]
-#[expect(
-    clippy::expect_used,
-    reason = "imported core standard proofs are expected to carry a complete clear-claim payload"
-)]
 fn convert_opening_claims<F>(
     claims: CoreClaims<F>,
     trace_length: usize,
-) -> crate::proof::ClearProofClaims<F::VerifierField>
+) -> Result<crate::proof::ClearProofClaims<F::VerifierField>, VerifierError>
 where
     F: CoreFieldBridge,
 {
@@ -596,7 +610,6 @@ where
         ),
         trace_length,
     )
-    .expect("core standard proof must contain all typed clear opening claims")
 }
 
 #[cfg(not(feature = "zk"))]

--- a/crates/jolt-verifier/src/compat/convert.rs
+++ b/crates/jolt-verifier/src/compat/convert.rs
@@ -29,7 +29,6 @@ use jolt_sumcheck::{
     ClearProof, ClearSumcheckProof, CommittedOutputClaims, CommittedRound, CommittedSumcheckProof,
     CompressedSumcheckProof, SumcheckProof,
 };
-use serde::Deserialize;
 
 #[cfg(feature = "zk")]
 use jolt_blindfold::BlindFoldProof as ModularBlindFoldProof;
@@ -89,7 +88,7 @@ where
 
     fn commitment_into_verifier(
         commitment: Self::Commitment,
-    ) -> Result<<Self::VerifierPcs as ModularCommitment>::Output, VerifierError>;
+    ) -> <Self::VerifierPcs as ModularCommitment>::Output;
 
     fn proof_into_verifier(
         proof: Self::Proof,
@@ -99,10 +98,8 @@ where
 impl CorePcsBridge<ark_bn254::Fr> for CoreDoryCommitmentScheme {
     type VerifierPcs = DoryScheme;
 
-    fn commitment_into_verifier(
-        commitment: Self::Commitment,
-    ) -> Result<DoryCommitment, VerifierError> {
-        core_dory_commitment_into_verifier(&commitment).map(DoryCommitment)
+    fn commitment_into_verifier(commitment: Self::Commitment) -> DoryCommitment {
+        DoryCommitment(core_dory_commitment_into_verifier(&commitment))
     }
 
     fn proof_into_verifier(proof: Self::Proof) -> DoryProof {
@@ -192,7 +189,7 @@ where
     let commitments = commitments
         .into_iter()
         .map(PCS::commitment_into_verifier)
-        .collect::<Result<Vec<_>, _>>()?;
+        .collect::<Vec<_>>();
 
     commitments_from_proof_payload_order(commitments, instruction_ra_count, ram_ra_count)
 }
@@ -283,8 +280,7 @@ where
             joint_opening_proof: PCS::proof_into_verifier(proof.joint_opening_proof),
             untrusted_advice_commitment: proof
                 .untrusted_advice_commitment
-                .map(PCS::commitment_into_verifier)
-                .transpose()?,
+                .map(PCS::commitment_into_verifier),
             claims: JoltProofClaims::Clear(convert_opening_claims(
                 proof.opening_claims,
                 proof.trace_length,
@@ -336,8 +332,7 @@ where
             joint_opening_proof: PCS::proof_into_verifier(proof.joint_opening_proof),
             untrusted_advice_commitment: proof
                 .untrusted_advice_commitment
-                .map(PCS::commitment_into_verifier)
-                .transpose()?,
+                .map(PCS::commitment_into_verifier),
             claims: JoltProofClaims::Zk {
                 blindfold_proof: legacy_blindfold_proof_into_modular::<F, C>(
                     &proof.blindfold_proof,
@@ -461,24 +456,10 @@ where
         .collect()
 }
 
-fn core_dory_commitment_into_verifier(
-    commitment: &CoreDoryCommitment,
-) -> Result<Bn254GT, VerifierError> {
-    use ark_serialize::CanonicalSerialize;
-
-    let mut bytes = Vec::with_capacity(commitment.0.compressed_size());
-    commitment
-        .0
-        .serialize_compressed(&mut bytes)
-        .map_err(|error| VerifierError::CommitmentConversionFailed {
-            reason: error.to_string(),
-        })?;
-
-    let deserializer =
-        serde::de::value::SeqDeserializer::<_, serde::de::value::Error>::new(bytes.into_iter());
-    Bn254GT::deserialize(deserializer).map_err(|error| VerifierError::CommitmentConversionFailed {
-        reason: error.to_string(),
-    })
+fn core_dory_commitment_into_verifier(commitment: &CoreDoryCommitment) -> Bn254GT {
+    // SAFETY: `jolt-core` Dory and modular `jolt-dory` use thin wrappers
+    // over the same arkworks `Fq12` target-group element.
+    unsafe { std::mem::transmute_copy(commitment) }
 }
 
 #[cfg(feature = "zk")]

--- a/crates/jolt-verifier/src/config.rs
+++ b/crates/jolt-verifier/src/config.rs
@@ -1,9 +1,15 @@
 //! Verifier-selected protocol configuration.
 
+use common::{
+    constants::{RAM_START_ADDRESS, REGISTER_COUNT, XLEN},
+    jolt_device::MemoryLayout,
+};
 use jolt_claims::protocols::field_inline::FieldInlineConfig;
+use jolt_claims::protocols::jolt::{JoltOneHotConfig, JoltReadWriteConfig};
+use jolt_program::preprocess::RAMPreprocessing;
 use serde::{Deserialize, Serialize};
 
-use crate::{proof::JoltProof, VerifierError};
+use crate::{preprocessing::JoltVerifierPreprocessing, proof::JoltProof, VerifierError};
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum ZkConfig {
@@ -55,12 +61,23 @@ pub const JOLT_VERIFIER_CONFIG: JoltProtocolConfig = JoltProtocolConfig {
 
 pub fn validate_proof_config<PCS, VC, ZkProof>(
     config: &JoltProtocolConfig,
+    preprocessing: &JoltVerifierPreprocessing<PCS, VC>,
     proof: &JoltProof<PCS, VC, ZkProof>,
+    zk: bool,
 ) -> Result<(), VerifierError>
 where
     PCS: jolt_openings::CommitmentScheme,
     VC: jolt_crypto::VectorCommitment<Field = PCS::Field>,
 {
+    if !proof.trace_length.is_power_of_two()
+        || proof.trace_length > preprocessing.program.max_padded_trace_length
+    {
+        return Err(VerifierError::InvalidTraceLength {
+            got: proof.trace_length,
+            max: preprocessing.program.max_padded_trace_length,
+        });
+    }
+
     if proof.protocol != *config {
         return Err(VerifierError::ProtocolConfigMismatch {
             expected: *config,
@@ -68,5 +85,133 @@ where
         });
     }
 
+    let runtime_config = JoltProtocolConfig::for_zk(zk);
+    if proof.protocol != runtime_config {
+        return Err(VerifierError::ProtocolConfigMismatch {
+            expected: runtime_config,
+            got: proof.protocol,
+        });
+    }
+
+    validate_one_hot_config(proof.one_hot_config)?;
+
+    let min_ram_k = compute_min_ram_K(
+        &preprocessing.program.ram,
+        &preprocessing.program.memory_layout,
+    );
+    let max_ram_k = compute_max_ram_K(&preprocessing.program.memory_layout);
+    if !proof.ram_K.is_power_of_two() || proof.ram_K < min_ram_k || proof.ram_K > max_ram_k {
+        return Err(VerifierError::InvalidRamK {
+            got: proof.ram_K,
+            min: min_ram_k,
+            max: max_ram_k,
+        });
+    }
+
+    validate_read_write_config(
+        proof.rw_config,
+        proof.trace_length.ilog2() as usize,
+        proof.ram_K.ilog2() as usize,
+    )?;
+
     Ok(())
+}
+
+pub fn validate_one_hot_config(config: JoltOneHotConfig) -> Result<(), VerifierError> {
+    if config.log_k_chunk != 4 && config.log_k_chunk != 8 {
+        return Err(VerifierError::InvalidOneHotConfig(format!(
+            "log_k_chunk ({}) must be either 4 or 8",
+            config.log_k_chunk
+        )));
+    }
+
+    let log_k_chunk = config.log_k_chunk as usize;
+    let lookups_chunk = config.lookups_ra_virtual_log_k_chunk as usize;
+    let instruction_address_bits = 2 * XLEN;
+
+    if lookups_chunk < log_k_chunk {
+        return Err(VerifierError::InvalidOneHotConfig(format!(
+            "lookups_ra_virtual_log_k_chunk ({lookups_chunk}) must be >= log_k_chunk ({log_k_chunk})"
+        )));
+    }
+
+    if lookups_chunk > instruction_address_bits {
+        return Err(VerifierError::InvalidOneHotConfig(format!(
+            "lookups_ra_virtual_log_k_chunk ({lookups_chunk}) must be <= LOG_K ({instruction_address_bits})"
+        )));
+    }
+
+    if !lookups_chunk.is_multiple_of(log_k_chunk) {
+        return Err(VerifierError::InvalidOneHotConfig(format!(
+            "lookups_ra_virtual_log_k_chunk ({lookups_chunk}) must be a multiple of log_k_chunk ({log_k_chunk})"
+        )));
+    }
+
+    if !instruction_address_bits.is_multiple_of(lookups_chunk) {
+        return Err(VerifierError::InvalidOneHotConfig(format!(
+            "LOG_K ({instruction_address_bits}) must be divisible by lookups_ra_virtual_log_k_chunk ({lookups_chunk})"
+        )));
+    }
+
+    Ok(())
+}
+
+pub fn validate_read_write_config(
+    config: JoltReadWriteConfig,
+    log_t: usize,
+    ram_log_k: usize,
+) -> Result<(), VerifierError> {
+    let log_register_count = REGISTER_COUNT.ilog2() as usize;
+    if (config.ram_rw_phase1_num_rounds as usize) > log_t {
+        return Err(VerifierError::InvalidReadWriteConfig(format!(
+            "ram_rw_phase1_num_rounds ({}) exceeds log_T ({log_t})",
+            config.ram_rw_phase1_num_rounds
+        )));
+    }
+    if (config.ram_rw_phase2_num_rounds as usize) > ram_log_k {
+        return Err(VerifierError::InvalidReadWriteConfig(format!(
+            "ram_rw_phase2_num_rounds ({}) exceeds log_ram_K ({ram_log_k})",
+            config.ram_rw_phase2_num_rounds
+        )));
+    }
+    if (config.registers_rw_phase1_num_rounds as usize) > log_t {
+        return Err(VerifierError::InvalidReadWriteConfig(format!(
+            "registers_rw_phase1_num_rounds ({}) exceeds log_T ({log_t})",
+            config.registers_rw_phase1_num_rounds
+        )));
+    }
+    if (config.registers_rw_phase2_num_rounds as usize) > log_register_count {
+        return Err(VerifierError::InvalidReadWriteConfig(format!(
+            "registers_rw_phase2_num_rounds ({}) exceeds log_register_count ({log_register_count})",
+            config.registers_rw_phase2_num_rounds
+        )));
+    }
+    Ok(())
+}
+
+#[expect(non_snake_case, reason = "Matches current jolt-core proof field name.")]
+pub fn compute_min_ram_K(
+    ram_preprocessing: &RAMPreprocessing,
+    memory_layout: &MemoryLayout,
+) -> usize {
+    let bytecode_end = memory_layout
+        .remap_word_address(ram_preprocessing.min_bytecode_address)
+        .ok()
+        .flatten()
+        .unwrap_or(0) as usize
+        + ram_preprocessing.bytecode_words.len();
+
+    let io_end = memory_layout
+        .remap_word_address(RAM_START_ADDRESS)
+        .ok()
+        .flatten()
+        .unwrap_or(0) as usize;
+
+    bytecode_end.max(io_end).next_power_of_two()
+}
+
+#[expect(non_snake_case, reason = "Matches current jolt-core proof field name.")]
+pub fn compute_max_ram_K(memory_layout: &MemoryLayout) -> usize {
+    let total_words = (memory_layout.heap_end - memory_layout.get_lowest_address()) / 8;
+    (total_words as usize).next_power_of_two()
 }

--- a/crates/jolt-verifier/src/error.rs
+++ b/crates/jolt-verifier/src/error.rs
@@ -62,8 +62,17 @@ pub enum VerifierError {
     #[error("invalid trace length {got}; expected a power of two no larger than {max}")]
     InvalidTraceLength { got: usize, max: usize },
 
-    #[error("invalid RAM domain size {got}; expected a power of two")]
-    InvalidRamK { got: usize },
+    #[error("invalid RAM domain size {got}; expected a power of two in [{min}, {max}]")]
+    InvalidRamK { got: usize, min: usize, max: usize },
+
+    #[error("invalid one-hot configuration: {0}")]
+    InvalidOneHotConfig(String),
+
+    #[error("invalid read-write checking configuration: {0}")]
+    InvalidReadWriteConfig(String),
+
+    #[error("commitment conversion failed: {reason}")]
+    CommitmentConversionFailed { reason: String },
 
     #[error("missing stage claim opening input {id:?}")]
     MissingStageClaimOpening { id: JoltOpeningId },

--- a/crates/jolt-verifier/src/error.rs
+++ b/crates/jolt-verifier/src/error.rs
@@ -71,9 +71,6 @@ pub enum VerifierError {
     #[error("invalid read-write checking configuration: {0}")]
     InvalidReadWriteConfig(String),
 
-    #[error("commitment conversion failed: {reason}")]
-    CommitmentConversionFailed { reason: String },
-
     #[error("missing stage claim opening input {id:?}")]
     MissingStageClaimOpening { id: JoltOpeningId },
 

--- a/crates/jolt-verifier/src/stages/stage6/verify_b.rs
+++ b/crates/jolt-verifier/src/stages/stage6/verify_b.rs
@@ -58,12 +58,7 @@ pub(super) fn verify_advice_cycle_phase<F: Field>(
     opening_claim: &AdviceCyclePhaseOutputClaim<F>,
     stage4: &Stage4ClearOutput<F>,
 ) -> Result<VerifiedAdviceCyclePhaseSumcheck<F>, VerifierError> {
-    let advice_point = batch
-        .try_instance_point_at(0, claim.sumcheck.rounds)
-        .map_err(|error| VerifierError::StageClaimSumcheckFailed {
-            stage: JoltRelationId::AdviceClaimReductionCyclePhase,
-            reason: error.to_string(),
-        })?;
+    let advice_point = advice_cycle_phase_point(batch, claim)?;
     let opening_point = layout
         .cycle_phase_opening_point(advice_point)
         .map_err(|error| VerifierError::StageClaimPublicInputFailed {
@@ -123,12 +118,7 @@ pub(super) fn advice_cycle_phase_public<F: Field, C>(
     layout: &AdviceClaimReductionLayout,
     kind: JoltAdviceKind,
 ) -> Result<AdviceCyclePhasePublicOutput<F>, VerifierError> {
-    let advice_point = batch
-        .try_instance_point_at(0, claim.sumcheck.rounds)
-        .map_err(|error| VerifierError::StageClaimSumcheckFailed {
-            stage: JoltRelationId::AdviceClaimReductionCyclePhase,
-            reason: error.to_string(),
-        })?;
+    let advice_point = advice_cycle_phase_committed_point(batch, claim)?;
     let opening_point = layout
         .cycle_phase_opening_point(&advice_point)
         .map_err(|error| VerifierError::StageClaimPublicInputFailed {
@@ -148,6 +138,33 @@ pub(super) fn advice_cycle_phase_public<F: Field, C>(
         opening_point,
         cycle_phase_variables,
     })
+}
+
+fn advice_cycle_phase_point<'a, F: Field>(
+    batch: &'a jolt_sumcheck::BatchedEvaluationClaim<F>,
+    claim: &JoltRelationClaims<F>,
+) -> Result<&'a [F], VerifierError> {
+    batch
+        .try_instance_point(claim.sumcheck.rounds)
+        .map_err(|error| VerifierError::StageClaimSumcheckFailed {
+            stage: JoltRelationId::AdviceClaimReductionCyclePhase,
+            reason: error.to_string(),
+        })
+}
+
+fn advice_cycle_phase_committed_point<F, C>(
+    batch: &jolt_sumcheck::BatchedCommittedSumcheckConsistency<F, C>,
+    claim: &JoltRelationClaims<F>,
+) -> Result<Vec<F>, VerifierError>
+where
+    F: Field + Copy,
+{
+    batch
+        .try_instance_point(claim.sumcheck.rounds)
+        .map_err(|error| VerifierError::StageClaimSumcheckFailed {
+            stage: JoltRelationId::AdviceClaimReductionCyclePhase,
+            reason: error.to_string(),
+        })
 }
 
 pub(super) fn append_opening_claims<F, T>(
@@ -197,5 +214,99 @@ pub(super) fn append_opening_claims<F, T>(
     }
     if let Some(opening_claim) = &claims.advice_cycle_phase.untrusted {
         transcript.append_labeled(b"opening_claim", &opening_claim.opening_claim);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![expect(clippy::expect_used, reason = "tests fail loudly on helper errors")]
+
+    use super::*;
+    use jolt_claims::protocols::jolt::formulas::dimensions::{
+        CommitmentMatrixShape, TracePolynomialOrder,
+    };
+    use jolt_field::{Fr, FromPrimitiveInt};
+    use jolt_sumcheck::{
+        BatchedCommittedSumcheckConsistency, BatchedEvaluationClaim, CommittedSumcheckConsistency,
+        EvaluationClaim, VerifiedCommittedRound,
+    };
+
+    #[test]
+    fn clear_advice_cycle_phase_uses_batched_suffix_for_cycle_major_layout() {
+        let layout = advice_layout(TracePolynomialOrder::CycleMajor);
+        assert!(layout.dimensions().has_address_phase());
+        let claim = advice::cycle_phase::<Fr>(JoltAdviceKind::Trusted, layout.dimensions());
+        let batch = clear_batch(claim.sumcheck.rounds + 3);
+
+        let point = advice_cycle_phase_point(&batch, &claim).expect("suffix point");
+        let expected = suffix(batch.reduction.point.as_slice(), claim.sumcheck.rounds);
+
+        assert_eq!(point, expected.as_slice());
+    }
+
+    #[test]
+    fn committed_advice_cycle_phase_uses_batched_suffix_for_address_major_layout() {
+        let layout = advice_layout(TracePolynomialOrder::AddressMajor);
+        assert!(layout.dimensions().has_address_phase());
+        let claim = advice::cycle_phase::<Fr>(JoltAdviceKind::Untrusted, layout.dimensions());
+        let batch = committed_batch(claim.sumcheck.rounds + 5);
+
+        let point = advice_cycle_phase_committed_point(&batch, &claim).expect("suffix point");
+        let challenges = batch
+            .consistency
+            .rounds
+            .iter()
+            .map(|round| round.challenge)
+            .collect::<Vec<_>>();
+
+        assert_eq!(point, suffix(&challenges, claim.sumcheck.rounds));
+    }
+
+    fn advice_layout(trace_order: TracePolynomialOrder) -> AdviceClaimReductionLayout {
+        AdviceClaimReductionLayout::new(
+            trace_order,
+            8,
+            4,
+            CommitmentMatrixShape::balanced(12),
+            CommitmentMatrixShape::balanced(8),
+        )
+    }
+
+    fn clear_batch(max_num_vars: usize) -> BatchedEvaluationClaim<Fr> {
+        BatchedEvaluationClaim {
+            reduction: EvaluationClaim {
+                point: challenges(max_num_vars).into(),
+                value: Fr::from_u64(0),
+            },
+            batching_coefficients: Vec::new(),
+            max_num_vars,
+            max_degree: 2,
+        }
+    }
+
+    fn committed_batch(max_num_vars: usize) -> BatchedCommittedSumcheckConsistency<Fr, ()> {
+        BatchedCommittedSumcheckConsistency {
+            consistency: CommittedSumcheckConsistency {
+                rounds: challenges(max_num_vars)
+                    .into_iter()
+                    .map(|challenge| VerifiedCommittedRound {
+                        commitment: (),
+                        degree: 2,
+                        challenge,
+                    })
+                    .collect(),
+            },
+            batching_coefficients: Vec::new(),
+            max_num_vars,
+            max_degree: 2,
+        }
+    }
+
+    fn challenges(count: usize) -> Vec<Fr> {
+        (1..=count as u64).map(Fr::from_u64).collect()
+    }
+
+    fn suffix(values: &[Fr], len: usize) -> Vec<Fr> {
+        values[values.len() - len..].to_vec()
     }
 }

--- a/crates/jolt-verifier/src/stages/stage7/verify.rs
+++ b/crates/jolt-verifier/src/stages/stage7/verify.rs
@@ -798,12 +798,7 @@ fn verify_advice_address_phase<F: Field>(
     stage4: &Stage4ClearOutput<F>,
     stage6: &Stage6ClearOutput<F>,
 ) -> Result<VerifiedAdviceAddressPhaseSumcheck<F>, VerifierError> {
-    let advice_point = batch
-        .try_instance_point_at(0, claim.sumcheck.rounds)
-        .map_err(|error| VerifierError::StageClaimSumcheckFailed {
-            stage: JoltRelationId::AdviceClaimReduction,
-            reason: error.to_string(),
-        })?;
+    let advice_point = advice_address_phase_point(batch, claim)?;
     let cycle_phase = stage6_verified_advice_cycle_phase(stage6, kind)?;
     let opening_point = layout
         .address_phase_opening_point(&cycle_phase.cycle_phase_variables, advice_point)
@@ -859,12 +854,7 @@ fn advice_address_phase_public<F: Field, C>(
     kind: JoltAdviceKind,
     stage6: &Stage6ZkOutput<F, C>,
 ) -> Result<AdviceAddressPhasePublicOutput<F>, VerifierError> {
-    let advice_point = batch
-        .try_instance_point_at(0, claim.sumcheck.rounds)
-        .map_err(|error| VerifierError::StageClaimSumcheckFailed {
-            stage: JoltRelationId::AdviceClaimReduction,
-            reason: error.to_string(),
-        })?;
+    let advice_point = advice_address_phase_committed_point(batch, claim)?;
     let cycle_phase = stage6_advice_cycle_phase_public(stage6, kind)?;
     let opening_point = layout
         .address_phase_opening_point(&cycle_phase.cycle_phase_variables, &advice_point)
@@ -878,6 +868,33 @@ fn advice_address_phase_public<F: Field, C>(
         sumcheck_point: advice_point,
         opening_point,
     })
+}
+
+fn advice_address_phase_point<'a, F: Field>(
+    batch: &'a jolt_sumcheck::BatchedEvaluationClaim<F>,
+    claim: &JoltRelationClaims<F>,
+) -> Result<&'a [F], VerifierError> {
+    batch
+        .try_instance_point(claim.sumcheck.rounds)
+        .map_err(|error| VerifierError::StageClaimSumcheckFailed {
+            stage: JoltRelationId::AdviceClaimReduction,
+            reason: error.to_string(),
+        })
+}
+
+fn advice_address_phase_committed_point<F, C>(
+    batch: &BatchedCommittedSumcheckConsistency<F, C>,
+    claim: &JoltRelationClaims<F>,
+) -> Result<Vec<F>, VerifierError>
+where
+    F: Field + Copy,
+{
+    batch
+        .try_instance_point(claim.sumcheck.rounds)
+        .map_err(|error| VerifierError::StageClaimSumcheckFailed {
+            stage: JoltRelationId::AdviceClaimReduction,
+            reason: error.to_string(),
+        })
 }
 
 fn stage6_advice_cycle_phase_claim<F: Field>(
@@ -940,5 +957,99 @@ where
     }
     if let Some(opening_claim) = &claims.advice_address_phase.untrusted {
         transcript.append_labeled(b"opening_claim", &opening_claim.opening_claim);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![expect(clippy::expect_used, reason = "tests fail loudly on helper errors")]
+
+    use super::*;
+    use jolt_claims::protocols::jolt::formulas::dimensions::{
+        CommitmentMatrixShape, TracePolynomialOrder,
+    };
+    use jolt_field::{Fr, FromPrimitiveInt};
+    use jolt_sumcheck::{
+        BatchedCommittedSumcheckConsistency, BatchedEvaluationClaim, CommittedSumcheckConsistency,
+        EvaluationClaim, VerifiedCommittedRound,
+    };
+
+    #[test]
+    fn clear_advice_address_phase_uses_batched_suffix_for_cycle_major_layout() {
+        let layout = advice_layout(TracePolynomialOrder::CycleMajor);
+        assert!(layout.dimensions().has_address_phase());
+        let claim = advice::address_phase::<Fr>(JoltAdviceKind::Trusted, layout.dimensions());
+        let batch = clear_batch(claim.sumcheck.rounds + 4);
+
+        let point = advice_address_phase_point(&batch, &claim).expect("suffix point");
+        let expected = suffix(batch.reduction.point.as_slice(), claim.sumcheck.rounds);
+
+        assert_eq!(point, expected.as_slice());
+    }
+
+    #[test]
+    fn committed_advice_address_phase_uses_batched_suffix_for_address_major_layout() {
+        let layout = advice_layout(TracePolynomialOrder::AddressMajor);
+        assert!(layout.dimensions().has_address_phase());
+        let claim = advice::address_phase::<Fr>(JoltAdviceKind::Untrusted, layout.dimensions());
+        let batch = committed_batch(claim.sumcheck.rounds + 6);
+
+        let point = advice_address_phase_committed_point(&batch, &claim).expect("suffix point");
+        let challenges = batch
+            .consistency
+            .rounds
+            .iter()
+            .map(|round| round.challenge)
+            .collect::<Vec<_>>();
+
+        assert_eq!(point, suffix(&challenges, claim.sumcheck.rounds));
+    }
+
+    fn advice_layout(trace_order: TracePolynomialOrder) -> AdviceClaimReductionLayout {
+        AdviceClaimReductionLayout::new(
+            trace_order,
+            8,
+            4,
+            CommitmentMatrixShape::balanced(12),
+            CommitmentMatrixShape::balanced(8),
+        )
+    }
+
+    fn clear_batch(max_num_vars: usize) -> BatchedEvaluationClaim<Fr> {
+        BatchedEvaluationClaim {
+            reduction: EvaluationClaim {
+                point: challenges(max_num_vars).into(),
+                value: Fr::from_u64(0),
+            },
+            batching_coefficients: Vec::new(),
+            max_num_vars,
+            max_degree: 2,
+        }
+    }
+
+    fn committed_batch(max_num_vars: usize) -> BatchedCommittedSumcheckConsistency<Fr, ()> {
+        BatchedCommittedSumcheckConsistency {
+            consistency: CommittedSumcheckConsistency {
+                rounds: challenges(max_num_vars)
+                    .into_iter()
+                    .map(|challenge| VerifiedCommittedRound {
+                        commitment: (),
+                        degree: 2,
+                        challenge,
+                    })
+                    .collect(),
+            },
+            batching_coefficients: Vec::new(),
+            max_num_vars,
+            max_degree: 2,
+        }
+    }
+
+    fn challenges(count: usize) -> Vec<Fr> {
+        (1..=count as u64).map(Fr::from_u64).collect()
+    }
+
+    fn suffix(values: &[Fr], len: usize) -> Vec<Fr> {
+        values[values.len() - len..].to_vec()
     }
 }

--- a/crates/jolt-verifier/src/verifier.rs
+++ b/crates/jolt-verifier/src/verifier.rs
@@ -8,6 +8,7 @@ use jolt_sumcheck::SumcheckProof;
 use jolt_transcript::{AppendToTranscript, Label, LabelWithCount, Transcript, U64Word};
 
 use crate::{
+    config::{validate_proof_config, JOLT_VERIFIER_CONFIG},
     preprocessing::JoltVerifierPreprocessing,
     proof::JoltProof,
     stages::{
@@ -191,9 +192,7 @@ where
         });
     }
 
-    if !proof.ram_K.is_power_of_two() {
-        return Err(VerifierError::InvalidRamK { got: proof.ram_K });
-    }
+    validate_proof_config(&JOLT_VERIFIER_CONFIG, preprocessing, proof, zk)?;
 
     let vc_capacity = if zk {
         Some(validate_zk_vector_commitment_setup::<PCS, VC>(
@@ -465,9 +464,11 @@ where
 mod tests {
     use super::*;
     use crate::proof::{ClearProofClaims, JoltProofClaims, JoltStageProofs};
-    use common::jolt_device::{JoltDevice, MemoryLayout};
+    use common::jolt_device::{JoltDevice, MemoryConfig};
     use jolt_claims::protocols::jolt::{JoltOneHotConfig, JoltReadWriteConfig};
-    use jolt_crypto::{Bn254G1, Commitment, Pedersen, PedersenSetup, VectorCommitmentOpening};
+    #[cfg(feature = "zk")]
+    use jolt_crypto::PedersenSetup;
+    use jolt_crypto::{Bn254G1, Commitment, Pedersen, VectorCommitmentOpening};
     use jolt_field::Fr;
     use jolt_openings::{CommitmentScheme, OpeningsError};
     use jolt_poly::{MultilinearPoly, Polynomial};
@@ -620,6 +621,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(not(feature = "zk"))]
     fn validate_inputs_normalizes_public_output() {
         let preprocessing = test_preprocessing();
         let mut public_io = JoltDevice {
@@ -651,6 +653,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(not(feature = "zk"))]
     fn validate_inputs_rejects_public_io_layout_mismatch() {
         let preprocessing = test_preprocessing();
         let public_io = JoltDevice::default();
@@ -663,6 +666,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "zk")]
     fn validate_inputs_rejects_missing_zk_vector_commitment_setup() {
         let preprocessing = test_preprocessing();
         let public_io = JoltDevice {
@@ -678,6 +682,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "zk")]
     fn validate_inputs_rejects_small_zk_vector_commitment_setup() {
         let mut preprocessing = test_preprocessing();
         preprocessing.vc_setup = Some(PedersenSetup::new(
@@ -696,6 +701,115 @@ mod tests {
         ));
     }
 
+    #[test]
+    #[cfg(not(feature = "zk"))]
+    fn validate_inputs_rejects_runtime_zk_flag_mismatch() {
+        let preprocessing = test_preprocessing();
+        let public_io = JoltDevice {
+            memory_layout: preprocessing.program.memory_layout.clone(),
+            ..JoltDevice::default()
+        };
+        let proof = proof_with_zk(false, clear_claims());
+
+        assert!(matches!(
+            validate_inputs(&preprocessing, &public_io, &proof, false, true),
+            Err(VerifierError::ProtocolConfigMismatch { .. })
+        ));
+    }
+
+    #[test]
+    #[cfg(not(feature = "zk"))]
+    fn validate_inputs_rejects_tampered_protocol_metadata() {
+        let preprocessing = test_preprocessing();
+        let public_io = JoltDevice {
+            memory_layout: preprocessing.program.memory_layout.clone(),
+            ..JoltDevice::default()
+        };
+        let mut proof = proof_with_zk(false, clear_claims());
+        proof.protocol = crate::config::JoltProtocolConfig::for_zk(true);
+
+        assert!(matches!(
+            validate_inputs(&preprocessing, &public_io, &proof, false, false),
+            Err(VerifierError::ProtocolConfigMismatch { .. })
+        ));
+    }
+
+    #[test]
+    #[cfg(not(feature = "zk"))]
+    fn validate_inputs_rejects_invalid_one_hot_chunk_size() {
+        let preprocessing = test_preprocessing();
+        let public_io = JoltDevice {
+            memory_layout: preprocessing.program.memory_layout.clone(),
+            ..JoltDevice::default()
+        };
+        let mut proof = proof_with_zk(false, clear_claims());
+        proof.one_hot_config.log_k_chunk = 6;
+
+        assert!(matches!(
+            validate_inputs(&preprocessing, &public_io, &proof, false, false),
+            Err(VerifierError::InvalidOneHotConfig(_))
+        ));
+    }
+
+    #[test]
+    #[cfg(not(feature = "zk"))]
+    fn validate_inputs_rejects_invalid_read_write_phase_split() {
+        let preprocessing = test_preprocessing();
+        let public_io = JoltDevice {
+            memory_layout: preprocessing.program.memory_layout.clone(),
+            ..JoltDevice::default()
+        };
+        let mut proof = proof_with_zk(false, clear_claims());
+        proof.rw_config.ram_rw_phase2_num_rounds = 3;
+
+        assert!(matches!(
+            validate_inputs(&preprocessing, &public_io, &proof, false, false),
+            Err(VerifierError::InvalidReadWriteConfig(_))
+        ));
+    }
+
+    #[test]
+    #[cfg(not(feature = "zk"))]
+    fn validate_inputs_rejects_ram_domain_below_static_minimum() {
+        let preprocessing = test_preprocessing();
+        let public_io = JoltDevice {
+            memory_layout: preprocessing.program.memory_layout.clone(),
+            ..JoltDevice::default()
+        };
+        let mut proof = proof_with_zk(false, clear_claims());
+        proof.ram_K = 2;
+
+        assert!(matches!(
+            validate_inputs(&preprocessing, &public_io, &proof, false, false),
+            Err(VerifierError::InvalidRamK {
+                got: 2,
+                min: 4,
+                max: 32,
+            })
+        ));
+    }
+
+    #[test]
+    #[cfg(not(feature = "zk"))]
+    fn validate_inputs_rejects_ram_domain_above_memory_layout_maximum() {
+        let preprocessing = test_preprocessing();
+        let public_io = JoltDevice {
+            memory_layout: preprocessing.program.memory_layout.clone(),
+            ..JoltDevice::default()
+        };
+        let mut proof = proof_with_zk(false, clear_claims());
+        proof.ram_K = 64;
+
+        assert!(matches!(
+            validate_inputs(&preprocessing, &public_io, &proof, false, false),
+            Err(VerifierError::InvalidRamK {
+                got: 64,
+                min: 4,
+                max: 32,
+            })
+        ));
+    }
+
     fn proof_with_zk(is_zk: bool, claims: TestClaims) -> TestProof {
         JoltProof::new(
             crate::proof::JoltCommitments::new(
@@ -711,17 +825,17 @@ mod tests {
             (),
             None,
             claims,
-            1,
-            1,
+            16,
+            4,
             JoltReadWriteConfig {
-                ram_rw_phase1_num_rounds: 0,
-                ram_rw_phase2_num_rounds: 0,
-                registers_rw_phase1_num_rounds: 0,
-                registers_rw_phase2_num_rounds: 0,
+                ram_rw_phase1_num_rounds: 4,
+                ram_rw_phase2_num_rounds: 2,
+                registers_rw_phase1_num_rounds: 4,
+                registers_rw_phase2_num_rounds: 7,
             },
             JoltOneHotConfig {
-                log_k_chunk: 0,
-                lookups_ra_virtual_log_k_chunk: 0,
+                log_k_chunk: 4,
+                lookups_ra_virtual_log_k_chunk: 16,
             },
             crate::proof::TracePolynomialOrder::CycleMajor,
         )
@@ -981,12 +1095,15 @@ mod tests {
     }
 
     fn test_preprocessing() -> JoltVerifierPreprocessing<TestPcs, Pedersen<Bn254G1>> {
-        let memory_layout = MemoryLayout {
+        let memory_layout = common::jolt_device::MemoryLayout::new(&MemoryConfig {
+            program_size: Some(8),
+            max_trusted_advice_size: 0,
+            max_untrusted_advice_size: 0,
             max_input_size: 8,
             max_output_size: 8,
+            stack_size: 8,
             heap_size: 8,
-            ..MemoryLayout::default()
-        };
+        });
         JoltVerifierPreprocessing::new(
             JoltProgramPreprocessing {
                 bytecode: BytecodePreprocessing::default(),

--- a/crates/jolt-verifier/tests/soundness/core_transitivity/commitments.rs
+++ b/crates/jolt-verifier/tests/soundness/core_transitivity/commitments.rs
@@ -1,15 +1,3 @@
-#[cfg(all(feature = "core-fixtures", not(feature = "zk")))]
-use crate::support::core_fixtures;
-
 #[test]
-#[cfg(all(feature = "core-fixtures", not(feature = "zk")))]
-fn precompat_dory_commitment_bridge_round_trips_nontrivial_commitment() {
-    let case = core_fixtures::standard_muldiv_precompat_case();
-
-    assert!(case.first_dory_commitment_round_trips_through_modular_type());
-}
-
-#[test]
-#[cfg(any(not(feature = "core-fixtures"), feature = "zk"))]
-#[ignore = "enable --features core-fixtures in a non-ZK build to check compat commitment conversion"]
-fn precompat_dory_commitment_bridge_round_trips_nontrivial_commitment() {}
+#[ignore = "core invalid-proof fixture generation is not wired yet"]
+fn core_rejects_trusted_advice_commitment_mismatch() {}

--- a/crates/jolt-verifier/tests/soundness/core_transitivity/commitments.rs
+++ b/crates/jolt-verifier/tests/soundness/core_transitivity/commitments.rs
@@ -1,3 +1,15 @@
+#[cfg(all(feature = "core-fixtures", not(feature = "zk")))]
+use crate::support::core_fixtures;
+
 #[test]
-#[ignore = "core invalid-proof fixture generation is not wired yet"]
-fn core_rejects_trusted_advice_commitment_mismatch() {}
+#[cfg(all(feature = "core-fixtures", not(feature = "zk")))]
+fn precompat_dory_commitment_bridge_round_trips_nontrivial_commitment() {
+    let case = core_fixtures::standard_muldiv_precompat_case();
+
+    assert!(case.first_dory_commitment_round_trips_through_modular_type());
+}
+
+#[test]
+#[cfg(any(not(feature = "core-fixtures"), feature = "zk"))]
+#[ignore = "enable --features core-fixtures in a non-ZK build to check compat commitment conversion"]
+fn precompat_dory_commitment_bridge_round_trips_nontrivial_commitment() {}

--- a/crates/jolt-verifier/tests/soundness/tampering/configs.rs
+++ b/crates/jolt-verifier/tests/soundness/tampering/configs.rs
@@ -1,3 +1,87 @@
+#[cfg(all(feature = "core-fixtures", not(feature = "zk")))]
+use crate::support::{core_fixtures, tamper_manifest};
+#[cfg(all(feature = "core-fixtures", not(feature = "zk")))]
+use jolt_verifier::{
+    config::{compute_max_ram_K, compute_min_ram_K, JoltProtocolConfig},
+    VerifierError,
+};
+
 #[test]
-#[ignore = "direct config tampering fixtures are not wired yet"]
-fn tampered_trace_length_reject() {}
+#[cfg(all(feature = "core-fixtures", not(feature = "zk")))]
+fn tampered_protocol_config_rejects_now() {
+    let base = real_core_case();
+    tamper_manifest::assert_core_tamper_rejects(
+        tamper_manifest::required_target("proof.protocol"),
+        &base,
+        |case| {
+            case.proof.protocol = JoltProtocolConfig::for_zk(true);
+        },
+    );
+}
+
+#[test]
+#[cfg(all(feature = "core-fixtures", not(feature = "zk")))]
+fn invalid_one_hot_chunk_size_rejects_now() {
+    let base = real_core_case();
+    tamper_manifest::assert_core_tamper_rejects(
+        tamper_manifest::required_target("proof.one_hot_config"),
+        &base,
+        |case| {
+            case.proof.one_hot_config.log_k_chunk = 6;
+        },
+    );
+}
+
+#[test]
+#[cfg(all(feature = "core-fixtures", not(feature = "zk")))]
+fn invalid_read_write_phase_split_rejects_now() {
+    let base = real_core_case();
+    tamper_manifest::assert_core_tamper_rejects(
+        tamper_manifest::required_target("proof.rw_config"),
+        &base,
+        |case| {
+            case.proof.rw_config.ram_rw_phase2_num_rounds = case.proof.ram_K.ilog2() as u8 + 1;
+        },
+    );
+}
+
+#[test]
+#[cfg(all(feature = "core-fixtures", not(feature = "zk")))]
+fn ram_domain_below_static_memory_minimum_rejects_now() {
+    let mut case = real_core_case();
+    let min = compute_min_ram_K(
+        &case.preprocessing.program.ram,
+        &case.public_io.memory_layout,
+    );
+    case.proof.ram_K = min / 2;
+
+    assert!(matches!(
+        case.verify(),
+        Err(VerifierError::InvalidRamK { got, min: err_min, .. })
+            if got == min / 2 && err_min == min
+    ));
+}
+
+#[test]
+#[cfg(all(feature = "core-fixtures", not(feature = "zk")))]
+fn ram_domain_above_memory_layout_maximum_rejects_now() {
+    let mut case = real_core_case();
+    let max = compute_max_ram_K(&case.public_io.memory_layout);
+    case.proof.ram_K = max * 2;
+
+    assert!(matches!(
+        case.verify(),
+        Err(VerifierError::InvalidRamK { got, max: err_max, .. })
+            if got == max * 2 && err_max == max
+    ));
+}
+
+#[cfg(all(feature = "core-fixtures", not(feature = "zk")))]
+fn real_core_case() -> core_fixtures::CoreVerifierCase {
+    core_fixtures::standard_muldiv_case()
+}
+
+#[test]
+#[cfg(any(not(feature = "core-fixtures"), feature = "zk"))]
+#[ignore = "enable --features core-fixtures in a non-ZK build to tamper real config proofs"]
+fn config_tampering_requires_core_fixtures() {}

--- a/crates/jolt-verifier/tests/soundness/tampering/openings.rs
+++ b/crates/jolt-verifier/tests/soundness/tampering/openings.rs
@@ -10,7 +10,10 @@
 use crate::support::{core_fixtures, tamper_manifest};
 #[cfg(all(feature = "core-fixtures", not(feature = "zk")))]
 use jolt_claims::protocols::jolt::{
-    formulas::{committed_openings::final_opening_ids, dimensions::JoltFormulaDimensions},
+    formulas::{
+        committed_openings::final_opening_ids, dimensions::JoltFormulaDimensions,
+        spartan::outer_uniskip_opening,
+    },
     JoltOpeningId,
 };
 #[cfg(all(feature = "core-fixtures", not(feature = "zk")))]
@@ -19,6 +22,8 @@ use jolt_field::{Fr, FromPrimitiveInt};
 use jolt_lookup_tables::XLEN as RISCV_XLEN;
 #[cfg(all(feature = "core-fixtures", not(feature = "zk")))]
 use jolt_verifier::compat::claims::offset_opening_claim;
+#[cfg(all(feature = "core-fixtures", not(feature = "zk")))]
+use jolt_verifier::VerifierError;
 
 #[test]
 #[cfg(all(feature = "core-fixtures", not(feature = "zk")))]
@@ -60,6 +65,26 @@ fn precompat_tampered_opening_value_reject() {
             },
         );
     }
+}
+
+#[test]
+#[cfg(all(feature = "core-fixtures", not(feature = "zk")))]
+fn precompat_missing_required_opening_claim_returns_error_without_panic() {
+    let mut case = core_fixtures::standard_muldiv_precompat_case();
+    let missing = outer_uniskip_opening();
+    assert!(
+        case.remove_opening_claim(missing),
+        "legacy core fixture is missing required opening claim {missing:?}"
+    );
+
+    let result =
+        std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| case.verify_after_compat()));
+
+    assert!(result.is_ok(), "compat conversion should not panic");
+    assert!(matches!(
+        result.expect("panic already checked"),
+        Err(VerifierError::MissingOpeningClaim { id }) if id == missing
+    ));
 }
 
 #[cfg(all(feature = "core-fixtures", not(feature = "zk")))]

--- a/crates/jolt-verifier/tests/support/core_fixtures.rs
+++ b/crates/jolt-verifier/tests/support/core_fixtures.rs
@@ -26,7 +26,7 @@ use common::jolt_device::JoltDevice;
 use jolt_claims::protocols::jolt::{
     JoltCommittedPolynomial, JoltOpeningId, JoltPolynomialId, JoltRelationId, JoltVirtualPolynomial,
 };
-use jolt_crypto::{Bn254G1, Pedersen, PedersenSetup};
+use jolt_crypto::{Bn254G1, JoltGroup, Pedersen, PedersenSetup};
 #[cfg(not(feature = "zk"))]
 use jolt_dory::DoryCommitment;
 use jolt_dory::{DoryScheme, DoryVerifierSetup};
@@ -418,6 +418,28 @@ impl CorePrecompatVerifierCase {
         *opening_claim += CoreField::from_u64(delta);
         true
     }
+
+    pub fn remove_opening_claim(&mut self, id: JoltOpeningId) -> bool {
+        self.proof
+            .opening_claims
+            .0
+            .remove(&core_opening_id(id))
+            .is_some()
+    }
+
+    pub fn first_dory_commitment_round_trips_through_modular_type(&self) -> bool {
+        let converted: ConvertedProof = self
+            .proof
+            .clone_via_bytes()
+            .try_into()
+            .expect("convert standard core proof");
+        let modular_inner: jolt_core::ark_bn254::Fq12 = converted.commitments.rd_inc.0.into();
+        let Some((core_commitment, _)) = self.proof.commitments.split_first() else {
+            return false;
+        };
+
+        modular_inner == core_commitment.0 && !converted.commitments.rd_inc.0.is_identity()
+    }
 }
 
 #[cfg(feature = "zk")]
@@ -604,7 +626,9 @@ fn case_from_parts(fixture: GeneratedCoreFixture, public_io: JoltDevice) -> Core
             .expect("convert standard core proof"),
         trusted_advice_commitment: fixture
             .trusted_advice_commitment
-            .map(<DoryCommitmentScheme as CorePcsBridge<CoreField>>::commitment_into_verifier),
+            .map(<DoryCommitmentScheme as CorePcsBridge<CoreField>>::commitment_into_verifier)
+            .transpose()
+            .expect("convert trusted advice commitment"),
     }
 }
 
@@ -615,7 +639,9 @@ fn precompat_case_from_parts(
 ) -> CorePrecompatVerifierCase {
     let modular_trusted_advice_commitment = fixture
         .trusted_advice_commitment
-        .map(<DoryCommitmentScheme as CorePcsBridge<CoreField>>::commitment_into_verifier);
+        .map(<DoryCommitmentScheme as CorePcsBridge<CoreField>>::commitment_into_verifier)
+        .transpose()
+        .expect("convert trusted advice commitment");
 
     CorePrecompatVerifierCase {
         preprocessing: convert_preprocessing(&fixture.core_preprocessing),

--- a/crates/jolt-verifier/tests/support/core_fixtures.rs
+++ b/crates/jolt-verifier/tests/support/core_fixtures.rs
@@ -26,7 +26,7 @@ use common::jolt_device::JoltDevice;
 use jolt_claims::protocols::jolt::{
     JoltCommittedPolynomial, JoltOpeningId, JoltPolynomialId, JoltRelationId, JoltVirtualPolynomial,
 };
-use jolt_crypto::{Bn254G1, JoltGroup, Pedersen, PedersenSetup};
+use jolt_crypto::{Bn254G1, Pedersen, PedersenSetup};
 #[cfg(not(feature = "zk"))]
 use jolt_dory::DoryCommitment;
 use jolt_dory::{DoryScheme, DoryVerifierSetup};
@@ -426,20 +426,6 @@ impl CorePrecompatVerifierCase {
             .remove(&core_opening_id(id))
             .is_some()
     }
-
-    pub fn first_dory_commitment_round_trips_through_modular_type(&self) -> bool {
-        let converted: ConvertedProof = self
-            .proof
-            .clone_via_bytes()
-            .try_into()
-            .expect("convert standard core proof");
-        let modular_inner: jolt_core::ark_bn254::Fq12 = converted.commitments.rd_inc.0.into();
-        let Some((core_commitment, _)) = self.proof.commitments.split_first() else {
-            return false;
-        };
-
-        modular_inner == core_commitment.0 && !converted.commitments.rd_inc.0.is_identity()
-    }
 }
 
 #[cfg(feature = "zk")]
@@ -626,9 +612,7 @@ fn case_from_parts(fixture: GeneratedCoreFixture, public_io: JoltDevice) -> Core
             .expect("convert standard core proof"),
         trusted_advice_commitment: fixture
             .trusted_advice_commitment
-            .map(<DoryCommitmentScheme as CorePcsBridge<CoreField>>::commitment_into_verifier)
-            .transpose()
-            .expect("convert trusted advice commitment"),
+            .map(<DoryCommitmentScheme as CorePcsBridge<CoreField>>::commitment_into_verifier),
     }
 }
 
@@ -639,9 +623,7 @@ fn precompat_case_from_parts(
 ) -> CorePrecompatVerifierCase {
     let modular_trusted_advice_commitment = fixture
         .trusted_advice_commitment
-        .map(<DoryCommitmentScheme as CorePcsBridge<CoreField>>::commitment_into_verifier)
-        .transpose()
-        .expect("convert trusted advice commitment");
+        .map(<DoryCommitmentScheme as CorePcsBridge<CoreField>>::commitment_into_verifier);
 
     CorePrecompatVerifierCase {
         preprocessing: convert_preprocessing(&fixture.core_preprocessing),

--- a/crates/jolt-verifier/tests/support/tamper_manifest.rs
+++ b/crates/jolt-verifier/tests/support/tamper_manifest.rs
@@ -232,6 +232,14 @@ pub const PREAMBLE_TARGETS: &[TamperTarget] = &[
         "invalid and excessive trace lengths are checked during input validation",
     ),
     checked_standard(
+        "proof.protocol",
+        "proof.protocol",
+        VerifierPhase::Preamble,
+        MutationStrategy::ChangeEnumVariant,
+        TamperCoverage::Active,
+        "proof protocol metadata must match the selected verifier build and runtime mode",
+    ),
+    checked_standard(
         "proof.ram_K",
         "proof.ram_K",
         VerifierPhase::Preamble,
@@ -242,18 +250,18 @@ pub const PREAMBLE_TARGETS: &[TamperTarget] = &[
     checked_standard(
         "proof.rw_config",
         "proof.rw_config",
-        VerifierPhase::Stage2,
+        VerifierPhase::Preamble,
         MutationStrategy::OffsetScalar,
         TamperCoverage::Active,
-        "stage 2 consumes RAM read-write phase lengths when slicing batched points",
+        "read-write phase splits are checked during input validation",
     ),
-    later_standard(
+    checked_standard(
         "proof.one_hot_config",
         "proof.one_hot_config",
-        VerifierPhase::Stage6,
+        VerifierPhase::Preamble,
         MutationStrategy::OffsetScalar,
-        TamperCoverage::Deferred,
-        "one-hot configuration is transcript-bound now but substantively checked by later RA virtualization stages",
+        TamperCoverage::Active,
+        "one-hot chunk parameters are checked during input validation",
     ),
     checked_standard(
         "proof.trace_polynomial_order",
@@ -1041,6 +1049,7 @@ pub fn proof_field_paths() -> &'static [&'static str] {
         "proof.joint_opening_proof",
         "proof.untrusted_advice_commitment",
         "proof.claims",
+        "proof.protocol",
         "proof.trace_length",
         "proof.ram_K",
         "proof.rw_config",


### PR DESCRIPTION
## Summary

Fixes all verifier-branch code-review findings against `stack/09-jolt-verifier-crate`.

## Findings checklist

- [x] **H-1 Public verifier proof-config validation**
  - Added a single pre-transcript config-validation gate from `validate_inputs` through `validate_proof_config`.
  - Enforces proof protocol metadata against the selected verifier build and runtime `zk` mode.
  - Ports strict one-hot config validation (`log_k_chunk` 4/8, lookup chunk ordering/range/divisibility).
  - Ports read/write phase-split validation for RAM and registers.
  - Ports preprocessing/memory-layout-derived `ram_K` min/max validation.
  - Added unit and core-fixture tamper tests for protocol, one-hot config, RW config, and `ram_K` min/max.

- [x] **H-2 Stage 6/7 advice reductions use wrong batched challenge slice**
  - Replaced prefix `try_instance_point_at(0, rounds)` calls with canonical `try_instance_point(rounds)` in Stage 6 cycle-phase and Stage 7 address-phase clear/ZK helpers.
  - Added clear and committed regression tests using shorter advice instances under both `CycleMajor` and `AddressMajor` layouts with non-empty address phases.

- [x] **M-1 Compat conversion panics on malformed clear opening claims**
  - Made clear opening-claim conversion return `Result` and propagate `VerifierError` from `TryFrom<JoltCoreProof<_>>`.
  - Added a precompat regression that removes a required clear opening claim and asserts conversion returns an error without panicking.

- [x] **L-1 Dory commitment bridge uses unchecked transmute — reverted per author; transmute assumed to succeed**
  - Restored the original `unsafe { std::mem::transmute_copy(...) }` Dory commitment bridge from `stack/09-jolt-verifier-crate`.
  - Removed the safe serialization/deserialization conversion path, `CommitmentConversionFailed` error variant, and L-1-specific round-trip regression.
  - H-1, H-2, and M-1 fixes remain intact.

- [x] **Nits**
  - No blocking nits were reported.

## Verification

- `cargo fmt -q` ✅
- `git diff --check` ✅
- `cargo build -p jolt-verifier` ✅
- `cargo test -p jolt-verifier` ✅
- `cargo build -p jolt-verifier --features zk` ✅
- `cargo test -p jolt-verifier --features zk` ✅
- `cargo test -p jolt-verifier --features core-fixtures soundness::tampering::configs -- --test-threads=1` ✅
- `cargo test -p jolt-verifier --features core-fixtures precompat -- --test-threads=1` ✅
- `cargo clippy -p jolt-verifier --all-targets -- -D warnings` ✅
- `cargo clippy -p jolt-verifier --features core-fixtures --all-targets -- -D warnings` ✅
- `cargo clippy -p jolt-verifier --features zk --all-targets -- -D warnings` ✅

Latest L-1 revert verification (commit `32581a026f1f79981690c4f2aa2124426fb50643`):

- `cargo build -p jolt-verifier` ✅
- `cargo test -p jolt-verifier` ✅
- `cargo clippy -p jolt-verifier --all-targets -- -D warnings` ✅
- `cargo machete` ✅