### PR TITLE
feat: add committed bytecode foundation

### DIFF
--- a/crates/jolt-claims/src/protocols/jolt/formulas/committed_openings.rs
+++ b/crates/jolt-claims/src/protocols/jolt/formulas/committed_openings.rs
@@ -67,6 +67,8 @@ pub fn final_opening_relation(polynomial: JoltCommittedPolynomial) -> JoltRelati
         JoltCommittedPolynomial::TrustedAdvice | JoltCommittedPolynomial::UntrustedAdvice => {
             JoltRelationId::AdviceClaimReduction
         }
+        JoltCommittedPolynomial::BytecodeChunk(_) => JoltRelationId::BytecodeClaimReduction,
+        JoltCommittedPolynomial::ProgramImageInit => JoltRelationId::ProgramImageClaimReduction,
     }
 }
 

--- a/crates/jolt-claims/src/protocols/jolt/ids.rs
+++ b/crates/jolt-claims/src/protocols/jolt/ids.rs
@@ -25,6 +25,10 @@ pub enum JoltRelationId {
     Booleanity,
     AdviceClaimReductionCyclePhase,
     AdviceClaimReduction,
+    BytecodeClaimReductionCyclePhase,
+    BytecodeClaimReduction,
+    ProgramImageClaimReductionCyclePhase,
+    ProgramImageClaimReduction,
     IncClaimReduction,
     HammingWeightClaimReduction,
 }
@@ -234,9 +238,11 @@ pub enum JoltCommittedPolynomial {
     RamInc,
     InstructionRa(usize),
     BytecodeRa(usize),
+    BytecodeChunk(usize),
     RamRa(usize),
     TrustedAdvice,
     UntrustedAdvice,
+    ProgramImageInit,
 }
 
 #[derive(Hash, PartialEq, Eq, Copy, Clone, Debug, PartialOrd, Ord, Serialize, Deserialize)]
@@ -280,8 +286,11 @@ pub enum JoltVirtualPolynomial {
     OpFlags(CircuitFlags),
     InstructionFlags(InstructionFlags),
     LookupTableFlag(usize),
+    BytecodeValStage(usize),
     BytecodeReadRafAddrClaim,
     BooleanityAddrClaim,
+    BytecodeClaimReductionIntermediate,
+    ProgramImageInitContributionRw,
 }
 
 #[derive(

--- a/crates/jolt-verifier/src/compat/claims.rs
+++ b/crates/jolt-verifier/src/compat/claims.rs
@@ -1710,12 +1710,18 @@ fn committed_polynomial(
         legacy::CommittedPolynomial::BytecodeRa(index) => {
             native::JoltCommittedPolynomial::BytecodeRa(index)
         }
+        legacy::CommittedPolynomial::BytecodeChunk(index) => {
+            native::JoltCommittedPolynomial::BytecodeChunk(index)
+        }
         legacy::CommittedPolynomial::RamRa(index) => native::JoltCommittedPolynomial::RamRa(index),
         legacy::CommittedPolynomial::TrustedAdvice => {
             native::JoltCommittedPolynomial::TrustedAdvice
         }
         legacy::CommittedPolynomial::UntrustedAdvice => {
             native::JoltCommittedPolynomial::UntrustedAdvice
+        }
+        legacy::CommittedPolynomial::ProgramImageInit => {
+            native::JoltCommittedPolynomial::ProgramImageInit
         }
     }
 }
@@ -1784,11 +1790,20 @@ fn virtual_polynomial(polynomial: legacy::VirtualPolynomial) -> native::JoltVirt
         legacy::VirtualPolynomial::LookupTableFlag(index) => {
             native::JoltVirtualPolynomial::LookupTableFlag(index)
         }
+        legacy::VirtualPolynomial::BytecodeValStage(index) => {
+            native::JoltVirtualPolynomial::BytecodeValStage(index)
+        }
         legacy::VirtualPolynomial::BytecodeReadRafAddrClaim => {
             native::JoltVirtualPolynomial::BytecodeReadRafAddrClaim
         }
         legacy::VirtualPolynomial::BooleanityAddrClaim => {
             native::JoltVirtualPolynomial::BooleanityAddrClaim
+        }
+        legacy::VirtualPolynomial::BytecodeClaimReductionIntermediate => {
+            native::JoltVirtualPolynomial::BytecodeClaimReductionIntermediate
+        }
+        legacy::VirtualPolynomial::ProgramImageInitContributionRw => {
+            native::JoltVirtualPolynomial::ProgramImageInitContributionRw
         }
     }
 }
@@ -1835,6 +1850,18 @@ fn stage_id(id: legacy::SumcheckId) -> native::JoltRelationId {
             native::JoltRelationId::AdviceClaimReductionCyclePhase
         }
         legacy::SumcheckId::AdviceClaimReduction => native::JoltRelationId::AdviceClaimReduction,
+        legacy::SumcheckId::BytecodeClaimReductionCyclePhase => {
+            native::JoltRelationId::BytecodeClaimReductionCyclePhase
+        }
+        legacy::SumcheckId::BytecodeClaimReduction => {
+            native::JoltRelationId::BytecodeClaimReduction
+        }
+        legacy::SumcheckId::ProgramImageClaimReductionCyclePhase => {
+            native::JoltRelationId::ProgramImageClaimReductionCyclePhase
+        }
+        legacy::SumcheckId::ProgramImageClaimReduction => {
+            native::JoltRelationId::ProgramImageClaimReduction
+        }
         legacy::SumcheckId::IncClaimReduction => native::JoltRelationId::IncClaimReduction,
         legacy::SumcheckId::HammingWeightClaimReduction => {
             native::JoltRelationId::HammingWeightClaimReduction

--- a/crates/jolt-verifier/src/compat/codec.rs
+++ b/crates/jolt-verifier/src/compat/codec.rs
@@ -266,13 +266,22 @@ impl CanonicalSerialize for CommittedPolynomial {
             Self::RamRa(i) => serialize_tagged_index(4, *i, writer, compress),
             Self::TrustedAdvice => 5u8.serialize_with_mode(writer, compress),
             Self::UntrustedAdvice => 6u8.serialize_with_mode(writer, compress),
+            Self::BytecodeChunk(i) => serialize_tagged_index(7, *i, writer, compress),
+            Self::ProgramImageInit => 8u8.serialize_with_mode(writer, compress),
         }
     }
 
     fn serialized_size(&self, _compress: Compress) -> usize {
         match self {
-            Self::RdInc | Self::RamInc | Self::TrustedAdvice | Self::UntrustedAdvice => 1,
-            Self::InstructionRa(_) | Self::BytecodeRa(_) | Self::RamRa(_) => 2,
+            Self::RdInc
+            | Self::RamInc
+            | Self::TrustedAdvice
+            | Self::UntrustedAdvice
+            | Self::ProgramImageInit => 1,
+            Self::InstructionRa(_)
+            | Self::BytecodeRa(_)
+            | Self::RamRa(_)
+            | Self::BytecodeChunk(_) => 2,
         }
     }
 }
@@ -298,6 +307,8 @@ impl CanonicalDeserialize for CommittedPolynomial {
                 4 => Self::RamRa(read_index(reader, compress, validate)?),
                 5 => Self::TrustedAdvice,
                 6 => Self::UntrustedAdvice,
+                7 => Self::BytecodeChunk(read_index(reader, compress, validate)?),
+                8 => Self::ProgramImageInit,
                 _ => return Err(SerializationError::InvalidData),
             },
         )
@@ -354,6 +365,9 @@ impl CanonicalSerialize for VirtualPolynomial {
             Self::LookupTableFlag(flag) => serialize_tagged_index(38, *flag, writer, compress),
             Self::BytecodeReadRafAddrClaim => 39u8.serialize_with_mode(writer, compress),
             Self::BooleanityAddrClaim => 40u8.serialize_with_mode(writer, compress),
+            Self::BytecodeValStage(i) => serialize_tagged_index(41, *i, writer, compress),
+            Self::BytecodeClaimReductionIntermediate => 42u8.serialize_with_mode(writer, compress),
+            Self::ProgramImageInitContributionRw => 43u8.serialize_with_mode(writer, compress),
         }
     }
 
@@ -395,11 +409,14 @@ impl CanonicalSerialize for VirtualPolynomial {
             | Self::RamHammingWeight
             | Self::UnivariateSkip
             | Self::BytecodeReadRafAddrClaim
-            | Self::BooleanityAddrClaim => 1,
+            | Self::BooleanityAddrClaim
+            | Self::BytecodeClaimReductionIntermediate
+            | Self::ProgramImageInitContributionRw => 1,
             Self::InstructionRa(_)
             | Self::OpFlags(_)
             | Self::InstructionFlags(_)
-            | Self::LookupTableFlag(_) => 2,
+            | Self::LookupTableFlag(_)
+            | Self::BytecodeValStage(_) => 2,
         }
     }
 }
@@ -471,6 +488,9 @@ impl CanonicalDeserialize for VirtualPolynomial {
                 38 => Self::LookupTableFlag(read_index(reader, compress, validate)?),
                 39 => Self::BytecodeReadRafAddrClaim,
                 40 => Self::BooleanityAddrClaim,
+                41 => Self::BytecodeValStage(read_index(reader, compress, validate)?),
+                42 => Self::BytecodeClaimReductionIntermediate,
+                43 => Self::ProgramImageInitContributionRw,
                 _ => return Err(SerializationError::InvalidData),
             },
         )
@@ -665,7 +685,7 @@ mod tests {
                 core_params.lookups_ra_virtual_log_k_chunk
             );
             assert_eq!(params.k_chunk, core_params.k_chunk);
-            assert_eq!(params.bytecode_k, core_params.bytecode_k);
+            assert_eq!(params.bytecode_k, core_params.bytecode_len);
             assert_eq!(params.ram_k, core_params.ram_k);
             assert_eq!(params.instruction_d, core_params.instruction_d);
             assert_eq!(params.bytecode_d, core_params.bytecode_d);
@@ -700,7 +720,7 @@ mod tests {
             round_trip(polynomial)?;
             assert_eq!(bytes(&polynomial)?, bytes(&core_committed(polynomial))?);
         }
-        assert!(CommittedPolynomial::deserialize_compressed([7u8].as_slice()).is_err());
+        assert!(CommittedPolynomial::deserialize_compressed([9u8].as_slice()).is_err());
         assert!(bytes(&CommittedPolynomial::InstructionRa(256)).is_err());
         Ok(())
     }
@@ -711,7 +731,7 @@ mod tests {
             round_trip(polynomial)?;
             assert_eq!(bytes(&polynomial)?, bytes(&core_virtual(polynomial))?);
         }
-        assert!(VirtualPolynomial::deserialize_compressed([41u8].as_slice()).is_err());
+        assert!(VirtualPolynomial::deserialize_compressed([44u8].as_slice()).is_err());
         assert!(VirtualPolynomial::deserialize_compressed([36u8, 14u8].as_slice()).is_err());
         assert!(VirtualPolynomial::deserialize_compressed([37u8, 6u8].as_slice()).is_err());
         assert!(bytes(&VirtualPolynomial::InstructionRa(256)).is_err());
@@ -806,11 +826,15 @@ mod tests {
             CommittedPolynomial::BytecodeRa(0),
             CommittedPolynomial::BytecodeRa(7),
             CommittedPolynomial::BytecodeRa(255),
+            CommittedPolynomial::BytecodeChunk(0),
+            CommittedPolynomial::BytecodeChunk(7),
+            CommittedPolynomial::BytecodeChunk(255),
             CommittedPolynomial::RamRa(0),
             CommittedPolynomial::RamRa(7),
             CommittedPolynomial::RamRa(255),
             CommittedPolynomial::TrustedAdvice,
             CommittedPolynomial::UntrustedAdvice,
+            CommittedPolynomial::ProgramImageInit,
         ]
     }
 
@@ -857,8 +881,13 @@ mod tests {
             VirtualPolynomial::LookupTableFlag(0),
             VirtualPolynomial::LookupTableFlag(7),
             VirtualPolynomial::LookupTableFlag(255),
+            VirtualPolynomial::BytecodeValStage(0),
+            VirtualPolynomial::BytecodeValStage(4),
+            VirtualPolynomial::BytecodeValStage(255),
             VirtualPolynomial::BytecodeReadRafAddrClaim,
             VirtualPolynomial::BooleanityAddrClaim,
+            VirtualPolynomial::BytecodeClaimReductionIntermediate,
+            VirtualPolynomial::ProgramImageInitContributionRw,
         ];
 
         for flag in circuit_flag_cases() {
@@ -932,6 +961,14 @@ mod tests {
                 CoreSumcheckId::AdviceClaimReductionCyclePhase
             }
             SumcheckId::AdviceClaimReduction => CoreSumcheckId::AdviceClaimReduction,
+            SumcheckId::BytecodeClaimReductionCyclePhase => {
+                CoreSumcheckId::BytecodeClaimReductionCyclePhase
+            }
+            SumcheckId::BytecodeClaimReduction => CoreSumcheckId::BytecodeClaimReduction,
+            SumcheckId::ProgramImageClaimReductionCyclePhase => {
+                CoreSumcheckId::ProgramImageClaimReductionCyclePhase
+            }
+            SumcheckId::ProgramImageClaimReduction => CoreSumcheckId::ProgramImageClaimReduction,
             SumcheckId::IncClaimReduction => CoreSumcheckId::IncClaimReduction,
             SumcheckId::HammingWeightClaimReduction => CoreSumcheckId::HammingWeightClaimReduction,
         }
@@ -959,9 +996,11 @@ mod tests {
             CommittedPolynomial::RamInc => CoreCommittedPolynomial::RamInc,
             CommittedPolynomial::InstructionRa(i) => CoreCommittedPolynomial::InstructionRa(i),
             CommittedPolynomial::BytecodeRa(i) => CoreCommittedPolynomial::BytecodeRa(i),
+            CommittedPolynomial::BytecodeChunk(i) => CoreCommittedPolynomial::BytecodeChunk(i),
             CommittedPolynomial::RamRa(i) => CoreCommittedPolynomial::RamRa(i),
             CommittedPolynomial::TrustedAdvice => CoreCommittedPolynomial::TrustedAdvice,
             CommittedPolynomial::UntrustedAdvice => CoreCommittedPolynomial::UntrustedAdvice,
+            CommittedPolynomial::ProgramImageInit => CoreCommittedPolynomial::ProgramImageInit,
         }
     }
 
@@ -1014,10 +1053,19 @@ mod tests {
             VirtualPolynomial::LookupTableFlag(flag) => {
                 CoreVirtualPolynomial::LookupTableFlag(flag)
             }
+            VirtualPolynomial::BytecodeValStage(stage) => {
+                CoreVirtualPolynomial::BytecodeValStage(stage)
+            }
             VirtualPolynomial::BytecodeReadRafAddrClaim => {
                 CoreVirtualPolynomial::BytecodeReadRafAddrClaim
             }
             VirtualPolynomial::BooleanityAddrClaim => CoreVirtualPolynomial::BooleanityAddrClaim,
+            VirtualPolynomial::BytecodeClaimReductionIntermediate => {
+                CoreVirtualPolynomial::BytecodeClaimReductionIntermediate
+            }
+            VirtualPolynomial::ProgramImageInitContributionRw => {
+                CoreVirtualPolynomial::ProgramImageInitContributionRw
+            }
         }
     }
 

