### PR TITLE
Fix CI: exclude advice-consumer

### DIFF
--- a/examples/run_ci_benchmarks.sh
+++ b/examples/run_ci_benchmarks.sh
@@ -20,7 +20,7 @@ failures=0
 export RUST_LOG=info
 
 # Define the exclude list
-exclusion_list=("collatz" "overflow" "sha3-chain" "verifier" "recursion" "malloc" "hash-bench" "sig-recovery")
+exclusion_list=("advice-consumer" "collatz" "overflow" "sha3-chain" "verifier" "recursion" "malloc" "hash-bench" "sig-recovery")
 # JSON file to store results
 output_file="benchmark_results.json"
 


### PR DESCRIPTION
## Summary
- Fixes the failing `CI Benchmarks` workflow on `main`.
- Excludes the `examples/advice-consumer` directory from `examples/run_ci_benchmarks.sh`.
- Reverted the earlier workspace-clippy exclusion; `Build and Test Jolt / clippy` is green on `main` and is not the failing job.

## Root cause
The failing main-branch runs are `CI Benchmarks / Performance benchmarks`, step `Run benchmark`:

- Run `26655489416` on `e455699f1`
- Run `26654166170` on `082ab3d3f`

The benchmark script enumerates every directory under `examples/` except its exclusion list. It selected `advice-consumer`, then tried:

```console
Building advice-consumer
error: package ID specification `advice-consumer` did not match any packages
```

`advice-consumer` is only a fixture directory with package `advice-consumer-guest` at `examples/advice-consumer/guest`, not a runnable benchmark package named `advice-consumer`.

## Changes
- Added `advice-consumer` to `examples/run_ci_benchmarks.sh`'s `exclusion_list`.
- No crate/source deletion.
- No clippy workflow changes remain in this PR.

## Testing
Before:
- `cd examples && PATH="/tmp/jolt-fakebin:$PATH" ./run_ci_benchmarks.sh` → reproduced the CI failure locally:
  - selected `advice-consumer`
  - failed at `cargo build --release -p advice-consumer`
  - exit `101`

After:
- Re-ran the benchmark selection logic from `examples/run_ci_benchmarks.sh` → selected benchmarks start at `advice-demo`; `advice-consumer` is absent.
- `bash -n examples/run_ci_benchmarks.sh` → passed.
- Smoke-ran `examples/run_ci_benchmarks.sh` with local `cargo`/`gtime` wrappers that fail if `-p advice-consumer` is invoked → passed; observed cargo calls for `advice-demo`, `alloc`, ..., `stdlib`, and none for `advice-consumer`.
- Pre-commit hook: typos, cargo fmt, cargo clippy → passed.
