### PR TITLE
fix: treat the full panic word as reserved

### DIFF
--- a/common/src/jolt_device.rs
+++ b/common/src/jolt_device.rs
@@ -107,10 +107,10 @@ impl JoltDevice {
     }
 
     pub fn store(&mut self, address: u64, value: u8) {
-        if address == self.memory_layout.panic {
+        if self.is_panic(address) {
             self.panic = true;
             return;
-        } else if self.is_panic(address) || self.is_termination(address) {
+        } else if self.is_termination(address) {
             return;
         }
 
@@ -246,7 +246,10 @@ pub struct MemoryLayout {
     pub stack_end: u64,
     pub heap_size: u64,
     pub heap_end: u64,
+    /// Start of the 8-byte panic word. Stores to any byte in this word set
+    /// [`JoltDevice::panic`].
     pub panic: u64,
+    /// Start of the 8-byte termination word.
     pub termination: u64,
     /// End of the memory region containing inputs, outputs, the panic bit,
     /// and the termination bit.
@@ -498,6 +501,29 @@ mod tests {
 
         assert_eq!(device.input_words_le(), vec![0x0807_0605_0403_0201, 9]);
         assert_eq!(device.output_words_le(), vec![0xbbaa]);
+    }
+
+    #[test]
+    fn writes_to_any_byte_of_panic_word_set_the_panic_bit() {
+        for byte_offset in 0..8 {
+            let mut device = JoltDevice::new(&MemoryConfig {
+                program_size: Some(1024),
+                ..Default::default()
+            });
+            let panic_byte = device.memory_layout.panic + byte_offset;
+
+            device.store(panic_byte, 1);
+
+            assert!(
+                device.panic,
+                "write to panic byte offset {byte_offset} must set the public panic bit"
+            );
+            assert_eq!(
+                device.load(device.memory_layout.panic),
+                1,
+                "panic word must read as set after write to byte offset {byte_offset}"
+            );
+        }
     }
 
     #[test]

--- a/tracer/src/emulator/mmu.rs
+++ b/tracer/src/emulator/mmu.rs
@@ -1208,6 +1208,21 @@ mod test_mmu {
     }
 
     #[test]
+    fn guest_word_store_to_upper_half_of_panic_word_sets_public_panic_bit() {
+        let mut mmu = setup_mmu();
+        let panic_upper_word = mmu.jolt_device.as_ref().unwrap().memory_layout.panic + 4;
+
+        mmu.store_word(panic_upper_word, 1).unwrap();
+
+        let device = mmu.jolt_device.as_ref().unwrap();
+        assert!(
+            device.panic,
+            "guest word store to panic+4 must set the public panic bit"
+        );
+        assert_eq!(device.load(device.memory_layout.panic), 1);
+    }
+
+    #[test]
     fn test_mprv_uses_mpp_machine_fast_path() {
         let mut mmu = setup_mmu();
 


### PR DESCRIPTION
## Summary

Fixes #1593. Stores to any byte of the 8-byte panic word now set the public panic bit.

## Changes

- Treat the full panic word range as panic-triggering in `JoltDevice::store`.
- Cover direct device stores and guest word stores to `panic + 4`.

## Testing

- [x] Ran tests for modified crates
- [x] `cargo clippy` and `cargo fmt` pass

Commands:
- `CARGO_TARGET_DIR=target-common CARGO_BUILD_JOBS=1 cargo test -p common writes_to_any_byte_of_panic_word_set_the_panic_bit`
- `CARGO_TARGET_DIR=target-tracer CARGO_BUILD_JOBS=1 cargo test -p tracer guest_word_store_to_upper_half_of_panic_word_sets_public_panic_bit`
- `cargo fmt --all --check`
- `cargo clippy -p common -p tracer --all-targets -- -D warnings`

## Security Considerations

This affects the guest panic public output. It does not change proof formats, verifier logic, or private input handling.

## Breaking Changes

None