--- a/crates/jolt-verifier/src/compat/ids.rs
+++ b/crates/jolt-verifier/src/compat/ids.rs
@@ -30,12 +30,16 @@ pub enum SumcheckId {
     Booleanity,
     AdviceClaimReductionCyclePhase,
     AdviceClaimReduction,
+    BytecodeClaimReductionCyclePhase,
+    BytecodeClaimReduction,
+    ProgramImageClaimReductionCyclePhase,
+    ProgramImageClaimReduction,
     IncClaimReduction,
     HammingWeightClaimReduction,
 }
 
 impl SumcheckId {
-    pub const COUNT: usize = 25;
+    pub const COUNT: usize = 29;
 
     #[cfg(test)]
     pub const ALL: [Self; Self::COUNT] = [
@@ -62,6 +66,10 @@ impl SumcheckId {
         Self::Booleanity,
         Self::AdviceClaimReductionCyclePhase,
         Self::AdviceClaimReduction,
+        Self::BytecodeClaimReductionCyclePhase,
+        Self::BytecodeClaimReduction,
+        Self::ProgramImageClaimReductionCyclePhase,
+        Self::ProgramImageClaimReduction,
         Self::IncClaimReduction,
         Self::HammingWeightClaimReduction,
     ];
@@ -101,8 +109,12 @@ impl TryFrom<u8> for SumcheckId {
             20 => Ok(Self::Booleanity),
             21 => Ok(Self::AdviceClaimReductionCyclePhase),
             22 => Ok(Self::AdviceClaimReduction),
-            23 => Ok(Self::IncClaimReduction),
-            24 => Ok(Self::HammingWeightClaimReduction),
+            23 => Ok(Self::BytecodeClaimReductionCyclePhase),
+            24 => Ok(Self::BytecodeClaimReduction),
+            25 => Ok(Self::ProgramImageClaimReductionCyclePhase),
+            26 => Ok(Self::ProgramImageClaimReduction),
+            27 => Ok(Self::IncClaimReduction),
+            28 => Ok(Self::HammingWeightClaimReduction),
             _ => Err(()),
         }
     }
@@ -116,9 +128,11 @@ pub enum CommittedPolynomial {
     RamInc,
     InstructionRa(usize),
     BytecodeRa(usize),
+    BytecodeChunk(usize),
     RamRa(usize),
     TrustedAdvice,
     UntrustedAdvice,
+    ProgramImageInit,
 }
 
 #[derive(
@@ -164,8 +178,11 @@ pub enum VirtualPolynomial {
     OpFlags(CircuitFlags),
     InstructionFlags(InstructionFlags),
     LookupTableFlag(usize),
+    BytecodeValStage(usize),
     BytecodeReadRafAddrClaim,
     BooleanityAddrClaim,
+    BytecodeClaimReductionIntermediate,
+    ProgramImageInitContributionRw,
 }
 
 #[derive(

--- a/jolt-core/src/poly/opening_proof.rs
+++ b/jolt-core/src/poly/opening_proof.rs
@@ -157,6 +157,10 @@ pub enum SumcheckId {
     Booleanity,
     AdviceClaimReductionCyclePhase,
     AdviceClaimReduction,
+    BytecodeClaimReductionCyclePhase,
+    BytecodeClaimReduction,
+    ProgramImageClaimReductionCyclePhase,
+    ProgramImageClaimReduction,
     IncClaimReduction,
     HammingWeightClaimReduction,
 }

--- a/jolt-core/src/poly/rlc_polynomial.rs
+++ b/jolt-core/src/poly/rlc_polynomial.rs
@@ -197,6 +197,9 @@ impl<F: JoltField> RLCPolynomial<F> {
                         advice_polys.push((*coeff, advice_poly_map.remove(poly_id).unwrap()));
                     }
                 }
+                CommittedPolynomial::BytecodeChunk(_) | CommittedPolynomial::ProgramImageInit => {
+                    panic!("committed program polynomials require precommitted opening integration")
+                }
             }
         }
 

--- a/jolt-core/src/zkvm/bytecode/chunks.rs
+++ b/jolt-core/src/zkvm/bytecode/chunks.rs
@@ -1,0 +1,195 @@
+use crate::field::JoltField;
+use crate::poly::commitment::dory::DoryGlobals;
+use crate::poly::multilinear_polynomial::MultilinearPolynomial;
+use crate::utils::thread::unsafe_allocate_zero_vec;
+use crate::zkvm::instruction::{
+    Flags, InstructionLookup, InterleavedBitsMarker, NUM_CIRCUIT_FLAGS, NUM_INSTRUCTION_FLAGS,
+};
+use crate::zkvm::lookup_table::LookupTables;
+use common::constants::{REGISTER_COUNT, XLEN};
+use tracer::instruction::Instruction;
+
+/// Total number of lanes encoded by committed-bytecode rows.
+pub const fn total_lanes() -> usize {
+    3 * (REGISTER_COUNT as usize)
+        + 2
+        + NUM_CIRCUIT_FLAGS
+        + NUM_INSTRUCTION_FLAGS
+        + <LookupTables<XLEN> as strum::EnumCount>::COUNT
+        + 1
+}
+
+/// Fixed lane capacity for committed bytecode rows.
+pub const COMMITTED_BYTECODE_LANE_CAPACITY: usize = total_lanes().next_power_of_two();
+
+#[inline(always)]
+pub const fn committed_lanes() -> usize {
+    COMMITTED_BYTECODE_LANE_CAPACITY
+}
+
+pub const DEFAULT_COMMITTED_BYTECODE_CHUNK_COUNT: usize = 1;
+
+#[inline]
+pub fn validate_committed_bytecode_chunk_count(chunk_count: usize) {
+    assert!(chunk_count > 0, "bytecode chunk count must be non-zero");
+    assert!(
+        chunk_count.is_power_of_two(),
+        "bytecode chunk count must be a power of two"
+    );
+}
+
+#[inline(always)]
+pub fn validate_committed_bytecode_chunking_for_len(bytecode_len: usize, chunk_count: usize) {
+    validate_committed_bytecode_chunk_count(chunk_count);
+    assert!(
+        bytecode_len.is_multiple_of(chunk_count),
+        "bytecode length ({bytecode_len}) must be divisible by chunk count ({chunk_count})"
+    );
+}
+
+#[inline(always)]
+pub fn committed_bytecode_chunk_cycle_len(bytecode_len: usize, chunk_count: usize) -> usize {
+    validate_committed_bytecode_chunking_for_len(bytecode_len, chunk_count);
+    bytecode_len / chunk_count
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct BytecodeLaneLayout {
+    pub rs1_start: usize,
+    pub rs2_start: usize,
+    pub rd_start: usize,
+    pub unexp_pc_idx: usize,
+    pub imm_idx: usize,
+    pub circuit_start: usize,
+    pub instr_start: usize,
+    pub lookup_start: usize,
+    pub raf_flag_idx: usize,
+}
+
+impl BytecodeLaneLayout {
+    pub const fn new() -> Self {
+        let reg_count = REGISTER_COUNT as usize;
+        let rs1_start = 0usize;
+        let rs2_start = rs1_start + reg_count;
+        let rd_start = rs2_start + reg_count;
+        let unexp_pc_idx = rd_start + reg_count;
+        let imm_idx = unexp_pc_idx + 1;
+        let circuit_start = imm_idx + 1;
+        let instr_start = circuit_start + NUM_CIRCUIT_FLAGS;
+        let lookup_start = instr_start + NUM_INSTRUCTION_FLAGS;
+        let raf_flag_idx = lookup_start + <LookupTables<XLEN> as strum::EnumCount>::COUNT;
+        Self {
+            rs1_start,
+            rs2_start,
+            rd_start,
+            unexp_pc_idx,
+            imm_idx,
+            circuit_start,
+            instr_start,
+            lookup_start,
+            raf_flag_idx,
+        }
+    }
+}
+
+pub const BYTECODE_LANE_LAYOUT: BytecodeLaneLayout = BytecodeLaneLayout::new();
+
+#[derive(Clone, Copy, Debug)]
+pub enum ActiveLaneValue<F: JoltField> {
+    One,
+    Scalar(F),
+}
+
+#[inline(always)]
+pub fn for_each_active_lane_value<F: JoltField>(
+    instr: &Instruction,
+    mut visit: impl FnMut(usize, ActiveLaneValue<F>),
+) {
+    let l = BYTECODE_LANE_LAYOUT;
+
+    let normalized = instr.normalize();
+    let circuit_flags = <Instruction as Flags>::circuit_flags(instr);
+    let instr_flags = <Instruction as Flags>::instruction_flags(instr);
+    let lookup_idx = <Instruction as InstructionLookup<XLEN>>::lookup_table(instr)
+        .map(|t| LookupTables::<XLEN>::enum_index(&t));
+    let raf_flag = !InterleavedBitsMarker::is_interleaved_operands(&circuit_flags);
+
+    if let Some(r) = normalized.operands.rs1 {
+        visit(l.rs1_start + (r as usize), ActiveLaneValue::One);
+    }
+    if let Some(r) = normalized.operands.rs2 {
+        visit(l.rs2_start + (r as usize), ActiveLaneValue::One);
+    }
+    if let Some(r) = normalized.operands.rd {
+        visit(l.rd_start + (r as usize), ActiveLaneValue::One);
+    }
+
+    let unexpanded_pc = F::from_u64(normalized.address as u64);
+    if !unexpanded_pc.is_zero() {
+        visit(l.unexp_pc_idx, ActiveLaneValue::Scalar(unexpanded_pc));
+    }
+    let imm = F::from_i128(normalized.operands.imm);
+    if !imm.is_zero() {
+        visit(l.imm_idx, ActiveLaneValue::Scalar(imm));
+    }
+
+    for i in 0..NUM_CIRCUIT_FLAGS {
+        if circuit_flags[i] {
+            visit(l.circuit_start + i, ActiveLaneValue::One);
+        }
+    }
+    for i in 0..NUM_INSTRUCTION_FLAGS {
+        if instr_flags[i] {
+            visit(l.instr_start + i, ActiveLaneValue::One);
+        }
+    }
+    if let Some(t) = lookup_idx {
+        visit(l.lookup_start + t, ActiveLaneValue::One);
+    }
+    if raf_flag {
+        visit(l.raf_flag_idx, ActiveLaneValue::One);
+    }
+}
+
+#[tracing::instrument(
+    skip_all,
+    name = "bytecode::build_committed_bytecode_chunk_polynomials"
+)]
+pub fn build_committed_bytecode_chunk_polynomials<F: JoltField>(
+    instructions: &[Instruction],
+    chunk_count: usize,
+) -> Vec<MultilinearPolynomial<F>> {
+    let bytecode_len = instructions.len();
+    validate_committed_bytecode_chunking_for_len(bytecode_len, chunk_count);
+
+    let chunk_cycle_len = committed_bytecode_chunk_cycle_len(bytecode_len, chunk_count);
+    let lane_capacity = committed_lanes();
+    let mut chunk_coeffs: Vec<Vec<F>> = (0..chunk_count)
+        .map(|_| unsafe_allocate_zero_vec(lane_capacity * chunk_cycle_len))
+        .collect();
+
+    for (cycle, instr) in instructions.iter().enumerate() {
+        let cycle_chunk_idx = cycle / chunk_cycle_len;
+        let chunk_cycle = cycle % chunk_cycle_len;
+        let coeffs = &mut chunk_coeffs[cycle_chunk_idx];
+
+        for_each_active_lane_value::<F>(instr, |global_lane, lane_val| {
+            let idx = DoryGlobals::get_layout().address_cycle_to_index(
+                global_lane,
+                chunk_cycle,
+                lane_capacity,
+                chunk_cycle_len,
+            );
+            let lane_value = match lane_val {
+                ActiveLaneValue::One => F::one(),
+                ActiveLaneValue::Scalar(v) => v,
+            };
+            coeffs[idx] += lane_value;
+        });
+    }
+
+    chunk_coeffs
+        .into_iter()
+        .map(MultilinearPolynomial::from)
+        .collect()
+}

--- a/jolt-core/src/zkvm/bytecode/chunks.rs
+++ b/jolt-core/src/zkvm/bytecode/chunks.rs
@@ -7,7 +7,7 @@ use crate::zkvm::instruction::{
 };
 use crate::zkvm::lookup_table::LookupTables;
 use common::constants::{REGISTER_COUNT, XLEN};
-use tracer::instruction::Instruction;
+use jolt_riscv::JoltInstructionRow;
 
 /// Total number of lanes encoded by committed-bytecode rows.
 pub const fn total_lanes() -> usize {
@@ -28,28 +28,26 @@ pub const fn committed_lanes() -> usize {
 }
 
 pub const DEFAULT_COMMITTED_BYTECODE_CHUNK_COUNT: usize = 1;
-
-#[inline]
-pub fn validate_committed_bytecode_chunk_count(chunk_count: usize) {
-    assert!(chunk_count > 0, "bytecode chunk count must be non-zero");
-    assert!(
-        chunk_count.is_power_of_two(),
-        "bytecode chunk count must be a power of two"
-    );
-}
+pub const MAX_COMMITTED_BYTECODE_CHUNK_COUNT: usize = 256;
 
 #[inline(always)]
-pub fn validate_committed_bytecode_chunking_for_len(bytecode_len: usize, chunk_count: usize) {
-    validate_committed_bytecode_chunk_count(chunk_count);
-    assert!(
-        bytecode_len.is_multiple_of(chunk_count),
-        "bytecode length ({bytecode_len}) must be divisible by chunk count ({chunk_count})"
-    );
+pub fn is_valid_committed_bytecode_chunking_for_len(
+    bytecode_len: usize,
+    chunk_count: usize,
+) -> bool {
+    chunk_count > 0
+        && chunk_count <= MAX_COMMITTED_BYTECODE_CHUNK_COUNT
+        && chunk_count.is_power_of_two()
+        && bytecode_len.is_multiple_of(chunk_count)
 }
 
 #[inline(always)]
 pub fn committed_bytecode_chunk_cycle_len(bytecode_len: usize, chunk_count: usize) -> usize {
-    validate_committed_bytecode_chunking_for_len(bytecode_len, chunk_count);
+    assert!(
+        is_valid_committed_bytecode_chunking_for_len(bytecode_len, chunk_count),
+        "bytecode chunk count ({chunk_count}) must be non-zero, a power of two, at most \
+         {MAX_COMMITTED_BYTECODE_CHUNK_COUNT}, and divide bytecode length ({bytecode_len})"
+    );
     bytecode_len / chunk_count
 }
 
@@ -102,33 +100,32 @@ pub enum ActiveLaneValue<F: JoltField> {
 
 #[inline(always)]
 pub fn for_each_active_lane_value<F: JoltField>(
-    instr: &Instruction,
+    instruction: &JoltInstructionRow,
     mut visit: impl FnMut(usize, ActiveLaneValue<F>),
 ) {
     let l = BYTECODE_LANE_LAYOUT;
 
-    let normalized = instr.normalize();
-    let circuit_flags = <Instruction as Flags>::circuit_flags(instr);
-    let instr_flags = <Instruction as Flags>::instruction_flags(instr);
-    let lookup_idx = <Instruction as InstructionLookup<XLEN>>::lookup_table(instr)
+    let circuit_flags = instruction.circuit_flags();
+    let instr_flags = instruction.instruction_flags();
+    let lookup_idx = InstructionLookup::<XLEN>::lookup_table(instruction)
         .map(|t| LookupTables::<XLEN>::enum_index(&t));
     let raf_flag = !InterleavedBitsMarker::is_interleaved_operands(&circuit_flags);
 
-    if let Some(r) = normalized.operands.rs1 {
+    if let Some(r) = instruction.operands.rs1 {
         visit(l.rs1_start + (r as usize), ActiveLaneValue::One);
     }
-    if let Some(r) = normalized.operands.rs2 {
+    if let Some(r) = instruction.operands.rs2 {
         visit(l.rs2_start + (r as usize), ActiveLaneValue::One);
     }
-    if let Some(r) = normalized.operands.rd {
+    if let Some(r) = instruction.operands.rd {
         visit(l.rd_start + (r as usize), ActiveLaneValue::One);
     }
 
-    let unexpanded_pc = F::from_u64(normalized.address as u64);
+    let unexpanded_pc = F::from_u64(instruction.address as u64);
     if !unexpanded_pc.is_zero() {
         visit(l.unexp_pc_idx, ActiveLaneValue::Scalar(unexpanded_pc));
     }
-    let imm = F::from_i128(normalized.operands.imm);
+    let imm = F::from_i128(instruction.operands.imm);
     if !imm.is_zero() {
         visit(l.imm_idx, ActiveLaneValue::Scalar(imm));
     }
@@ -151,17 +148,12 @@ pub fn for_each_active_lane_value<F: JoltField>(
     }
 }
 
-#[tracing::instrument(
-    skip_all,
-    name = "bytecode::build_committed_bytecode_chunk_polynomials"
-)]
-pub fn build_committed_bytecode_chunk_polynomials<F: JoltField>(
-    instructions: &[Instruction],
+#[tracing::instrument(skip_all, name = "bytecode::build_committed_bytecode_chunk_coeffs")]
+pub fn build_committed_bytecode_chunk_coeffs<F: JoltField>(
+    instructions: &[JoltInstructionRow],
     chunk_count: usize,
-) -> Vec<MultilinearPolynomial<F>> {
+) -> Vec<Vec<F>> {
     let bytecode_len = instructions.len();
-    validate_committed_bytecode_chunking_for_len(bytecode_len, chunk_count);
-
     let chunk_cycle_len = committed_bytecode_chunk_cycle_len(bytecode_len, chunk_count);
     let lane_capacity = committed_lanes();
     let mut chunk_coeffs: Vec<Vec<F>> = (0..chunk_count)
@@ -189,6 +181,17 @@ pub fn build_committed_bytecode_chunk_polynomials<F: JoltField>(
     }
 
     chunk_coeffs
+}
+
+#[tracing::instrument(
+    skip_all,
+    name = "bytecode::build_committed_bytecode_chunk_polynomials"
+)]
+pub fn build_committed_bytecode_chunk_polynomials<F: JoltField>(
+    instructions: &[JoltInstructionRow],
+    chunk_count: usize,
+) -> Vec<MultilinearPolynomial<F>> {
+    build_committed_bytecode_chunk_coeffs::<F>(instructions, chunk_count)
         .into_iter()
         .map(MultilinearPolynomial::from)
         .collect()

--- a/jolt-core/src/zkvm/bytecode/mod.rs
+++ b/jolt-core/src/zkvm/bytecode/mod.rs
@@ -1,5 +1,6 @@
 use tracer::instruction::Cycle;
 
+pub mod chunks;
 pub mod read_raf_checking;
 
 pub use jolt_program::preprocess::{BytecodePCMapper, BytecodePreprocessing, PreprocessingError};

--- a/jolt-core/src/zkvm/bytecode/read_raf_checking.rs
+++ b/jolt-core/src/zkvm/bytecode/read_raf_checking.rs
@@ -1576,7 +1576,7 @@ impl<F: JoltField> BytecodeReadRafSumcheckParams<F> {
             &stage5_gammas,
         );
 
-        let int_poly = IdentityPolynomial::new(one_hot_params.bytecode_k.log_2());
+        let int_poly = IdentityPolynomial::new(one_hot_params.bytecode_len.log_2());
 
         let (_, raf_claim) = opening_accumulator
             .get_virtual_polynomial_opening(VirtualPolynomial::PC, SumcheckId::SpartanOuter);
@@ -1641,8 +1641,8 @@ impl<F: JoltField> BytecodeReadRafSumcheckParams<F> {
             stage5_gammas,
             input_claim,
             one_hot_params: one_hot_params.clone(),
-            K: one_hot_params.bytecode_k,
-            log_K: one_hot_params.bytecode_k.log_2(),
+            K: one_hot_params.bytecode_len,
+            log_K: one_hot_params.bytecode_len.log_2(),
             d: one_hot_params.bytecode_d,
             log_T: n_cycle_vars,
             val_polys,

--- a/jolt-core/src/zkvm/claim_reductions/bytecode.rs
+++ b/jolt-core/src/zkvm/claim_reductions/bytecode.rs
@@ -45,7 +45,7 @@ pub struct BytecodeClaimReductionParams<F: JoltField> {
     pub eta_powers: [F; NUM_VAL_STAGES],
     /// Eq weights over high bytecode address bits (one per committed chunk).
     pub chunk_rbc_weights: Vec<F>,
-    pub bytecode_T: usize,
+    pub log_bytecode_chunk_size: usize,
     pub bytecode_chunk_count: usize,
     pub bytecode_col_vars: usize,
     pub bytecode_row_vars: usize,
@@ -56,18 +56,18 @@ pub struct BytecodeClaimReductionParams<F: JoltField> {
 impl<F: JoltField> BytecodeClaimReductionParams<F> {
     pub fn new(
         bytecode_read_raf_params: &BytecodeReadRafSumcheckParams<F>,
-        full_bytecode_len: usize,
+        bytecode_len: usize,
         bytecode_chunk_count: usize,
         scheduling_reference: PrecommittedSchedulingReference,
         accumulator: &dyn OpeningAccumulator<F>,
         transcript: &mut impl Transcript,
     ) -> Self {
         assert!(
-            full_bytecode_len.is_multiple_of(bytecode_chunk_count),
-            "bytecode chunk count ({bytecode_chunk_count}) must divide bytecode_len ({full_bytecode_len})"
+            bytecode_len.is_multiple_of(bytecode_chunk_count),
+            "bytecode chunk count ({bytecode_chunk_count}) must divide bytecode_len ({bytecode_len})"
         );
-        let bytecode_t = (full_bytecode_len / bytecode_chunk_count).log_2();
-        let bytecode_t_full = full_bytecode_len.log_2();
+        let log_bytecode_chunk_size = (bytecode_len / bytecode_chunk_count).log_2();
+        let log_bytecode_len = bytecode_len.log_2();
 
         let eta: F = transcript.challenge_scalar();
         let mut eta_powers = [F::one(); NUM_VAL_STAGES];
@@ -79,8 +79,8 @@ impl<F: JoltField> BytecodeClaimReductionParams<F> {
             VirtualPolynomial::BytecodeReadRafAddrClaim,
             SumcheckId::BytecodeReadRafAddressPhase,
         );
-        debug_assert_eq!(r_bc_full.r.len(), bytecode_t_full);
-        let dropped_bits = bytecode_t_full - bytecode_t;
+        debug_assert_eq!(r_bc_full.r.len(), log_bytecode_len);
+        let dropped_bits = log_bytecode_len - log_bytecode_chunk_size;
         let chunk_rbc_weights = if dropped_bits == 0 {
             vec![F::one()]
         } else {
@@ -91,9 +91,8 @@ impl<F: JoltField> BytecodeClaimReductionParams<F> {
 
         let lane_weights = compute_lane_weights(bytecode_read_raf_params, accumulator, &eta_powers);
 
-        // bytecode_K is the committed lane capacity (already next-power-of-two padded).
-        let bytecode_k = committed_lanes();
-        let total_vars = bytecode_k.log_2() + bytecode_t;
+        let log_committed_lane_count = committed_lanes().log_2();
+        let total_vars = log_committed_lane_count + log_bytecode_chunk_size;
         // Bytecode uses its own balanced dimensions (independent from Main).
         // In Stage 8 it is embedded as a top-left block in Joint.
         let (bytecode_col_vars, bytecode_row_vars) = DoryGlobals::balanced_sigma_nu(total_vars);
@@ -109,7 +108,7 @@ impl<F: JoltField> BytecodeClaimReductionParams<F> {
             eta,
             eta_powers,
             chunk_rbc_weights,
-            bytecode_T: bytecode_t,
+            log_bytecode_chunk_size,
             bytecode_chunk_count,
             bytecode_col_vars,
             bytecode_row_vars,
@@ -459,7 +458,7 @@ fn evaluate_bytecode_eq_combined<F: JoltField>(
             (lane, cycle)
         }
         DoryLayout::AddressMajor => {
-            let (cycle, lane) = opening_point.r.split_at(params.bytecode_T);
+            let (cycle, lane) = opening_point.r.split_at(params.log_bytecode_chunk_size);
             (lane, cycle)
         }
     };
@@ -484,7 +483,7 @@ fn native_index_to_lane_cycle<F: JoltField>(
     params: &BytecodeClaimReductionParams<F>,
     index: usize,
 ) -> (usize, usize) {
-    let bytecode_len = 1usize << params.bytecode_T;
+    let bytecode_len = 1usize << params.log_bytecode_chunk_size;
     match DoryGlobals::get_layout() {
         DoryLayout::CycleMajor => (index / bytecode_len, index % bytecode_len),
         DoryLayout::AddressMajor => (index % committed_lanes(), index / committed_lanes()),

--- a/jolt-core/src/zkvm/claim_reductions/bytecode.rs
+++ b/jolt-core/src/zkvm/claim_reductions/bytecode.rs
@@ -1,7 +1,5 @@
 //! Two-phase bytecode claim reduction (Stage 6b cycle -> Stage 7 address).
 
-use std::cell::RefCell;
-
 use allocative::Allocative;
 use rayon::prelude::*;
 
@@ -192,42 +190,70 @@ impl<F: JoltField> SumcheckInstanceParams<F> for BytecodeClaimReductionParams<F>
     fn output_claim_constraint(&self) -> Option<OutputClaimConstraint> {
         match self.precommitted.phase {
             PrecommittedPhase::CycleVariables => {
-                Some(OutputClaimConstraint::direct(OpeningId::virt(
-                    VirtualPolynomial::BytecodeClaimReductionIntermediate,
-                    SumcheckId::BytecodeClaimReductionCyclePhase,
-                )))
+                if self.precommitted.num_address_phase_rounds() > 0 {
+                    return Some(OutputClaimConstraint::direct(OpeningId::virt(
+                        VirtualPolynomial::BytecodeClaimReductionIntermediate,
+                        SumcheckId::BytecodeClaimReductionCyclePhase,
+                    )));
+                }
+                self.final_bytecode_output_claim_constraint()
             }
-            PrecommittedPhase::AddressVariables => {
-                let terms = (0..self.bytecode_chunk_count)
-                    .map(|chunk_idx| {
-                        let opening = OpeningId::committed(
-                            CommittedPolynomial::BytecodeChunk(chunk_idx),
-                            SumcheckId::BytecodeClaimReduction,
-                        );
-                        (
-                            ValueSource::Challenge(chunk_idx),
-                            ValueSource::Opening(opening),
-                        )
-                    })
-                    .collect();
-                Some(OutputClaimConstraint::linear(terms))
-            }
+            PrecommittedPhase::AddressVariables => self.final_bytecode_output_claim_constraint(),
         }
     }
 
     #[cfg(feature = "zk")]
     fn output_constraint_challenge_values(&self, sumcheck_challenges: &[F::Challenge]) -> Vec<F> {
         match self.precommitted.phase {
-            PrecommittedPhase::CycleVariables => vec![],
-            PrecommittedPhase::AddressVariables => {
-                let eq_combined = evaluate_bytecode_eq_combined(self, sumcheck_challenges);
-                let scale: F = precommitted_skip_round_scale(&self.precommitted);
-                self.chunk_rbc_weights
-                    .iter()
-                    .map(|w| *w * eq_combined * scale)
-                    .collect()
+            PrecommittedPhase::CycleVariables
+                if self.precommitted.num_address_phase_rounds() > 0 =>
+            {
+                vec![]
+            }
+            PrecommittedPhase::CycleVariables | PrecommittedPhase::AddressVariables => {
+                self.final_bytecode_output_weights(sumcheck_challenges)
             }
         }
+    }
+}
+
+impl<F: JoltField> BytecodeClaimReductionParams<F> {
+    #[cfg(feature = "zk")]
+    fn final_bytecode_output_claim_constraint(&self) -> Option<OutputClaimConstraint> {
+        let terms = (0..self.bytecode_chunk_count)
+            .map(|chunk_idx| {
+                let opening = OpeningId::committed(
+                    CommittedPolynomial::BytecodeChunk(chunk_idx),
+                    SumcheckId::BytecodeClaimReduction,
+                );
+                (
+                    ValueSource::Challenge(chunk_idx),
+                    ValueSource::Opening(opening),
+                )
+            })
+            .collect();
+        Some(OutputClaimConstraint::linear(terms))
+    }
+
+    fn final_bytecode_output_scale(&self, sumcheck_challenges: &[F::Challenge]) -> F {
+        let opening_point = self.normalize_opening_point(sumcheck_challenges);
+        let eq_combined = evaluate_bytecode_eq_combined(self, &opening_point);
+        let scale = match self.precommitted.phase {
+            PrecommittedPhase::CycleVariables => self.precommitted.cycle_phase_skip_scale(),
+            PrecommittedPhase::AddressVariables => {
+                precommitted_skip_round_scale(&self.precommitted)
+            }
+        };
+        eq_combined * scale
+    }
+
+    #[cfg(feature = "zk")]
+    fn final_bytecode_output_weights(&self, sumcheck_challenges: &[F::Challenge]) -> Vec<F> {
+        let output_scale = self.final_bytecode_output_scale(sumcheck_challenges);
+        self.chunk_rbc_weights
+            .iter()
+            .map(|w| *w * output_scale)
+            .collect()
     }
 }
 
@@ -238,6 +264,19 @@ impl<F: JoltField> PrecommittedParams<F> for BytecodeClaimReductionParams<F> {
 
     fn precommitted_mut(&mut self) -> &mut PrecommittedClaimReduction<F> {
         &mut self.precommitted
+    }
+
+    fn get_cycle_challenges<A: AbstractVerifierOpeningAccumulator<F>>(
+        &self,
+        accumulator: &A,
+    ) -> Vec<F::Challenge> {
+        let (cycle_opening_point, _) = accumulator.get_virtual_polynomial_opening(
+            VirtualPolynomial::BytecodeClaimReductionIntermediate,
+            SumcheckId::BytecodeClaimReductionCyclePhase,
+        );
+        let opening_point_le: OpeningPoint<LITTLE_ENDIAN, F> =
+            cycle_opening_point.match_endianness();
+        opening_point_le.r
     }
 }
 
@@ -324,7 +363,7 @@ impl<F: JoltField, T: Transcript> SumcheckInstanceProver<F, T> for BytecodeClaim
         let params = self.core.params();
         let opening_point = params.normalize_opening_point(sumcheck_challenges);
 
-        if params.is_cycle_phase() {
+        if params.is_cycle_phase() && params.precommitted.num_address_phase_rounds() > 0 {
             accumulator.append_virtual(
                 VirtualPolynomial::BytecodeClaimReductionIntermediate,
                 SumcheckId::BytecodeClaimReductionCyclePhase,
@@ -364,14 +403,12 @@ impl<F: JoltField, T: Transcript> SumcheckInstanceProver<F, T> for BytecodeClaim
 }
 
 pub struct BytecodeClaimReductionVerifier<F: JoltField> {
-    pub params: RefCell<BytecodeClaimReductionParams<F>>,
+    pub params: BytecodeClaimReductionParams<F>,
 }
 
 impl<F: JoltField> BytecodeClaimReductionVerifier<F> {
     pub fn new(params: BytecodeClaimReductionParams<F>) -> Self {
-        Self {
-            params: RefCell::new(params),
-        }
+        Self { params }
     }
 }
 
@@ -379,7 +416,7 @@ impl<F: JoltField, T: Transcript, A: AbstractVerifierOpeningAccumulator<F>>
     SumcheckInstanceVerifier<F, T, A> for BytecodeClaimReductionVerifier<F>
 {
     fn get_params(&self) -> &dyn SumcheckInstanceParams<F> {
-        unsafe { &*self.params.as_ptr() }
+        &self.params
     }
 
     fn round_offset(&self, _max_num_rounds: usize) -> usize {
@@ -387,9 +424,11 @@ impl<F: JoltField, T: Transcript, A: AbstractVerifierOpeningAccumulator<F>>
     }
 
     fn expected_output_claim(&self, accumulator: &A, sumcheck_challenges: &[F::Challenge]) -> F {
-        let params = self.params.borrow();
+        let params = &self.params;
         match params.precommitted.phase {
-            PrecommittedPhase::CycleVariables => {
+            PrecommittedPhase::CycleVariables
+                if params.precommitted.num_address_phase_rounds() > 0 =>
+            {
                 accumulator
                     .get_virtual_polynomial_opening(
                         VirtualPolynomial::BytecodeClaimReductionIntermediate,
@@ -397,7 +436,7 @@ impl<F: JoltField, T: Transcript, A: AbstractVerifierOpeningAccumulator<F>>
                     )
                     .1
             }
-            PrecommittedPhase::AddressVariables => {
+            PrecommittedPhase::CycleVariables | PrecommittedPhase::AddressVariables => {
                 let bytecode_opening: F = (0..params.bytecode_chunk_count)
                     .map(|chunk_idx| {
                         params.chunk_rbc_weights[chunk_idx]
@@ -408,28 +447,22 @@ impl<F: JoltField, T: Transcript, A: AbstractVerifierOpeningAccumulator<F>>
                                 )
                                 .1
                     })
-                    .sum();
-                let eq_combined = evaluate_bytecode_eq_combined(&params, sumcheck_challenges);
-                let scale: F = precommitted_skip_round_scale(&params.precommitted);
+                    .sum::<F>();
 
-                bytecode_opening * eq_combined * scale
+                bytecode_opening * params.final_bytecode_output_scale(sumcheck_challenges)
             }
         }
     }
 
     fn cache_openings(&self, accumulator: &mut A, sumcheck_challenges: &[F::Challenge]) {
-        let mut params = self.params.borrow_mut();
-        if params.is_cycle_phase() {
+        let params = &self.params;
+        if params.is_cycle_phase() && params.precommitted.num_address_phase_rounds() > 0 {
             let opening_point = params.normalize_opening_point(sumcheck_challenges);
             accumulator.append_virtual(
                 VirtualPolynomial::BytecodeClaimReductionIntermediate,
                 SumcheckId::BytecodeClaimReductionCyclePhase,
-                opening_point.clone(),
+                opening_point,
             );
-            let opening_point_le: OpeningPoint<LITTLE_ENDIAN, F> = opening_point.match_endianness();
-            params
-                .precommitted
-                .set_cycle_var_challenges(opening_point_le.r);
         }
 
         if params.precommitted.num_address_phase_rounds() == 0 || !params.is_cycle_phase() {
@@ -447,9 +480,8 @@ impl<F: JoltField, T: Transcript, A: AbstractVerifierOpeningAccumulator<F>>
 
 fn evaluate_bytecode_eq_combined<F: JoltField>(
     params: &BytecodeClaimReductionParams<F>,
-    sumcheck_challenges: &[F::Challenge],
+    opening_point: &OpeningPoint<BIG_ENDIAN, F>,
 ) -> F {
-    let opening_point = params.normalize_opening_point(sumcheck_challenges);
     let lane_var_count = committed_lanes().log_2();
 
     let (lane_challenges, cycle_challenges) = match DoryGlobals::get_layout() {

--- a/jolt-core/src/zkvm/claim_reductions/bytecode.rs
+++ b/jolt-core/src/zkvm/claim_reductions/bytecode.rs
@@ -1,0 +1,577 @@
+//! Two-phase bytecode claim reduction (Stage 6b cycle -> Stage 7 address).
+
+use std::cell::RefCell;
+
+use allocative::Allocative;
+use rayon::prelude::*;
+
+use crate::field::JoltField;
+use crate::poly::commitment::dory::{DoryGlobals, DoryLayout};
+use crate::poly::eq_poly::EqPolynomial;
+use crate::poly::multilinear_polynomial::{MultilinearPolynomial, PolynomialBinding};
+#[cfg(feature = "zk")]
+use crate::poly::opening_proof::OpeningId;
+use crate::poly::opening_proof::{
+    AbstractVerifierOpeningAccumulator, OpeningAccumulator, OpeningPoint, ProverOpeningAccumulator,
+    SumcheckId, BIG_ENDIAN, LITTLE_ENDIAN,
+};
+use crate::poly::unipoly::UniPoly;
+#[cfg(feature = "zk")]
+use crate::subprotocols::blindfold::{InputClaimConstraint, OutputClaimConstraint, ValueSource};
+use crate::subprotocols::sumcheck_prover::SumcheckInstanceProver;
+use crate::subprotocols::sumcheck_verifier::{SumcheckInstanceParams, SumcheckInstanceVerifier};
+use crate::transcripts::Transcript;
+use crate::utils::math::Math;
+use crate::zkvm::bytecode::chunks::{committed_lanes, total_lanes, BYTECODE_LANE_LAYOUT};
+use crate::zkvm::bytecode::read_raf_checking::BytecodeReadRafSumcheckParams;
+use crate::zkvm::claim_reductions::{
+    permute_precommitted_polys, precommitted_skip_round_scale, PrecommittedClaimReduction,
+    PrecommittedPhase, PrecommittedSchedulingReference, TWO_PHASE_DEGREE_BOUND,
+};
+use crate::zkvm::instruction::{CircuitFlags, InstructionFlags, NUM_CIRCUIT_FLAGS};
+use crate::zkvm::lookup_table::LookupTables;
+use crate::zkvm::witness::{CommittedPolynomial, VirtualPolynomial};
+use common::constants::{REGISTER_COUNT, XLEN};
+use strum::EnumCount;
+
+use super::precommitted::{PrecommittedParams, PrecommittedProver};
+
+const NUM_VAL_STAGES: usize = 5;
+
+#[derive(Clone, Allocative)]
+pub struct BytecodeClaimReductionParams<F: JoltField> {
+    pub precommitted: PrecommittedClaimReduction<F>,
+    pub eta: F,
+    pub eta_powers: [F; NUM_VAL_STAGES],
+    /// Eq weights over high bytecode address bits (one per committed chunk).
+    pub chunk_rbc_weights: Vec<F>,
+    pub bytecode_T: usize,
+    pub bytecode_chunk_count: usize,
+    pub bytecode_col_vars: usize,
+    pub bytecode_row_vars: usize,
+    pub r_bc: OpeningPoint<BIG_ENDIAN, F>,
+    pub lane_weights: Vec<F>,
+}
+
+impl<F: JoltField> BytecodeClaimReductionParams<F> {
+    pub fn new(
+        bytecode_read_raf_params: &BytecodeReadRafSumcheckParams<F>,
+        full_bytecode_len: usize,
+        bytecode_chunk_count: usize,
+        scheduling_reference: PrecommittedSchedulingReference,
+        accumulator: &dyn OpeningAccumulator<F>,
+        transcript: &mut impl Transcript,
+    ) -> Self {
+        assert!(
+            full_bytecode_len.is_multiple_of(bytecode_chunk_count),
+            "bytecode chunk count ({bytecode_chunk_count}) must divide bytecode_len ({full_bytecode_len})"
+        );
+        let bytecode_t = (full_bytecode_len / bytecode_chunk_count).log_2();
+        let bytecode_t_full = full_bytecode_len.log_2();
+
+        let eta: F = transcript.challenge_scalar();
+        let mut eta_powers = [F::one(); NUM_VAL_STAGES];
+        for i in 1..NUM_VAL_STAGES {
+            eta_powers[i] = eta_powers[i - 1] * eta;
+        }
+
+        let (r_bc_full, _) = accumulator.get_virtual_polynomial_opening(
+            VirtualPolynomial::BytecodeReadRafAddrClaim,
+            SumcheckId::BytecodeReadRafAddressPhase,
+        );
+        debug_assert_eq!(r_bc_full.r.len(), bytecode_t_full);
+        let dropped_bits = bytecode_t_full - bytecode_t;
+        let chunk_rbc_weights = if dropped_bits == 0 {
+            vec![F::one()]
+        } else {
+            EqPolynomial::<F>::evals(&r_bc_full.r[..dropped_bits])
+        };
+        debug_assert_eq!(chunk_rbc_weights.len(), bytecode_chunk_count);
+        let r_bc = OpeningPoint::new(r_bc_full.r[dropped_bits..].to_vec());
+
+        let lane_weights = compute_lane_weights(bytecode_read_raf_params, accumulator, &eta_powers);
+
+        // bytecode_K is the committed lane capacity (already next-power-of-two padded).
+        let bytecode_k = committed_lanes();
+        let total_vars = bytecode_k.log_2() + bytecode_t;
+        // Bytecode uses its own balanced dimensions (independent from Main).
+        // In Stage 8 it is embedded as a top-left block in Joint.
+        let (bytecode_col_vars, bytecode_row_vars) = DoryGlobals::balanced_sigma_nu(total_vars);
+        let precommitted = PrecommittedClaimReduction::new(
+            bytecode_row_vars,
+            bytecode_col_vars,
+            scheduling_reference,
+        );
+        // Align all precommitted scheduling/permutation to the shared reference domain.
+
+        Self {
+            precommitted,
+            eta,
+            eta_powers,
+            chunk_rbc_weights,
+            bytecode_T: bytecode_t,
+            bytecode_chunk_count,
+            bytecode_col_vars,
+            bytecode_row_vars,
+            r_bc,
+            lane_weights,
+        }
+    }
+}
+
+impl<F: JoltField> BytecodeClaimReductionParams<F> {
+    fn num_rounds_for_current_phase(&self) -> usize {
+        self.precommitted.num_rounds_for_current_phase()
+    }
+}
+
+impl<F: JoltField> SumcheckInstanceParams<F> for BytecodeClaimReductionParams<F> {
+    fn input_claim(&self, accumulator: &dyn OpeningAccumulator<F>) -> F {
+        match self.precommitted.phase {
+            PrecommittedPhase::CycleVariables => (0..NUM_VAL_STAGES)
+                .map(|stage| {
+                    let (_, val_claim) = accumulator.get_virtual_polynomial_opening(
+                        VirtualPolynomial::BytecodeValStage(stage),
+                        SumcheckId::BytecodeReadRafAddressPhase,
+                    );
+                    self.eta_powers[stage] * val_claim
+                })
+                .sum(),
+            PrecommittedPhase::AddressVariables => {
+                accumulator
+                    .get_virtual_polynomial_opening(
+                        VirtualPolynomial::BytecodeClaimReductionIntermediate,
+                        SumcheckId::BytecodeClaimReductionCyclePhase,
+                    )
+                    .1
+            }
+        }
+    }
+
+    fn degree(&self) -> usize {
+        TWO_PHASE_DEGREE_BOUND
+    }
+
+    fn num_rounds(&self) -> usize {
+        self.num_rounds_for_current_phase()
+    }
+
+    fn normalize_opening_point(&self, challenges: &[F::Challenge]) -> OpeningPoint<BIG_ENDIAN, F> {
+        self.precommitted.normalize_opening_point(challenges)
+    }
+
+    #[cfg(feature = "zk")]
+    fn input_claim_constraint(&self) -> InputClaimConstraint {
+        match self.precommitted.phase {
+            PrecommittedPhase::CycleVariables => {
+                let openings: Vec<OpeningId> = (0..NUM_VAL_STAGES)
+                    .map(|stage| {
+                        OpeningId::virt(
+                            VirtualPolynomial::BytecodeValStage(stage),
+                            SumcheckId::BytecodeReadRafAddressPhase,
+                        )
+                    })
+                    .collect();
+                InputClaimConstraint::all_weighted_openings(&openings)
+            }
+            PrecommittedPhase::AddressVariables => InputClaimConstraint::direct(OpeningId::virt(
+                VirtualPolynomial::BytecodeClaimReductionIntermediate,
+                SumcheckId::BytecodeClaimReductionCyclePhase,
+            )),
+        }
+    }
+
+    #[cfg(feature = "zk")]
+    fn input_constraint_challenge_values(&self, _: &dyn OpeningAccumulator<F>) -> Vec<F> {
+        match self.precommitted.phase {
+            PrecommittedPhase::CycleVariables => self.eta_powers.to_vec(),
+            PrecommittedPhase::AddressVariables => Vec::new(),
+        }
+    }
+
+    #[cfg(feature = "zk")]
+    fn output_claim_constraint(&self) -> Option<OutputClaimConstraint> {
+        match self.precommitted.phase {
+            PrecommittedPhase::CycleVariables => {
+                Some(OutputClaimConstraint::direct(OpeningId::virt(
+                    VirtualPolynomial::BytecodeClaimReductionIntermediate,
+                    SumcheckId::BytecodeClaimReductionCyclePhase,
+                )))
+            }
+            PrecommittedPhase::AddressVariables => {
+                let terms = (0..self.bytecode_chunk_count)
+                    .map(|chunk_idx| {
+                        let opening = OpeningId::committed(
+                            CommittedPolynomial::BytecodeChunk(chunk_idx),
+                            SumcheckId::BytecodeClaimReduction,
+                        );
+                        (
+                            ValueSource::Challenge(chunk_idx),
+                            ValueSource::Opening(opening),
+                        )
+                    })
+                    .collect();
+                Some(OutputClaimConstraint::linear(terms))
+            }
+        }
+    }
+
+    #[cfg(feature = "zk")]
+    fn output_constraint_challenge_values(&self, sumcheck_challenges: &[F::Challenge]) -> Vec<F> {
+        match self.precommitted.phase {
+            PrecommittedPhase::CycleVariables => vec![],
+            PrecommittedPhase::AddressVariables => {
+                let eq_combined = evaluate_bytecode_eq_combined(self, sumcheck_challenges);
+                let scale: F = precommitted_skip_round_scale(&self.precommitted);
+                self.chunk_rbc_weights
+                    .iter()
+                    .map(|w| *w * eq_combined * scale)
+                    .collect()
+            }
+        }
+    }
+}
+
+impl<F: JoltField> PrecommittedParams<F> for BytecodeClaimReductionParams<F> {
+    fn precommitted(&self) -> &PrecommittedClaimReduction<F> {
+        &self.precommitted
+    }
+
+    fn precommitted_mut(&mut self) -> &mut PrecommittedClaimReduction<F> {
+        &mut self.precommitted
+    }
+}
+
+#[derive(Allocative)]
+pub struct BytecodeClaimReductionProver<F: JoltField> {
+    core: PrecommittedProver<F, BytecodeClaimReductionParams<F>>,
+}
+
+impl<F: JoltField> BytecodeClaimReductionProver<F> {
+    pub fn params(&self) -> &BytecodeClaimReductionParams<F> {
+        self.core.params()
+    }
+
+    pub fn transition_to_address_phase(&mut self) {
+        self.core.transition_to_address_phase();
+    }
+
+    pub fn initialize(
+        params: BytecodeClaimReductionParams<F>,
+        raw_chunk_coeffs: &[Vec<F>],
+    ) -> Self {
+        let eq_cycle = EqPolynomial::<F>::evals(&params.r_bc.r);
+        let eq_coeffs_template: Vec<F> = (0..raw_chunk_coeffs[0].len())
+            .map(|idx| {
+                let (lane, cycle) = native_index_to_lane_cycle(&params, idx);
+                params.lane_weights[lane] * eq_cycle[cycle]
+            })
+            .collect();
+
+        let raw_value_coeffs: Vec<F> = (0..raw_chunk_coeffs[0].len())
+            .into_par_iter()
+            .map(|idx| {
+                raw_chunk_coeffs
+                    .iter()
+                    .zip(params.chunk_rbc_weights.iter())
+                    .map(|(coeffs, weight)| coeffs[idx] * *weight)
+                    .sum::<F>()
+            })
+            .collect();
+        let mut coeffs_by_poly = Vec::with_capacity(2 + raw_chunk_coeffs.len());
+        coeffs_by_poly.push(raw_value_coeffs);
+        coeffs_by_poly.push(eq_coeffs_template);
+        for coeffs in raw_chunk_coeffs.iter() {
+            coeffs_by_poly.push(coeffs.clone());
+        }
+        let mut permuted_polys =
+            permute_precommitted_polys(coeffs_by_poly, &params.precommitted).into_iter();
+        let value_poly = permuted_polys
+            .next()
+            .expect("expected permuted bytecode value polynomial");
+        let eq_poly = permuted_polys
+            .next()
+            .expect("expected permuted bytecode eq polynomial");
+        let chunk_value_polys: Vec<MultilinearPolynomial<F>> = permuted_polys.collect();
+
+        Self {
+            core: PrecommittedProver::new(params, value_poly, eq_poly, Some(chunk_value_polys)),
+        }
+    }
+}
+
+impl<F: JoltField, T: Transcript> SumcheckInstanceProver<F, T> for BytecodeClaimReductionProver<F> {
+    fn get_params(&self) -> &dyn SumcheckInstanceParams<F> {
+        self.core.params()
+    }
+
+    fn round_offset(&self, _max_num_rounds: usize) -> usize {
+        0
+    }
+
+    fn compute_message(&mut self, round: usize, previous_claim: F) -> UniPoly<F> {
+        self.core.compute_message(round, previous_claim)
+    }
+
+    fn ingest_challenge(&mut self, r_j: F::Challenge, round: usize) {
+        self.core.ingest_challenge(r_j, round);
+    }
+
+    fn cache_openings(
+        &self,
+        accumulator: &mut ProverOpeningAccumulator<F>,
+        sumcheck_challenges: &[F::Challenge],
+    ) {
+        let params = self.core.params();
+        let opening_point = params.normalize_opening_point(sumcheck_challenges);
+
+        if params.is_cycle_phase() {
+            accumulator.append_virtual(
+                VirtualPolynomial::BytecodeClaimReductionIntermediate,
+                SumcheckId::BytecodeClaimReductionCyclePhase,
+                opening_point.clone(),
+                self.core.cycle_intermediate_claim(),
+            );
+        }
+
+        if let Some(bytecode_claim) = self.core.final_claim_if_ready() {
+            let chunk_claims: Vec<F> = self
+                .core
+                .aux_polys()
+                .iter()
+                .map(|poly| poly.final_sumcheck_claim())
+                .collect();
+            let weighted_chunk_sum = chunk_claims
+                .iter()
+                .zip(params.chunk_rbc_weights.iter())
+                .map(|(claim, weight)| *claim * *weight)
+                .sum::<F>();
+            debug_assert_eq!(weighted_chunk_sum, bytecode_claim);
+            for (chunk_idx, claim) in chunk_claims.into_iter().enumerate() {
+                accumulator.append_dense(
+                    CommittedPolynomial::BytecodeChunk(chunk_idx),
+                    SumcheckId::BytecodeClaimReduction,
+                    opening_point.r.clone(),
+                    claim,
+                );
+            }
+        }
+    }
+
+    #[cfg(feature = "allocative")]
+    fn update_flamegraph(&self, flamegraph: &mut allocative::FlameGraphBuilder) {
+        flamegraph.visit_root(self);
+    }
+}
+
+pub struct BytecodeClaimReductionVerifier<F: JoltField> {
+    pub params: RefCell<BytecodeClaimReductionParams<F>>,
+}
+
+impl<F: JoltField> BytecodeClaimReductionVerifier<F> {
+    pub fn new(params: BytecodeClaimReductionParams<F>) -> Self {
+        Self {
+            params: RefCell::new(params),
+        }
+    }
+}
+
+impl<F: JoltField, T: Transcript, A: AbstractVerifierOpeningAccumulator<F>>
+    SumcheckInstanceVerifier<F, T, A> for BytecodeClaimReductionVerifier<F>
+{
+    fn get_params(&self) -> &dyn SumcheckInstanceParams<F> {
+        unsafe { &*self.params.as_ptr() }
+    }
+
+    fn round_offset(&self, _max_num_rounds: usize) -> usize {
+        0
+    }
+
+    fn expected_output_claim(&self, accumulator: &A, sumcheck_challenges: &[F::Challenge]) -> F {
+        let params = self.params.borrow();
+        match params.precommitted.phase {
+            PrecommittedPhase::CycleVariables => {
+                accumulator
+                    .get_virtual_polynomial_opening(
+                        VirtualPolynomial::BytecodeClaimReductionIntermediate,
+                        SumcheckId::BytecodeClaimReductionCyclePhase,
+                    )
+                    .1
+            }
+            PrecommittedPhase::AddressVariables => {
+                let bytecode_opening: F = (0..params.bytecode_chunk_count)
+                    .map(|chunk_idx| {
+                        params.chunk_rbc_weights[chunk_idx]
+                            * accumulator
+                                .get_committed_polynomial_opening(
+                                    CommittedPolynomial::BytecodeChunk(chunk_idx),
+                                    SumcheckId::BytecodeClaimReduction,
+                                )
+                                .1
+                    })
+                    .sum();
+                let eq_combined = evaluate_bytecode_eq_combined(&params, sumcheck_challenges);
+                let scale: F = precommitted_skip_round_scale(&params.precommitted);
+
+                bytecode_opening * eq_combined * scale
+            }
+        }
+    }
+
+    fn cache_openings(&self, accumulator: &mut A, sumcheck_challenges: &[F::Challenge]) {
+        let mut params = self.params.borrow_mut();
+        if params.is_cycle_phase() {
+            let opening_point = params.normalize_opening_point(sumcheck_challenges);
+            accumulator.append_virtual(
+                VirtualPolynomial::BytecodeClaimReductionIntermediate,
+                SumcheckId::BytecodeClaimReductionCyclePhase,
+                opening_point.clone(),
+            );
+            let opening_point_le: OpeningPoint<LITTLE_ENDIAN, F> = opening_point.match_endianness();
+            params
+                .precommitted
+                .set_cycle_var_challenges(opening_point_le.r);
+        }
+
+        if params.precommitted.num_address_phase_rounds() == 0 || !params.is_cycle_phase() {
+            let opening_point = params.normalize_opening_point(sumcheck_challenges);
+            for chunk_idx in 0..params.bytecode_chunk_count {
+                accumulator.append_dense(
+                    CommittedPolynomial::BytecodeChunk(chunk_idx),
+                    SumcheckId::BytecodeClaimReduction,
+                    opening_point.r.clone(),
+                );
+            }
+        }
+    }
+}
+
+fn evaluate_bytecode_eq_combined<F: JoltField>(
+    params: &BytecodeClaimReductionParams<F>,
+    sumcheck_challenges: &[F::Challenge],
+) -> F {
+    let opening_point = params.normalize_opening_point(sumcheck_challenges);
+    let lane_var_count = committed_lanes().log_2();
+
+    let (lane_challenges, cycle_challenges) = match DoryGlobals::get_layout() {
+        DoryLayout::CycleMajor => {
+            let (lane, cycle) = opening_point.r.split_at(lane_var_count);
+            (lane, cycle)
+        }
+        DoryLayout::AddressMajor => {
+            let (cycle, lane) = opening_point.r.split_at(params.bytecode_T);
+            (lane, cycle)
+        }
+    };
+
+    debug_assert_eq!(lane_challenges.len(), lane_var_count);
+    debug_assert_eq!(cycle_challenges.len(), params.r_bc.r.len());
+
+    let eq_cycle = EqPolynomial::mle(cycle_challenges, &params.r_bc.r);
+    let eq_lane = EqPolynomial::<F>::evals(lane_challenges);
+    let lane_weight_eval: F = params
+        .lane_weights
+        .iter()
+        .zip(eq_lane.iter())
+        .map(|(w, eq)| *w * *eq)
+        .sum();
+
+    lane_weight_eval * eq_cycle
+}
+
+#[inline(always)]
+fn native_index_to_lane_cycle<F: JoltField>(
+    params: &BytecodeClaimReductionParams<F>,
+    index: usize,
+) -> (usize, usize) {
+    let bytecode_len = 1usize << params.bytecode_T;
+    match DoryGlobals::get_layout() {
+        DoryLayout::CycleMajor => (index / bytecode_len, index % bytecode_len),
+        DoryLayout::AddressMajor => (index % committed_lanes(), index / committed_lanes()),
+    }
+}
+
+fn compute_lane_weights<F: JoltField>(
+    bytecode_read_raf_params: &BytecodeReadRafSumcheckParams<F>,
+    accumulator: &dyn OpeningAccumulator<F>,
+    eta_powers: &[F; NUM_VAL_STAGES],
+) -> Vec<F> {
+    let reg_count = REGISTER_COUNT as usize;
+    let layout = BYTECODE_LANE_LAYOUT;
+    debug_assert_eq!(layout.raf_flag_idx + 1, total_lanes());
+
+    let log_reg = reg_count.log_2();
+    let r_register_4 = accumulator
+        .get_virtual_polynomial_opening(
+            VirtualPolynomial::RdWa,
+            SumcheckId::RegistersReadWriteChecking,
+        )
+        .0
+        .r;
+    let eq_r_register_4 = EqPolynomial::<F>::evals(&r_register_4[..log_reg]);
+
+    let r_register_5 = accumulator
+        .get_virtual_polynomial_opening(VirtualPolynomial::RdWa, SumcheckId::RegistersValEvaluation)
+        .0
+        .r;
+    let eq_r_register_5 = EqPolynomial::<F>::evals(&r_register_5[..log_reg]);
+
+    let mut weights = vec![F::zero(); committed_lanes()];
+
+    {
+        let coeff = eta_powers[0];
+        let g = &bytecode_read_raf_params.stage1_gammas;
+        weights[layout.unexp_pc_idx] += coeff * g[0];
+        weights[layout.imm_idx] += coeff * g[1];
+        for i in 0..NUM_CIRCUIT_FLAGS {
+            weights[layout.circuit_start + i] += coeff * g[2 + i];
+        }
+    }
+    {
+        let coeff = eta_powers[1];
+        let g = &bytecode_read_raf_params.stage2_gammas;
+        weights[layout.circuit_start + (CircuitFlags::Jump as usize)] += coeff * g[0];
+        weights[layout.instr_start + (InstructionFlags::Branch as usize)] += coeff * g[1];
+        weights[layout.circuit_start + (CircuitFlags::WriteLookupOutputToRD as usize)] +=
+            coeff * g[2];
+        weights[layout.circuit_start + (CircuitFlags::VirtualInstruction as usize)] += coeff * g[3];
+    }
+    {
+        let coeff = eta_powers[2];
+        let g = &bytecode_read_raf_params.stage3_gammas;
+        weights[layout.imm_idx] += coeff * g[0];
+        weights[layout.unexp_pc_idx] += coeff * g[1];
+        weights[layout.instr_start + (InstructionFlags::LeftOperandIsRs1Value as usize)] +=
+            coeff * g[2];
+        weights[layout.instr_start + (InstructionFlags::LeftOperandIsPC as usize)] += coeff * g[3];
+        weights[layout.instr_start + (InstructionFlags::RightOperandIsRs2Value as usize)] +=
+            coeff * g[4];
+        weights[layout.instr_start + (InstructionFlags::RightOperandIsImm as usize)] +=
+            coeff * g[5];
+        weights[layout.instr_start + (InstructionFlags::IsNoop as usize)] += coeff * g[6];
+        weights[layout.circuit_start + (CircuitFlags::VirtualInstruction as usize)] += coeff * g[7];
+        weights[layout.circuit_start + (CircuitFlags::IsFirstInSequence as usize)] += coeff * g[8];
+    }
+    {
+        let coeff = eta_powers[3];
+        let g = &bytecode_read_raf_params.stage4_gammas;
+        for r in 0..reg_count {
+            weights[layout.rd_start + r] += coeff * g[0] * eq_r_register_4[r];
+            weights[layout.rs1_start + r] += coeff * g[1] * eq_r_register_4[r];
+            weights[layout.rs2_start + r] += coeff * g[2] * eq_r_register_4[r];
+        }
+    }
+    {
+        let coeff = eta_powers[4];
+        let g = &bytecode_read_raf_params.stage5_gammas;
+        for r in 0..reg_count {
+            weights[layout.rd_start + r] += coeff * g[0] * eq_r_register_5[r];
+        }
+        weights[layout.raf_flag_idx] += coeff * g[1];
+        for i in 0..LookupTables::<XLEN>::COUNT {
+            weights[layout.lookup_start + i] += coeff * g[2 + i];
+        }
+    }
+
+    weights
+}

--- a/jolt-core/src/zkvm/claim_reductions/mod.rs
+++ b/jolt-core/src/zkvm/claim_reductions/mod.rs
@@ -1,14 +1,19 @@
 pub mod advice;
+pub mod bytecode;
 pub mod hamming_weight;
 pub mod increments;
 pub mod instruction_lookups;
 mod precommitted;
+pub mod program_image;
 pub mod ram_ra;
 pub mod registers;
 
 pub use advice::{
     AdviceClaimReductionParams, AdviceClaimReductionProver, AdviceClaimReductionVerifier,
     AdviceKind,
+};
+pub use bytecode::{
+    BytecodeClaimReductionParams, BytecodeClaimReductionProver, BytecodeClaimReductionVerifier,
 };
 pub use hamming_weight::{
     HammingWeightClaimReductionParams, HammingWeightClaimReductionProver,
@@ -26,6 +31,10 @@ pub use precommitted::{
     permute_precommitted_polys, precommitted_eq_evals_with_scaling, precommitted_skip_round_scale,
     precommitted_sumcheck_inverse_index_permutation, PrecommittedClaimReduction,
     PrecommittedParams, PrecommittedPhase, PrecommittedSchedulingReference, TWO_PHASE_DEGREE_BOUND,
+};
+pub use program_image::{
+    ProgramImageClaimReductionParams, ProgramImageClaimReductionProver,
+    ProgramImageClaimReductionVerifier,
 };
 pub use ram_ra::{
     RaReductionParams, RamRaClaimReductionSumcheckProver, RamRaClaimReductionSumcheckVerifier,

--- a/jolt-core/src/zkvm/claim_reductions/precommitted.rs
+++ b/jolt-core/src/zkvm/claim_reductions/precommitted.rs
@@ -560,7 +560,6 @@ impl<F: JoltField, P: PrecommittedParams<F>> PrecommittedProver<F, P> {
         self.scale = scale;
     }
 
-    #[expect(dead_code)]
     pub fn aux_polys(&self) -> &[MultilinearPolynomial<F>] {
         &self.aux_polys
     }

--- a/jolt-core/src/zkvm/claim_reductions/program_image.rs
+++ b/jolt-core/src/zkvm/claim_reductions/program_image.rs
@@ -5,7 +5,6 @@
 //! This sumcheck binds those scalars to a trusted commitment to the program-image words polynomial.
 
 use allocative::Allocative;
-use std::cell::RefCell;
 
 use crate::field::JoltField;
 use crate::poly::commitment::dory::DoryGlobals;
@@ -149,41 +148,66 @@ impl<F: JoltField> SumcheckInstanceParams<F> for ProgramImageClaimReductionParam
     fn output_claim_constraint(&self) -> Option<OutputClaimConstraint> {
         match self.precommitted.phase {
             PrecommittedPhase::CycleVariables => {
-                Some(OutputClaimConstraint::direct(OpeningId::committed(
-                    CommittedPolynomial::ProgramImageInit,
-                    SumcheckId::ProgramImageClaimReductionCyclePhase,
-                )))
+                if self.precommitted.num_address_phase_rounds() > 0 {
+                    return Some(OutputClaimConstraint::direct(OpeningId::committed(
+                        CommittedPolynomial::ProgramImageInit,
+                        SumcheckId::ProgramImageClaimReductionCyclePhase,
+                    )));
+                }
+                self.final_program_image_output_claim_constraint()
             }
-            PrecommittedPhase::AddressVariables => Some(OutputClaimConstraint::linear(vec![(
-                ValueSource::Challenge(0),
-                ValueSource::Opening(OpeningId::committed(
-                    CommittedPolynomial::ProgramImageInit,
-                    SumcheckId::ProgramImageClaimReduction,
-                )),
-            )])),
+            PrecommittedPhase::AddressVariables => {
+                self.final_program_image_output_claim_constraint()
+            }
         }
     }
 
     #[cfg(feature = "zk")]
     fn output_constraint_challenge_values(&self, sumcheck_challenges: &[F::Challenge]) -> Vec<F> {
         match self.precommitted.phase {
-            PrecommittedPhase::CycleVariables => vec![],
-            PrecommittedPhase::AddressVariables => {
-                let opening_point = self.normalize_opening_point(sumcheck_challenges);
-                let eq_combined = eval_shifted_eq_poly_at_opening_point::<F>(
-                    &self.r_addr_rw,
-                    self.start_index,
-                    &opening_point.r,
-                );
-                debug_assert_eq!(
-                    eq_combined,
-                    evaluate_shifted_eq_poly::<F, _>(&self.shifted_eq_coeffs, &opening_point.r),
-                    "program_image eq_slice optimized evaluation mismatch"
-                );
-                let scale: F = precommitted_skip_round_scale(&self.precommitted);
-                vec![eq_combined * scale]
+            PrecommittedPhase::CycleVariables
+                if self.precommitted.num_address_phase_rounds() > 0 =>
+            {
+                vec![]
+            }
+            PrecommittedPhase::CycleVariables | PrecommittedPhase::AddressVariables => {
+                vec![self.final_program_image_output_scale(sumcheck_challenges)]
             }
         }
+    }
+}
+
+impl<F: JoltField> ProgramImageClaimReductionParams<F> {
+    #[cfg(feature = "zk")]
+    fn final_program_image_output_claim_constraint(&self) -> Option<OutputClaimConstraint> {
+        Some(OutputClaimConstraint::linear(vec![(
+            ValueSource::Challenge(0),
+            ValueSource::Opening(OpeningId::committed(
+                CommittedPolynomial::ProgramImageInit,
+                SumcheckId::ProgramImageClaimReduction,
+            )),
+        )]))
+    }
+
+    fn final_program_image_output_scale(&self, sumcheck_challenges: &[F::Challenge]) -> F {
+        let opening_point = self.normalize_opening_point(sumcheck_challenges);
+        let eq_combined = eval_shifted_eq_poly_at_opening_point::<F>(
+            &self.r_addr_rw,
+            self.start_index,
+            &opening_point.r,
+        );
+        debug_assert_eq!(
+            eq_combined,
+            evaluate_shifted_eq_poly::<F, _>(&self.shifted_eq_coeffs, &opening_point.r),
+            "program_image eq_slice optimized evaluation mismatch"
+        );
+        let scale = match self.precommitted.phase {
+            PrecommittedPhase::CycleVariables => self.precommitted.cycle_phase_skip_scale(),
+            PrecommittedPhase::AddressVariables => {
+                precommitted_skip_round_scale(&self.precommitted)
+            }
+        };
+        eq_combined * scale
     }
 }
 
@@ -194,6 +218,19 @@ impl<F: JoltField> PrecommittedParams<F> for ProgramImageClaimReductionParams<F>
 
     fn precommitted_mut(&mut self) -> &mut PrecommittedClaimReduction<F> {
         &mut self.precommitted
+    }
+
+    fn get_cycle_challenges<A: AbstractVerifierOpeningAccumulator<F>>(
+        &self,
+        accumulator: &A,
+    ) -> Vec<F::Challenge> {
+        let (cycle_opening_point, _) = accumulator.get_committed_polynomial_opening(
+            CommittedPolynomial::ProgramImageInit,
+            SumcheckId::ProgramImageClaimReductionCyclePhase,
+        );
+        let opening_point_le: OpeningPoint<LITTLE_ENDIAN, F> =
+            cycle_opening_point.match_endianness();
+        opening_point_le.r
     }
 }
 
@@ -327,13 +364,11 @@ impl<F: JoltField, T: Transcript> SumcheckInstanceProver<F, T>
     ) {
         let params = self.core.params();
         let opening_point = params.normalize_opening_point(sumcheck_challenges);
-        if params.is_cycle_phase() {
+        if params.is_cycle_phase() && params.precommitted.num_address_phase_rounds() > 0 {
             accumulator.append_dense(
                 CommittedPolynomial::ProgramImageInit,
                 SumcheckId::ProgramImageClaimReductionCyclePhase,
-                // This is a phase-boundary intermediate claim, not a real program-image opening.
-                // Keep a sentinel point so it cannot alias with the final opening claim.
-                vec![],
+                opening_point.r.clone(),
                 self.core.cycle_intermediate_claim(),
             );
         }
@@ -355,14 +390,12 @@ impl<F: JoltField, T: Transcript> SumcheckInstanceProver<F, T>
 }
 
 pub struct ProgramImageClaimReductionVerifier<F: JoltField> {
-    pub params: RefCell<ProgramImageClaimReductionParams<F>>,
+    pub params: ProgramImageClaimReductionParams<F>,
 }
 
 impl<F: JoltField> ProgramImageClaimReductionVerifier<F> {
     pub fn new(params: ProgramImageClaimReductionParams<F>) -> Self {
-        Self {
-            params: RefCell::new(params),
-        }
+        Self { params }
     }
 }
 
@@ -370,7 +403,7 @@ impl<F: JoltField, T: Transcript, A: AbstractVerifierOpeningAccumulator<F>>
     SumcheckInstanceVerifier<F, T, A> for ProgramImageClaimReductionVerifier<F>
 {
     fn get_params(&self) -> &dyn SumcheckInstanceParams<F> {
-        unsafe { &*self.params.as_ptr() }
+        &self.params
     }
 
     fn round_offset(&self, _max_num_rounds: usize) -> usize {
@@ -378,9 +411,11 @@ impl<F: JoltField, T: Transcript, A: AbstractVerifierOpeningAccumulator<F>>
     }
 
     fn expected_output_claim(&self, accumulator: &A, sumcheck_challenges: &[F::Challenge]) -> F {
-        let params = self.params.borrow();
+        let params = &self.params;
         match params.precommitted.phase {
-            PrecommittedPhase::CycleVariables => {
+            PrecommittedPhase::CycleVariables
+                if params.precommitted.num_address_phase_rounds() > 0 =>
+            {
                 accumulator
                     .get_committed_polynomial_opening(
                         CommittedPolynomial::ProgramImageInit,
@@ -388,48 +423,31 @@ impl<F: JoltField, T: Transcript, A: AbstractVerifierOpeningAccumulator<F>>
                     )
                     .1
             }
-            PrecommittedPhase::AddressVariables => {
-                let opening_point = params.normalize_opening_point(sumcheck_challenges);
-                debug_assert_eq!(opening_point.len(), params.m);
+            PrecommittedPhase::CycleVariables | PrecommittedPhase::AddressVariables => {
                 let pw_eval = accumulator
                     .get_committed_polynomial_opening(
                         CommittedPolynomial::ProgramImageInit,
                         SumcheckId::ProgramImageClaimReduction,
                     )
                     .1;
-                let eq_combined = eval_shifted_eq_poly_at_opening_point::<F>(
-                    &params.r_addr_rw,
-                    params.start_index,
-                    &opening_point.r,
-                );
-                debug_assert_eq!(
-                    eq_combined,
-                    evaluate_shifted_eq_poly::<F, _>(&params.shifted_eq_coeffs, &opening_point.r),
-                    "program_image eq_slice optimized evaluation mismatch"
-                );
-                let scale: F = precommitted_skip_round_scale(&params.precommitted);
-                pw_eval * eq_combined * scale
+                pw_eval * params.final_program_image_output_scale(sumcheck_challenges)
             }
         }
     }
 
     fn cache_openings(&self, accumulator: &mut A, sumcheck_challenges: &[F::Challenge]) {
-        let mut params = self.params.borrow_mut();
-        let opening_point = params.normalize_opening_point(sumcheck_challenges);
-        if params.is_cycle_phase() {
+        let params = &self.params;
+        if params.is_cycle_phase() && params.precommitted.num_address_phase_rounds() > 0 {
+            let opening_point = params.normalize_opening_point(sumcheck_challenges);
             accumulator.append_dense(
                 CommittedPolynomial::ProgramImageInit,
                 SumcheckId::ProgramImageClaimReductionCyclePhase,
-                // Match prover behavior: the cycle-phase intermediate claim is not a real opening.
-                vec![],
+                opening_point.r,
             );
-            let opening_point_le: OpeningPoint<LITTLE_ENDIAN, F> = opening_point.match_endianness();
-            params
-                .precommitted
-                .set_cycle_var_challenges(opening_point_le.r);
         }
 
         if !params.is_cycle_phase() || params.precommitted.num_address_phase_rounds() == 0 {
+            let opening_point = params.normalize_opening_point(sumcheck_challenges);
             accumulator.append_dense(
                 CommittedPolynomial::ProgramImageInit,
                 SumcheckId::ProgramImageClaimReduction,

--- a/jolt-core/src/zkvm/claim_reductions/program_image.rs
+++ b/jolt-core/src/zkvm/claim_reductions/program_image.rs
@@ -1,0 +1,525 @@
+//! Program-image (initial RAM) claim reduction.
+//!
+//! In committed bytecode mode, Stage 4 consumes prover-supplied scalar claims for the
+//! program-image contribution to `Val_init(r_address)` without materializing the initial RAM.
+//! This sumcheck binds those scalars to a trusted commitment to the program-image words polynomial.
+
+use allocative::Allocative;
+use std::cell::RefCell;
+
+use crate::field::JoltField;
+use crate::poly::commitment::dory::DoryGlobals;
+use crate::poly::eq_poly::EqPolynomial;
+use crate::poly::multilinear_polynomial::{MultilinearPolynomial, PolynomialEvaluation};
+#[cfg(feature = "zk")]
+use crate::poly::opening_proof::OpeningId;
+use crate::poly::opening_proof::{
+    AbstractVerifierOpeningAccumulator, OpeningAccumulator, OpeningPoint, ProverOpeningAccumulator,
+    SumcheckId, BIG_ENDIAN, LITTLE_ENDIAN,
+};
+use crate::poly::unipoly::UniPoly;
+#[cfg(feature = "zk")]
+use crate::subprotocols::blindfold::{InputClaimConstraint, OutputClaimConstraint, ValueSource};
+use crate::subprotocols::sumcheck_prover::SumcheckInstanceProver;
+use crate::subprotocols::sumcheck_verifier::{SumcheckInstanceParams, SumcheckInstanceVerifier};
+use crate::transcripts::Transcript;
+use crate::utils::math::Math;
+use crate::zkvm::claim_reductions::{
+    permute_precommitted_polys, precommitted_skip_round_scale, PrecommittedClaimReduction,
+    PrecommittedPhase, PrecommittedSchedulingReference, TWO_PHASE_DEGREE_BOUND,
+};
+use crate::zkvm::ram::remap_address;
+use crate::zkvm::witness::{CommittedPolynomial, VirtualPolynomial};
+use tracer::JoltDevice;
+
+use super::precommitted::{PrecommittedParams, PrecommittedProver};
+
+#[derive(Clone, Allocative)]
+pub struct ProgramImageClaimReductionParams<F: JoltField> {
+    pub precommitted: PrecommittedClaimReduction<F>,
+    pub prog_col_vars: usize,
+    pub prog_row_vars: usize,
+    pub ram_num_vars: usize,
+    pub start_index: usize,
+    pub padded_len_words: usize,
+    pub m: usize,
+    pub r_addr_rw: Vec<F::Challenge>,
+    pub shifted_eq_coeffs: Vec<F>,
+}
+
+impl<F: JoltField> ProgramImageClaimReductionParams<F> {
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        program_io: &JoltDevice,
+        ram_min_bytecode_address: u64,
+        padded_len_words: usize,
+        ram_K: usize,
+        scheduling_reference: PrecommittedSchedulingReference,
+        accumulator: &dyn OpeningAccumulator<F>,
+    ) -> Self {
+        let ram_num_vars = ram_K.log_2();
+        let start_index =
+            remap_address(ram_min_bytecode_address, &program_io.memory_layout).unwrap() as usize;
+        let m = padded_len_words.log_2();
+        debug_assert!(padded_len_words.is_power_of_two());
+        debug_assert!(padded_len_words > 0);
+        let (prog_col_vars, prog_row_vars) = DoryGlobals::balanced_sigma_nu(m);
+        let precommitted =
+            PrecommittedClaimReduction::new(prog_row_vars, prog_col_vars, scheduling_reference);
+
+        let (r_rw, _) = accumulator.get_virtual_polynomial_opening(
+            VirtualPolynomial::RamVal,
+            SumcheckId::RamReadWriteChecking,
+        );
+        let (r_addr_rw, _) = r_rw.split_at(ram_num_vars);
+        let shifted_eq_coeffs =
+            shifted_program_image_eq_slice::<F>(&r_addr_rw.r, start_index, padded_len_words);
+
+        Self {
+            precommitted,
+            prog_col_vars,
+            prog_row_vars,
+            ram_num_vars,
+            start_index,
+            padded_len_words,
+            m,
+            r_addr_rw: r_addr_rw.r,
+            shifted_eq_coeffs,
+        }
+    }
+}
+
+impl<F: JoltField> SumcheckInstanceParams<F> for ProgramImageClaimReductionParams<F> {
+    fn input_claim(&self, accumulator: &dyn OpeningAccumulator<F>) -> F {
+        match self.precommitted.phase {
+            PrecommittedPhase::CycleVariables => {
+                // Scalar claims were staged in Stage 4 as virtual openings.
+                accumulator
+                    .get_virtual_polynomial_opening(
+                        VirtualPolynomial::ProgramImageInitContributionRw,
+                        SumcheckId::RamValCheck,
+                    )
+                    .1
+            }
+            PrecommittedPhase::AddressVariables => {
+                accumulator
+                    .get_committed_polynomial_opening(
+                        CommittedPolynomial::ProgramImageInit,
+                        SumcheckId::ProgramImageClaimReductionCyclePhase,
+                    )
+                    .1
+            }
+        }
+    }
+
+    fn degree(&self) -> usize {
+        TWO_PHASE_DEGREE_BOUND
+    }
+
+    fn num_rounds(&self) -> usize {
+        self.precommitted.num_rounds_for_current_phase()
+    }
+
+    fn normalize_opening_point(&self, challenges: &[F::Challenge]) -> OpeningPoint<BIG_ENDIAN, F> {
+        self.precommitted.normalize_opening_point(challenges)
+    }
+
+    #[cfg(feature = "zk")]
+    fn input_claim_constraint(&self) -> InputClaimConstraint {
+        match self.precommitted.phase {
+            PrecommittedPhase::CycleVariables => InputClaimConstraint::direct(OpeningId::virt(
+                VirtualPolynomial::ProgramImageInitContributionRw,
+                SumcheckId::RamValCheck,
+            )),
+            PrecommittedPhase::AddressVariables => {
+                InputClaimConstraint::direct(OpeningId::committed(
+                    CommittedPolynomial::ProgramImageInit,
+                    SumcheckId::ProgramImageClaimReductionCyclePhase,
+                ))
+            }
+        }
+    }
+
+    #[cfg(feature = "zk")]
+    fn input_constraint_challenge_values(&self, _: &dyn OpeningAccumulator<F>) -> Vec<F> {
+        Vec::new()
+    }
+
+    #[cfg(feature = "zk")]
+    fn output_claim_constraint(&self) -> Option<OutputClaimConstraint> {
+        match self.precommitted.phase {
+            PrecommittedPhase::CycleVariables => {
+                Some(OutputClaimConstraint::direct(OpeningId::committed(
+                    CommittedPolynomial::ProgramImageInit,
+                    SumcheckId::ProgramImageClaimReductionCyclePhase,
+                )))
+            }
+            PrecommittedPhase::AddressVariables => Some(OutputClaimConstraint::linear(vec![(
+                ValueSource::Challenge(0),
+                ValueSource::Opening(OpeningId::committed(
+                    CommittedPolynomial::ProgramImageInit,
+                    SumcheckId::ProgramImageClaimReduction,
+                )),
+            )])),
+        }
+    }
+
+    #[cfg(feature = "zk")]
+    fn output_constraint_challenge_values(&self, sumcheck_challenges: &[F::Challenge]) -> Vec<F> {
+        match self.precommitted.phase {
+            PrecommittedPhase::CycleVariables => vec![],
+            PrecommittedPhase::AddressVariables => {
+                let opening_point = self.normalize_opening_point(sumcheck_challenges);
+                let eq_combined = eval_shifted_eq_poly_at_opening_point::<F>(
+                    &self.r_addr_rw,
+                    self.start_index,
+                    &opening_point.r,
+                );
+                debug_assert_eq!(
+                    eq_combined,
+                    evaluate_shifted_eq_poly::<F, _>(&self.shifted_eq_coeffs, &opening_point.r),
+                    "program_image eq_slice optimized evaluation mismatch"
+                );
+                let scale: F = precommitted_skip_round_scale(&self.precommitted);
+                vec![eq_combined * scale]
+            }
+        }
+    }
+}
+
+impl<F: JoltField> PrecommittedParams<F> for ProgramImageClaimReductionParams<F> {
+    fn precommitted(&self) -> &PrecommittedClaimReduction<F> {
+        &self.precommitted
+    }
+
+    fn precommitted_mut(&mut self) -> &mut PrecommittedClaimReduction<F> {
+        &mut self.precommitted
+    }
+}
+
+#[derive(Allocative)]
+pub struct ProgramImageClaimReductionProver<F: JoltField> {
+    core: PrecommittedProver<F, ProgramImageClaimReductionParams<F>>,
+}
+
+fn shifted_program_image_eq_slice<F>(
+    r_addr: &[F::Challenge],
+    start_index: usize,
+    padded_len_words: usize,
+) -> Vec<F>
+where
+    F: JoltField + std::ops::Mul<F::Challenge, Output = F> + std::ops::SubAssign<F>,
+{
+    let mut eq_slice = Vec::with_capacity(padded_len_words);
+    let mut idx = start_index;
+    let mut remaining = padded_len_words;
+
+    while remaining > 0 {
+        let (block_size, block_evals) =
+            EqPolynomial::<F>::evals_for_max_aligned_block(r_addr, idx, remaining);
+        eq_slice.extend(block_evals);
+        idx += block_size;
+        remaining -= block_size;
+    }
+
+    eq_slice
+}
+
+fn evaluate_shifted_eq_poly<F, C>(shifted_eq_coeffs: &[F], opening_point: &[C]) -> F
+where
+    C: Copy + Send + Sync + Into<F> + crate::field::ChallengeFieldOps<F>,
+    F: JoltField + crate::field::FieldChallengeOps<C>,
+{
+    MultilinearPolynomial::from(shifted_eq_coeffs.to_vec()).evaluate(opening_point)
+}
+
+impl<F: JoltField> ProgramImageClaimReductionProver<F> {
+    pub fn params(&self) -> &ProgramImageClaimReductionParams<F> {
+        self.core.params()
+    }
+
+    pub fn transition_to_address_phase(&mut self) {
+        self.core.transition_to_address_phase();
+    }
+
+    #[tracing::instrument(skip_all, name = "ProgramImageClaimReductionProver::initialize")]
+    pub fn initialize(
+        params: ProgramImageClaimReductionParams<F>,
+        program_image_words_padded: Vec<u64>,
+    ) -> Self {
+        debug_assert_eq!(program_image_words_padded.len(), params.padded_len_words);
+        debug_assert_eq!(params.padded_len_words, 1usize << params.m);
+
+        let eq_slice = permute_precommitted_polys(
+            vec![params.shifted_eq_coeffs.clone()],
+            &params.precommitted,
+        )
+        .into_iter()
+        .next()
+        .expect("expected one permuted shifted eq polynomial");
+
+        // Permute ProgramWord and eq_slice so low-to-high binding follows the two-phase
+        // schedule while preserving top-left projection semantics against the joint point.
+        let program_word: MultilinearPolynomial<F> = {
+            let mut permuted =
+                permute_precommitted_polys(vec![program_image_words_padded], &params.precommitted)
+                    .into_iter();
+            permuted
+                .next()
+                .expect("expected one permuted program image polynomial")
+        };
+
+        Self {
+            core: PrecommittedProver::new(params, program_word, eq_slice, None),
+        }
+    }
+
+    pub fn from_bound_state(
+        params: ProgramImageClaimReductionParams<F>,
+        program_word_coeffs: Vec<F>,
+        eq_slice_coeffs: Vec<F>,
+    ) -> Self {
+        Self::from_bound_state_with_scale(params, program_word_coeffs, eq_slice_coeffs, F::one())
+    }
+
+    pub fn from_bound_state_with_scale(
+        params: ProgramImageClaimReductionParams<F>,
+        program_word_coeffs: Vec<F>,
+        eq_slice_coeffs: Vec<F>,
+        scale: F,
+    ) -> Self {
+        let mut prover = Self {
+            core: PrecommittedProver::new(
+                params,
+                MultilinearPolynomial::from(program_word_coeffs),
+                MultilinearPolynomial::from(eq_slice_coeffs),
+                None,
+            ),
+        };
+        prover.core.set_scale(scale);
+        prover
+    }
+}
+
+impl<F: JoltField, T: Transcript> SumcheckInstanceProver<F, T>
+    for ProgramImageClaimReductionProver<F>
+{
+    fn get_params(&self) -> &dyn SumcheckInstanceParams<F> {
+        self.core.params()
+    }
+
+    fn round_offset(&self, _max_num_rounds: usize) -> usize {
+        0
+    }
+
+    fn compute_message(&mut self, round: usize, previous_claim: F) -> UniPoly<F> {
+        self.core.compute_message(round, previous_claim)
+    }
+
+    fn ingest_challenge(&mut self, r_j: F::Challenge, round: usize) {
+        self.core.ingest_challenge(r_j, round);
+    }
+
+    fn cache_openings(
+        &self,
+        accumulator: &mut ProverOpeningAccumulator<F>,
+        sumcheck_challenges: &[F::Challenge],
+    ) {
+        let params = self.core.params();
+        let opening_point = params.normalize_opening_point(sumcheck_challenges);
+        if params.is_cycle_phase() {
+            accumulator.append_dense(
+                CommittedPolynomial::ProgramImageInit,
+                SumcheckId::ProgramImageClaimReductionCyclePhase,
+                // This is a phase-boundary intermediate claim, not a real program-image opening.
+                // Keep a sentinel point so it cannot alias with the final opening claim.
+                vec![],
+                self.core.cycle_intermediate_claim(),
+            );
+        }
+
+        if let Some(claim) = self.core.final_claim_if_ready() {
+            accumulator.append_dense(
+                CommittedPolynomial::ProgramImageInit,
+                SumcheckId::ProgramImageClaimReduction,
+                opening_point.r,
+                claim,
+            );
+        }
+    }
+
+    #[cfg(feature = "allocative")]
+    fn update_flamegraph(&self, flamegraph: &mut allocative::FlameGraphBuilder) {
+        flamegraph.visit_root(self);
+    }
+}
+
+pub struct ProgramImageClaimReductionVerifier<F: JoltField> {
+    pub params: RefCell<ProgramImageClaimReductionParams<F>>,
+}
+
+impl<F: JoltField> ProgramImageClaimReductionVerifier<F> {
+    pub fn new(params: ProgramImageClaimReductionParams<F>) -> Self {
+        Self {
+            params: RefCell::new(params),
+        }
+    }
+}
+
+impl<F: JoltField, T: Transcript, A: AbstractVerifierOpeningAccumulator<F>>
+    SumcheckInstanceVerifier<F, T, A> for ProgramImageClaimReductionVerifier<F>
+{
+    fn get_params(&self) -> &dyn SumcheckInstanceParams<F> {
+        unsafe { &*self.params.as_ptr() }
+    }
+
+    fn round_offset(&self, _max_num_rounds: usize) -> usize {
+        0
+    }
+
+    fn expected_output_claim(&self, accumulator: &A, sumcheck_challenges: &[F::Challenge]) -> F {
+        let params = self.params.borrow();
+        match params.precommitted.phase {
+            PrecommittedPhase::CycleVariables => {
+                accumulator
+                    .get_committed_polynomial_opening(
+                        CommittedPolynomial::ProgramImageInit,
+                        SumcheckId::ProgramImageClaimReductionCyclePhase,
+                    )
+                    .1
+            }
+            PrecommittedPhase::AddressVariables => {
+                let opening_point = params.normalize_opening_point(sumcheck_challenges);
+                debug_assert_eq!(opening_point.len(), params.m);
+                let pw_eval = accumulator
+                    .get_committed_polynomial_opening(
+                        CommittedPolynomial::ProgramImageInit,
+                        SumcheckId::ProgramImageClaimReduction,
+                    )
+                    .1;
+                let eq_combined = eval_shifted_eq_poly_at_opening_point::<F>(
+                    &params.r_addr_rw,
+                    params.start_index,
+                    &opening_point.r,
+                );
+                debug_assert_eq!(
+                    eq_combined,
+                    evaluate_shifted_eq_poly::<F, _>(&params.shifted_eq_coeffs, &opening_point.r),
+                    "program_image eq_slice optimized evaluation mismatch"
+                );
+                let scale: F = precommitted_skip_round_scale(&params.precommitted);
+                pw_eval * eq_combined * scale
+            }
+        }
+    }
+
+    fn cache_openings(&self, accumulator: &mut A, sumcheck_challenges: &[F::Challenge]) {
+        let mut params = self.params.borrow_mut();
+        let opening_point = params.normalize_opening_point(sumcheck_challenges);
+        if params.is_cycle_phase() {
+            accumulator.append_dense(
+                CommittedPolynomial::ProgramImageInit,
+                SumcheckId::ProgramImageClaimReductionCyclePhase,
+                // Match prover behavior: the cycle-phase intermediate claim is not a real opening.
+                vec![],
+            );
+            let opening_point_le: OpeningPoint<LITTLE_ENDIAN, F> = opening_point.match_endianness();
+            params
+                .precommitted
+                .set_cycle_var_challenges(opening_point_le.r);
+        }
+
+        if !params.is_cycle_phase() || params.precommitted.num_address_phase_rounds() == 0 {
+            accumulator.append_dense(
+                CommittedPolynomial::ProgramImageInit,
+                SumcheckId::ProgramImageClaimReduction,
+                opening_point.r,
+            );
+        }
+    }
+}
+
+fn eval_shifted_eq_poly_at_opening_point<F>(
+    r_addr_be: &[F::Challenge],
+    start_index: usize,
+    opening_point_be: &[F::Challenge],
+) -> F
+where
+    F: JoltField,
+{
+    let ell = r_addr_be.len();
+    let m = opening_point_be.len();
+    debug_assert!(m <= ell);
+
+    let challenge_for_old_lsb = |old_lsb: usize| -> F {
+        debug_assert!(old_lsb < m);
+        opening_point_be[m - 1 - old_lsb].into()
+    };
+
+    // Match the current verifier path exactly: `opening_point_be` is already arranged in the
+    // variable order expected by `evaluate_shifted_eq_poly`.
+    let mut dp0 = F::one();
+    let mut dp1 = F::zero();
+
+    for old_lsb in 0..ell {
+        let start_bit = ((start_index >> old_lsb) & 1) as u8;
+        let r_addr_bit: F = r_addr_be[ell - 1 - old_lsb].into();
+        let k0 = F::one() - r_addr_bit;
+        let k1 = r_addr_bit;
+        let y_var = old_lsb < m;
+        let r_y = if y_var {
+            challenge_for_old_lsb(old_lsb)
+        } else {
+            F::zero()
+        };
+
+        let mut next_dp0 = F::zero();
+        let mut next_dp1 = F::zero();
+
+        let update_state = |weight: F, carry: u8, next_dp0: &mut F, next_dp1: &mut F| {
+            if weight.is_zero() {
+                return;
+            }
+
+            if y_var {
+                let sum0 = start_bit + carry;
+                let k_bit0 = sum0 & 1;
+                let carry0 = (sum0 >> 1) & 1;
+                let addr_factor0 = if k_bit0 == 1 { k1 } else { k0 };
+                let y_factor0 = F::one() - r_y;
+                if carry0 == 0 {
+                    *next_dp0 += weight * addr_factor0 * y_factor0;
+                } else {
+                    *next_dp1 += weight * addr_factor0 * y_factor0;
+                }
+
+                let sum1 = start_bit + carry + 1;
+                let k_bit1 = sum1 & 1;
+                let carry1 = (sum1 >> 1) & 1;
+                let addr_factor1 = if k_bit1 == 1 { k1 } else { k0 };
+                if carry1 == 0 {
+                    *next_dp0 += weight * addr_factor1 * r_y;
+                } else {
+                    *next_dp1 += weight * addr_factor1 * r_y;
+                }
+            } else {
+                let sum0 = start_bit + carry;
+                let k_bit0 = sum0 & 1;
+                let carry0 = (sum0 >> 1) & 1;
+                let addr_factor0 = if k_bit0 == 1 { k1 } else { k0 };
+                if carry0 == 0 {
+                    *next_dp0 += weight * addr_factor0;
+                } else {
+                    *next_dp1 += weight * addr_factor0;
+                }
+            }
+        };
+
+        update_state(dp0, 0, &mut next_dp0, &mut next_dp1);
+        update_state(dp1, 1, &mut next_dp0, &mut next_dp1);
+        dp0 = next_dp0;
+        dp1 = next_dp1;
+    }
+
+    dp0 + dp1
+}

--- a/jolt-core/src/zkvm/config.rs
+++ b/jolt-core/src/zkvm/config.rs
@@ -200,14 +200,14 @@ impl OneHotConfig {
 /// Full one-hot parameters with cached derived values.
 ///
 /// This struct is NOT serialized in the proof. It is constructed by the prover
-/// and verifier from `OneHotConfig`, `bytecode_K` (from preprocessing), and `ram_K` (from proof).
+/// and verifier from `OneHotConfig`, `bytecode_len` (from preprocessing), and `ram_K` (from proof).
 #[derive(Allocative, Clone, Debug, Default)]
 pub struct OneHotParams {
     pub log_k_chunk: usize,
     pub lookups_ra_virtual_log_k_chunk: usize,
     pub k_chunk: usize,
 
-    pub bytecode_k: usize,
+    pub bytecode_len: usize,
     pub ram_k: usize,
 
     pub instruction_d: usize,
@@ -224,12 +224,12 @@ impl OneHotParams {
     ///
     /// This is used by the verifier to reconstruct the full params from
     /// the minimal config stored in the proof.
-    pub fn from_config(config: &OneHotConfig, bytecode_k: usize, ram_k: usize) -> Self {
+    pub fn from_config(config: &OneHotConfig, bytecode_len: usize, ram_k: usize) -> Self {
         let log_k_chunk = config.log_k_chunk as usize;
         let lookups_ra_virtual_log_k_chunk = config.lookups_ra_virtual_log_k_chunk as usize;
 
         let instruction_d = LOG_K.div_ceil(log_k_chunk);
-        let bytecode_d = bytecode_k.log_2().div_ceil(log_k_chunk);
+        let bytecode_d = bytecode_len.log_2().div_ceil(log_k_chunk);
         let ram_d = ram_k.log_2().div_ceil(log_k_chunk);
 
         let instruction_shifts = (0..instruction_d)
@@ -244,7 +244,7 @@ impl OneHotParams {
             log_k_chunk,
             lookups_ra_virtual_log_k_chunk,
             k_chunk: 1 << log_k_chunk,
-            bytecode_k,
+            bytecode_len,
             ram_k,
             instruction_d,
             bytecode_d,
@@ -258,9 +258,9 @@ impl OneHotParams {
     /// Create OneHotParams for the given trace parameters using default config.
     ///
     /// This is a convenience constructor for the prover.
-    pub fn new(log_T: usize, bytecode_k: usize, ram_k: usize) -> Self {
+    pub fn new(log_T: usize, bytecode_len: usize, ram_k: usize) -> Self {
         let config = OneHotConfig::new(log_T);
-        Self::from_config(&config, bytecode_k, ram_k)
+        Self::from_config(&config, bytecode_len, ram_k)
     }
 
     /// Extract the minimal config for serialization in the proof.

--- a/jolt-core/src/zkvm/program.rs
+++ b/jolt-core/src/zkvm/program.rs
@@ -1,0 +1,334 @@
+use std::io::{Read, Write};
+use std::sync::Arc;
+
+use ark_serialize::{
+    CanonicalDeserialize, CanonicalSerialize, Compress, SerializationError, Valid, Validate,
+};
+
+use crate::poly::commitment::commitment_scheme::CommitmentScheme;
+use crate::poly::commitment::dory::{DoryContext, DoryGlobals};
+use crate::poly::multilinear_polynomial::MultilinearPolynomial;
+use crate::utils::errors::ProofVerifyError;
+use crate::utils::math::Math;
+use crate::zkvm::bytecode::BytecodePreprocessing;
+use crate::zkvm::ram::RAMPreprocessing;
+use tracer::instruction::{Cycle, Instruction};
+
+#[derive(Debug, Clone, CanonicalSerialize, CanonicalDeserialize)]
+pub struct ProgramPreprocessing {
+    pub bytecode: BytecodePreprocessing,
+    pub ram: RAMPreprocessing,
+}
+
+impl Default for ProgramPreprocessing {
+    fn default() -> Self {
+        Self {
+            bytecode: BytecodePreprocessing::default(),
+            ram: RAMPreprocessing {
+                min_bytecode_address: 0,
+                bytecode_words: Vec::new(),
+            },
+        }
+    }
+}
+
+impl ProgramPreprocessing {
+    #[tracing::instrument(skip_all, name = "ProgramPreprocessing::preprocess")]
+    pub fn preprocess(instructions: Vec<Instruction>, memory_init: Vec<(u64, u8)>) -> Self {
+        let entry_address = instructions
+            .first()
+            .map(|instr| instr.normalize().address as u64)
+            .unwrap_or(0);
+        Self {
+            bytecode: BytecodePreprocessing::preprocess(instructions, entry_address),
+            ram: RAMPreprocessing::preprocess(memory_init),
+        }
+    }
+
+    pub fn bytecode_len(&self) -> usize {
+        self.bytecode.code_size
+    }
+
+    pub fn program_image_len_words(&self) -> usize {
+        self.ram.bytecode_words.len()
+    }
+
+    pub fn program_image_len_words_padded(&self) -> usize {
+        self.program_image_len_words().next_power_of_two().max(2)
+    }
+
+    pub fn meta(&self) -> ProgramMetadata {
+        ProgramMetadata {
+            entry_address: self.bytecode.entry_address,
+            min_bytecode_address: self.ram.min_bytecode_address,
+            program_image_len_words: self.program_image_len_words(),
+            bytecode_len: self.bytecode_len(),
+        }
+    }
+
+    #[inline(always)]
+    pub fn get_pc(&self, cycle: &Cycle) -> usize {
+        self.bytecode.get_pc(cycle)
+    }
+
+    #[inline(always)]
+    pub fn entry_bytecode_index(&self) -> usize {
+        self.bytecode.entry_bytecode_index()
+    }
+
+    pub fn as_bytecode(&self) -> BytecodePreprocessing {
+        self.bytecode.clone()
+    }
+}
+
+#[derive(Debug, Clone, CanonicalSerialize, CanonicalDeserialize)]
+pub struct ProgramMetadata {
+    pub entry_address: u64,
+    pub min_bytecode_address: u64,
+    pub program_image_len_words: usize,
+    pub bytecode_len: usize,
+}
+
+impl ProgramMetadata {
+    pub fn from_program(program: &ProgramPreprocessing) -> Self {
+        program.meta()
+    }
+
+    pub fn program_image_len_words_padded(&self) -> usize {
+        self.program_image_len_words.next_power_of_two().max(2)
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, CanonicalSerialize, CanonicalDeserialize)]
+pub struct TrustedProgramCommitments<PCS: CommitmentScheme> {
+    pub program_image_commitment: PCS::Commitment,
+    pub program_image_num_columns: usize,
+    pub program_image_num_words: usize,
+}
+
+#[derive(Clone)]
+pub struct TrustedProgramHints<PCS: CommitmentScheme> {
+    pub program_image_hint: PCS::OpeningProofHint,
+}
+
+impl<PCS: CommitmentScheme> CanonicalSerialize for TrustedProgramHints<PCS>
+where
+    PCS::OpeningProofHint: CanonicalSerialize,
+{
+    fn serialize_with_mode<W: Write>(
+        &self,
+        mut writer: W,
+        compress: Compress,
+    ) -> Result<(), SerializationError> {
+        self.program_image_hint
+            .serialize_with_mode(&mut writer, compress)?;
+        Ok(())
+    }
+
+    fn serialized_size(&self, compress: Compress) -> usize {
+        self.program_image_hint.serialized_size(compress)
+    }
+}
+
+impl<PCS: CommitmentScheme> Valid for TrustedProgramHints<PCS>
+where
+    PCS::OpeningProofHint: Valid,
+{
+    fn check(&self) -> Result<(), SerializationError> {
+        self.program_image_hint.check()
+    }
+}
+
+impl<PCS: CommitmentScheme> CanonicalDeserialize for TrustedProgramHints<PCS>
+where
+    PCS::OpeningProofHint: CanonicalDeserialize,
+{
+    fn deserialize_with_mode<R: Read>(
+        mut reader: R,
+        compress: Compress,
+        validate: Validate,
+    ) -> Result<Self, SerializationError> {
+        Ok(Self {
+            program_image_hint: PCS::OpeningProofHint::deserialize_with_mode(
+                &mut reader,
+                compress,
+                validate,
+            )?,
+        })
+    }
+}
+
+impl<PCS: CommitmentScheme> TrustedProgramCommitments<PCS> {
+    #[tracing::instrument(skip_all, name = "TrustedProgramCommitments::derive")]
+    pub fn derive(
+        program: &ProgramPreprocessing,
+        generators: &PCS::ProverSetup,
+    ) -> (Self, TrustedProgramHints<PCS>) {
+        let program_image_num_words = program.program_image_len_words_padded();
+        let (program_image_sigma, _) =
+            crate::poly::commitment::dory::DoryGlobals::balanced_sigma_nu(
+                program_image_num_words.log_2(),
+            );
+        let program_image_num_columns = 1usize << program_image_sigma;
+        let program_image_poly =
+            build_program_image_polynomial_padded::<PCS::Field>(program, program_image_num_words);
+        let _program_image_guard = DoryGlobals::initialize_context(
+            1,
+            program_image_num_words,
+            DoryContext::UntrustedAdvice,
+            None,
+        );
+        let (program_image_commitment, program_image_hint) = {
+            let _ctx = DoryGlobals::with_context(DoryContext::UntrustedAdvice);
+            PCS::commit(&program_image_poly, generators)
+        };
+
+        (
+            Self {
+                program_image_commitment,
+                program_image_num_columns,
+                program_image_num_words,
+            },
+            TrustedProgramHints { program_image_hint },
+        )
+    }
+}
+
+pub(crate) fn build_program_image_polynomial_padded<F: crate::field::JoltField>(
+    program: &ProgramPreprocessing,
+    padded_len: usize,
+) -> MultilinearPolynomial<F> {
+    debug_assert!(padded_len.is_power_of_two());
+    debug_assert!(padded_len >= program.ram.bytecode_words.len());
+    let mut coeffs = vec![0u64; padded_len];
+    for (i, &word) in program.ram.bytecode_words.iter().enumerate() {
+        coeffs[i] = word;
+    }
+    MultilinearPolynomial::from(coeffs)
+}
+
+#[derive(Debug, Clone)]
+pub enum VerifierProgram<PCS: CommitmentScheme> {
+    Full(Arc<ProgramPreprocessing>),
+    Committed(TrustedProgramCommitments<PCS>),
+}
+
+impl<PCS: CommitmentScheme> VerifierProgram<PCS> {
+    pub fn as_full(&self) -> Result<&Arc<ProgramPreprocessing>, ProofVerifyError> {
+        match self {
+            VerifierProgram::Full(program) => Ok(program),
+            VerifierProgram::Committed(_) => Err(ProofVerifyError::BytecodeTypeMismatch(
+                "expected Full, got Committed".to_string(),
+            )),
+        }
+    }
+
+    pub fn as_committed(&self) -> Result<&TrustedProgramCommitments<PCS>, ProofVerifyError> {
+        match self {
+            VerifierProgram::Committed(program) => Ok(program),
+            VerifierProgram::Full(_) => Err(ProofVerifyError::BytecodeTypeMismatch(
+                "expected Committed, got Full".to_string(),
+            )),
+        }
+    }
+
+    pub fn is_full(&self) -> bool {
+        matches!(self, VerifierProgram::Full(_))
+    }
+
+    pub fn is_committed(&self) -> bool {
+        matches!(self, VerifierProgram::Committed(_))
+    }
+
+    pub fn full(&self) -> Option<&Arc<ProgramPreprocessing>> {
+        match self {
+            VerifierProgram::Full(program) => Some(program),
+            VerifierProgram::Committed(_) => None,
+        }
+    }
+
+    pub fn instructions(&self) -> Option<&[Instruction]> {
+        match self {
+            VerifierProgram::Full(program) => Some(&program.bytecode.bytecode),
+            VerifierProgram::Committed(_) => None,
+        }
+    }
+
+    pub fn program_image_words(&self) -> Option<&[u64]> {
+        match self {
+            VerifierProgram::Full(program) => Some(&program.ram.bytecode_words),
+            VerifierProgram::Committed(_) => None,
+        }
+    }
+
+    pub fn as_bytecode(&self) -> Option<BytecodePreprocessing> {
+        match self {
+            VerifierProgram::Full(program) => Some(program.as_bytecode()),
+            VerifierProgram::Committed(_) => None,
+        }
+    }
+}
+
+impl<PCS: CommitmentScheme> CanonicalSerialize for VerifierProgram<PCS> {
+    fn serialize_with_mode<W: Write>(
+        &self,
+        mut writer: W,
+        compress: Compress,
+    ) -> Result<(), SerializationError> {
+        match self {
+            VerifierProgram::Full(program) => {
+                0u8.serialize_with_mode(&mut writer, compress)?;
+                program
+                    .as_ref()
+                    .serialize_with_mode(&mut writer, compress)?;
+            }
+            VerifierProgram::Committed(program) => {
+                1u8.serialize_with_mode(&mut writer, compress)?;
+                program.serialize_with_mode(&mut writer, compress)?;
+            }
+        }
+        Ok(())
+    }
+
+    fn serialized_size(&self, compress: Compress) -> usize {
+        1 + match self {
+            VerifierProgram::Full(program) => program.serialized_size(compress),
+            VerifierProgram::Committed(program) => program.serialized_size(compress),
+        }
+    }
+}
+
+impl<PCS: CommitmentScheme> Valid for VerifierProgram<PCS> {
+    fn check(&self) -> Result<(), SerializationError> {
+        match self {
+            VerifierProgram::Full(program) => program.check(),
+            VerifierProgram::Committed(program) => program.check(),
+        }
+    }
+}
+
+impl<PCS: CommitmentScheme> CanonicalDeserialize for VerifierProgram<PCS> {
+    fn deserialize_with_mode<R: Read>(
+        mut reader: R,
+        compress: Compress,
+        validate: Validate,
+    ) -> Result<Self, SerializationError> {
+        let tag = u8::deserialize_with_mode(&mut reader, compress, validate)?;
+        match tag {
+            0 => {
+                let program =
+                    ProgramPreprocessing::deserialize_with_mode(&mut reader, compress, validate)?;
+                Ok(VerifierProgram::Full(Arc::new(program)))
+            }
+            1 => {
+                let program = TrustedProgramCommitments::<PCS>::deserialize_with_mode(
+                    &mut reader,
+                    compress,
+                    validate,
+                )?;
+                Ok(VerifierProgram::Committed(program))
+            }
+            _ => Err(SerializationError::InvalidData),
+        }
+    }
+}

--- a/jolt-core/src/zkvm/proof_serialization.rs
+++ b/jolt-core/src/zkvm/proof_serialization.rs
@@ -300,13 +300,25 @@ impl CanonicalSerialize for CommittedPolynomial {
             }
             Self::TrustedAdvice => 5u8.serialize_with_mode(writer, compress),
             Self::UntrustedAdvice => 6u8.serialize_with_mode(writer, compress),
+            Self::BytecodeChunk(i) => {
+                7u8.serialize_with_mode(&mut writer, compress)?;
+                (u8::try_from(*i).unwrap()).serialize_with_mode(writer, compress)
+            }
+            Self::ProgramImageInit => 8u8.serialize_with_mode(writer, compress),
         }
     }
 
     fn serialized_size(&self, _compress: Compress) -> usize {
         match self {
-            Self::RdInc | Self::RamInc | Self::TrustedAdvice | Self::UntrustedAdvice => 1,
-            Self::InstructionRa(_) | Self::BytecodeRa(_) | Self::RamRa(_) => 2,
+            Self::RdInc
+            | Self::RamInc
+            | Self::TrustedAdvice
+            | Self::UntrustedAdvice
+            | Self::ProgramImageInit => 1,
+            Self::InstructionRa(_)
+            | Self::BytecodeRa(_)
+            | Self::RamRa(_)
+            | Self::BytecodeChunk(_) => 2,
         }
     }
 }
@@ -341,6 +353,11 @@ impl CanonicalDeserialize for CommittedPolynomial {
                 }
                 5 => Self::TrustedAdvice,
                 6 => Self::UntrustedAdvice,
+                7 => {
+                    let i = u8::deserialize_with_mode(reader, compress, validate)?;
+                    Self::BytecodeChunk(i as usize)
+                }
+                8 => Self::ProgramImageInit,
                 _ => return Err(SerializationError::InvalidData),
             },
         )
@@ -407,6 +424,14 @@ impl CanonicalSerialize for VirtualPolynomial {
             }
             Self::BytecodeReadRafAddrClaim => 39u8.serialize_with_mode(&mut writer, compress),
             Self::BooleanityAddrClaim => 40u8.serialize_with_mode(&mut writer, compress),
+            Self::BytecodeValStage(i) => {
+                41u8.serialize_with_mode(&mut writer, compress)?;
+                (u8::try_from(*i).unwrap()).serialize_with_mode(&mut writer, compress)
+            }
+            Self::BytecodeClaimReductionIntermediate => {
+                42u8.serialize_with_mode(&mut writer, compress)
+            }
+            Self::ProgramImageInitContributionRw => 43u8.serialize_with_mode(&mut writer, compress),
         }
     }
 
@@ -448,11 +473,14 @@ impl CanonicalSerialize for VirtualPolynomial {
             | Self::RamHammingWeight
             | Self::UnivariateSkip
             | Self::BytecodeReadRafAddrClaim
-            | Self::BooleanityAddrClaim => 1,
+            | Self::BooleanityAddrClaim
+            | Self::BytecodeClaimReductionIntermediate
+            | Self::ProgramImageInitContributionRw => 1,
             Self::InstructionRa(_)
             | Self::OpFlags(_)
             | Self::InstructionFlags(_)
-            | Self::LookupTableFlag(_) => 2,
+            | Self::LookupTableFlag(_)
+            | Self::BytecodeValStage(_) => 2,
         }
     }
 }
@@ -528,6 +556,12 @@ impl CanonicalDeserialize for VirtualPolynomial {
                 }
                 39 => Self::BytecodeReadRafAddrClaim,
                 40 => Self::BooleanityAddrClaim,
+                41 => {
+                    let i = u8::deserialize_with_mode(&mut reader, compress, validate)?;
+                    Self::BytecodeValStage(i as usize)
+                }
+                42 => Self::BytecodeClaimReductionIntermediate,
+                43 => Self::ProgramImageInitContributionRw,
                 _ => return Err(SerializationError::InvalidData),
             },
         )

--- a/jolt-core/src/zkvm/witness.rs
+++ b/jolt-core/src/zkvm/witness.rs
@@ -31,6 +31,8 @@ pub enum CommittedPolynomial {
     InstructionRa(usize),
     /// One-hot ra polynomial for the bytecode instance of Shout
     BytecodeRa(usize),
+    /// Dense committed bytecode chunk polynomial for committed program mode.
+    BytecodeChunk(usize),
     /// One-hot ra/wa polynomial for the RAM instance of Twist
     /// Note that for RAM, ra and wa are the same polynomial because
     /// there is at most one load or store per cycle.
@@ -41,6 +43,8 @@ pub enum CommittedPolynomial {
     /// Untrusted advice polynomial - committed during proving, commitment in proof.
     /// Length cannot exceed max_trace_length.
     UntrustedAdvice,
+    /// Program image (initial RAM image) polynomial for committed program mode.
+    ProgramImageInit,
 }
 
 /// Returns a list of symbols representing all committed polynomials.
@@ -128,8 +132,11 @@ impl CommittedPolynomial {
                     .collect();
                 PCS::process_chunk_onehot(setup, one_hot_params.k_chunk, &row)
             }
-            CommittedPolynomial::TrustedAdvice | CommittedPolynomial::UntrustedAdvice => {
-                panic!("Advice polynomials should not use streaming witness generation")
+            CommittedPolynomial::TrustedAdvice
+            | CommittedPolynomial::UntrustedAdvice
+            | CommittedPolynomial::ProgramImageInit
+            | CommittedPolynomial::BytecodeChunk(_) => {
+                panic!("Precommitted polynomials should not use streaming witness generation")
             }
         }
     }
@@ -214,8 +221,11 @@ impl CommittedPolynomial {
                     one_hot_params.k_chunk,
                 ))
             }
-            CommittedPolynomial::TrustedAdvice | CommittedPolynomial::UntrustedAdvice => {
-                panic!("Advice polynomials should not use generate_witness")
+            CommittedPolynomial::TrustedAdvice
+            | CommittedPolynomial::UntrustedAdvice
+            | CommittedPolynomial::ProgramImageInit
+            | CommittedPolynomial::BytecodeChunk(_) => {
+                panic!("Precommitted polynomials should not use generate_witness")
             }
         }
     }
@@ -271,6 +281,9 @@ pub enum VirtualPolynomial {
     OpFlags(CircuitFlags),
     InstructionFlags(InstructionFlags),
     LookupTableFlag(usize),
+    BytecodeValStage(usize),
     BytecodeReadRafAddrClaim,
     BooleanityAddrClaim,
+    BytecodeClaimReductionIntermediate,
+    ProgramImageInitContributionRw,
 }


### PR DESCRIPTION
Generated stack PR from `amir/bytecode-commitment-merged` after PR02 merged into `a16z/main`.

Stack position: `03`
Base branch: `a16z/main`
Replaces: https://github.com/LayerZero-Research/jolt/pull/18

Owned paths:
```text
jolt-core/src/zkvm/program.rs
jolt-core/src/zkvm/bytecode/chunks.rs
jolt-core/src/zkvm/bytecode/mod.rs
jolt-core/src/zkvm/claim_reductions/bytecode.rs
jolt-core/src/zkvm/claim_reductions/program_image.rs
jolt-core/src/zkvm/claim_reductions/precommitted.rs
jolt-core/src/zkvm/claim_reductions/mod.rs
jolt-core/src/poly/opening_proof.rs
jolt-core/src/poly/rlc_polynomial.rs
jolt-core/src/zkvm/witness.rs
jolt-core/src/zkvm/proof_serialization.rs
```

This PR is expected to be updated manually when `amir/bytecode-commitment-merged` is resliced.

Made with [Cursor](https://cursor.com)