### PR TITLE
feat: extend Jolt claim protocol formulas

### DIFF
--- a/.github/workflows/arch-tests.yml
+++ b/.github/workflows/arch-tests.yml
@@ -6,8 +6,9 @@ on:
       - main
   pull_request:
     branches:
-      - "**"
+      - main
     paths:
+      - ".github/workflows/arch-tests.yml"
       - "tracer/**"
       - "Makefile"
       - "tests/arch-tests/**"

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -64,7 +64,32 @@ jobs:
       # workspace-wide invocations above never build it. Lint the crates that
       # define it explicitly so the feature keeps compiling.
       - name: cargo clippy --features field-inline
-        run: cargo clippy -p tracer -p jolt-program -p jolt-riscv -p jolt-lookup-tables --all-targets --features field-inline
+        run: >
+          cargo clippy
+          -q
+          --message-format=short
+          -p jolt-claims
+          -p jolt-r1cs
+          -p jolt-verifier
+          -p tracer
+          -p jolt-program
+          -p jolt-riscv
+          -p jolt-lookup-tables
+          --all-targets
+          --features field-inline
+          --
+          -D warnings
+      - name: cargo clippy -p jolt-core -p jolt-sdk --features host,field-inline
+        run: >
+          cargo clippy
+          -q
+          --message-format=short
+          -p jolt-core
+          -p jolt-sdk
+          --all-targets
+          --features host,field-inline
+          --
+          -D warnings
 
   machete:
     runs-on: ubuntu-latest
@@ -176,6 +201,10 @@ jobs:
         working-directory: ./sample_project
         run: cargo run --release
 
+      - name: Make sure the generated code runs with field-inline
+        working-directory: ./sample_project
+        run: cargo run --release -q --message-format=short --features field-inline
+
   test-wasm-verify:
     name: WASM Verifier E2E
     runs-on: ubuntu-latest
@@ -258,12 +287,17 @@ jobs:
             fi
             cargo nextest run -p "$pkg" "${features[@]}" --no-tests=pass
           done
+      - name: Test lookup table core ABI
+        run: cargo nextest run -p jolt-lookup-tables --features core-abi-tests --test core_lookup_table_abi --cargo-quiet
       - name: Test crates with field-inline
         shell: bash
         run: |
           set -euo pipefail
-          cargo nextest run -p jolt-program -p jolt-riscv -p jolt-lookup-tables \
-            --features field-inline --no-tests=pass
+          cargo nextest run -p jolt-claims -p jolt-r1cs -p jolt-verifier \
+            -p jolt-program -p jolt-riscv -p jolt-lookup-tables \
+            --features field-inline --no-tests=pass --cargo-quiet
+          cargo nextest run -p tracer --features test-utils,field-inline \
+            --no-tests=pass --cargo-quiet
 
   test-inlines:
     name: Test inlines

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -296,8 +296,6 @@ jobs:
           cargo nextest run -p jolt-claims -p jolt-r1cs -p jolt-verifier \
             -p jolt-program -p jolt-riscv -p jolt-lookup-tables \
             --features field-inline --no-tests=pass --cargo-quiet
-          cargo nextest run -p tracer --features test-utils,field-inline \
-            --no-tests=pass --cargo-quiet
 
   test-inlines:
     name: Test inlines
@@ -354,7 +352,9 @@ jobs:
       - name: Install nextest
         uses: taiki-e/install-action@nextest
       - name: Run tracer tests
-        run: cargo nextest run --release -p tracer --features test-utils
+        run: cargo nextest run --release -p tracer --features test-utils --cargo-quiet
+      - name: Run tracer tests with field-inline
+        run: cargo nextest run --release -p tracer --features test-utils,field-inline --cargo-quiet
 
   zklean-extractor-tests:
     name: ZkLean extractor tests

--- a/crates/jolt-claims/src/claims.rs
+++ b/crates/jolt-claims/src/claims.rs
@@ -291,6 +291,32 @@ pub type InputClaimExpression<F, O, P = (), C = usize> = ClaimExpression<F, O, P
 pub type OutputClaimExpression<F, O, P = (), C = usize> = ClaimExpression<F, O, P, C>;
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SameEvaluation<O> {
+    pub left: O,
+    pub right: O,
+}
+
+impl<O> SameEvaluation<O> {
+    pub fn new(left: O, right: O) -> Self {
+        Self { left, right }
+    }
+}
+
+pub trait SameEvaluationAs<Rhs = Self> {
+    type Output;
+
+    fn same_evaluation_as(self, rhs: Rhs) -> Self::Output;
+}
+
+impl<O> SameEvaluationAs for O {
+    type Output = SameEvaluation<O>;
+
+    fn same_evaluation_as(self, rhs: Self) -> Self::Output {
+        SameEvaluation::new(self, rhs)
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum ConsistencyClaim<F, O, P = (), C = usize> {
     EqualExpressions {
         left: Expr<F, O, P, C>,
@@ -308,6 +334,12 @@ impl<F: RingCore, O, P, C> ConsistencyClaim<F, O, P, C> {
 
     pub fn equal_expressions(left: Expr<F, O, P, C>, right: Expr<F, O, P, C>) -> Self {
         Self::EqualExpressions { left, right }
+    }
+}
+
+impl<F: RingCore, O, P, C> From<SameEvaluation<O>> for ConsistencyClaim<F, O, P, C> {
+    fn from(value: SameEvaluation<O>) -> Self {
+        Self::same_evaluation(value.left, value.right)
     }
 }
 
@@ -483,7 +515,7 @@ mod tests {
     #[test]
     fn same_evaluation_claim_requires_both_openings() {
         let consistency: ConsistencyClaim<Fr, Opening, Public, Challenge> =
-            ConsistencyClaim::same_evaluation(Opening::A, Opening::B);
+            Opening::A.same_evaluation_as(Opening::B).into();
 
         assert_eq!(
             consistency,

--- a/crates/jolt-claims/src/lib.rs
+++ b/crates/jolt-claims/src/lib.rs
@@ -7,5 +7,5 @@ mod util;
 
 pub use claims::{
     challenge, constant, opening, public, ClaimExpression, ConsistencyClaim, Expr,
-    InputClaimExpression, OutputClaimExpression, Source, Term,
+    InputClaimExpression, OutputClaimExpression, SameEvaluation, SameEvaluationAs, Source, Term,
 };

--- a/crates/jolt-claims/src/protocols/field_inline/config.rs
+++ b/crates/jolt-claims/src/protocols/field_inline/config.rs
@@ -1,5 +1,7 @@
 use serde::{Deserialize, Serialize};
 
+use super::formulas::dimensions::FieldRegistersReadWriteDimensions;
+
 pub const FIELD_REGISTERS_LOG_K: usize = 4;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -29,5 +31,14 @@ impl FieldInlineConfig {
             field_register_log_k: FIELD_REGISTERS_LOG_K,
             representation: FieldInlineRepresentation::NativeFieldElement,
         }
+    }
+
+    pub const fn read_write_dimensions(self, log_t: usize) -> FieldRegistersReadWriteDimensions {
+        FieldRegistersReadWriteDimensions::new(
+            log_t,
+            self.field_register_log_k,
+            log_t,
+            self.field_register_log_k,
+        )
     }
 }

--- a/crates/jolt-claims/src/protocols/field_inline/formulas/bytecode.rs
+++ b/crates/jolt-claims/src/protocols/field_inline/formulas/bytecode.rs
@@ -1,0 +1,915 @@
+use jolt_field::{Field, RingCore};
+use jolt_lookup_tables::{LookupTableKind, XLEN};
+use jolt_poly::EqPolynomial;
+use jolt_riscv::{JoltInstructionRow, NUM_CIRCUIT_FLAGS};
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+use crate::{challenge, opening, Expr};
+
+use super::super::{
+    FieldInlineOpFlag, FieldInlineOpeningId, FieldInlineRelationId, FieldInlineVirtualPolynomial,
+};
+use crate::protocols::jolt::formulas::bytecode as jolt_bytecode;
+use crate::protocols::jolt::formulas::dimensions::JoltFormulaPointError;
+use crate::protocols::jolt::{BytecodeReadRafChallenge, JoltChallengeId};
+
+pub const FIELD_INLINE_BYTECODE_STAGE1_FLAGS: [FieldInlineOpFlag; 8] = [
+    FieldInlineOpFlag::Add,
+    FieldInlineOpFlag::Sub,
+    FieldInlineOpFlag::Mul,
+    FieldInlineOpFlag::Inv,
+    FieldInlineOpFlag::AssertEq,
+    FieldInlineOpFlag::LoadFromX,
+    FieldInlineOpFlag::StoreToX,
+    FieldInlineOpFlag::LoadImm,
+];
+
+pub const FIELD_INLINE_BYTECODE_STAGE1_GAMMA_COUNT: usize =
+    2 + NUM_CIRCUIT_FLAGS + FIELD_INLINE_BYTECODE_STAGE1_FLAGS.len();
+pub const FIELD_INLINE_BYTECODE_STAGE4_GAMMA_COUNT: usize = 6;
+pub const FIELD_INLINE_BYTECODE_STAGE5_EXTRA_GAMMAS: usize = 1;
+
+const FIELD_ADD_TAG: u16 = 0x0100;
+const FIELD_SUB_TAG: u16 = 0x0101;
+const FIELD_MUL_TAG: u16 = 0x0102;
+const FIELD_INV_TAG: u16 = 0x0103;
+const FIELD_ASSERT_EQ_TAG: u16 = 0x0104;
+const FIELD_LOAD_FROM_X_TAG: u16 = 0x0105;
+const FIELD_STORE_TO_X_TAG: u16 = 0x0106;
+const FIELD_LOAD_IMM_TAG: u16 = 0x0107;
+
+pub type FieldInlineBytecodeExpr<F> = Expr<F, FieldInlineOpeningId, (), JoltChallengeId>;
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FieldInlineBytecodeRow {
+    pub operands: FieldInlineBytecodeOperands,
+    pub flags: FieldInlineBytecodeFlags,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FieldInlineBytecodeOperands {
+    pub rd: Option<u8>,
+    pub rs1: Option<u8>,
+    pub rs2: Option<u8>,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FieldInlineBytecodeFlags {
+    pub add: bool,
+    pub sub: bool,
+    pub mul: bool,
+    pub inv: bool,
+    pub assert_eq: bool,
+    pub load_from_x: bool,
+    pub store_to_x: bool,
+    pub load_imm: bool,
+}
+
+impl FieldInlineBytecodeFlags {
+    pub const fn get(self, flag: FieldInlineOpFlag) -> bool {
+        match flag {
+            FieldInlineOpFlag::Add => self.add,
+            FieldInlineOpFlag::Sub => self.sub,
+            FieldInlineOpFlag::Mul => self.mul,
+            FieldInlineOpFlag::Inv => self.inv,
+            FieldInlineOpFlag::AssertEq => self.assert_eq,
+            FieldInlineOpFlag::LoadFromX => self.load_from_x,
+            FieldInlineOpFlag::StoreToX => self.store_to_x,
+            FieldInlineOpFlag::LoadImm => self.load_imm,
+        }
+    }
+
+    pub fn active_count(self) -> usize {
+        FIELD_INLINE_BYTECODE_STAGE1_FLAGS
+            .into_iter()
+            .filter(|flag| self.get(*flag))
+            .count()
+    }
+
+    pub fn active_flag(self) -> Option<FieldInlineOpFlag> {
+        if self.active_count() != 1 {
+            return None;
+        }
+        FIELD_INLINE_BYTECODE_STAGE1_FLAGS
+            .into_iter()
+            .find(|flag| self.get(*flag))
+    }
+
+    pub fn transcript_bits(self) -> u8 {
+        FIELD_INLINE_BYTECODE_STAGE1_FLAGS
+            .into_iter()
+            .enumerate()
+            .fold(0, |bits, (index, flag)| {
+                bits | (u8::from(self.get(flag)) << index)
+            })
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Error)]
+pub enum FieldInlineBytecodeValidationError {
+    #[error("field-register log_k {log_k} is too large for this target")]
+    InvalidFieldRegisterLogK { log_k: usize },
+    #[error("field-inline bytecode length mismatch: expected {expected}, got {got}")]
+    LengthMismatch { expected: usize, got: usize },
+    #[error("inactive field-inline bytecode row {row} carries operands")]
+    InactiveRowHasOperands { row: usize },
+    #[error("field-inline bytecode row {row} has {active_count} active flags")]
+    InvalidActiveFlagCount { row: usize, active_count: usize },
+    #[error("field-inline bytecode row {row} flag {flag:?}: {reason}")]
+    InvalidOperands {
+        row: usize,
+        flag: FieldInlineOpFlag,
+        reason: &'static str,
+    },
+    #[error(
+        "field-inline bytecode row {row} {operand} register {register} is outside field register domain {field_register_count}"
+    )]
+    RegisterOutOfRange {
+        row: usize,
+        operand: &'static str,
+        register: u8,
+        field_register_count: usize,
+    },
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Error)]
+pub enum FieldInlineBytecodeReadRafError {
+    #[error("{0}")]
+    Point(#[from] JoltFormulaPointError),
+    #[error("{0}")]
+    Validation(#[from] FieldInlineBytecodeValidationError),
+}
+
+pub fn validate_bytecode_rows(
+    bytecode: &[FieldInlineBytecodeRow],
+    expected_len: usize,
+    field_register_log_k: usize,
+) -> Result<(), FieldInlineBytecodeValidationError> {
+    if bytecode.len() != expected_len {
+        return Err(FieldInlineBytecodeValidationError::LengthMismatch {
+            expected: expected_len,
+            got: bytecode.len(),
+        });
+    }
+    let shift = u32::try_from(field_register_log_k).map_err(|_| {
+        FieldInlineBytecodeValidationError::InvalidFieldRegisterLogK {
+            log_k: field_register_log_k,
+        }
+    })?;
+    let field_register_count = 1usize.checked_shl(shift).ok_or(
+        FieldInlineBytecodeValidationError::InvalidFieldRegisterLogK {
+            log_k: field_register_log_k,
+        },
+    )?;
+
+    for (row, entry) in bytecode.iter().enumerate() {
+        validate_bytecode_row(row, entry, field_register_count)?;
+    }
+    Ok(())
+}
+
+pub fn bytecode_transcript_bytes(
+    bytecode: &[FieldInlineBytecodeRow],
+    field_register_log_k: usize,
+) -> Vec<u8> {
+    let mut bytes = Vec::with_capacity(16 + bytecode.len() * 7);
+    bytes.extend_from_slice(&(field_register_log_k as u64).to_le_bytes());
+    bytes.extend_from_slice(&(bytecode.len() as u64).to_le_bytes());
+    for row in bytecode {
+        encode_operand(row.operands.rd, &mut bytes);
+        encode_operand(row.operands.rs1, &mut bytes);
+        encode_operand(row.operands.rs2, &mut bytes);
+        bytes.push(row.flags.transcript_bits());
+    }
+    bytes
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct FieldInlineBytecodeReadRafPublicValues<F: Field> {
+    pub stage_values: [F; 5],
+}
+
+pub struct FieldInlineBytecodeReadRafEvaluationInputs<'a, F> {
+    pub bytecode: &'a [FieldInlineBytecodeRow],
+    pub field_register_log_k: usize,
+    pub r_address: &'a [F],
+    pub r_cycle: &'a [F],
+    pub stage1_cycle_point: &'a [F],
+    pub field_register_read_write_point: &'a [F],
+    pub field_register_read_write_cycle_point: &'a [F],
+    pub field_register_val_evaluation_point: &'a [F],
+    pub field_register_val_evaluation_cycle_point: &'a [F],
+    pub stage1_gammas: &'a [F],
+    pub stage4_gammas: &'a [F],
+    pub stage5_gammas: &'a [F],
+}
+
+pub fn read_raf_input_extension<F>() -> FieldInlineBytecodeExpr<F>
+where
+    F: RingCore,
+{
+    let gamma = bytecode_challenge(BytecodeReadRafChallenge::Gamma);
+
+    stage1_claim() + gamma.clone().pow(3) * stage4_claim() + gamma.pow(4) * stage5_claim::<F>()
+}
+
+pub fn base_jolt_bytecode_row(row: &JoltInstructionRow) -> JoltInstructionRow {
+    let mut row = *row;
+    // Keep this helper usable by verifier-only field-inline builds that do not
+    // enable the field-inline `jolt-riscv` enum variants.
+    match row.instruction_kind.tag().0 {
+        FIELD_LOAD_FROM_X_TAG => {
+            row.operands.rd = None;
+            row.operands.rs2 = None;
+        }
+        FIELD_STORE_TO_X_TAG => {
+            row.operands.rs1 = None;
+            row.operands.rs2 = None;
+        }
+        FIELD_ADD_TAG..=FIELD_ASSERT_EQ_TAG | FIELD_LOAD_IMM_TAG => {
+            row.operands.rd = None;
+            row.operands.rs1 = None;
+            row.operands.rs2 = None;
+        }
+        _ => {}
+    }
+    row
+}
+
+pub fn field_inline_bytecode_row(instruction: &JoltInstructionRow) -> FieldInlineBytecodeRow {
+    let operands = FieldInlineBytecodeOperands {
+        rd: instruction.operands.rd,
+        rs1: instruction.operands.rs1,
+        rs2: instruction.operands.rs2,
+    };
+    let mut row = FieldInlineBytecodeRow::default();
+    match instruction.instruction_kind.tag().0 {
+        FIELD_ADD_TAG => {
+            row.operands = operands;
+            row.flags.add = true;
+        }
+        FIELD_SUB_TAG => {
+            row.operands = operands;
+            row.flags.sub = true;
+        }
+        FIELD_MUL_TAG => {
+            row.operands = operands;
+            row.flags.mul = true;
+        }
+        FIELD_INV_TAG => {
+            row.operands = FieldInlineBytecodeOperands {
+                rd: instruction.operands.rd,
+                rs1: instruction.operands.rs1,
+                rs2: None,
+            };
+            row.flags.inv = true;
+        }
+        FIELD_ASSERT_EQ_TAG => {
+            row.operands = FieldInlineBytecodeOperands {
+                rd: None,
+                rs1: instruction.operands.rs1,
+                rs2: instruction.operands.rs2,
+            };
+            row.flags.assert_eq = true;
+        }
+        FIELD_LOAD_FROM_X_TAG => {
+            row.operands = FieldInlineBytecodeOperands {
+                rd: instruction.operands.rd,
+                rs1: None,
+                rs2: None,
+            };
+            row.flags.load_from_x = true;
+        }
+        FIELD_STORE_TO_X_TAG => {
+            row.operands = FieldInlineBytecodeOperands {
+                rd: None,
+                rs1: instruction.operands.rs1,
+                rs2: None,
+            };
+            row.flags.store_to_x = true;
+        }
+        FIELD_LOAD_IMM_TAG => {
+            row.operands = FieldInlineBytecodeOperands {
+                rd: instruction.operands.rd,
+                rs1: None,
+                rs2: None,
+            };
+            row.flags.load_imm = true;
+        }
+        _ => {}
+    }
+    row
+}
+
+pub fn read_raf_public_values<F>(
+    inputs: FieldInlineBytecodeReadRafEvaluationInputs<'_, F>,
+) -> Result<FieldInlineBytecodeReadRafPublicValues<F>, FieldInlineBytecodeReadRafError>
+where
+    F: Field,
+{
+    require_len(
+        inputs.stage1_gammas,
+        FIELD_INLINE_BYTECODE_STAGE1_GAMMA_COUNT,
+    )?;
+    require_len(
+        inputs.stage4_gammas,
+        FIELD_INLINE_BYTECODE_STAGE4_GAMMA_COUNT,
+    )?;
+    require_len(
+        inputs.stage5_gammas,
+        2 + LookupTableKind::<XLEN>::COUNT + FIELD_INLINE_BYTECODE_STAGE5_EXTRA_GAMMAS,
+    )?;
+
+    let expected_domain = 1usize << inputs.r_address.len();
+    if inputs.bytecode.len() != expected_domain {
+        return Err(FieldInlineBytecodeReadRafError::Point(
+            JoltFormulaPointError::EvaluationDomainLengthMismatch {
+                expected: expected_domain,
+                got: inputs.bytecode.len(),
+            },
+        ));
+    }
+    validate_bytecode_rows(
+        inputs.bytecode,
+        expected_domain,
+        inputs.field_register_log_k,
+    )?;
+
+    let address_eq_evals = EqPolynomial::<F>::evals(inputs.r_address, None);
+    let row_values = read_raf_stage_values(FieldInlineBytecodeReadRafStageValueInputs {
+        bytecode: inputs.bytecode,
+        field_register_read_write_point: inputs.field_register_read_write_point,
+        field_register_val_evaluation_point: inputs.field_register_val_evaluation_point,
+        stage1_gammas: inputs.stage1_gammas,
+        stage4_gammas: inputs.stage4_gammas,
+        stage5_gammas: inputs.stage5_gammas,
+    });
+
+    let mut stage_values = [F::zero(); 5];
+    for (row_values, eq_address) in row_values.into_iter().zip(address_eq_evals) {
+        for (stage_value, row_value) in stage_values.iter_mut().zip(row_values) {
+            *stage_value += row_value * eq_address;
+        }
+    }
+
+    stage_values[0] *= EqPolynomial::<F>::mle(inputs.stage1_cycle_point, inputs.r_cycle);
+    stage_values[3] *=
+        EqPolynomial::<F>::mle(inputs.field_register_read_write_cycle_point, inputs.r_cycle);
+    stage_values[4] *= EqPolynomial::<F>::mle(
+        inputs.field_register_val_evaluation_cycle_point,
+        inputs.r_cycle,
+    );
+
+    Ok(FieldInlineBytecodeReadRafPublicValues { stage_values })
+}
+
+pub fn merge_read_raf_public_values<F: Field>(
+    bytecode_public_values: &mut jolt_bytecode::BytecodeReadRafPublicValues<F>,
+    field_values: FieldInlineBytecodeReadRafPublicValues<F>,
+) {
+    for (stage_value, field_value) in bytecode_public_values
+        .stage_values
+        .iter_mut()
+        .zip(field_values.stage_values)
+    {
+        *stage_value += field_value;
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct FieldInlineBytecodeReadRafRegisterEqEvals<F> {
+    pub read_write: Vec<F>,
+    pub val_evaluation: Vec<F>,
+}
+
+pub struct FieldInlineBytecodeReadRafStageValueInputs<'a, F> {
+    pub bytecode: &'a [FieldInlineBytecodeRow],
+    pub field_register_read_write_point: &'a [F],
+    pub field_register_val_evaluation_point: &'a [F],
+    pub stage1_gammas: &'a [F],
+    pub stage4_gammas: &'a [F],
+    pub stage5_gammas: &'a [F],
+}
+
+pub fn read_raf_register_eq_evals<F>(
+    field_register_read_write_point: &[F],
+    field_register_val_evaluation_point: &[F],
+) -> FieldInlineBytecodeReadRafRegisterEqEvals<F>
+where
+    F: Field,
+{
+    FieldInlineBytecodeReadRafRegisterEqEvals {
+        read_write: EqPolynomial::<F>::evals(field_register_read_write_point, None),
+        val_evaluation: EqPolynomial::<F>::evals(field_register_val_evaluation_point, None),
+    }
+}
+
+pub fn read_raf_stage_values<F>(
+    inputs: FieldInlineBytecodeReadRafStageValueInputs<'_, F>,
+) -> Vec<[F; 5]>
+where
+    F: Field,
+{
+    let field_register_eq = read_raf_register_eq_evals(
+        inputs.field_register_read_write_point,
+        inputs.field_register_val_evaluation_point,
+    );
+    inputs
+        .bytecode
+        .iter()
+        .map(|row| {
+            read_raf_row_values(
+                row,
+                &field_register_eq.read_write,
+                &field_register_eq.val_evaluation,
+                inputs.stage1_gammas,
+                inputs.stage4_gammas,
+                inputs.stage5_gammas,
+            )
+        })
+        .collect()
+}
+
+pub fn read_raf_input_openings() -> [FieldInlineOpeningId; 12] {
+    [
+        field_op_flag_spartan_outer(FieldInlineOpFlag::Add),
+        field_op_flag_spartan_outer(FieldInlineOpFlag::Sub),
+        field_op_flag_spartan_outer(FieldInlineOpFlag::Mul),
+        field_op_flag_spartan_outer(FieldInlineOpFlag::Inv),
+        field_op_flag_spartan_outer(FieldInlineOpFlag::AssertEq),
+        field_op_flag_spartan_outer(FieldInlineOpFlag::LoadFromX),
+        field_op_flag_spartan_outer(FieldInlineOpFlag::StoreToX),
+        field_op_flag_spartan_outer(FieldInlineOpFlag::LoadImm),
+        field_rd_wa_read_write(),
+        field_rs1_ra_read_write(),
+        field_rs2_ra_read_write(),
+        field_rd_wa_val_evaluation(),
+    ]
+}
+
+fn stage1_claim<F>() -> FieldInlineBytecodeExpr<F>
+where
+    F: RingCore,
+{
+    let beta = bytecode_challenge(BytecodeReadRafChallenge::Stage1Gamma);
+    let mut claim = FieldInlineBytecodeExpr::zero();
+    for (index, flag) in FIELD_INLINE_BYTECODE_STAGE1_FLAGS.into_iter().enumerate() {
+        claim = claim
+            + beta.clone().pow(2 + NUM_CIRCUIT_FLAGS + index)
+                * opening(field_op_flag_spartan_outer(flag));
+    }
+    claim
+}
+
+fn stage4_claim<F>() -> FieldInlineBytecodeExpr<F>
+where
+    F: RingCore,
+{
+    let beta = bytecode_challenge(BytecodeReadRafChallenge::Stage4Gamma);
+    beta.clone().pow(3) * opening(field_rd_wa_read_write())
+        + beta.clone().pow(4) * opening(field_rs1_ra_read_write())
+        + beta.pow(5) * opening(field_rs2_ra_read_write())
+}
+
+fn stage5_claim<F>() -> FieldInlineBytecodeExpr<F>
+where
+    F: RingCore,
+{
+    let beta = bytecode_challenge(BytecodeReadRafChallenge::Stage5Gamma);
+    beta.pow(2 + LookupTableKind::<XLEN>::COUNT) * opening(field_rd_wa_val_evaluation())
+}
+
+pub fn read_raf_row_values<F>(
+    row: &FieldInlineBytecodeRow,
+    field_read_write_eq: &[F],
+    field_val_evaluation_eq: &[F],
+    stage1_gammas: &[F],
+    stage4_gammas: &[F],
+    stage5_gammas: &[F],
+) -> [F; 5]
+where
+    F: Field,
+{
+    let mut stage1 = F::zero();
+    for (index, flag) in FIELD_INLINE_BYTECODE_STAGE1_FLAGS.into_iter().enumerate() {
+        if row.flags.get(flag) {
+            stage1 += stage1_gammas[2 + NUM_CIRCUIT_FLAGS + index];
+        }
+    }
+
+    let stage4 = register_eq(row.operands.rd, field_read_write_eq) * stage4_gammas[3]
+        + register_eq(row.operands.rs1, field_read_write_eq) * stage4_gammas[4]
+        + register_eq(row.operands.rs2, field_read_write_eq) * stage4_gammas[5];
+    let stage5 = register_eq(row.operands.rd, field_val_evaluation_eq)
+        * stage5_gammas[2 + LookupTableKind::<XLEN>::COUNT];
+
+    [stage1, F::zero(), F::zero(), stage4, stage5]
+}
+
+fn validate_bytecode_row(
+    row: usize,
+    entry: &FieldInlineBytecodeRow,
+    field_register_count: usize,
+) -> Result<(), FieldInlineBytecodeValidationError> {
+    let active_count = entry.flags.active_count();
+    if active_count == 0 {
+        if entry.operands.rd.is_some()
+            || entry.operands.rs1.is_some()
+            || entry.operands.rs2.is_some()
+        {
+            return Err(FieldInlineBytecodeValidationError::InactiveRowHasOperands { row });
+        }
+        return Ok(());
+    }
+    if active_count != 1 {
+        return Err(FieldInlineBytecodeValidationError::InvalidActiveFlagCount {
+            row,
+            active_count,
+        });
+    }
+
+    let Some(flag) = entry.flags.active_flag() else {
+        return Err(FieldInlineBytecodeValidationError::InvalidActiveFlagCount {
+            row,
+            active_count,
+        });
+    };
+    validate_operand_layout(row, flag, entry.operands)?;
+    validate_register(row, "rd", entry.operands.rd, field_register_count)?;
+    validate_register(row, "rs1", entry.operands.rs1, field_register_count)?;
+    validate_register(row, "rs2", entry.operands.rs2, field_register_count)?;
+    Ok(())
+}
+
+fn validate_operand_layout(
+    row: usize,
+    flag: FieldInlineOpFlag,
+    operands: FieldInlineBytecodeOperands,
+) -> Result<(), FieldInlineBytecodeValidationError> {
+    let valid = match flag {
+        FieldInlineOpFlag::Add | FieldInlineOpFlag::Sub | FieldInlineOpFlag::Mul => {
+            operands.rd.is_some() && operands.rs1.is_some() && operands.rs2.is_some()
+        }
+        FieldInlineOpFlag::Inv => {
+            operands.rd.is_some() && operands.rs1.is_some() && operands.rs2.is_none()
+        }
+        FieldInlineOpFlag::AssertEq => {
+            operands.rd.is_none() && operands.rs1.is_some() && operands.rs2.is_some()
+        }
+        FieldInlineOpFlag::LoadFromX | FieldInlineOpFlag::LoadImm => {
+            operands.rd.is_some() && operands.rs1.is_none() && operands.rs2.is_none()
+        }
+        FieldInlineOpFlag::StoreToX => {
+            operands.rd.is_none() && operands.rs1.is_some() && operands.rs2.is_none()
+        }
+    };
+    if valid {
+        Ok(())
+    } else {
+        Err(FieldInlineBytecodeValidationError::InvalidOperands {
+            row,
+            flag,
+            reason: "operand presence does not match the active field-inline instruction",
+        })
+    }
+}
+
+fn validate_register(
+    row: usize,
+    operand: &'static str,
+    register: Option<u8>,
+    field_register_count: usize,
+) -> Result<(), FieldInlineBytecodeValidationError> {
+    if let Some(register) = register {
+        if usize::from(register) >= field_register_count {
+            return Err(FieldInlineBytecodeValidationError::RegisterOutOfRange {
+                row,
+                operand,
+                register,
+                field_register_count,
+            });
+        }
+    }
+    Ok(())
+}
+
+fn register_eq<F: Field>(register: Option<u8>, eq: &[F]) -> F {
+    register
+        .and_then(|register| eq.get(register as usize))
+        .copied()
+        .unwrap_or_else(F::zero)
+}
+
+fn require_len<F>(values: &[F], expected: usize) -> Result<(), FieldInlineBytecodeReadRafError> {
+    if values.len() < expected {
+        return Err(FieldInlineBytecodeReadRafError::Point(
+            JoltFormulaPointError::ChallengeLengthMismatch {
+                expected,
+                got: values.len(),
+            },
+        ));
+    }
+    Ok(())
+}
+
+fn encode_operand(register: Option<u8>, bytes: &mut Vec<u8>) {
+    if let Some(register) = register {
+        bytes.push(1);
+        bytes.push(register);
+    } else {
+        bytes.push(0);
+        bytes.push(0);
+    }
+}
+
+fn bytecode_challenge<F>(id: BytecodeReadRafChallenge) -> FieldInlineBytecodeExpr<F>
+where
+    F: RingCore,
+{
+    challenge(JoltChallengeId::from(id))
+}
+
+fn field_op_flag_spartan_outer(flag: FieldInlineOpFlag) -> FieldInlineOpeningId {
+    FieldInlineOpeningId::virtual_polynomial(
+        FieldInlineVirtualPolynomial::FieldOpFlag(flag),
+        FieldInlineRelationId::FieldRegistersSpartanOuter,
+    )
+}
+
+fn field_rs1_ra_read_write() -> FieldInlineOpeningId {
+    FieldInlineOpeningId::virtual_polynomial(
+        FieldInlineVirtualPolynomial::FieldRs1Ra,
+        FieldInlineRelationId::FieldRegistersReadWriteChecking,
+    )
+}
+
+fn field_rs2_ra_read_write() -> FieldInlineOpeningId {
+    FieldInlineOpeningId::virtual_polynomial(
+        FieldInlineVirtualPolynomial::FieldRs2Ra,
+        FieldInlineRelationId::FieldRegistersReadWriteChecking,
+    )
+}
+
+fn field_rd_wa_read_write() -> FieldInlineOpeningId {
+    FieldInlineOpeningId::virtual_polynomial(
+        FieldInlineVirtualPolynomial::FieldRdWa,
+        FieldInlineRelationId::FieldRegistersReadWriteChecking,
+    )
+}
+
+fn field_rd_wa_val_evaluation() -> FieldInlineOpeningId {
+    FieldInlineOpeningId::virtual_polynomial(
+        FieldInlineVirtualPolynomial::FieldRdWa,
+        FieldInlineRelationId::FieldRegistersValEvaluation,
+    )
+}
+
+#[cfg(test)]
+#[expect(clippy::panic)]
+mod tests {
+    use jolt_field::{Fr, FromPrimitiveInt};
+    use jolt_poly::EqPolynomial;
+
+    use super::*;
+
+    #[test]
+    fn input_extension_uses_field_inline_openings_and_bytecode_challenges() {
+        let expr = read_raf_input_extension::<Fr>();
+        assert_eq!(expr.required_openings(), read_raf_input_openings().to_vec());
+        assert_eq!(
+            expr.required_challenges(),
+            vec![
+                JoltChallengeId::from(BytecodeReadRafChallenge::Stage1Gamma),
+                JoltChallengeId::from(BytecodeReadRafChallenge::Gamma),
+                JoltChallengeId::from(BytecodeReadRafChallenge::Stage4Gamma),
+                JoltChallengeId::from(BytecodeReadRafChallenge::Stage5Gamma),
+            ]
+        );
+    }
+
+    #[test]
+    fn read_raf_register_eq_evals_builds_field_register_address_tables() {
+        let read_write = vec![Fr::from_u64(2), Fr::from_u64(3)];
+        let val_evaluation = vec![Fr::from_u64(5), Fr::from_u64(7)];
+        let eq = read_raf_register_eq_evals(&read_write, &val_evaluation);
+
+        assert_eq!(
+            eq,
+            FieldInlineBytecodeReadRafRegisterEqEvals {
+                read_write: EqPolynomial::<Fr>::evals(&read_write, None),
+                val_evaluation: EqPolynomial::<Fr>::evals(&val_evaluation, None),
+            }
+        );
+    }
+
+    #[test]
+    fn read_raf_stage_values_match_field_row_formula() {
+        let rows = vec![
+            FieldInlineBytecodeRow {
+                operands: FieldInlineBytecodeOperands {
+                    rd: Some(1),
+                    rs1: Some(2),
+                    rs2: Some(3),
+                },
+                flags: FieldInlineBytecodeFlags {
+                    mul: true,
+                    ..FieldInlineBytecodeFlags::default()
+                },
+            },
+            FieldInlineBytecodeRow::default(),
+        ];
+        let read_write_point = vec![Fr::from_u64(2); 4];
+        let val_evaluation_point = vec![Fr::from_u64(3); 4];
+        let stage1_gammas = (0..FIELD_INLINE_BYTECODE_STAGE1_GAMMA_COUNT)
+            .map(|value| Fr::from_u64(value as u64 + 1))
+            .collect::<Vec<_>>();
+        let stage4_gammas = (0..FIELD_INLINE_BYTECODE_STAGE4_GAMMA_COUNT)
+            .map(|value| Fr::from_u64(value as u64 + 11))
+            .collect::<Vec<_>>();
+        let stage5_gammas = (0..=2 + LookupTableKind::<XLEN>::COUNT)
+            .map(|value| Fr::from_u64(value as u64 + 17))
+            .collect::<Vec<_>>();
+        let register_eq = read_raf_register_eq_evals(&read_write_point, &val_evaluation_point);
+
+        let stage_values = read_raf_stage_values(FieldInlineBytecodeReadRafStageValueInputs {
+            bytecode: &rows,
+            field_register_read_write_point: &read_write_point,
+            field_register_val_evaluation_point: &val_evaluation_point,
+            stage1_gammas: &stage1_gammas,
+            stage4_gammas: &stage4_gammas,
+            stage5_gammas: &stage5_gammas,
+        });
+        let expected = rows
+            .iter()
+            .map(|row| {
+                read_raf_row_values(
+                    row,
+                    &register_eq.read_write,
+                    &register_eq.val_evaluation,
+                    &stage1_gammas,
+                    &stage4_gammas,
+                    &stage5_gammas,
+                )
+            })
+            .collect::<Vec<_>>();
+
+        assert_eq!(stage_values, expected);
+    }
+
+    #[test]
+    fn public_values_evaluate_field_rows() {
+        let rows = vec![
+            FieldInlineBytecodeRow {
+                operands: FieldInlineBytecodeOperands {
+                    rd: Some(1),
+                    rs1: Some(2),
+                    rs2: Some(3),
+                },
+                flags: FieldInlineBytecodeFlags {
+                    mul: true,
+                    ..FieldInlineBytecodeFlags::default()
+                },
+            },
+            FieldInlineBytecodeRow::default(),
+        ];
+        let stage1_gammas = (0..FIELD_INLINE_BYTECODE_STAGE1_GAMMA_COUNT)
+            .map(|value| Fr::from_u64(value as u64))
+            .collect::<Vec<_>>();
+        let stage4_gammas = (0..FIELD_INLINE_BYTECODE_STAGE4_GAMMA_COUNT)
+            .map(|value| Fr::from_u64(value as u64))
+            .collect::<Vec<_>>();
+        let stage5_gammas = (0..=2 + LookupTableKind::<XLEN>::COUNT)
+            .map(|value| Fr::from_u64(value as u64))
+            .collect::<Vec<_>>();
+        let zero_scalar = Fr::from_u64(0);
+        let zero = vec![zero_scalar];
+        let zero_point = [zero_scalar; 4];
+
+        let values = read_raf_public_values(FieldInlineBytecodeReadRafEvaluationInputs {
+            bytecode: &rows,
+            field_register_log_k: 4,
+            r_address: &[zero_scalar],
+            r_cycle: &[zero_scalar],
+            stage1_cycle_point: &zero,
+            field_register_read_write_point: &zero_point,
+            field_register_read_write_cycle_point: &zero,
+            field_register_val_evaluation_point: &zero_point,
+            field_register_val_evaluation_cycle_point: &zero,
+            stage1_gammas: &stage1_gammas,
+            stage4_gammas: &stage4_gammas,
+            stage5_gammas: &stage5_gammas,
+        })
+        .unwrap_or_else(|error| panic!("field bytecode public values should evaluate: {error}"));
+
+        assert_eq!(
+            values.stage_values[0],
+            stage1_gammas[2 + NUM_CIRCUIT_FLAGS + 2]
+        );
+        assert_eq!(values.stage_values[3], zero_scalar);
+        assert_eq!(values.stage_values[4], zero_scalar);
+    }
+
+    #[test]
+    fn merge_read_raf_public_values_adds_field_stage_values() {
+        let mut public_values = jolt_bytecode::BytecodeReadRafPublicValues {
+            stage_values: [
+                Fr::from_u64(2),
+                Fr::from_u64(3),
+                Fr::from_u64(5),
+                Fr::from_u64(7),
+                Fr::from_u64(11),
+            ],
+            spartan_outer_raf: Fr::from_u64(13),
+            spartan_shift_raf: Fr::from_u64(17),
+            entry: Fr::from_u64(19),
+        };
+        let field_values = FieldInlineBytecodeReadRafPublicValues {
+            stage_values: [
+                Fr::from_u64(23),
+                Fr::from_u64(29),
+                Fr::from_u64(31),
+                Fr::from_u64(37),
+                Fr::from_u64(41),
+            ],
+        };
+
+        merge_read_raf_public_values(&mut public_values, field_values);
+
+        assert_eq!(
+            public_values.stage_values,
+            [
+                Fr::from_u64(25),
+                Fr::from_u64(32),
+                Fr::from_u64(36),
+                Fr::from_u64(44),
+                Fr::from_u64(52),
+            ]
+        );
+        assert_eq!(public_values.spartan_outer_raf, Fr::from_u64(13));
+        assert_eq!(public_values.spartan_shift_raf, Fr::from_u64(17));
+        assert_eq!(public_values.entry, Fr::from_u64(19));
+    }
+
+    #[test]
+    fn rejects_missing_operands_for_active_field_row() {
+        let rows = [FieldInlineBytecodeRow {
+            flags: FieldInlineBytecodeFlags {
+                mul: true,
+                ..FieldInlineBytecodeFlags::default()
+            },
+            ..FieldInlineBytecodeRow::default()
+        }];
+
+        assert!(matches!(
+            validate_bytecode_rows(&rows, 1, 4),
+            Err(FieldInlineBytecodeValidationError::InvalidOperands {
+                row: 0,
+                flag: FieldInlineOpFlag::Mul,
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn rejects_out_of_range_field_register_operand() {
+        let rows = [FieldInlineBytecodeRow {
+            operands: FieldInlineBytecodeOperands {
+                rd: Some(16),
+                ..FieldInlineBytecodeOperands::default()
+            },
+            flags: FieldInlineBytecodeFlags {
+                load_imm: true,
+                ..FieldInlineBytecodeFlags::default()
+            },
+        }];
+
+        assert!(matches!(
+            validate_bytecode_rows(&rows, 1, 4),
+            Err(FieldInlineBytecodeValidationError::RegisterOutOfRange {
+                row: 0,
+                operand: "rd",
+                register: 16,
+                field_register_count: 16
+            })
+        ));
+    }
+
+    #[test]
+    fn transcript_bytes_bind_field_bytecode_payload() {
+        let mut rows = vec![FieldInlineBytecodeRow {
+            operands: FieldInlineBytecodeOperands {
+                rd: Some(1),
+                ..FieldInlineBytecodeOperands::default()
+            },
+            flags: FieldInlineBytecodeFlags {
+                load_imm: true,
+                ..FieldInlineBytecodeFlags::default()
+            },
+        }];
+        let original = bytecode_transcript_bytes(&rows, 4);
+        rows[0].operands.rd = Some(2);
+
+        assert_ne!(original, bytecode_transcript_bytes(&rows, 4));
+    }
+}

--- a/crates/jolt-claims/src/protocols/field_inline/formulas/dimensions.rs
+++ b/crates/jolt-claims/src/protocols/field_inline/formulas/dimensions.rs
@@ -1,4 +1,7 @@
+use jolt_field::Field;
 use serde::{Deserialize, Serialize};
+
+use crate::protocols::jolt::formulas::dimensions::JoltFormulaPointError;
 
 pub const FIELD_REGISTERS_ADDRESS_BITS: usize = super::super::FIELD_REGISTERS_LOG_K;
 
@@ -75,4 +78,61 @@ impl FieldRegistersReadWriteDimensions {
     pub const fn read_write_sumcheck(self) -> FieldInlineSumcheckSpec {
         FieldInlineSumcheckSpec::boolean(self.log_t + self.log_k, 3)
     }
+
+    pub fn read_write_opening_point<F: Field>(
+        self,
+        challenges: &[F],
+    ) -> Result<FieldRegistersReadWriteOpeningPoint<F>, JoltFormulaPointError> {
+        self.validate_phase_split()?;
+        let expected = self.log_t + self.log_k;
+        if challenges.len() != expected {
+            return Err(JoltFormulaPointError::ChallengeLengthMismatch {
+                expected,
+                got: challenges.len(),
+            });
+        }
+
+        let (phase1, rest) = challenges.split_at(self.phase1_num_rounds);
+        let (phase2, rest) = rest.split_at(self.phase2_num_rounds);
+        let (phase3_cycle, phase3_address) = rest.split_at(self.log_t - self.phase1_num_rounds);
+
+        let r_cycle = phase3_cycle
+            .iter()
+            .rev()
+            .copied()
+            .chain(phase1.iter().rev().copied())
+            .collect::<Vec<_>>();
+        let r_address = phase3_address
+            .iter()
+            .rev()
+            .copied()
+            .chain(phase2.iter().rev().copied())
+            .collect::<Vec<_>>();
+        let opening_point = [r_address.as_slice(), r_cycle.as_slice()].concat();
+
+        Ok(FieldRegistersReadWriteOpeningPoint {
+            r_address,
+            r_cycle,
+            opening_point,
+        })
+    }
+
+    const fn validate_phase_split(self) -> Result<(), JoltFormulaPointError> {
+        if self.phase1_num_rounds > self.log_t || self.phase2_num_rounds > self.log_k {
+            return Err(JoltFormulaPointError::InvalidReadWritePhaseSplit {
+                phase1_num_rounds: self.phase1_num_rounds,
+                log_t: self.log_t,
+                phase2_num_rounds: self.phase2_num_rounds,
+                log_k: self.log_k,
+            });
+        }
+        Ok(())
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct FieldRegistersReadWriteOpeningPoint<F: Field> {
+    pub r_address: Vec<F>,
+    pub r_cycle: Vec<F>,
+    pub opening_point: Vec<F>,
 }

--- a/crates/jolt-claims/src/protocols/field_inline/formulas/mod.rs
+++ b/crates/jolt-claims/src/protocols/field_inline/formulas/mod.rs
@@ -1,4 +1,6 @@
+pub mod bytecode;
 pub mod claim_reductions;
 pub mod dimensions;
 pub mod product;
 pub mod registers;
+pub mod spartan;

--- a/crates/jolt-claims/src/protocols/field_inline/formulas/product.rs
+++ b/crates/jolt-claims/src/protocols/field_inline/formulas/product.rs
@@ -34,9 +34,57 @@ pub fn field_product_output_openings() -> [FieldInlineOpeningId; 2] {
     [field_rs1_value_product(), field_rs2_value_product()]
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum FieldRegistersProductLane {
+    Product,
+    InverseProduct,
+}
+
+impl FieldRegistersProductLane {
+    pub fn input_opening(self) -> FieldInlineOpeningId {
+        match self {
+            Self::Product => field_product_opening(),
+            Self::InverseProduct => field_inv_product_opening(),
+        }
+    }
+
+    pub fn factor_openings(self) -> [FieldInlineOpeningId; 2] {
+        match self {
+            Self::Product => [field_rs1_value_product(), field_rs2_value_product()],
+            Self::InverseProduct => [field_rs1_value_product(), field_rd_value_product()],
+        }
+    }
+}
+
+pub const fn selected_product_lanes() -> [FieldRegistersProductLane; 2] {
+    [
+        FieldRegistersProductLane::Product,
+        FieldRegistersProductLane::InverseProduct,
+    ]
+}
+
+pub fn selected_product_uniskip_input_openings() -> [FieldInlineOpeningId; 2] {
+    selected_product_lanes().map(FieldRegistersProductLane::input_opening)
+}
+
+pub fn selected_product_remainder_output_openings() -> [FieldInlineOpeningId; 3] {
+    [
+        field_rs1_value_product(),
+        field_rs2_value_product(),
+        field_rd_value_product(),
+    ]
+}
+
 fn field_product_opening() -> FieldInlineOpeningId {
     FieldInlineOpeningId::virtual_polynomial(
         FieldInlineVirtualPolynomial::FieldProduct,
+        FieldInlineRelationId::FieldRegistersProduct,
+    )
+}
+
+fn field_inv_product_opening() -> FieldInlineOpeningId {
+    FieldInlineOpeningId::virtual_polynomial(
+        FieldInlineVirtualPolynomial::FieldInvProduct,
         FieldInlineRelationId::FieldRegistersProduct,
     )
 }
@@ -51,6 +99,13 @@ fn field_rs1_value_product() -> FieldInlineOpeningId {
 fn field_rs2_value_product() -> FieldInlineOpeningId {
     FieldInlineOpeningId::virtual_polynomial(
         FieldInlineVirtualPolynomial::FieldRs2Value,
+        FieldInlineRelationId::FieldRegistersProduct,
+    )
+}
+
+fn field_rd_value_product() -> FieldInlineOpeningId {
+    FieldInlineOpeningId::virtual_polynomial(
+        FieldInlineVirtualPolynomial::FieldRdValue,
         FieldInlineRelationId::FieldRegistersProduct,
     )
 }
@@ -81,6 +136,25 @@ mod tests {
         assert!(claims.required_challenges().is_empty());
         assert!(claims.required_publics().is_empty());
         assert_eq!(claims.num_challenges(), 0);
+        assert_eq!(
+            selected_product_uniskip_input_openings(),
+            [field_product_opening(), field_inv_product_opening()]
+        );
+        assert_eq!(
+            selected_product_lanes().map(FieldRegistersProductLane::factor_openings),
+            [
+                [field_rs1_value_product(), field_rs2_value_product()],
+                [field_rs1_value_product(), field_rd_value_product()],
+            ]
+        );
+        assert_eq!(
+            selected_product_remainder_output_openings(),
+            [
+                field_rs1_value_product(),
+                field_rs2_value_product(),
+                field_rd_value_product(),
+            ]
+        );
     }
 
     #[test]

--- a/crates/jolt-claims/src/protocols/field_inline/formulas/spartan.rs
+++ b/crates/jolt-claims/src/protocols/field_inline/formulas/spartan.rs
@@ -1,0 +1,89 @@
+use super::super::{
+    FieldInlineOpFlag, FieldInlineOpeningId, FieldInlineRelationId, FieldInlineVirtualPolynomial,
+};
+
+pub const FIELD_INLINE_SPARTAN_OUTER_R1CS_INPUTS: [FieldInlineVirtualPolynomial; 13] = [
+    FieldInlineVirtualPolynomial::FieldRs1Value,
+    FieldInlineVirtualPolynomial::FieldRs2Value,
+    FieldInlineVirtualPolynomial::FieldRdValue,
+    FieldInlineVirtualPolynomial::FieldProduct,
+    FieldInlineVirtualPolynomial::FieldInvProduct,
+    FieldInlineVirtualPolynomial::FieldOpFlag(FieldInlineOpFlag::Add),
+    FieldInlineVirtualPolynomial::FieldOpFlag(FieldInlineOpFlag::Sub),
+    FieldInlineVirtualPolynomial::FieldOpFlag(FieldInlineOpFlag::Mul),
+    FieldInlineVirtualPolynomial::FieldOpFlag(FieldInlineOpFlag::Inv),
+    FieldInlineVirtualPolynomial::FieldOpFlag(FieldInlineOpFlag::AssertEq),
+    FieldInlineVirtualPolynomial::FieldOpFlag(FieldInlineOpFlag::LoadFromX),
+    FieldInlineVirtualPolynomial::FieldOpFlag(FieldInlineOpFlag::StoreToX),
+    FieldInlineVirtualPolynomial::FieldOpFlag(FieldInlineOpFlag::LoadImm),
+];
+
+pub const FIELD_INLINE_SPARTAN_OUTER_R1CS_INPUT_COUNT: usize =
+    FIELD_INLINE_SPARTAN_OUTER_R1CS_INPUTS.len();
+
+pub fn outer_opening(polynomial: FieldInlineVirtualPolynomial) -> FieldInlineOpeningId {
+    FieldInlineOpeningId::virtual_polynomial(
+        polynomial,
+        FieldInlineRelationId::FieldRegistersSpartanOuter,
+    )
+}
+
+pub fn outer_output_openings() -> [FieldInlineOpeningId; FIELD_INLINE_SPARTAN_OUTER_R1CS_INPUT_COUNT]
+{
+    [
+        outer_opening(FieldInlineVirtualPolynomial::FieldRs1Value),
+        outer_opening(FieldInlineVirtualPolynomial::FieldRs2Value),
+        outer_opening(FieldInlineVirtualPolynomial::FieldRdValue),
+        outer_opening(FieldInlineVirtualPolynomial::FieldProduct),
+        outer_opening(FieldInlineVirtualPolynomial::FieldInvProduct),
+        outer_opening(FieldInlineVirtualPolynomial::FieldOpFlag(
+            FieldInlineOpFlag::Add,
+        )),
+        outer_opening(FieldInlineVirtualPolynomial::FieldOpFlag(
+            FieldInlineOpFlag::Sub,
+        )),
+        outer_opening(FieldInlineVirtualPolynomial::FieldOpFlag(
+            FieldInlineOpFlag::Mul,
+        )),
+        outer_opening(FieldInlineVirtualPolynomial::FieldOpFlag(
+            FieldInlineOpFlag::Inv,
+        )),
+        outer_opening(FieldInlineVirtualPolynomial::FieldOpFlag(
+            FieldInlineOpFlag::AssertEq,
+        )),
+        outer_opening(FieldInlineVirtualPolynomial::FieldOpFlag(
+            FieldInlineOpFlag::LoadFromX,
+        )),
+        outer_opening(FieldInlineVirtualPolynomial::FieldOpFlag(
+            FieldInlineOpFlag::StoreToX,
+        )),
+        outer_opening(FieldInlineVirtualPolynomial::FieldOpFlag(
+            FieldInlineOpFlag::LoadImm,
+        )),
+    ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn spartan_outer_openings_follow_input_order() {
+        let openings = outer_output_openings();
+        assert_eq!(openings.len(), FIELD_INLINE_SPARTAN_OUTER_R1CS_INPUT_COUNT);
+
+        let expected = FIELD_INLINE_SPARTAN_OUTER_R1CS_INPUTS
+            .into_iter()
+            .map(outer_opening)
+            .collect::<Vec<_>>();
+        assert_eq!(openings.to_vec(), expected);
+    }
+
+    #[test]
+    fn spartan_outer_openings_use_field_registers_relation() {
+        for opening in outer_output_openings() {
+            let FieldInlineOpeningId::Polynomial { relation, .. } = opening;
+            assert_eq!(relation, FieldInlineRelationId::FieldRegistersSpartanOuter);
+        }
+    }
+}

--- a/crates/jolt-claims/src/protocols/field_inline/ids.rs
+++ b/crates/jolt-claims/src/protocols/field_inline/ids.rs
@@ -49,15 +49,29 @@ pub enum FieldInlineCommittedPolynomial {
 }
 
 #[derive(Hash, PartialEq, Eq, Copy, Clone, Debug, PartialOrd, Ord, Serialize, Deserialize)]
+pub enum FieldInlineOpFlag {
+    Add,
+    Sub,
+    Mul,
+    Inv,
+    AssertEq,
+    LoadFromX,
+    StoreToX,
+    LoadImm,
+}
+
+#[derive(Hash, PartialEq, Eq, Copy, Clone, Debug, PartialOrd, Ord, Serialize, Deserialize)]
 pub enum FieldInlineVirtualPolynomial {
     FieldRs1Value,
     FieldRs2Value,
     FieldRdValue,
     FieldProduct,
+    FieldInvProduct,
     FieldRs1Ra,
     FieldRs2Ra,
     FieldRdWa,
     FieldRegistersVal,
+    FieldOpFlag(FieldInlineOpFlag),
 }
 
 #[derive(

--- a/crates/jolt-claims/src/protocols/field_inline/mod.rs
+++ b/crates/jolt-claims/src/protocols/field_inline/mod.rs
@@ -6,11 +6,12 @@ mod relation;
 
 pub use config::{FieldInlineConfig, FieldInlineRepresentation, FIELD_REGISTERS_LOG_K};
 pub use formulas::dimensions::{
-    FieldInlineSumcheckSpec, FieldRegistersReadWriteDimensions, FieldRegistersTraceDimensions,
+    FieldInlineSumcheckSpec, FieldRegistersReadWriteDimensions,
+    FieldRegistersReadWriteOpeningPoint, FieldRegistersTraceDimensions,
 };
 pub use ids::{
-    FieldInlineChallengeId, FieldInlineCommittedPolynomial, FieldInlineOpeningId,
-    FieldInlinePolynomialId, FieldInlinePublicId, FieldInlineRelationId,
+    FieldInlineChallengeId, FieldInlineCommittedPolynomial, FieldInlineOpFlag,
+    FieldInlineOpeningId, FieldInlinePolynomialId, FieldInlinePublicId, FieldInlineRelationId,
     FieldInlineVirtualPolynomial, FieldRegistersClaimReductionChallenge,
     FieldRegistersIncClaimReductionChallenge, FieldRegistersIncClaimReductionPublic,
     FieldRegistersReadWriteChallenge, FieldRegistersValEvaluationChallenge,

--- a/crates/jolt-claims/src/protocols/jolt/formulas/booleanity.rs
+++ b/crates/jolt-claims/src/protocols/jolt/formulas/booleanity.rs
@@ -5,7 +5,7 @@ use crate::{challenge, opening, public};
 
 use super::super::{
     BooleanityChallenge, BooleanityPublic, JoltChallengeId, JoltExpr, JoltOpeningId, JoltPublicId,
-    JoltRelationClaims, JoltRelationId,
+    JoltRelationClaims, JoltRelationId, JoltVirtualPolynomial,
 };
 use super::dimensions::{JoltFormulaPointError, JoltSumcheckSpec};
 use super::ra::{JoltRaPolynomial, JoltRaPolynomialLayout};
@@ -28,6 +28,14 @@ impl BooleanityDimensions {
 
     pub const fn sumcheck(self) -> JoltSumcheckSpec {
         JoltSumcheckSpec::boolean(self.log_t + self.log_k_chunk, 3)
+    }
+
+    pub const fn address_sumcheck(self) -> JoltSumcheckSpec {
+        JoltSumcheckSpec::boolean(self.log_k_chunk, 3)
+    }
+
+    pub const fn cycle_sumcheck(self) -> JoltSumcheckSpec {
+        JoltSumcheckSpec::boolean(self.log_t, 3)
     }
 
     pub fn opening_point<F: Field>(
@@ -66,6 +74,44 @@ pub fn booleanity<F>(dimensions: BooleanityDimensions) -> JoltRelationClaims<F>
 where
     F: RingCore,
 {
+    JoltRelationClaims::new(
+        JoltRelationId::Booleanity,
+        dimensions.sumcheck(),
+        JoltExpr::zero(),
+        booleanity_cycle_output(dimensions),
+    )
+    .with_input_challenges([JoltChallengeId::from(BooleanityChallenge::Gamma)])
+}
+
+pub fn booleanity_address_phase<F>(dimensions: BooleanityDimensions) -> JoltRelationClaims<F>
+where
+    F: RingCore,
+{
+    JoltRelationClaims::new(
+        JoltRelationId::Booleanity,
+        dimensions.address_sumcheck(),
+        JoltExpr::zero(),
+        opening(booleanity_address_phase_opening()),
+    )
+}
+
+pub fn booleanity_cycle_phase<F>(dimensions: BooleanityDimensions) -> JoltRelationClaims<F>
+where
+    F: RingCore,
+{
+    JoltRelationClaims::new(
+        JoltRelationId::Booleanity,
+        dimensions.cycle_sumcheck(),
+        opening(booleanity_address_phase_opening()),
+        booleanity_cycle_output(dimensions),
+    )
+    .with_input_challenges([JoltChallengeId::from(BooleanityChallenge::Gamma)])
+}
+
+fn booleanity_cycle_output<F>(dimensions: BooleanityDimensions) -> JoltExpr<F>
+where
+    F: RingCore,
+{
     let gamma = booleanity_challenge(BooleanityChallenge::Gamma);
     let eq_address_cycle = booleanity_public(BooleanityPublic::EqAddressCycle);
     let mut output = JoltExpr::zero();
@@ -78,13 +124,7 @@ where
         output = output + gamma.clone().pow(2 * i) * (ra.clone() * ra.clone() - ra);
     }
 
-    JoltRelationClaims::new(
-        JoltRelationId::Booleanity,
-        dimensions.sumcheck(),
-        JoltExpr::zero(),
-        eq_address_cycle * output,
-    )
-    .with_input_challenges([JoltChallengeId::from(BooleanityChallenge::Gamma)])
+    eq_address_cycle * output
 }
 
 fn booleanity_challenge<F>(id: BooleanityChallenge) -> JoltExpr<F>
@@ -103,6 +143,13 @@ where
 
 pub fn booleanity_output_openings(layout: JoltRaPolynomialLayout) -> Vec<JoltOpeningId> {
     layout.openings(JoltRelationId::Booleanity).collect()
+}
+
+pub fn booleanity_address_phase_opening() -> JoltOpeningId {
+    JoltOpeningId::virtual_polynomial(
+        JoltVirtualPolynomial::BooleanityAddrClaim,
+        JoltRelationId::Booleanity,
+    )
 }
 
 pub fn eq_address_cycle_polynomial<F>(

--- a/crates/jolt-claims/src/protocols/jolt/formulas/booleanity.rs
+++ b/crates/jolt-claims/src/protocols/jolt/formulas/booleanity.rs
@@ -1,13 +1,14 @@
 use jolt_field::{Field, RingCore};
+use jolt_poly::{EqPolynomial, Polynomial};
 
 use crate::{challenge, opening, public};
 
 use super::super::{
     BooleanityChallenge, BooleanityPublic, JoltChallengeId, JoltExpr, JoltOpeningId, JoltPublicId,
-    JoltRelationClaims, JoltRelationId, JoltVirtualPolynomial,
+    JoltRelationClaims, JoltRelationId,
 };
 use super::dimensions::{JoltFormulaPointError, JoltSumcheckSpec};
-use super::ra::JoltRaPolynomialLayout;
+use super::ra::{JoltRaPolynomial, JoltRaPolynomialLayout};
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct BooleanityDimensions {
@@ -27,14 +28,6 @@ impl BooleanityDimensions {
 
     pub const fn sumcheck(self) -> JoltSumcheckSpec {
         JoltSumcheckSpec::boolean(self.log_t + self.log_k_chunk, 3)
-    }
-
-    pub const fn address_sumcheck(self) -> JoltSumcheckSpec {
-        JoltSumcheckSpec::boolean(self.log_k_chunk, 3)
-    }
-
-    pub const fn cycle_sumcheck(self) -> JoltSumcheckSpec {
-        JoltSumcheckSpec::boolean(self.log_t, 3)
     }
 
     pub fn opening_point<F: Field>(
@@ -73,44 +66,6 @@ pub fn booleanity<F>(dimensions: BooleanityDimensions) -> JoltRelationClaims<F>
 where
     F: RingCore,
 {
-    JoltRelationClaims::new(
-        JoltRelationId::Booleanity,
-        dimensions.sumcheck(),
-        JoltExpr::zero(),
-        booleanity_cycle_output(dimensions),
-    )
-    .with_input_challenges([JoltChallengeId::from(BooleanityChallenge::Gamma)])
-}
-
-pub fn booleanity_address_phase<F>(dimensions: BooleanityDimensions) -> JoltRelationClaims<F>
-where
-    F: RingCore,
-{
-    JoltRelationClaims::new(
-        JoltRelationId::Booleanity,
-        dimensions.address_sumcheck(),
-        JoltExpr::zero(),
-        opening(booleanity_address_phase_opening()),
-    )
-}
-
-pub fn booleanity_cycle_phase<F>(dimensions: BooleanityDimensions) -> JoltRelationClaims<F>
-where
-    F: RingCore,
-{
-    JoltRelationClaims::new(
-        JoltRelationId::Booleanity,
-        dimensions.cycle_sumcheck(),
-        opening(booleanity_address_phase_opening()),
-        booleanity_cycle_output(dimensions),
-    )
-    .with_input_challenges([JoltChallengeId::from(BooleanityChallenge::Gamma)])
-}
-
-fn booleanity_cycle_output<F>(dimensions: BooleanityDimensions) -> JoltExpr<F>
-where
-    F: RingCore,
-{
     let gamma = booleanity_challenge(BooleanityChallenge::Gamma);
     let eq_address_cycle = booleanity_public(BooleanityPublic::EqAddressCycle);
     let mut output = JoltExpr::zero();
@@ -123,7 +78,13 @@ where
         output = output + gamma.clone().pow(2 * i) * (ra.clone() * ra.clone() - ra);
     }
 
-    eq_address_cycle * output
+    JoltRelationClaims::new(
+        JoltRelationId::Booleanity,
+        dimensions.sumcheck(),
+        JoltExpr::zero(),
+        eq_address_cycle * output,
+    )
+    .with_input_challenges([JoltChallengeId::from(BooleanityChallenge::Gamma)])
 }
 
 fn booleanity_challenge<F>(id: BooleanityChallenge) -> JoltExpr<F>
@@ -144,11 +105,89 @@ pub fn booleanity_output_openings(layout: JoltRaPolynomialLayout) -> Vec<JoltOpe
     layout.openings(JoltRelationId::Booleanity).collect()
 }
 
-pub fn booleanity_address_phase_opening() -> JoltOpeningId {
-    JoltOpeningId::virtual_polynomial(
-        JoltVirtualPolynomial::BooleanityAddrClaim,
-        JoltRelationId::Booleanity,
-    )
+pub fn eq_address_cycle_polynomial<F>(
+    reference_address: &[F],
+    reference_cycle: &[F],
+) -> Polynomial<F>
+where
+    F: Field,
+{
+    let eq_point = reference_address
+        .iter()
+        .rev()
+        .chain(reference_cycle.iter().rev())
+        .copied()
+        .collect::<Vec<_>>();
+    Polynomial::new(EqPolynomial::<F>::evals(&eq_point, None))
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct BooleanityRelationState<F: Field> {
+    eq_address_cycle: Polynomial<F>,
+    ra: Vec<Polynomial<F>>,
+    gamma_squared: F,
+}
+
+impl<F: Field> BooleanityRelationState<F> {
+    pub fn new(eq_address_cycle: Polynomial<F>, ra: Vec<Polynomial<F>>, gamma_squared: F) -> Self {
+        Self {
+            eq_address_cycle,
+            ra,
+            gamma_squared,
+        }
+    }
+
+    pub fn bind(&mut self, challenge: F) {
+        self.eq_address_cycle.bind(challenge);
+        for polynomial in &mut self.ra {
+            polynomial.bind(challenge);
+        }
+    }
+
+    pub fn round_rows(&self) -> usize {
+        self.eq_address_cycle.len() / 2
+    }
+
+    pub fn round_eval(&self, index: usize, point: F) -> F {
+        let eq = self.eq_address_cycle.sumcheck_round_eval(index, point);
+        let mut coeff = F::one();
+        let mut output = F::zero();
+        for polynomial in &self.ra {
+            let value = polynomial.sumcheck_round_eval(index, point);
+            output += coeff * (value * value - value);
+            coeff *= self.gamma_squared;
+        }
+        eq * output
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct BooleanityOutputOpeningGroups {
+    pub instruction_ra: Vec<JoltOpeningId>,
+    pub bytecode_ra: Vec<JoltOpeningId>,
+    pub ram_ra: Vec<JoltOpeningId>,
+}
+
+impl BooleanityOutputOpeningGroups {
+    pub fn total_len(&self) -> usize {
+        self.instruction_ra.len() + self.bytecode_ra.len() + self.ram_ra.len()
+    }
+}
+
+pub fn booleanity_output_opening_groups(
+    layout: JoltRaPolynomialLayout,
+) -> BooleanityOutputOpeningGroups {
+    BooleanityOutputOpeningGroups {
+        instruction_ra: (0..layout.instruction())
+            .map(|index| JoltRaPolynomial::Instruction(index).opening(JoltRelationId::Booleanity))
+            .collect(),
+        bytecode_ra: (0..layout.bytecode())
+            .map(|index| JoltRaPolynomial::Bytecode(index).opening(JoltRelationId::Booleanity))
+            .collect(),
+        ram_ra: (0..layout.ram())
+            .map(|index| JoltRaPolynomial::Ram(index).opening(JoltRelationId::Booleanity))
+            .collect(),
+    }
 }
 
 #[cfg(test)]
@@ -157,6 +196,7 @@ mod tests {
     use super::super::dimensions::JoltFormulaDimensionsError;
     use super::*;
     use jolt_field::{Fr, FromPrimitiveInt};
+    use jolt_poly::EqPolynomial;
 
     fn layout(
         instruction: usize,
@@ -200,6 +240,101 @@ mod tests {
         );
         assert_eq!(claims.num_challenges(), 1);
         Ok(())
+    }
+
+    #[test]
+    fn booleanity_groups_output_openings_by_ra_family() -> Result<(), JoltFormulaDimensionsError> {
+        let layout = layout(2, 1, 2)?;
+        let groups = booleanity_output_opening_groups(layout);
+
+        assert_eq!(groups.instruction_ra.len(), 2);
+        assert_eq!(groups.bytecode_ra.len(), 1);
+        assert_eq!(groups.ram_ra.len(), 2);
+        assert_eq!(groups.total_len(), 5);
+        assert_eq!(
+            groups
+                .instruction_ra
+                .iter()
+                .chain(&groups.bytecode_ra)
+                .chain(&groups.ram_ra)
+                .copied()
+                .collect::<Vec<_>>(),
+            booleanity_output_openings(layout)
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn eq_address_cycle_polynomial_reverses_address_then_cycle() {
+        let address = vec![Fr::from_u64(2), Fr::from_u64(3)];
+        let cycle = vec![Fr::from_u64(5), Fr::from_u64(7), Fr::from_u64(11)];
+        let eq_point = vec![
+            Fr::from_u64(3),
+            Fr::from_u64(2),
+            Fr::from_u64(11),
+            Fr::from_u64(7),
+            Fr::from_u64(5),
+        ];
+
+        assert_eq!(
+            eq_address_cycle_polynomial(&address, &cycle).evals(),
+            EqPolynomial::<Fr>::evals(&eq_point, None)
+        );
+    }
+
+    #[test]
+    fn booleanity_relation_state_evaluates_eq_weighted_bitness_terms() {
+        let point = Fr::from_u64(7);
+        let eq_address_cycle = Polynomial::new(vec![Fr::from_u64(2), Fr::from_u64(3)]);
+        let ra = vec![
+            Polynomial::new(vec![Fr::from_u64(5), Fr::from_u64(11)]),
+            Polynomial::new(vec![Fr::from_u64(13), Fr::from_u64(17)]),
+            Polynomial::new(vec![Fr::from_u64(19), Fr::from_u64(23)]),
+        ];
+        let gamma_squared = Fr::from_u64(29);
+        let expected = eq_address_cycle.sumcheck_round_eval(0, point)
+            * ra.iter()
+                .scan(Fr::from_u64(1), |coeff, polynomial| {
+                    let value = polynomial.sumcheck_round_eval(0, point);
+                    let term = *coeff * (value * value - value);
+                    *coeff *= gamma_squared;
+                    Some(term)
+                })
+                .sum::<Fr>();
+
+        let state = BooleanityRelationState::new(eq_address_cycle, ra, gamma_squared);
+
+        assert_eq!(state.round_rows(), 1);
+        assert_eq!(state.round_eval(0, point), expected);
+    }
+
+    #[test]
+    fn booleanity_relation_state_binds_all_polynomials() {
+        let challenge = Fr::from_u64(31);
+        let mut eq_address_cycle =
+            Polynomial::new((0..4).map(|value| Fr::from_u64(value as u64 + 2)).collect());
+        let mut ra = vec![
+            Polynomial::new((0..4).map(|value| Fr::from_u64(value as u64 + 7)).collect()),
+            Polynomial::new(
+                (0..4)
+                    .map(|value| Fr::from_u64(value as u64 + 13))
+                    .collect(),
+            ),
+        ];
+        let gamma_squared = Fr::from_u64(19);
+        let mut state =
+            BooleanityRelationState::new(eq_address_cycle.clone(), ra.clone(), gamma_squared);
+
+        state.bind(challenge);
+        eq_address_cycle.bind(challenge);
+        for polynomial in &mut ra {
+            polynomial.bind(challenge);
+        }
+
+        assert_eq!(
+            state,
+            BooleanityRelationState::new(eq_address_cycle, ra, gamma_squared)
+        );
     }
 
     #[test]

--- a/crates/jolt-claims/src/protocols/jolt/formulas/bytecode.rs
+++ b/crates/jolt-claims/src/protocols/jolt/formulas/bytecode.rs
@@ -1,17 +1,20 @@
 use jolt_field::{Field, RingCore};
 use jolt_lookup_tables::{InstructionLookupTable, LookupTableKind, XLEN};
-use jolt_poly::{EqPolynomial, IdentityPolynomial, MultilinearEvaluation};
+use jolt_poly::{
+    boolean_index_msb, eq_index_msb, EqPolynomial, IdentityPolynomial, MultilinearEvaluation,
+    Polynomial,
+};
 use jolt_riscv::{
     instructions::Noop, CircuitFlags, Flags, InstructionFlags, InterleavedBitsMarker,
     JoltInstruction, JoltInstructionRow, CIRCUIT_FLAGS, NUM_CIRCUIT_FLAGS,
 };
 
-use crate::{challenge, opening, public};
+use crate::{challenge, opening, public, SameEvaluationAs};
 
 use super::super::{
     BytecodeReadRafChallenge, BytecodeReadRafPublic, JoltChallengeId, JoltCommittedPolynomial,
-    JoltConsistencyClaim, JoltExpr, JoltOpeningId, JoltPublicId, JoltRelationClaims,
-    JoltRelationId, JoltVirtualPolynomial,
+    JoltExpr, JoltOpeningId, JoltPublicId, JoltRelationClaims, JoltRelationId,
+    JoltVirtualPolynomial,
 };
 use super::claim_reductions::bytecode::NUM_BYTECODE_VAL_STAGES;
 use super::dimensions::{JoltFormulaPointError, JoltSumcheckSpec};
@@ -118,10 +121,9 @@ where
         JoltChallengeId::from(BytecodeReadRafChallenge::Stage4Gamma),
         JoltChallengeId::from(BytecodeReadRafChallenge::Stage5Gamma),
     ])
-    .with_consistency([JoltConsistencyClaim::same_evaluation(
-        unexpanded_pc_spartan_shift(),
-        unexpanded_pc_instruction_input(),
-    )])
+    .with_consistency([
+        unexpanded_pc_spartan_shift().same_evaluation_as(unexpanded_pc_instruction_input())
+    ])
 }
 
 pub fn read_raf_address_phase<F>(dimensions: BytecodeReadRafDimensions) -> JoltRelationClaims<F>
@@ -153,10 +155,9 @@ where
         JoltChallengeId::from(BytecodeReadRafChallenge::Stage4Gamma),
         JoltChallengeId::from(BytecodeReadRafChallenge::Stage5Gamma),
     ])
-    .with_consistency([JoltConsistencyClaim::same_evaluation(
-        unexpanded_pc_spartan_shift(),
-        unexpanded_pc_instruction_input(),
-    )])
+    .with_consistency([
+        unexpanded_pc_spartan_shift().same_evaluation_as(unexpanded_pc_instruction_input())
+    ])
 }
 
 pub fn read_raf_cycle_phase<F>(dimensions: BytecodeReadRafDimensions) -> JoltRelationClaims<F>
@@ -293,13 +294,6 @@ pub struct BytecodeReadRafOutputOpenings {
     pub bytecode_ra: Vec<JoltOpeningId>,
 }
 
-pub fn bytecode_read_raf_address_phase_opening() -> JoltOpeningId {
-    JoltOpeningId::virtual_polynomial(
-        JoltVirtualPolynomial::BytecodeReadRafAddrClaim,
-        JoltRelationId::BytecodeReadRaf,
-    )
-}
-
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct BytecodeReadRafPublicValues<F: Field> {
     pub stage_values: [F; 5],
@@ -423,6 +417,241 @@ pub struct BytecodeReadRafEvaluationInputs<'a, F> {
     pub stage5_gammas: &'a [F],
 }
 
+pub struct BytecodeReadRafBooleanEvaluationInputs<'a, F> {
+    pub bytecode: &'a [JoltInstructionRow],
+    pub r_address: &'a [F],
+    pub r_cycle: &'a [F],
+    pub stage_cycle_points: [&'a [F]; 5],
+    pub register_read_write_point: &'a [F],
+    pub register_val_evaluation_point: &'a [F],
+    pub entry_bytecode_index: usize,
+    pub stage1_gammas: &'a [F],
+    pub stage2_gammas: &'a [F],
+    pub stage3_gammas: &'a [F],
+    pub stage4_gammas: &'a [F],
+    pub stage5_gammas: &'a [F],
+}
+
+pub struct BytecodeReadRafStageValueInputs<'a, F> {
+    pub bytecode: &'a [JoltInstructionRow],
+    pub register_read_write_point: &'a [F],
+    pub register_val_evaluation_point: &'a [F],
+    pub stage1_gammas: &'a [F],
+    pub stage2_gammas: &'a [F],
+    pub stage3_gammas: &'a [F],
+    pub stage4_gammas: &'a [F],
+    pub stage5_gammas: &'a [F],
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct BytecodeReadRafAddressPhaseIdentityCoefficients<F> {
+    pub stage1: F,
+    pub stage3: F,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct BytecodeReadRafAddressPhaseState<F: Field> {
+    log_k: usize,
+    stage_f: Vec<Polynomial<F>>,
+    stage_val: Vec<Polynomial<F>>,
+    entry_trace: Polynomial<F>,
+    entry_expected: Polynomial<F>,
+    gamma_powers: Vec<F>,
+}
+
+impl<F: Field> BytecodeReadRafAddressPhaseState<F> {
+    pub fn new(
+        log_k: usize,
+        stage_f: Vec<Polynomial<F>>,
+        stage_val: Vec<Polynomial<F>>,
+        entry_trace: Polynomial<F>,
+        entry_expected: Polynomial<F>,
+        gamma_powers: Vec<F>,
+    ) -> Self {
+        Self {
+            log_k,
+            stage_f,
+            stage_val,
+            entry_trace,
+            entry_expected,
+            gamma_powers,
+        }
+    }
+
+    pub const fn log_k(&self) -> usize {
+        self.log_k
+    }
+
+    pub fn bind(&mut self, challenge: F) {
+        for polynomial in &mut self.stage_f {
+            polynomial.bind(challenge);
+        }
+        for polynomial in &mut self.stage_val {
+            polynomial.bind(challenge);
+        }
+        self.entry_trace.bind(challenge);
+        self.entry_expected.bind(challenge);
+    }
+
+    pub fn round_rows(&self) -> usize {
+        self.entry_trace.len() / 2
+    }
+
+    pub fn round_eval(&self, index: usize, point: F) -> F {
+        let mut output = F::zero();
+        for stage in 0..self.stage_f.len() {
+            output += self.gamma_powers[stage]
+                * self.stage_f[stage].sumcheck_round_eval(index, point)
+                * self.stage_val[stage].sumcheck_round_eval(index, point);
+        }
+        output
+            + self.gamma_powers[7]
+                * self.entry_trace.sumcheck_round_eval(index, point)
+                * self.entry_expected.sumcheck_round_eval(index, point)
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct BytecodeReadRafRelationState<F: Field> {
+    public_coeff: Polynomial<F>,
+    bytecode_ra: Vec<Polynomial<F>>,
+    address_phase: Option<BytecodeReadRafAddressPhaseState<F>>,
+}
+
+impl<F: Field> BytecodeReadRafRelationState<F> {
+    pub fn new(
+        public_coeff: Polynomial<F>,
+        bytecode_ra: Vec<Polynomial<F>>,
+        address_phase: Option<BytecodeReadRafAddressPhaseState<F>>,
+    ) -> Self {
+        Self {
+            public_coeff,
+            bytecode_ra,
+            address_phase,
+        }
+    }
+
+    pub fn round_degree(&self, local_round: usize, fallback: usize) -> usize {
+        if self.is_address_phase_round(local_round) {
+            2
+        } else {
+            fallback
+        }
+    }
+
+    pub fn bind(&mut self, local_round: usize, challenge: F) {
+        self.public_coeff.bind(challenge);
+        for polynomial in &mut self.bytecode_ra {
+            polynomial.bind(challenge);
+        }
+        if let Some(address_phase) = &mut self.address_phase {
+            if local_round < address_phase.log_k() {
+                address_phase.bind(challenge);
+            }
+        }
+    }
+
+    pub fn round_rows(&self, local_round: usize) -> usize {
+        if let Some(address_phase) = &self.address_phase {
+            if local_round < address_phase.log_k() {
+                return address_phase.round_rows();
+            }
+        }
+        self.public_coeff.len() / 2
+    }
+
+    pub fn round_eval(&self, local_round: usize, index: usize, point: F) -> F {
+        if let Some(address_phase) = &self.address_phase {
+            if local_round < address_phase.log_k() {
+                return address_phase.round_eval(index, point);
+            }
+        }
+        let public_coeff = self.public_coeff.sumcheck_round_eval(index, point);
+        let ra_product = self.bytecode_ra.iter().fold(F::one(), |acc, polynomial| {
+            acc * polynomial.sumcheck_round_eval(index, point)
+        });
+        public_coeff * ra_product
+    }
+
+    fn is_address_phase_round(&self, local_round: usize) -> bool {
+        self.address_phase
+            .as_ref()
+            .is_some_and(|address_phase| local_round < address_phase.log_k())
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct BytecodeReadRafRegisterEqEvals<F> {
+    pub read_write: Vec<F>,
+    pub val_evaluation: Vec<F>,
+}
+
+pub fn read_raf_register_eq_evals<F>(
+    register_read_write_point: &[F],
+    register_val_evaluation_point: &[F],
+) -> BytecodeReadRafRegisterEqEvals<F>
+where
+    F: Field,
+{
+    BytecodeReadRafRegisterEqEvals {
+        read_write: EqPolynomial::<F>::evals(register_read_write_point, None),
+        val_evaluation: EqPolynomial::<F>::evals(register_val_evaluation_point, None),
+    }
+}
+
+pub fn read_raf_stage_values<F>(inputs: BytecodeReadRafStageValueInputs<'_, F>) -> Vec<[F; 5]>
+where
+    F: Field,
+{
+    let register_eq = read_raf_register_eq_evals(
+        inputs.register_read_write_point,
+        inputs.register_val_evaluation_point,
+    );
+    inputs
+        .bytecode
+        .iter()
+        .map(|instruction| {
+            read_raf_row_values::<F>(
+                instruction,
+                &register_eq.read_write,
+                &register_eq.val_evaluation,
+                inputs.stage1_gammas,
+                inputs.stage2_gammas,
+                inputs.stage3_gammas,
+                inputs.stage4_gammas,
+                inputs.stage5_gammas,
+            )
+        })
+        .collect()
+}
+
+pub fn read_raf_address_phase_identity_coefficients<F>(
+    bytecode_gamma_powers: &[F],
+) -> Result<BytecodeReadRafAddressPhaseIdentityCoefficients<F>, JoltFormulaPointError>
+where
+    F: Field,
+{
+    require_len(bytecode_gamma_powers, 8)?;
+    Ok(BytecodeReadRafAddressPhaseIdentityCoefficients {
+        stage1: bytecode_gamma_powers[5],
+        stage3: bytecode_gamma_powers[4],
+    })
+}
+
+pub fn read_raf_address_phase_stage_values<F>(
+    mut row_values: [F; 5],
+    row_index: usize,
+    coefficients: BytecodeReadRafAddressPhaseIdentityCoefficients<F>,
+) -> [F; 5]
+where
+    F: Field,
+{
+    let identity = F::from_u64(row_index as u64);
+    row_values[0] += coefficients.stage1 * identity;
+    row_values[2] += coefficients.stage3 * identity;
+    row_values
+}
+
 pub fn read_raf_public_values<F>(
     inputs: BytecodeReadRafEvaluationInputs<'_, F>,
 ) -> Result<BytecodeReadRafPublicValues<F>, JoltFormulaPointError>
@@ -444,22 +673,19 @@ where
     }
 
     let address_eq_evals = EqPolynomial::<F>::evals(inputs.r_address, None);
-    let register_read_write_eq = EqPolynomial::<F>::evals(inputs.register_read_write_point, None);
-    let register_val_evaluation_eq =
-        EqPolynomial::<F>::evals(inputs.register_val_evaluation_point, None);
+    let row_values = read_raf_stage_values(BytecodeReadRafStageValueInputs {
+        bytecode: inputs.bytecode,
+        register_read_write_point: inputs.register_read_write_point,
+        register_val_evaluation_point: inputs.register_val_evaluation_point,
+        stage1_gammas: inputs.stage1_gammas,
+        stage2_gammas: inputs.stage2_gammas,
+        stage3_gammas: inputs.stage3_gammas,
+        stage4_gammas: inputs.stage4_gammas,
+        stage5_gammas: inputs.stage5_gammas,
+    });
 
     let mut stage_values = [F::zero(); 5];
-    for (instruction, eq_address) in inputs.bytecode.iter().zip(address_eq_evals) {
-        let row_values = read_raf_row_values::<F>(
-            instruction,
-            &register_read_write_eq,
-            &register_val_evaluation_eq,
-            inputs.stage1_gammas,
-            inputs.stage2_gammas,
-            inputs.stage3_gammas,
-            inputs.stage4_gammas,
-            inputs.stage5_gammas,
-        );
+    for (row_values, eq_address) in row_values.into_iter().zip(address_eq_evals) {
         for (stage_value, row_value) in stage_values.iter_mut().zip(row_values) {
             *stage_value += row_value * eq_address;
         }
@@ -488,11 +714,77 @@ where
     })
 }
 
+pub fn read_raf_public_values_at_boolean_point<F>(
+    inputs: BytecodeReadRafBooleanEvaluationInputs<'_, F>,
+) -> Result<Option<BytecodeReadRafPublicValues<F>>, JoltFormulaPointError>
+where
+    F: Field,
+{
+    require_len(inputs.stage1_gammas, 2 + NUM_CIRCUIT_FLAGS)?;
+    require_len(inputs.stage2_gammas, 4)?;
+    require_len(inputs.stage3_gammas, 9)?;
+    require_len(inputs.stage4_gammas, 3)?;
+    require_len(inputs.stage5_gammas, 2 + LookupTableKind::<XLEN>::COUNT)?;
+
+    let expected_domain = 1usize << inputs.r_address.len();
+    if inputs.bytecode.len() != expected_domain {
+        return Err(JoltFormulaPointError::EvaluationDomainLengthMismatch {
+            expected: expected_domain,
+            got: inputs.bytecode.len(),
+        });
+    }
+
+    let Some(address_index) = boolean_index_msb(inputs.r_address) else {
+        return Ok(None);
+    };
+    let Some(cycle_index) = boolean_index_msb(inputs.r_cycle) else {
+        return Ok(None);
+    };
+
+    let register_eq = read_raf_register_eq_evals(
+        inputs.register_read_write_point,
+        inputs.register_val_evaluation_point,
+    );
+    let mut stage_values = read_raf_row_values::<F>(
+        &inputs.bytecode[address_index],
+        &register_eq.read_write,
+        &register_eq.val_evaluation,
+        inputs.stage1_gammas,
+        inputs.stage2_gammas,
+        inputs.stage3_gammas,
+        inputs.stage4_gammas,
+        inputs.stage5_gammas,
+    );
+
+    for (stage_value, stage_cycle_point) in stage_values
+        .iter_mut()
+        .zip(inputs.stage_cycle_points.into_iter())
+    {
+        *stage_value *= eq_index_msb(stage_cycle_point, cycle_index);
+    }
+
+    let identity = IdentityPolynomial::new(inputs.r_address.len()).evaluate(inputs.r_address);
+    let spartan_outer_raf = identity * eq_index_msb(inputs.stage_cycle_points[0], cycle_index);
+    let spartan_shift_raf = identity * eq_index_msb(inputs.stage_cycle_points[2], cycle_index);
+    let entry = if address_index == inputs.entry_bytecode_index && cycle_index == 0 {
+        F::one()
+    } else {
+        F::zero()
+    };
+
+    Ok(Some(BytecodeReadRafPublicValues {
+        stage_values,
+        spartan_outer_raf,
+        spartan_shift_raf,
+        entry,
+    }))
+}
+
 #[expect(
     clippy::too_many_arguments,
     reason = "Each gamma slice corresponds to one protocol subexpression."
 )]
-fn read_raf_row_values<F>(
+pub fn read_raf_row_values<F>(
     instruction: &JoltInstructionRow,
     register_read_write_eq: &[F],
     register_val_evaluation_eq: &[F],
@@ -884,6 +1176,7 @@ mod tests {
     use super::*;
     use crate::protocols::jolt::{JoltCommittedPolynomial, JoltConsistencyClaim, JoltPolynomialId};
     use jolt_field::{Fr, FromPrimitiveInt};
+    use jolt_poly::EqPolynomial;
     use jolt_riscv::{JoltInstructionKind, NormalizedOperands};
 
     fn dimensions(num_committed_ra_polys: usize) -> BytecodeReadRafDimensions {
@@ -931,6 +1224,237 @@ mod tests {
                 Fr::from_u64(3),
             ]
         );
+    }
+
+    #[test]
+    fn read_raf_register_eq_evals_builds_register_address_tables() {
+        let read_write = vec![Fr::from_u64(2), Fr::from_u64(3)];
+        let val_evaluation = vec![Fr::from_u64(5), Fr::from_u64(7)];
+        let eq = read_raf_register_eq_evals(&read_write, &val_evaluation);
+
+        assert_eq!(
+            eq,
+            BytecodeReadRafRegisterEqEvals {
+                read_write: EqPolynomial::<Fr>::evals(&read_write, None),
+                val_evaluation: EqPolynomial::<Fr>::evals(&val_evaluation, None),
+            }
+        );
+    }
+
+    #[test]
+    fn read_raf_stage_values_match_row_formula() {
+        let bytecode = vec![
+            JoltInstructionRow {
+                instruction_kind: JoltInstructionKind::ADD,
+                address: 9,
+                operands: NormalizedOperands {
+                    rs1: Some(1),
+                    rs2: Some(2),
+                    rd: Some(3),
+                    imm: 4,
+                },
+                virtual_sequence_remaining: None,
+                is_first_in_sequence: false,
+                is_compressed: false,
+            },
+            JoltInstructionRow::default(),
+        ];
+        let register_read_write_point = vec![Fr::from_u64(2); 4];
+        let register_val_evaluation_point = vec![Fr::from_u64(3); 4];
+        let stage1_gammas = (0..2 + NUM_CIRCUIT_FLAGS)
+            .map(|value| Fr::from_u64(value as u64 + 1))
+            .collect::<Vec<_>>();
+        let stage2_gammas = (0..4)
+            .map(|value| Fr::from_u64(value as u64 + 11))
+            .collect::<Vec<_>>();
+        let stage3_gammas = (0..9)
+            .map(|value| Fr::from_u64(value as u64 + 17))
+            .collect::<Vec<_>>();
+        let stage4_gammas = (0..3)
+            .map(|value| Fr::from_u64(value as u64 + 29))
+            .collect::<Vec<_>>();
+        let stage5_gammas = (0..2 + LookupTableKind::<XLEN>::COUNT)
+            .map(|value| Fr::from_u64(value as u64 + 37))
+            .collect::<Vec<_>>();
+        let register_eq =
+            read_raf_register_eq_evals(&register_read_write_point, &register_val_evaluation_point);
+
+        let stage_values = read_raf_stage_values(BytecodeReadRafStageValueInputs {
+            bytecode: &bytecode,
+            register_read_write_point: &register_read_write_point,
+            register_val_evaluation_point: &register_val_evaluation_point,
+            stage1_gammas: &stage1_gammas,
+            stage2_gammas: &stage2_gammas,
+            stage3_gammas: &stage3_gammas,
+            stage4_gammas: &stage4_gammas,
+            stage5_gammas: &stage5_gammas,
+        });
+        let expected = bytecode
+            .iter()
+            .map(|row| {
+                read_raf_row_values(
+                    row,
+                    &register_eq.read_write,
+                    &register_eq.val_evaluation,
+                    &stage1_gammas,
+                    &stage2_gammas,
+                    &stage3_gammas,
+                    &stage4_gammas,
+                    &stage5_gammas,
+                )
+            })
+            .collect::<Vec<_>>();
+
+        assert_eq!(stage_values, expected);
+    }
+
+    #[test]
+    fn read_raf_address_phase_identity_coefficients_select_gamma_offsets() {
+        let gamma_powers = (0..8)
+            .map(|value| Fr::from_u64(value as u64 + 1))
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            read_raf_address_phase_identity_coefficients(&gamma_powers),
+            Ok(BytecodeReadRafAddressPhaseIdentityCoefficients {
+                stage1: gamma_powers[5],
+                stage3: gamma_powers[4],
+            })
+        );
+        assert_eq!(
+            read_raf_address_phase_identity_coefficients::<Fr>(&gamma_powers[..7]),
+            Err(JoltFormulaPointError::ChallengeLengthMismatch {
+                expected: 8,
+                got: 7
+            })
+        );
+    }
+
+    #[test]
+    fn read_raf_address_phase_stage_values_add_identity_terms() {
+        let row_values = [
+            Fr::from_u64(2),
+            Fr::from_u64(3),
+            Fr::from_u64(5),
+            Fr::from_u64(7),
+            Fr::from_u64(11),
+        ];
+        let coefficients = BytecodeReadRafAddressPhaseIdentityCoefficients {
+            stage1: Fr::from_u64(13),
+            stage3: Fr::from_u64(17),
+        };
+
+        assert_eq!(
+            read_raf_address_phase_stage_values(row_values, 3, coefficients),
+            [
+                Fr::from_u64(2) + Fr::from_u64(13) * Fr::from_u64(3),
+                Fr::from_u64(3),
+                Fr::from_u64(5) + Fr::from_u64(17) * Fr::from_u64(3),
+                Fr::from_u64(7),
+                Fr::from_u64(11),
+            ]
+        );
+    }
+
+    #[test]
+    fn read_raf_address_phase_state_evaluates_round_formula() {
+        let point = Fr::from_u64(3);
+        let stage_f = (0..5)
+            .map(|stage| {
+                Polynomial::new(vec![
+                    Fr::from_u64(stage as u64 + 2),
+                    Fr::from_u64(stage as u64 + 7),
+                ])
+            })
+            .collect::<Vec<_>>();
+        let stage_val = (0..5)
+            .map(|stage| {
+                Polynomial::new(vec![
+                    Fr::from_u64(stage as u64 + 11),
+                    Fr::from_u64(stage as u64 + 19),
+                ])
+            })
+            .collect::<Vec<_>>();
+        let entry_trace = Polynomial::new(vec![Fr::from_u64(29), Fr::from_u64(31)]);
+        let entry_expected = Polynomial::new(vec![Fr::from_u64(37), Fr::from_u64(41)]);
+        let gamma_powers = (0..8)
+            .map(|value| Fr::from_u64(value as u64 + 43))
+            .collect::<Vec<_>>();
+
+        let state = BytecodeReadRafAddressPhaseState::new(
+            1,
+            stage_f.clone(),
+            stage_val.clone(),
+            entry_trace.clone(),
+            entry_expected.clone(),
+            gamma_powers.clone(),
+        );
+        let expected = stage_f
+            .iter()
+            .zip(stage_val.iter())
+            .zip(gamma_powers.iter())
+            .map(|((stage_f, stage_val), gamma)| {
+                *gamma
+                    * stage_f.sumcheck_round_eval(0, point)
+                    * stage_val.sumcheck_round_eval(0, point)
+            })
+            .sum::<Fr>()
+            + gamma_powers[7]
+                * entry_trace.sumcheck_round_eval(0, point)
+                * entry_expected.sumcheck_round_eval(0, point);
+
+        assert_eq!(state.log_k(), 1);
+        assert_eq!(state.round_rows(), 1);
+        assert_eq!(state.round_eval(0, point), expected);
+    }
+
+    #[test]
+    fn read_raf_relation_state_evaluates_public_coeff_times_ra_product() {
+        let point = Fr::from_u64(5);
+        let public_coeff = Polynomial::new(vec![Fr::from_u64(2), Fr::from_u64(7)]);
+        let bytecode_ra = vec![
+            Polynomial::new(vec![Fr::from_u64(11), Fr::from_u64(13)]),
+            Polynomial::new(vec![Fr::from_u64(17), Fr::from_u64(19)]),
+        ];
+        let expected = public_coeff.sumcheck_round_eval(0, point)
+            * bytecode_ra[0].sumcheck_round_eval(0, point)
+            * bytecode_ra[1].sumcheck_round_eval(0, point);
+
+        let state = BytecodeReadRafRelationState::new(public_coeff, bytecode_ra, None);
+
+        assert_eq!(state.round_degree(0, 3), 3);
+        assert_eq!(state.round_rows(0), 1);
+        assert_eq!(state.round_eval(0, 0, point), expected);
+    }
+
+    #[test]
+    fn read_raf_relation_state_uses_address_phase_for_initial_address_rounds() {
+        let point = Fr::from_u64(5);
+        let public_coeff = Polynomial::new(vec![Fr::from_u64(2), Fr::from_u64(7)]);
+        let bytecode_ra = vec![Polynomial::new(vec![Fr::from_u64(11), Fr::from_u64(13)])];
+        let address_phase = BytecodeReadRafAddressPhaseState::new(
+            1,
+            (0..5)
+                .map(|_| Polynomial::new(vec![Fr::from_u64(3), Fr::from_u64(5)]))
+                .collect(),
+            (0..5)
+                .map(|_| Polynomial::new(vec![Fr::from_u64(7), Fr::from_u64(11)]))
+                .collect(),
+            Polynomial::new(vec![Fr::from_u64(13), Fr::from_u64(17)]),
+            Polynomial::new(vec![Fr::from_u64(19), Fr::from_u64(23)]),
+            (0..8)
+                .map(|value| Fr::from_u64(value as u64 + 29))
+                .collect(),
+        );
+        let address_phase_expected = address_phase.round_eval(0, point);
+
+        let state =
+            BytecodeReadRafRelationState::new(public_coeff, bytecode_ra, Some(address_phase));
+
+        assert_eq!(state.round_degree(0, 4), 2);
+        assert_eq!(state.round_rows(0), 1);
+        assert_eq!(state.round_eval(0, 0, point), address_phase_expected);
+        assert_eq!(state.round_degree(1, 4), 4);
     }
 
     #[test]
@@ -1022,6 +1546,53 @@ mod tests {
         assert_eq!(public_values.spartan_outer_raf, zero);
         assert_eq!(public_values.spartan_shift_raf, zero);
         assert_eq!(public_values.entry, one);
+
+        let direct =
+            read_raf_public_values_at_boolean_point::<Fr>(BytecodeReadRafBooleanEvaluationInputs {
+                bytecode: &bytecode,
+                r_address: &r_address,
+                r_cycle: &r_cycle,
+                stage_cycle_points,
+                register_read_write_point: &[],
+                register_val_evaluation_point: &[],
+                entry_bytecode_index: 0,
+                stage1_gammas: &stage1_gammas,
+                stage2_gammas: &[one; 4],
+                stage3_gammas: &[one; 9],
+                stage4_gammas: &[one; 3],
+                stage5_gammas: &stage5_gammas,
+            })
+            .unwrap_or_else(|error| panic!("boolean point helper should evaluate: {error}"));
+
+        assert_eq!(direct, Some(public_values));
+    }
+
+    #[test]
+    fn read_raf_boolean_public_values_skip_non_boolean_points() {
+        let one = Fr::from_u64(1);
+        let two = Fr::from_u64(2);
+        let zero = Fr::from_u64(0);
+        let bytecode = vec![JoltInstructionRow::default(), JoltInstructionRow::default()];
+        let stage1_gammas = vec![one; 2 + NUM_CIRCUIT_FLAGS];
+        let stage5_gammas = vec![one; 2 + LookupTableKind::<XLEN>::COUNT];
+        let direct =
+            read_raf_public_values_at_boolean_point::<Fr>(BytecodeReadRafBooleanEvaluationInputs {
+                bytecode: &bytecode,
+                r_address: &[two],
+                r_cycle: &[zero],
+                stage_cycle_points: [&[zero][..]; 5],
+                register_read_write_point: &[],
+                register_val_evaluation_point: &[],
+                entry_bytecode_index: 0,
+                stage1_gammas: &stage1_gammas,
+                stage2_gammas: &[one; 4],
+                stage3_gammas: &[one; 9],
+                stage4_gammas: &[one; 3],
+                stage5_gammas: &stage5_gammas,
+            })
+            .unwrap_or_else(|error| panic!("boolean point helper should evaluate: {error}"));
+
+        assert_eq!(direct, None);
     }
 
     #[test]

--- a/crates/jolt-claims/src/protocols/jolt/formulas/bytecode.rs
+++ b/crates/jolt-claims/src/protocols/jolt/formulas/bytecode.rs
@@ -294,6 +294,13 @@ pub struct BytecodeReadRafOutputOpenings {
     pub bytecode_ra: Vec<JoltOpeningId>,
 }
 
+pub fn bytecode_read_raf_address_phase_opening() -> JoltOpeningId {
+    JoltOpeningId::virtual_polynomial(
+        JoltVirtualPolynomial::BytecodeReadRafAddrClaim,
+        JoltRelationId::BytecodeReadRaf,
+    )
+}
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct BytecodeReadRafPublicValues<F: Field> {
     pub stage_values: [F; 5],
@@ -756,10 +763,7 @@ where
         inputs.stage5_gammas,
     );
 
-    for (stage_value, stage_cycle_point) in stage_values
-        .iter_mut()
-        .zip(inputs.stage_cycle_points.into_iter())
-    {
+    for (stage_value, stage_cycle_point) in stage_values.iter_mut().zip(inputs.stage_cycle_points) {
         *stage_value *= eq_index_msb(stage_cycle_point, cycle_index);
     }
 

--- a/crates/jolt-claims/src/protocols/jolt/formulas/claim_reductions/advice.rs
+++ b/crates/jolt-claims/src/protocols/jolt/formulas/claim_reductions/advice.rs
@@ -155,6 +155,10 @@ where
     )
 }
 
+pub fn cycle_phase_input_openings(kind: JoltAdviceKind) -> [JoltOpeningId; 1] {
+    [ram_val_check_advice_opening(kind)]
+}
+
 pub fn cycle_phase_output_openings(
     kind: JoltAdviceKind,
     dimensions: PrecommittedReductionDimensions,

--- a/crates/jolt-claims/src/protocols/jolt/formulas/claim_reductions/hamming_weight.rs
+++ b/crates/jolt-claims/src/protocols/jolt/formulas/claim_reductions/hamming_weight.rs
@@ -4,8 +4,8 @@ use crate::{challenge, opening, public};
 
 use super::super::super::{
     HammingWeightClaimReductionChallenge, HammingWeightClaimReductionPublic, JoltChallengeId,
-    JoltExpr, JoltOpeningId, JoltPublicId, JoltRelationClaims, JoltRelationId,
-    JoltVirtualPolynomial,
+    JoltCommittedPolynomial, JoltExpr, JoltOpeningId, JoltPublicId, JoltRelationClaims,
+    JoltRelationId, JoltVirtualPolynomial,
 };
 use super::super::dimensions::{JoltFormulaPointError, JoltSumcheckSpec};
 use super::super::ra::{JoltRaPolynomial, JoltRaPolynomialLayout};
@@ -100,6 +100,46 @@ pub fn claim_reduction_input_openings(
             .polynomials()
             .map(virtualization_claim)
             .collect(),
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct HammingWeightClaimReductionCommittedPolynomials {
+    pub instruction_ra: Vec<JoltCommittedPolynomial>,
+    pub bytecode_ra: Vec<JoltCommittedPolynomial>,
+    pub ram_ra: Vec<JoltCommittedPolynomial>,
+}
+
+impl HammingWeightClaimReductionCommittedPolynomials {
+    pub fn all(&self) -> Vec<JoltCommittedPolynomial> {
+        self.instruction_ra
+            .iter()
+            .chain(&self.bytecode_ra)
+            .chain(&self.ram_ra)
+            .copied()
+            .collect()
+    }
+}
+
+pub fn claim_reduction_committed_polynomials(
+    dimensions: HammingWeightClaimReductionDimensions,
+) -> HammingWeightClaimReductionCommittedPolynomials {
+    let mut instruction_ra = Vec::with_capacity(dimensions.layout.instruction());
+    let mut bytecode_ra = Vec::with_capacity(dimensions.layout.bytecode());
+    let mut ram_ra = Vec::with_capacity(dimensions.layout.ram());
+
+    for polynomial in dimensions.layout.polynomials() {
+        match polynomial {
+            JoltRaPolynomial::Instruction(_) => instruction_ra.push(polynomial.committed()),
+            JoltRaPolynomial::Bytecode(_) => bytecode_ra.push(polynomial.committed()),
+            JoltRaPolynomial::Ram(_) => ram_ra.push(polynomial.committed()),
+        }
+    }
+
+    HammingWeightClaimReductionCommittedPolynomials {
+        instruction_ra,
+        bytecode_ra,
+        ram_ra,
     }
 }
 
@@ -284,6 +324,27 @@ mod tests {
                 reduced_claim(instruction),
                 reduced_claim(bytecode),
                 reduced_claim(ram),
+            ]
+        );
+        let committed_polynomials = claim_reduction_committed_polynomials(dimensions(layout));
+        assert_eq!(
+            committed_polynomials.instruction_ra,
+            vec![JoltCommittedPolynomial::InstructionRa(0)]
+        );
+        assert_eq!(
+            committed_polynomials.bytecode_ra,
+            vec![JoltCommittedPolynomial::BytecodeRa(0)]
+        );
+        assert_eq!(
+            committed_polynomials.ram_ra,
+            vec![JoltCommittedPolynomial::RamRa(0)]
+        );
+        assert_eq!(
+            committed_polynomials.all(),
+            vec![
+                JoltCommittedPolynomial::InstructionRa(0),
+                JoltCommittedPolynomial::BytecodeRa(0),
+                JoltCommittedPolynomial::RamRa(0),
             ]
         );
         assert_eq!(

--- a/crates/jolt-claims/src/protocols/jolt/formulas/claim_reductions/increments.rs
+++ b/crates/jolt-claims/src/protocols/jolt/formulas/claim_reductions/increments.rs
@@ -1,4 +1,5 @@
-use jolt_field::RingCore;
+use jolt_field::{Field, RingCore};
+use jolt_poly::{boolean_point_msb, EqPolynomial, Polynomial};
 
 use crate::{challenge, opening, public};
 
@@ -6,7 +7,7 @@ use super::super::super::{
     IncClaimReductionChallenge, IncClaimReductionPublic, JoltChallengeId, JoltCommittedPolynomial,
     JoltExpr, JoltOpeningId, JoltPublicId, JoltRelationClaims, JoltRelationId,
 };
-use super::super::dimensions::TraceDimensions;
+use super::super::{dimensions::TraceDimensions, error::JoltFormulaPointError};
 
 pub fn claim_reduction<F>(dimensions: TraceDimensions) -> JoltRelationClaims<F>
 where
@@ -59,6 +60,137 @@ pub fn claim_reduction_input_openings() -> [JoltOpeningId; 4] {
 
 pub fn claim_reduction_output_openings() -> [JoltOpeningId; 2] {
     [ram_inc_reduced(), rd_inc_reduced()]
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ClaimReductionOutputCoefficients<F> {
+    pub ram: F,
+    pub rd: F,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct ClaimReductionOutputCoefficientInputs<'a, F> {
+    pub opening_point: &'a [F],
+    pub ram_read_write_cycle: &'a [F],
+    pub ram_val_check_cycle: &'a [F],
+    pub registers_read_write_cycle: &'a [F],
+    pub registers_val_evaluation_cycle: &'a [F],
+    pub gamma: F,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct ClaimReductionOutputClaimInputs<'a, F> {
+    pub coefficients: ClaimReductionOutputCoefficientInputs<'a, F>,
+    pub ram_inc: F,
+    pub rd_inc: F,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct ClaimReductionOutputCoefficientPolynomialInputs<'a, F> {
+    pub num_vars: usize,
+    pub trace_dimensions: TraceDimensions,
+    pub ram_read_write_cycle: &'a [F],
+    pub ram_val_check_cycle: &'a [F],
+    pub registers_read_write_cycle: &'a [F],
+    pub registers_val_evaluation_cycle: &'a [F],
+    pub gamma: F,
+}
+
+pub fn claim_reduction_output_coefficients<F: Field>(
+    inputs: ClaimReductionOutputCoefficientInputs<'_, F>,
+) -> Result<ClaimReductionOutputCoefficients<F>, JoltFormulaPointError> {
+    let eq_ram_read_write = eq_mle(inputs.opening_point, inputs.ram_read_write_cycle)?;
+    let eq_ram_val_check = eq_mle(inputs.opening_point, inputs.ram_val_check_cycle)?;
+    let eq_registers_read_write = eq_mle(inputs.opening_point, inputs.registers_read_write_cycle)?;
+    let eq_registers_val_evaluation =
+        eq_mle(inputs.opening_point, inputs.registers_val_evaluation_cycle)?;
+
+    Ok(ClaimReductionOutputCoefficients {
+        ram: eq_ram_read_write + inputs.gamma * eq_ram_val_check,
+        rd: eq_registers_read_write + inputs.gamma * eq_registers_val_evaluation,
+    })
+}
+
+pub fn claim_reduction_output_claim<F: Field>(
+    inputs: ClaimReductionOutputClaimInputs<'_, F>,
+) -> Result<F, JoltFormulaPointError> {
+    let coefficients = claim_reduction_output_coefficients(inputs.coefficients)?;
+    Ok(inputs.ram_inc * coefficients.ram
+        + inputs.coefficients.gamma * inputs.coefficients.gamma * inputs.rd_inc * coefficients.rd)
+}
+
+pub fn claim_reduction_output_coefficient_polynomials<F: Field>(
+    inputs: ClaimReductionOutputCoefficientPolynomialInputs<'_, F>,
+) -> Result<(Polynomial<F>, Polynomial<F>), JoltFormulaPointError> {
+    let rows = 1usize.checked_shl(inputs.num_vars as u32).ok_or(
+        JoltFormulaPointError::EvaluationDomainSizeOverflow {
+            num_vars: inputs.num_vars,
+        },
+    )?;
+    let mut ram_coeff = Vec::with_capacity(rows);
+    let mut rd_coeff = Vec::with_capacity(rows);
+    for index in 0..rows {
+        let point = boolean_point_msb(inputs.num_vars, index);
+        let opening_point = inputs.trace_dimensions.cycle_opening_point(&point)?;
+        let coefficients =
+            claim_reduction_output_coefficients(ClaimReductionOutputCoefficientInputs {
+                opening_point: &opening_point,
+                ram_read_write_cycle: inputs.ram_read_write_cycle,
+                ram_val_check_cycle: inputs.ram_val_check_cycle,
+                registers_read_write_cycle: inputs.registers_read_write_cycle,
+                registers_val_evaluation_cycle: inputs.registers_val_evaluation_cycle,
+                gamma: inputs.gamma,
+            })?;
+        ram_coeff.push(coefficients.ram);
+        rd_coeff.push(coefficients.rd);
+    }
+    Ok((Polynomial::new(ram_coeff), Polynomial::new(rd_coeff)))
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct IncClaimReductionRelationState<F: Field> {
+    ram_coeff: Polynomial<F>,
+    rd_coeff: Polynomial<F>,
+    ram_inc: Polynomial<F>,
+    rd_inc: Polynomial<F>,
+    gamma_squared: F,
+}
+
+impl<F: Field> IncClaimReductionRelationState<F> {
+    pub fn new(
+        ram_coeff: Polynomial<F>,
+        rd_coeff: Polynomial<F>,
+        ram_inc: Polynomial<F>,
+        rd_inc: Polynomial<F>,
+        gamma_squared: F,
+    ) -> Self {
+        Self {
+            ram_coeff,
+            rd_coeff,
+            ram_inc,
+            rd_inc,
+            gamma_squared,
+        }
+    }
+
+    pub fn bind(&mut self, challenge: F) {
+        self.ram_coeff.bind(challenge);
+        self.rd_coeff.bind(challenge);
+        self.ram_inc.bind(challenge);
+        self.rd_inc.bind(challenge);
+    }
+
+    pub fn round_rows(&self) -> usize {
+        self.ram_coeff.len() / 2
+    }
+
+    pub fn round_eval(&self, index: usize, point: F) -> F {
+        self.ram_inc.sumcheck_round_eval(index, point)
+            * self.ram_coeff.sumcheck_round_eval(index, point)
+            + self.gamma_squared
+                * self.rd_inc.sumcheck_round_eval(index, point)
+                * self.rd_coeff.sumcheck_round_eval(index, point)
+    }
 }
 
 pub fn ram_inc_read_write_opening() -> JoltOpeningId {
@@ -122,6 +254,19 @@ fn rd_inc_reduced() -> JoltOpeningId {
         JoltCommittedPolynomial::RdInc,
         JoltRelationId::IncClaimReduction,
     )
+}
+
+fn eq_mle<F: Field>(
+    opening_point: &[F],
+    reference_point: &[F],
+) -> Result<F, JoltFormulaPointError> {
+    if opening_point.len() != reference_point.len() {
+        return Err(JoltFormulaPointError::OpeningPointLengthMismatch {
+            expected: opening_point.len(),
+            got: reference_point.len(),
+        });
+    }
+    Ok(EqPolynomial::mle(opening_point, reference_point))
 }
 
 #[cfg(test)]
@@ -231,6 +376,207 @@ mod tests {
             output,
             ram_reduced * (eq_ram_rw + gamma * eq_ram_val)
                 + gamma_2 * rd_reduced * (eq_rd_rw + gamma * eq_rd_val)
+        );
+    }
+
+    #[test]
+    fn output_coefficients_evaluate_eq_weighted_cycles() {
+        let opening_point = vec![Fr::from_u64(0), Fr::from_u64(1)];
+        let ram_read_write_cycle = vec![Fr::from_u64(0), Fr::from_u64(1)];
+        let ram_val_check_cycle = vec![Fr::from_u64(1), Fr::from_u64(0)];
+        let registers_read_write_cycle = vec![Fr::from_u64(0), Fr::from_u64(0)];
+        let registers_val_evaluation_cycle = vec![Fr::from_u64(0), Fr::from_u64(1)];
+        let gamma = Fr::from_u64(7);
+
+        let coefficients =
+            claim_reduction_output_coefficients(ClaimReductionOutputCoefficientInputs {
+                opening_point: &opening_point,
+                ram_read_write_cycle: &ram_read_write_cycle,
+                ram_val_check_cycle: &ram_val_check_cycle,
+                registers_read_write_cycle: &registers_read_write_cycle,
+                registers_val_evaluation_cycle: &registers_val_evaluation_cycle,
+                gamma,
+            });
+
+        assert_eq!(
+            coefficients,
+            Ok(ClaimReductionOutputCoefficients {
+                ram: Fr::from_u64(1),
+                rd: gamma,
+            })
+        );
+    }
+
+    #[test]
+    fn output_coefficient_polynomials_follow_boolean_sumcheck_order() {
+        let ram_read_write_cycle = vec![Fr::from_u64(0), Fr::from_u64(0)];
+        let ram_val_check_cycle = vec![Fr::from_u64(1), Fr::from_u64(0)];
+        let registers_read_write_cycle = vec![Fr::from_u64(0), Fr::from_u64(1)];
+        let registers_val_evaluation_cycle = vec![Fr::from_u64(1), Fr::from_u64(1)];
+        let gamma = Fr::from_u64(7);
+
+        let polynomials = claim_reduction_output_coefficient_polynomials(
+            ClaimReductionOutputCoefficientPolynomialInputs {
+                num_vars: 2,
+                trace_dimensions: TraceDimensions::new(2),
+                ram_read_write_cycle: &ram_read_write_cycle,
+                ram_val_check_cycle: &ram_val_check_cycle,
+                registers_read_write_cycle: &registers_read_write_cycle,
+                registers_val_evaluation_cycle: &registers_val_evaluation_cycle,
+                gamma,
+            },
+        )
+        .map(|(ram, rd)| (ram.evals().to_vec(), rd.evals().to_vec()))
+        .map_err(|error| error.to_string());
+
+        assert_eq!(
+            polynomials,
+            Ok((
+                vec![Fr::from_u64(1), gamma, Fr::from_u64(0), Fr::from_u64(0)],
+                vec![Fr::from_u64(0), Fr::from_u64(0), Fr::from_u64(1), gamma],
+            )),
+        );
+    }
+
+    #[test]
+    fn output_coefficient_polynomials_reject_trace_dimension_mismatch() {
+        let cycle = vec![Fr::from_u64(0)];
+
+        assert_eq!(
+            claim_reduction_output_coefficient_polynomials(
+                ClaimReductionOutputCoefficientPolynomialInputs {
+                    num_vars: 1,
+                    trace_dimensions: TraceDimensions::new(2),
+                    ram_read_write_cycle: &cycle,
+                    ram_val_check_cycle: &cycle,
+                    registers_read_write_cycle: &cycle,
+                    registers_val_evaluation_cycle: &cycle,
+                    gamma: Fr::from_u64(7),
+                },
+            ),
+            Err(JoltFormulaPointError::ChallengeLengthMismatch {
+                expected: 2,
+                got: 1,
+            })
+        );
+    }
+
+    #[test]
+    fn output_claim_uses_shared_coefficients() {
+        let opening_point = vec![Fr::from_u64(0), Fr::from_u64(1)];
+        let ram_read_write_cycle = vec![Fr::from_u64(0), Fr::from_u64(1)];
+        let ram_val_check_cycle = vec![Fr::from_u64(1), Fr::from_u64(0)];
+        let registers_read_write_cycle = vec![Fr::from_u64(0), Fr::from_u64(0)];
+        let registers_val_evaluation_cycle = vec![Fr::from_u64(0), Fr::from_u64(1)];
+        let gamma = Fr::from_u64(7);
+
+        let output = claim_reduction_output_claim(ClaimReductionOutputClaimInputs {
+            coefficients: ClaimReductionOutputCoefficientInputs {
+                opening_point: &opening_point,
+                ram_read_write_cycle: &ram_read_write_cycle,
+                ram_val_check_cycle: &ram_val_check_cycle,
+                registers_read_write_cycle: &registers_read_write_cycle,
+                registers_val_evaluation_cycle: &registers_val_evaluation_cycle,
+                gamma,
+            },
+            ram_inc: Fr::from_u64(3),
+            rd_inc: Fr::from_u64(5),
+        });
+
+        assert_eq!(
+            output,
+            Ok(Fr::from_u64(3) + gamma * gamma * gamma * Fr::from_u64(5))
+        );
+    }
+
+    #[test]
+    fn relation_state_evaluates_increment_output_terms() {
+        let point = Fr::from_u64(7);
+        let ram_coeff = Polynomial::new(vec![Fr::from_u64(2), Fr::from_u64(3)]);
+        let rd_coeff = Polynomial::new(vec![Fr::from_u64(5), Fr::from_u64(11)]);
+        let ram_inc = Polynomial::new(vec![Fr::from_u64(13), Fr::from_u64(17)]);
+        let rd_inc = Polynomial::new(vec![Fr::from_u64(19), Fr::from_u64(23)]);
+        let gamma_squared = Fr::from_u64(29);
+        let expected = ram_inc.sumcheck_round_eval(0, point)
+            * ram_coeff.sumcheck_round_eval(0, point)
+            + gamma_squared
+                * rd_inc.sumcheck_round_eval(0, point)
+                * rd_coeff.sumcheck_round_eval(0, point);
+
+        let state = IncClaimReductionRelationState::new(
+            ram_coeff,
+            rd_coeff,
+            ram_inc,
+            rd_inc,
+            gamma_squared,
+        );
+
+        assert_eq!(state.round_rows(), 1);
+        assert_eq!(state.round_eval(0, point), expected);
+    }
+
+    #[test]
+    fn relation_state_binds_all_polynomials() {
+        let challenge = Fr::from_u64(31);
+        let mut ram_coeff =
+            Polynomial::new((0..4).map(|value| Fr::from_u64(value as u64 + 2)).collect());
+        let mut rd_coeff =
+            Polynomial::new((0..4).map(|value| Fr::from_u64(value as u64 + 7)).collect());
+        let mut ram_inc = Polynomial::new(
+            (0..4)
+                .map(|value| Fr::from_u64(value as u64 + 13))
+                .collect(),
+        );
+        let mut rd_inc = Polynomial::new(
+            (0..4)
+                .map(|value| Fr::from_u64(value as u64 + 17))
+                .collect(),
+        );
+        let gamma_squared = Fr::from_u64(19);
+        let mut state = IncClaimReductionRelationState::new(
+            ram_coeff.clone(),
+            rd_coeff.clone(),
+            ram_inc.clone(),
+            rd_inc.clone(),
+            gamma_squared,
+        );
+
+        state.bind(challenge);
+        ram_coeff.bind(challenge);
+        rd_coeff.bind(challenge);
+        ram_inc.bind(challenge);
+        rd_inc.bind(challenge);
+
+        assert_eq!(
+            state,
+            IncClaimReductionRelationState::new(
+                ram_coeff,
+                rd_coeff,
+                ram_inc,
+                rd_inc,
+                gamma_squared
+            )
+        );
+    }
+
+    #[test]
+    fn output_coefficients_reject_cycle_length_mismatch() {
+        let point = vec![Fr::from_u64(0), Fr::from_u64(1)];
+        let short = vec![Fr::from_u64(0)];
+
+        assert_eq!(
+            claim_reduction_output_coefficients(ClaimReductionOutputCoefficientInputs {
+                opening_point: &point,
+                ram_read_write_cycle: &short,
+                ram_val_check_cycle: &point,
+                registers_read_write_cycle: &point,
+                registers_val_evaluation_cycle: &point,
+                gamma: Fr::from_u64(7),
+            }),
+            Err(JoltFormulaPointError::OpeningPointLengthMismatch {
+                expected: 2,
+                got: 1,
+            })
         );
     }
 }

--- a/crates/jolt-claims/src/protocols/jolt/formulas/claim_reductions/instruction.rs
+++ b/crates/jolt-claims/src/protocols/jolt/formulas/claim_reductions/instruction.rs
@@ -47,6 +47,13 @@ pub fn claim_reduction_output_openings() -> [JoltOpeningId; 5] {
     ]
 }
 
+pub fn stage2_claim_reduction_output_openings() -> [JoltOpeningId; 2] {
+    [
+        left_lookup_operand_reduced(),
+        right_lookup_operand_reduced(),
+    ]
+}
+
 pub fn claim_reduction_input_openings() -> [JoltOpeningId; 5] {
     [
         lookup_output_spartan(),
@@ -204,6 +211,16 @@ mod tests {
         );
         assert!(claims.required_publics().is_empty());
         assert_eq!(claims.num_challenges(), 2);
+    }
+
+    #[test]
+    fn stage2_claim_reduction_openings_are_reduced_lookup_operands() {
+        let output_openings = claim_reduction_output_openings();
+
+        assert_eq!(
+            stage2_claim_reduction_output_openings(),
+            [output_openings[1], output_openings[2]]
+        );
     }
 
     #[test]

--- a/crates/jolt-claims/src/protocols/jolt/formulas/committed_openings.rs
+++ b/crates/jolt-claims/src/protocols/jolt/formulas/committed_openings.rs
@@ -90,6 +90,8 @@ pub fn final_opening_relation(polynomial: JoltCommittedPolynomial) -> JoltRelati
         JoltCommittedPolynomial::TrustedAdvice | JoltCommittedPolynomial::UntrustedAdvice => {
             JoltRelationId::AdviceClaimReduction
         }
+        JoltCommittedPolynomial::BytecodeChunk(_) => JoltRelationId::BytecodeClaimReduction,
+        JoltCommittedPolynomial::ProgramImageInit => JoltRelationId::ProgramImageClaimReduction,
     }
 }
 

--- a/crates/jolt-claims/src/protocols/jolt/formulas/committed_openings.rs
+++ b/crates/jolt-claims/src/protocols/jolt/formulas/committed_openings.rs
@@ -1,4 +1,4 @@
-//! Jolt committed-polynomial opening order used by the final PCS check.
+//! Jolt committed-polynomial proof and final-opening orders.
 
 use jolt_field::Field;
 
@@ -8,7 +8,13 @@ use super::error::JoltFormulaPointError;
 use super::ra::JoltRaPolynomialLayout;
 
 pub fn proof_commitment_order(layout: JoltRaPolynomialLayout) -> Vec<JoltCommittedPolynomial> {
-    final_opening_polynomial_order(layout, false, false, None)
+    let mut polynomials = Vec::with_capacity(2 + layout.total());
+    polynomials.push(JoltCommittedPolynomial::RdInc);
+    polynomials.push(JoltCommittedPolynomial::RamInc);
+    polynomials.extend((0..layout.instruction()).map(JoltCommittedPolynomial::InstructionRa));
+    polynomials.extend((0..layout.ram()).map(JoltCommittedPolynomial::RamRa));
+    polynomials.extend((0..layout.bytecode()).map(JoltCommittedPolynomial::BytecodeRa));
+    polynomials
 }
 
 /// `committed_program_chunks` is `Some(bytecode_chunk_count)` in committed
@@ -84,8 +90,6 @@ pub fn final_opening_relation(polynomial: JoltCommittedPolynomial) -> JoltRelati
         JoltCommittedPolynomial::TrustedAdvice | JoltCommittedPolynomial::UntrustedAdvice => {
             JoltRelationId::AdviceClaimReduction
         }
-        JoltCommittedPolynomial::BytecodeChunk(_) => JoltRelationId::BytecodeClaimReduction,
-        JoltCommittedPolynomial::ProgramImageInit => JoltRelationId::ProgramImageClaimReduction,
     }
 }
 
@@ -204,17 +208,17 @@ mod tests {
     }
 
     #[test]
-    fn proof_commitment_order_reuses_final_opening_order() {
+    fn proof_commitment_order_matches_proof_payload_order() {
         assert_eq!(
             proof_commitment_order(layout()),
             vec![
-                JoltCommittedPolynomial::RamInc,
                 JoltCommittedPolynomial::RdInc,
+                JoltCommittedPolynomial::RamInc,
                 JoltCommittedPolynomial::InstructionRa(0),
                 JoltCommittedPolynomial::InstructionRa(1),
-                JoltCommittedPolynomial::BytecodeRa(0),
                 JoltCommittedPolynomial::RamRa(0),
                 JoltCommittedPolynomial::RamRa(1),
+                JoltCommittedPolynomial::BytecodeRa(0),
             ]
         );
     }

--- a/crates/jolt-claims/src/protocols/jolt/formulas/dimensions.rs
+++ b/crates/jolt-claims/src/protocols/jolt/formulas/dimensions.rs
@@ -367,22 +367,7 @@ impl JoltOneHotConfig {
     }
 
     pub fn committed_address_chunks<F: Field>(self, r_address: &[F]) -> Vec<Vec<F>> {
-        let chunk_bits = self.committed_chunk_bits();
-        if chunk_bits == 0 {
-            return Vec::new();
-        }
-
-        let padding = r_address
-            .len()
-            .next_multiple_of(chunk_bits)
-            .saturating_sub(r_address.len());
-        let mut padded = Vec::with_capacity(r_address.len() + padding);
-        padded.extend((0..padding).map(|_| F::zero()));
-        padded.extend_from_slice(r_address);
-        padded
-            .chunks(chunk_bits)
-            .map(<[F]>::to_vec)
-            .collect::<Vec<_>>()
+        committed_address_chunks(r_address, self.committed_chunk_bits())
     }
 
     pub const fn dimensions(
@@ -401,6 +386,24 @@ impl JoltOneHotConfig {
             lookup_virtual_chunk_bits: self.lookup_virtual_chunk_bits(),
         }
     }
+}
+
+pub fn committed_address_chunks<F: Field>(r_address: &[F], chunk_bits: usize) -> Vec<Vec<F>> {
+    if chunk_bits == 0 {
+        return Vec::new();
+    }
+
+    let padding = r_address
+        .len()
+        .next_multiple_of(chunk_bits)
+        .saturating_sub(r_address.len());
+    let mut padded = Vec::with_capacity(r_address.len() + padding);
+    padded.extend((0..padding).map(|_| F::zero()));
+    padded.extend_from_slice(r_address);
+    padded
+        .chunks(chunk_bits)
+        .map(<[F]>::to_vec)
+        .collect::<Vec<_>>()
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]

--- a/crates/jolt-claims/src/protocols/jolt/formulas/error.rs
+++ b/crates/jolt-claims/src/protocols/jolt/formulas/error.rs
@@ -47,6 +47,8 @@ pub enum JoltFormulaPointError {
         bytecode_len: usize,
         chunk_count: usize,
     },
+    #[error("evaluation domain size overflow for {num_vars} variables")]
+    EvaluationDomainSizeOverflow { num_vars: usize },
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Error)]
@@ -62,12 +64,21 @@ pub enum JoltFormulaDimensionsError {
         committed_chunk_bits: usize,
         lookup_virtual_chunk_bits: usize,
     },
+    #[error("{name} underflowed")]
+    Underflow { name: &'static str },
     #[error("{value_name} ({value}) must be divisible by {divisor_name} ({divisor})")]
     NotDivisible {
         value_name: &'static str,
         value: usize,
         divisor_name: &'static str,
         divisor: usize,
+    },
+    #[error("{value_name} ({value}) must be at most {max_name} ({max})")]
+    Exceeds {
+        value_name: &'static str,
+        value: usize,
+        max_name: &'static str,
+        max: usize,
     },
     #[error("phase1_num_rounds ({phase1_num_rounds}) must be <= log_t ({log_t})")]
     InvalidPhaseRounds {

--- a/crates/jolt-claims/src/protocols/jolt/formulas/instruction.rs
+++ b/crates/jolt-claims/src/protocols/jolt/formulas/instruction.rs
@@ -2,15 +2,16 @@ use std::num::NonZeroUsize;
 
 use jolt_field::{Field, RingCore};
 use jolt_lookup_tables::{LookupTableKind, XLEN};
+use jolt_poly::{EqPolynomial, Polynomial};
 use jolt_riscv::InstructionFlags;
 
-use crate::{challenge, opening};
+use crate::{challenge, opening, SameEvaluationAs};
 
 use super::super::InstructionRaVirtualizationChallenge;
 use super::super::{
     InstructionInputChallenge, InstructionReadRafChallenge, JoltChallengeId,
-    JoltCommittedPolynomial, JoltConsistencyClaim, JoltExpr, JoltOpeningId, JoltRelationClaims,
-    JoltRelationId, JoltVirtualPolynomial,
+    JoltCommittedPolynomial, JoltExpr, JoltOpeningId, JoltRelationClaims, JoltRelationId,
+    JoltVirtualPolynomial,
 };
 use super::dimensions::{
     JoltFormulaDimensionsError, JoltFormulaPointError, JoltSumcheckSpec, TraceDimensions,
@@ -24,6 +25,22 @@ pub struct InstructionReadRafDimensions {
     log_t: usize,
     instruction_address_bits: usize,
     num_virtual_ra_polys: NonZeroUsize,
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct InstructionReadRafAddressLayout {
+    address_bits: usize,
+    virtual_ra_chunk_bits: usize,
+}
+
+impl InstructionReadRafAddressLayout {
+    pub const fn address_bits(self) -> usize {
+        self.address_bits
+    }
+
+    pub const fn virtual_ra_chunk_bits(self) -> usize {
+        self.virtual_ra_chunk_bits
+    }
 }
 
 impl InstructionReadRafDimensions {
@@ -49,6 +66,42 @@ impl InstructionReadRafDimensions {
 
     pub fn num_virtual_ra_polys(self) -> usize {
         self.num_virtual_ra_polys.get()
+    }
+
+    pub fn address_layout(
+        self,
+    ) -> Result<InstructionReadRafAddressLayout, JoltFormulaDimensionsError> {
+        let virtual_ra_count = self.num_virtual_ra_polys();
+        if !self
+            .instruction_address_bits
+            .is_multiple_of(virtual_ra_count)
+        {
+            return Err(JoltFormulaDimensionsError::NotDivisible {
+                value_name: "instruction_address_bits",
+                value: self.instruction_address_bits,
+                divisor_name: "instruction virtual RA polynomial count",
+                divisor: virtual_ra_count,
+            });
+        }
+        Ok(InstructionReadRafAddressLayout {
+            address_bits: self.instruction_address_bits,
+            virtual_ra_chunk_bits: self.instruction_address_bits / virtual_ra_count,
+        })
+    }
+
+    pub fn u128_address_layout(
+        self,
+    ) -> Result<InstructionReadRafAddressLayout, JoltFormulaDimensionsError> {
+        let layout = self.address_layout()?;
+        if layout.address_bits > u128::BITS as usize {
+            return Err(JoltFormulaDimensionsError::Exceeds {
+                value_name: "instruction_address_bits",
+                value: layout.address_bits,
+                max_name: "u128::BITS",
+                max: u128::BITS as usize,
+            });
+        }
+        Ok(layout)
     }
 
     pub fn sumcheck(self) -> JoltSumcheckSpec {
@@ -214,14 +267,8 @@ where
         output,
     )
     .with_consistency([
-        JoltConsistencyClaim::same_evaluation(
-            left_instruction_input_reduced(),
-            left_instruction_input_product(),
-        ),
-        JoltConsistencyClaim::same_evaluation(
-            right_instruction_input_reduced(),
-            right_instruction_input_product(),
-        ),
+        left_instruction_input_reduced().same_evaluation_as(left_instruction_input_product()),
+        right_instruction_input_reduced().same_evaluation_as(right_instruction_input_product()),
     ])
 }
 
@@ -289,10 +336,7 @@ where
         input,
         output,
     )
-    .with_consistency([JoltConsistencyClaim::same_evaluation(
-        lookup_output_reduced(),
-        lookup_output_product(),
-    )])
+    .with_consistency([lookup_output_reduced().same_evaluation_as(lookup_output_product())])
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -367,6 +411,69 @@ where
     .with_input_challenges([JoltChallengeId::from(
         InstructionRaVirtualizationChallenge::Gamma,
     )])
+}
+
+pub fn ra_virtualization_eq_cycle_polynomial<F>(instruction_read_raf_cycle: &[F]) -> Polynomial<F>
+where
+    F: Field,
+{
+    let eq_point = instruction_read_raf_cycle
+        .iter()
+        .rev()
+        .copied()
+        .collect::<Vec<_>>();
+    Polynomial::new(EqPolynomial::<F>::evals(&eq_point, None))
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct InstructionRaVirtualizationRelationState<F: Field> {
+    eq_cycle: Polynomial<F>,
+    gamma_powers: Vec<F>,
+    committed_instruction_ra_by_virtual: Vec<Vec<Polynomial<F>>>,
+}
+
+impl<F: Field> InstructionRaVirtualizationRelationState<F> {
+    pub fn new(
+        eq_cycle: Polynomial<F>,
+        gamma_powers: Vec<F>,
+        committed_instruction_ra_by_virtual: Vec<Vec<Polynomial<F>>>,
+    ) -> Self {
+        Self {
+            eq_cycle,
+            gamma_powers,
+            committed_instruction_ra_by_virtual,
+        }
+    }
+
+    pub fn bind(&mut self, challenge: F) {
+        self.eq_cycle.bind(challenge);
+        for group in &mut self.committed_instruction_ra_by_virtual {
+            for polynomial in group {
+                polynomial.bind(challenge);
+            }
+        }
+    }
+
+    pub fn round_rows(&self) -> usize {
+        self.eq_cycle.len() / 2
+    }
+
+    pub fn round_eval(&self, index: usize, point: F) -> F {
+        let eq = self.eq_cycle.sumcheck_round_eval(index, point);
+        let mut output = F::zero();
+        for (gamma, group) in self
+            .gamma_powers
+            .iter()
+            .copied()
+            .zip(&self.committed_instruction_ra_by_virtual)
+        {
+            let product = group.iter().fold(F::one(), |acc, polynomial| {
+                acc * polynomial.sumcheck_round_eval(index, point)
+            });
+            output += gamma * product;
+        }
+        eq * output
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -628,6 +735,7 @@ mod tests {
     use super::*;
     use crate::protocols::jolt::{JoltConsistencyClaim, JoltPolynomialId};
     use jolt_field::{Fr, FromPrimitiveInt};
+    use jolt_poly::EqPolynomial;
 
     fn read_raf_dimensions(num_virtual_ra_polys: usize) -> InstructionReadRafDimensions {
         InstructionReadRafDimensions::try_from((5, 128, num_virtual_ra_polys))
@@ -827,6 +935,43 @@ mod tests {
     fn read_raf_rejects_empty_dimensions() {
         assert!(InstructionReadRafDimensions::try_from((5, 128, 0)).is_err());
         assert!(InstructionReadRafDimensions::try_from((5, 0, 1)).is_err());
+    }
+
+    #[test]
+    fn read_raf_address_layout_derives_virtual_ra_chunk_bits() {
+        let layout = InstructionReadRafDimensions::try_from((5, 128, 4))
+            .unwrap_or_else(|err| panic!("test read-RAF dimensions should be valid: {err}"))
+            .address_layout()
+            .unwrap_or_else(|err| panic!("address layout should derive: {err}"));
+
+        assert_eq!(layout.address_bits(), 128);
+        assert_eq!(layout.virtual_ra_chunk_bits(), 32);
+    }
+
+    #[test]
+    fn read_raf_address_layout_rejects_invalid_widths() {
+        assert_eq!(
+            InstructionReadRafDimensions::try_from((5, 130, 4))
+                .unwrap_or_else(|err| panic!("test read-RAF dimensions should be valid: {err}"))
+                .address_layout(),
+            Err(JoltFormulaDimensionsError::NotDivisible {
+                value_name: "instruction_address_bits",
+                value: 130,
+                divisor_name: "instruction virtual RA polynomial count",
+                divisor: 4,
+            })
+        );
+        assert_eq!(
+            InstructionReadRafDimensions::try_from((5, 192, 4))
+                .unwrap_or_else(|err| panic!("test read-RAF dimensions should be valid: {err}"))
+                .u128_address_layout(),
+            Err(JoltFormulaDimensionsError::Exceeds {
+                value_name: "instruction_address_bits",
+                value: 192,
+                max_name: "u128::BITS",
+                max: 128,
+            })
+        );
     }
 
     #[test]
@@ -1255,6 +1400,103 @@ mod tests {
                 * (committed_ra[0] * committed_ra[1]
                     + gamma * committed_ra[2] * committed_ra[3]
                     + gamma * gamma * committed_ra[4] * committed_ra[5])
+        );
+    }
+
+    #[test]
+    fn ra_virtualization_eq_cycle_polynomial_reverses_read_raf_cycle() {
+        let read_raf_cycle = vec![Fr::from_u64(2), Fr::from_u64(3), Fr::from_u64(5)];
+        let eq_point = vec![Fr::from_u64(5), Fr::from_u64(3), Fr::from_u64(2)];
+
+        assert_eq!(
+            ra_virtualization_eq_cycle_polynomial(&read_raf_cycle).evals(),
+            EqPolynomial::<Fr>::evals(&eq_point, None)
+        );
+    }
+
+    #[test]
+    fn ra_virtualization_relation_state_evaluates_eq_weighted_virtual_products() {
+        let point = Fr::from_u64(7);
+        let eq_cycle = Polynomial::new(vec![Fr::from_u64(2), Fr::from_u64(3)]);
+        let gamma_powers = vec![Fr::from_u64(1), Fr::from_u64(11), Fr::from_u64(121)];
+        let groups = vec![
+            vec![
+                Polynomial::new(vec![Fr::from_u64(5), Fr::from_u64(13)]),
+                Polynomial::new(vec![Fr::from_u64(17), Fr::from_u64(19)]),
+            ],
+            vec![
+                Polynomial::new(vec![Fr::from_u64(23), Fr::from_u64(29)]),
+                Polynomial::new(vec![Fr::from_u64(31), Fr::from_u64(37)]),
+            ],
+            vec![
+                Polynomial::new(vec![Fr::from_u64(41), Fr::from_u64(43)]),
+                Polynomial::new(vec![Fr::from_u64(47), Fr::from_u64(53)]),
+            ],
+        ];
+        let expected = eq_cycle.sumcheck_round_eval(0, point)
+            * gamma_powers
+                .iter()
+                .copied()
+                .zip(&groups)
+                .map(|(gamma, group)| {
+                    gamma
+                        * group.iter().fold(Fr::from_u64(1), |acc, polynomial| {
+                            acc * polynomial.sumcheck_round_eval(0, point)
+                        })
+                })
+                .sum::<Fr>();
+
+        let state = InstructionRaVirtualizationRelationState::new(eq_cycle, gamma_powers, groups);
+
+        assert_eq!(state.round_rows(), 1);
+        assert_eq!(state.round_eval(0, point), expected);
+    }
+
+    #[test]
+    fn ra_virtualization_relation_state_binds_all_polynomials() {
+        let challenge = Fr::from_u64(19);
+        let mut eq_cycle =
+            Polynomial::new((0..4).map(|value| Fr::from_u64(value as u64 + 2)).collect());
+        let gamma_powers = vec![Fr::from_u64(1), Fr::from_u64(11)];
+        let mut groups = vec![
+            vec![
+                Polynomial::new((0..4).map(|value| Fr::from_u64(value as u64 + 7)).collect()),
+                Polynomial::new(
+                    (0..4)
+                        .map(|value| Fr::from_u64(value as u64 + 13))
+                        .collect(),
+                ),
+            ],
+            vec![
+                Polynomial::new(
+                    (0..4)
+                        .map(|value| Fr::from_u64(value as u64 + 17))
+                        .collect(),
+                ),
+                Polynomial::new(
+                    (0..4)
+                        .map(|value| Fr::from_u64(value as u64 + 23))
+                        .collect(),
+                ),
+            ],
+        ];
+        let mut state = InstructionRaVirtualizationRelationState::new(
+            eq_cycle.clone(),
+            gamma_powers.clone(),
+            groups.clone(),
+        );
+
+        state.bind(challenge);
+        eq_cycle.bind(challenge);
+        for group in &mut groups {
+            for polynomial in group {
+                polynomial.bind(challenge);
+            }
+        }
+
+        assert_eq!(
+            state,
+            InstructionRaVirtualizationRelationState::new(eq_cycle, gamma_powers, groups)
         );
     }
 }

--- a/crates/jolt-claims/src/protocols/jolt/formulas/ram.rs
+++ b/crates/jolt-claims/src/protocols/jolt/formulas/ram.rs
@@ -1,4 +1,5 @@
 use jolt_field::{Field, RingCore};
+use jolt_poly::{EqPolynomial, Polynomial};
 
 use crate::{challenge, constant, opening, public};
 
@@ -245,6 +246,10 @@ pub fn output_check_output_openings() -> [JoltOpeningId; 1] {
     [ram_val_final()]
 }
 
+pub fn stage2_terminal_output_openings() -> [JoltOpeningId; 2] {
+    [ram_ra_raf_evaluation(), ram_val_final()]
+}
+
 pub fn val_check_input_openings() -> [JoltOpeningId; 2] {
     [ram_val(), ram_val_final()]
 }
@@ -351,6 +356,45 @@ where
     )
 }
 
+pub fn ra_virtualization_eq_cycle_polynomial<F>(ram_reduced_cycle: &[F]) -> Polynomial<F>
+where
+    F: Field,
+{
+    let eq_point = ram_reduced_cycle.iter().rev().copied().collect::<Vec<_>>();
+    Polynomial::new(EqPolynomial::<F>::evals(&eq_point, None))
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RamRaVirtualizationRelationState<F: Field> {
+    eq_cycle: Polynomial<F>,
+    ram_ra: Vec<Polynomial<F>>,
+}
+
+impl<F: Field> RamRaVirtualizationRelationState<F> {
+    pub fn new(eq_cycle: Polynomial<F>, ram_ra: Vec<Polynomial<F>>) -> Self {
+        Self { eq_cycle, ram_ra }
+    }
+
+    pub fn bind(&mut self, challenge: F) {
+        self.eq_cycle.bind(challenge);
+        for polynomial in &mut self.ram_ra {
+            polynomial.bind(challenge);
+        }
+    }
+
+    pub fn round_rows(&self) -> usize {
+        self.eq_cycle.len() / 2
+    }
+
+    pub fn round_eval(&self, index: usize, point: F) -> F {
+        let eq = self.eq_cycle.sumcheck_round_eval(index, point);
+        let product = self.ram_ra.iter().fold(F::one(), |acc, polynomial| {
+            acc * polynomial.sumcheck_round_eval(index, point)
+        });
+        eq * product
+    }
+}
+
 pub fn hamming_booleanity<F>(dimensions: TraceDimensions) -> JoltRelationClaims<F>
 where
     F: RingCore,
@@ -365,6 +409,43 @@ where
         JoltExpr::zero(),
         output,
     )
+}
+
+pub fn hamming_booleanity_eq_cycle_polynomial<F>(stage1_cycle_binding: &[F]) -> Polynomial<F>
+where
+    F: Field,
+{
+    Polynomial::new(EqPolynomial::<F>::evals(stage1_cycle_binding, None))
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RamHammingBooleanityRelationState<F: Field> {
+    eq_cycle: Polynomial<F>,
+    hamming_weight: Polynomial<F>,
+}
+
+impl<F: Field> RamHammingBooleanityRelationState<F> {
+    pub fn new(eq_cycle: Polynomial<F>, hamming_weight: Polynomial<F>) -> Self {
+        Self {
+            eq_cycle,
+            hamming_weight,
+        }
+    }
+
+    pub fn bind(&mut self, challenge: F) {
+        self.eq_cycle.bind(challenge);
+        self.hamming_weight.bind(challenge);
+    }
+
+    pub fn round_rows(&self) -> usize {
+        self.eq_cycle.len() / 2
+    }
+
+    pub fn round_eval(&self, index: usize, point: F) -> F {
+        let eq = self.eq_cycle.sumcheck_round_eval(index, point);
+        let hamming = self.hamming_weight.sumcheck_round_eval(index, point);
+        eq * (hamming * hamming - hamming)
+    }
 }
 
 pub fn ra_virtualization_input_openings() -> [JoltOpeningId; 1] {
@@ -581,6 +662,7 @@ fn ram_hamming_weight() -> JoltOpeningId {
 mod tests {
     use super::*;
     use jolt_field::{Fr, FromPrimitiveInt};
+    use jolt_poly::EqPolynomial;
 
     fn trace_dimensions() -> TraceDimensions {
         TraceDimensions::new(5)
@@ -871,6 +953,17 @@ mod tests {
     }
 
     #[test]
+    fn stage2_terminal_openings_are_ram_raf_then_output_check() {
+        assert_eq!(
+            stage2_terminal_output_openings(),
+            [
+                raf_evaluation_output_openings()[0],
+                output_check_output_openings()[0]
+            ]
+        );
+    }
+
+    #[test]
     fn ra_claim_reduction_exposes_expected_dependencies() {
         let claims = ra_claim_reduction::<Fr>(trace_dimensions());
 
@@ -1088,6 +1181,63 @@ mod tests {
     }
 
     #[test]
+    fn ra_virtualization_eq_cycle_polynomial_reverses_reduced_cycle() {
+        let reduced_cycle = vec![Fr::from_u64(2), Fr::from_u64(3), Fr::from_u64(5)];
+        let eq_point = vec![Fr::from_u64(5), Fr::from_u64(3), Fr::from_u64(2)];
+
+        assert_eq!(
+            ra_virtualization_eq_cycle_polynomial(&reduced_cycle).evals(),
+            EqPolynomial::<Fr>::evals(&eq_point, None)
+        );
+    }
+
+    #[test]
+    fn ra_virtualization_relation_state_evaluates_eq_weighted_ra_product() {
+        let point = Fr::from_u64(7);
+        let eq_cycle = Polynomial::new(vec![Fr::from_u64(2), Fr::from_u64(3)]);
+        let ram_ra = vec![
+            Polynomial::new(vec![Fr::from_u64(5), Fr::from_u64(11)]),
+            Polynomial::new(vec![Fr::from_u64(13), Fr::from_u64(17)]),
+        ];
+        let expected = eq_cycle.sumcheck_round_eval(0, point)
+            * ram_ra.iter().fold(Fr::from_u64(1), |acc, polynomial| {
+                acc * polynomial.sumcheck_round_eval(0, point)
+            });
+
+        let state = RamRaVirtualizationRelationState::new(eq_cycle, ram_ra);
+
+        assert_eq!(state.round_rows(), 1);
+        assert_eq!(state.round_eval(0, point), expected);
+    }
+
+    #[test]
+    fn ra_virtualization_relation_state_binds_all_polynomials() {
+        let challenge = Fr::from_u64(19);
+        let mut eq_cycle =
+            Polynomial::new((0..4).map(|value| Fr::from_u64(value as u64 + 2)).collect());
+        let mut ram_ra = vec![
+            Polynomial::new((0..4).map(|value| Fr::from_u64(value as u64 + 7)).collect()),
+            Polynomial::new(
+                (0..4)
+                    .map(|value| Fr::from_u64(value as u64 + 13))
+                    .collect(),
+            ),
+        ];
+        let mut state = RamRaVirtualizationRelationState::new(eq_cycle.clone(), ram_ra.clone());
+
+        state.bind(challenge);
+        eq_cycle.bind(challenge);
+        for polynomial in &mut ram_ra {
+            polynomial.bind(challenge);
+        }
+
+        assert_eq!(
+            state,
+            RamRaVirtualizationRelationState::new(eq_cycle, ram_ra)
+        );
+    }
+
+    #[test]
     fn hamming_booleanity_exposes_expected_dependencies() {
         let claims = hamming_booleanity::<Fr>(trace_dimensions());
 
@@ -1142,6 +1292,50 @@ mod tests {
 
         assert_eq!(input, zero);
         assert_eq!(output, eq_cycle * (h * h - h));
+    }
+
+    #[test]
+    fn hamming_booleanity_eq_cycle_polynomial_uses_stage1_cycle_binding() {
+        let cycle_binding = vec![Fr::from_u64(2), Fr::from_u64(3), Fr::from_u64(5)];
+
+        assert_eq!(
+            hamming_booleanity_eq_cycle_polynomial(&cycle_binding).evals(),
+            EqPolynomial::<Fr>::evals(&cycle_binding, None)
+        );
+    }
+
+    #[test]
+    fn hamming_booleanity_relation_state_evaluates_eq_weighted_bitness_term() {
+        let point = Fr::from_u64(7);
+        let eq_cycle = Polynomial::new(vec![Fr::from_u64(2), Fr::from_u64(3)]);
+        let hamming_weight = Polynomial::new(vec![Fr::from_u64(5), Fr::from_u64(11)]);
+        let hamming = hamming_weight.sumcheck_round_eval(0, point);
+        let expected = eq_cycle.sumcheck_round_eval(0, point) * (hamming * hamming - hamming);
+
+        let state = RamHammingBooleanityRelationState::new(eq_cycle, hamming_weight);
+
+        assert_eq!(state.round_rows(), 1);
+        assert_eq!(state.round_eval(0, point), expected);
+    }
+
+    #[test]
+    fn hamming_booleanity_relation_state_binds_all_polynomials() {
+        let challenge = Fr::from_u64(19);
+        let mut eq_cycle =
+            Polynomial::new((0..4).map(|value| Fr::from_u64(value as u64 + 2)).collect());
+        let mut hamming_weight =
+            Polynomial::new((0..4).map(|value| Fr::from_u64(value as u64 + 7)).collect());
+        let mut state =
+            RamHammingBooleanityRelationState::new(eq_cycle.clone(), hamming_weight.clone());
+
+        state.bind(challenge);
+        eq_cycle.bind(challenge);
+        hamming_weight.bind(challenge);
+
+        assert_eq!(
+            state,
+            RamHammingBooleanityRelationState::new(eq_cycle, hamming_weight)
+        );
     }
 
     #[test]

--- a/crates/jolt-claims/src/protocols/jolt/ids.rs
+++ b/crates/jolt-claims/src/protocols/jolt/ids.rs
@@ -25,10 +25,6 @@ pub enum JoltRelationId {
     Booleanity,
     AdviceClaimReductionCyclePhase,
     AdviceClaimReduction,
-    BytecodeClaimReductionCyclePhase,
-    BytecodeClaimReduction,
-    ProgramImageClaimReductionCyclePhase,
-    ProgramImageClaimReduction,
     IncClaimReduction,
     HammingWeightClaimReduction,
 }
@@ -260,11 +256,9 @@ pub enum JoltCommittedPolynomial {
     RamInc,
     InstructionRa(usize),
     BytecodeRa(usize),
-    BytecodeChunk(usize),
     RamRa(usize),
     TrustedAdvice,
     UntrustedAdvice,
-    ProgramImageInit,
 }
 
 #[derive(Hash, PartialEq, Eq, Copy, Clone, Debug, PartialOrd, Ord, Serialize, Deserialize)]
@@ -308,11 +302,6 @@ pub enum JoltVirtualPolynomial {
     OpFlags(CircuitFlags),
     InstructionFlags(InstructionFlags),
     LookupTableFlag(usize),
-    BytecodeValStage(usize),
-    BytecodeReadRafAddrClaim,
-    BooleanityAddrClaim,
-    BytecodeClaimReductionIntermediate,
-    ProgramImageInitContributionRw,
 }
 
 #[derive(

--- a/crates/jolt-claims/src/protocols/jolt/ids.rs
+++ b/crates/jolt-claims/src/protocols/jolt/ids.rs
@@ -25,6 +25,10 @@ pub enum JoltRelationId {
     Booleanity,
     AdviceClaimReductionCyclePhase,
     AdviceClaimReduction,
+    BytecodeClaimReductionCyclePhase,
+    BytecodeClaimReduction,
+    ProgramImageClaimReductionCyclePhase,
+    ProgramImageClaimReduction,
     IncClaimReduction,
     HammingWeightClaimReduction,
 }
@@ -256,9 +260,11 @@ pub enum JoltCommittedPolynomial {
     RamInc,
     InstructionRa(usize),
     BytecodeRa(usize),
+    BytecodeChunk(usize),
     RamRa(usize),
     TrustedAdvice,
     UntrustedAdvice,
+    ProgramImageInit,
 }
 
 #[derive(Hash, PartialEq, Eq, Copy, Clone, Debug, PartialOrd, Ord, Serialize, Deserialize)]
@@ -302,6 +308,11 @@ pub enum JoltVirtualPolynomial {
     OpFlags(CircuitFlags),
     InstructionFlags(InstructionFlags),
     LookupTableFlag(usize),
+    BytecodeValStage(usize),
+    BytecodeReadRafAddrClaim,
+    BooleanityAddrClaim,
+    BytecodeClaimReductionIntermediate,
+    ProgramImageInitContributionRw,
 }
 
 #[derive(

--- a/crates/jolt-claims/src/protocols/jolt/relation.rs
+++ b/crates/jolt-claims/src/protocols/jolt/relation.rs
@@ -19,10 +19,6 @@ pub struct JoltRelationClaims<F> {
     pub sumcheck: JoltSumcheckSpec,
     pub input: JoltInputClaimExpression<F>,
     pub output: JoltOutputClaimExpression<F>,
-    /// Extra equality constraints that are part of the relation's soundness contract.
-    ///
-    /// Consumers must enforce these in the same constraint system as the input and output
-    /// claims; treating them as metadata can leave alternate opening chains unbound.
     pub consistency: Vec<JoltConsistencyClaim<F>>,
 }
 
@@ -183,7 +179,7 @@ fn debug_assert_unique_relation_ids<F>(relations: &[JoltRelationClaims<F>]) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{challenge, constant, opening, public};
+    use crate::{challenge, constant, opening, public, SameEvaluationAs};
     use jolt_field::{Fr, FromPrimitiveInt};
 
     use super::super::{JoltCommittedPolynomial, JoltVirtualPolynomial, RamReadWriteChallenge};
@@ -214,7 +210,7 @@ mod tests {
             input,
             output,
         )
-        .with_consistency([JoltConsistencyClaim::same_evaluation(rd_inc, ram_val)]);
+        .with_consistency([rd_inc.same_evaluation_as(ram_val)]);
 
         assert_eq!(relation.id, JoltRelationId::RamReadWriteChecking);
         assert_eq!(relation.sumcheck, sumcheck);

--- a/crates/jolt-poly/src/dense.rs
+++ b/crates/jolt-poly/src/dense.rs
@@ -274,6 +274,23 @@ impl<F: Field> Polynomial<F> {
         }
     }
 
+    #[inline]
+    pub fn sumcheck_round_eval(&self, index: usize, point: F) -> F {
+        let (lo, hi) = self.sumcheck_eval_pair(index, crate::BindingOrder::HighToLow);
+        lo + point * (hi - lo)
+    }
+
+    #[inline]
+    pub fn sumcheck_round_eval_with_order(
+        &self,
+        index: usize,
+        point: F,
+        order: crate::BindingOrder,
+    ) -> F {
+        let (lo, hi) = self.sumcheck_eval_pair(index, order);
+        lo + point * (hi - lo)
+    }
+
     /// Evaluates the polynomial at `point` using the multilinear extension formula:
     /// $$f(r) = \sum_{x \in \{0,1\}^n} f(x) \cdot \widetilde{eq}(x, r)$$
     pub fn evaluate(&self, point: &[F]) -> F {

--- a/crates/jolt-poly/src/eq.rs
+++ b/crates/jolt-poly/src/eq.rs
@@ -145,6 +145,33 @@ pub fn eq_index_msb<F: Field>(point: &[F], index: usize) -> F {
     eq
 }
 
+pub fn boolean_point_msb<F: Field>(num_vars: usize, index: usize) -> Vec<F> {
+    (0..num_vars)
+        .map(|position| {
+            let shift = num_vars - 1 - position;
+            let bit = if shift < usize::BITS as usize {
+                (index >> shift) & 1
+            } else {
+                0
+            };
+            F::from_u64(bit as u64)
+        })
+        .collect()
+}
+
+pub fn boolean_index_msb<F: Field>(point: &[F]) -> Option<usize> {
+    let mut index = 0usize;
+    for value in point {
+        index = index.checked_shl(1)?;
+        if value.is_one() {
+            index |= 1;
+        } else if !value.is_zero() {
+            return None;
+        }
+    }
+    Some(index)
+}
+
 /// Static (point-free) evaluation methods for eq polynomial tables.
 ///
 /// These accept challenge or field-element slices and produce materialized

--- a/crates/jolt-poly/src/lib.rs
+++ b/crates/jolt-poly/src/lib.rs
@@ -62,7 +62,7 @@ mod univariate;
 pub use binding::BindingOrder;
 pub use compressed_univariate::CompressedPoly;
 pub use dense::Polynomial;
-pub use eq::{eq_index_msb, try_eq_mle, EqPolynomial};
+pub use eq::{boolean_index_msb, boolean_point_msb, eq_index_msb, try_eq_mle, EqPolynomial};
 pub use eq_plus_one::{EqPlusOnePolynomial, EqPlusOnePrefixSuffix};
 pub use identity::{IdentityPolynomial, OperandPolynomial, OperandSide};
 pub use lt::LtPolynomial;

--- a/crates/jolt-verifier/src/compat/claims.rs
+++ b/crates/jolt-verifier/src/compat/claims.rs
@@ -5,6 +5,14 @@ use std::collections::BTreeMap;
 
 #[cfg(all(any(feature = "jolt-core-compat", test), not(feature = "zk")))]
 use crate::compat::ids as legacy;
+#[cfg(feature = "field-inline")]
+use crate::stages::{
+    stage1::inputs::FieldInlineStage1Claims,
+    stage2::inputs::{FieldInlineProductOutputOpeningClaims, FieldInlineStage2OutputOpeningClaims},
+    stage4::inputs::{FieldInlineStage4Claims, FieldRegistersReadWriteOutputOpeningClaims},
+    stage5::inputs::{FieldInlineStage5Claims, FieldRegistersValEvaluationOutputOpeningClaims},
+    stage6::inputs::{FieldInlineStage6Claims, FieldRegistersIncClaimReductionOutputOpeningClaims},
+};
 use crate::{
     proof::{ClearProofClaims, JoltProof, JoltProofClaims},
     stages::{
@@ -101,6 +109,8 @@ pub(crate) fn clear_claims_from_native<F: Field>(
         stage1: Stage1Claims {
             uniskip_output_claim: claims.require(outer_uniskip_opening())?,
             outer: spartan_outer_claims_from_native(&claims)?,
+            #[cfg(feature = "field-inline")]
+            field_inline: zero_field_inline_stage1_claims(),
         },
         stage2: stage2_claims_from_native(&claims)?,
         stage3: stage3_claims_from_native(&claims)?,
@@ -187,6 +197,8 @@ fn stage2_claims_from_native<F: Field>(
                 next_is_noop: claims.get_or_zero(product_next_is_noop),
                 virtual_instruction: claims.get_or_zero(product_virtual_instruction),
             },
+            #[cfg(feature = "field-inline")]
+            field_inline: zero_field_inline_stage2_claims(),
             instruction_claim_reduction: InstructionClaimReductionOutputOpeningClaims {
                 lookup_output: claims.get(instruction_lookup_output),
                 left_lookup_operand: claims.get_or_zero(instruction_left_lookup_operand),
@@ -266,6 +278,8 @@ fn stage4_claims_from_native<F: Field>(
             rd_wa: claims.require(rd_wa)?,
             rd_inc: claims.require(rd_inc)?,
         },
+        #[cfg(feature = "field-inline")]
+        field_inline: zero_field_inline_stage4_claims(),
         ram_val_check: RamValCheckOutputOpeningClaims {
             ram_ra: claims.require(ram_ra)?,
             ram_inc: claims.require(ram_inc)?,
@@ -309,6 +323,8 @@ fn stage5_claims_from_native<F: Field>(
             rd_inc: claims.require(rd_inc)?,
             rd_wa: claims.require(rd_wa)?,
         },
+        #[cfg(feature = "field-inline")]
+        field_inline: zero_field_inline_stage5_claims(),
     })
 }
 
@@ -435,6 +451,8 @@ fn stage6_claims_from_native<F: Field>(
             ram_inc: claims.require(ram_inc)?,
             rd_inc: claims.require(rd_inc)?,
         },
+        #[cfg(feature = "field-inline")]
+        field_inline: zero_field_inline_stage6_claims(),
         advice_cycle_phase: Stage6AdviceCyclePhaseClaims {
             trusted: advice_cycle_phase_claim_from_native(claims, JoltAdviceKind::Trusted),
             untrusted: advice_cycle_phase_claim_from_native(claims, JoltAdviceKind::Untrusted),
@@ -637,6 +655,8 @@ fn empty_clear_claims<F: Field>(_trace_length: usize) -> ClearProofClaims<F> {
         stage1: Stage1Claims {
             uniskip_output_claim: zero,
             outer: empty_spartan_outer_claims(),
+            #[cfg(feature = "field-inline")]
+            field_inline: zero_field_inline_stage1_claims(),
         },
         stage2: Stage2Claims {
             product_uniskip_output_claim: zero,
@@ -656,6 +676,8 @@ fn empty_clear_claims<F: Field>(_trace_length: usize) -> ClearProofClaims<F> {
                     next_is_noop: zero,
                     virtual_instruction: zero,
                 },
+                #[cfg(feature = "field-inline")]
+                field_inline: zero_field_inline_stage2_claims(),
                 instruction_claim_reduction: InstructionClaimReductionOutputOpeningClaims {
                     lookup_output: None,
                     left_lookup_operand: zero,
@@ -704,6 +726,8 @@ fn empty_clear_claims<F: Field>(_trace_length: usize) -> ClearProofClaims<F> {
                 rd_wa: zero,
                 rd_inc: zero,
             },
+            #[cfg(feature = "field-inline")]
+            field_inline: zero_field_inline_stage4_claims(),
             ram_val_check: RamValCheckOutputOpeningClaims {
                 ram_ra: zero,
                 ram_inc: zero,
@@ -720,6 +744,8 @@ fn empty_clear_claims<F: Field>(_trace_length: usize) -> ClearProofClaims<F> {
                 rd_inc: zero,
                 rd_wa: zero,
             },
+            #[cfg(feature = "field-inline")]
+            field_inline: zero_field_inline_stage5_claims(),
         },
         stage6: Stage6Claims {
             address_phase: Stage6AddressPhaseClaims {
@@ -746,6 +772,8 @@ fn empty_clear_claims<F: Field>(_trace_length: usize) -> ClearProofClaims<F> {
                 ram_inc: zero,
                 rd_inc: zero,
             },
+            #[cfg(feature = "field-inline")]
+            field_inline: zero_field_inline_stage6_claims(),
             advice_cycle_phase: Stage6AdviceCyclePhaseClaims {
                 trusted: None,
                 untrusted: None,
@@ -765,6 +793,57 @@ fn empty_clear_claims<F: Field>(_trace_length: usize) -> ClearProofClaims<F> {
             },
             bytecode_address_phase: None,
             program_image_address_phase: None,
+        },
+    }
+}
+
+#[cfg(feature = "field-inline")]
+fn zero_field_inline_stage1_claims<F: Field>() -> FieldInlineStage1Claims<F> {
+    FieldInlineStage1Claims::zero()
+}
+
+#[cfg(feature = "field-inline")]
+fn zero_field_inline_stage2_claims<F: Field>() -> FieldInlineStage2OutputOpeningClaims<F> {
+    let zero = F::zero();
+    FieldInlineStage2OutputOpeningClaims {
+        product: FieldInlineProductOutputOpeningClaims {
+            field_rs1_value: zero,
+            field_rs2_value: zero,
+            field_rd_value: zero,
+        },
+    }
+}
+
+#[cfg(feature = "field-inline")]
+fn zero_field_inline_stage4_claims<F: Field>() -> FieldInlineStage4Claims<F> {
+    let zero = F::zero();
+    FieldInlineStage4Claims {
+        field_registers_read_write: FieldRegistersReadWriteOutputOpeningClaims {
+            field_registers_val: zero,
+            field_rs1_ra: zero,
+            field_rs2_ra: zero,
+            field_rd_wa: zero,
+            field_rd_inc: zero,
+        },
+    }
+}
+
+#[cfg(feature = "field-inline")]
+fn zero_field_inline_stage5_claims<F: Field>() -> FieldInlineStage5Claims<F> {
+    let zero = F::zero();
+    FieldInlineStage5Claims {
+        field_registers_val_evaluation: FieldRegistersValEvaluationOutputOpeningClaims {
+            field_rd_inc: zero,
+            field_rd_wa: zero,
+        },
+    }
+}
+
+#[cfg(feature = "field-inline")]
+fn zero_field_inline_stage6_claims<F: Field>() -> FieldInlineStage6Claims<F> {
+    FieldInlineStage6Claims {
+        field_registers_inc_claim_reduction: FieldRegistersIncClaimReductionOutputOpeningClaims {
+            field_rd_inc: F::zero(),
         },
     }
 }

--- a/crates/jolt-verifier/src/stages/stage6/inputs.rs
+++ b/crates/jolt-verifier/src/stages/stage6/inputs.rs
@@ -80,9 +80,25 @@ pub struct Stage6Claims<F: Field> {
     pub ram_ra_virtualization: RamRaVirtualizationOutputOpeningClaims<F>,
     pub instruction_ra_virtualization: InstructionRaVirtualizationOutputOpeningClaims<F>,
     pub inc_claim_reduction: IncClaimReductionOutputOpeningClaims<F>,
+    #[cfg(feature = "field-inline")]
+    pub field_inline: FieldInlineStage6Claims<F>,
     pub advice_cycle_phase: Stage6AdviceCyclePhaseClaims<F>,
     /// Committed program mode only.
     pub bytecode_claim_reduction: Option<BytecodeCyclePhaseOutputClaims<F>>,
     /// Committed program mode only.
     pub program_image_claim_reduction: Option<ProgramImageCyclePhaseOutputClaim<F>>,
+}
+
+#[cfg(feature = "field-inline")]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(bound = "")]
+pub struct FieldInlineStage6Claims<F: Field> {
+    pub field_registers_inc_claim_reduction: FieldRegistersIncClaimReductionOutputOpeningClaims<F>,
+}
+
+#[cfg(feature = "field-inline")]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(bound = "")]
+pub struct FieldRegistersIncClaimReductionOutputOpeningClaims<F: Field> {
+    pub field_rd_inc: F,
 }

--- a/crates/jolt-verifier/src/stages/stage6/outputs.rs
+++ b/crates/jolt-verifier/src/stages/stage6/outputs.rs
@@ -35,9 +35,17 @@ pub struct Stage6PublicOutput<F: Field> {
     pub booleanity_gamma: F,
     pub instruction_ra_gamma_powers: Vec<F>,
     pub inc_gamma: F,
+    #[cfg(feature = "field-inline")]
+    pub field_inline: FieldInlineStage6PublicOutput<F>,
     /// Committed program mode only: bytecode claim-reduction batching
     /// challenge (core's `eta`).
     pub bytecode_reduction_eta: Option<F>,
+}
+
+#[cfg(feature = "field-inline")]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct FieldInlineStage6PublicOutput<F: Field> {
+    pub field_inc_gamma: F,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -62,10 +70,18 @@ pub struct Stage6ZkOutput<F: Field, C> {
     pub ram_ra_virtualization: RamRaVirtualizationPublicOutput<F>,
     pub instruction_ra_virtualization: InstructionRaVirtualizationPublicOutput<F>,
     pub inc_claim_reduction: Stage6SumcheckPublicOutput<F>,
+    #[cfg(feature = "field-inline")]
+    pub field_inline: FieldInlineStage6ZkOutput<F>,
     pub trusted_advice_cycle_phase: Option<AdviceCyclePhasePublicOutput<F>>,
     pub untrusted_advice_cycle_phase: Option<AdviceCyclePhasePublicOutput<F>>,
     pub bytecode_cycle_phase: Option<CommittedReductionCyclePhasePublicOutput<F>>,
     pub program_image_cycle_phase: Option<CommittedReductionCyclePhasePublicOutput<F>>,
+}
+
+#[cfg(feature = "field-inline")]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct FieldInlineStage6ZkOutput<F: Field> {
+    pub field_registers_inc_claim_reduction: Stage6SumcheckPublicOutput<F>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -92,6 +108,8 @@ pub struct VerifiedStage6Batch<F: Field> {
     pub ram_ra_virtualization: VerifiedRamRaVirtualizationSumcheck<F>,
     pub instruction_ra_virtualization: VerifiedInstructionRaVirtualizationSumcheck<F>,
     pub inc_claim_reduction: VerifiedStage6Sumcheck<F>,
+    #[cfg(feature = "field-inline")]
+    pub field_registers_inc_claim_reduction: VerifiedStage6Sumcheck<F>,
     pub trusted_advice_cycle_phase: Option<VerifiedAdviceCyclePhaseSumcheck<F>>,
     pub untrusted_advice_cycle_phase: Option<VerifiedAdviceCyclePhaseSumcheck<F>>,
     pub bytecode_cycle_phase: Option<VerifiedBytecodeCyclePhaseSumcheck<F>>,

--- a/crates/jolt-verifier/src/stages/stage6/verify.rs
+++ b/crates/jolt-verifier/src/stages/stage6/verify.rs
@@ -1,3 +1,11 @@
+#[cfg(feature = "field-inline")]
+use jolt_claims::protocols::field_inline::{
+    formulas::{
+        claim_reductions::increments as field_increments, dimensions::FieldRegistersTraceDimensions,
+    },
+    FieldInlineChallengeId, FieldInlinePublicId, FieldInlineRelationClaims,
+    FieldRegistersIncClaimReductionChallenge, FieldRegistersIncClaimReductionPublic,
+};
 use jolt_claims::protocols::jolt::{
     formulas::{
         booleanity::{self, BooleanityDimensions},
@@ -42,6 +50,16 @@ use crate::{
     verifier::CheckedInputs, VerifierError,
 };
 
+#[cfg(feature = "field-inline")]
+const fn field_inline_stage6_output_claim_count() -> usize {
+    1
+}
+
+#[cfg(not(feature = "field-inline"))]
+const fn field_inline_stage6_output_claim_count() -> usize {
+    0
+}
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 struct Stage6BatchInputClaims<F: Field> {
     bytecode_read_raf_address: F,
@@ -52,6 +70,8 @@ struct Stage6BatchInputClaims<F: Field> {
     ram_ra_virtualization: F,
     instruction_ra_virtualization: F,
     inc_claim_reduction: F,
+    #[cfg(feature = "field-inline")]
+    field_registers_inc_claim_reduction: F,
     trusted_advice_cycle_phase: Option<F>,
     untrusted_advice_cycle_phase: Option<F>,
     bytecode_claim_reduction: Option<F>,
@@ -68,6 +88,8 @@ struct Stage6BatchExpectedOutputClaims<F: Field> {
     ram_ra_virtualization: F,
     instruction_ra_virtualization: F,
     inc_claim_reduction: F,
+    #[cfg(feature = "field-inline")]
+    field_registers_inc_claim_reduction: F,
     trusted_advice_cycle_phase: Option<F>,
     untrusted_advice_cycle_phase: Option<F>,
     bytecode_claim_reduction: Option<F>,
@@ -137,6 +159,9 @@ where
         formula_dimensions.instruction_ra_virtualization,
     );
     let inc_claims = increments::claim_reduction::<PCS::Field>(trace_dimensions);
+    #[cfg(feature = "field-inline")]
+    let field_inc_claims =
+        field_increments::claim_reduction::<PCS::Field>(FieldRegistersTraceDimensions::new(log_t));
 
     let trusted_advice_layout = checked.precommitted.trusted_advice.as_ref();
     let untrusted_advice_layout = checked.precommitted.untrusted_advice.as_ref();
@@ -164,6 +189,8 @@ where
     ] {
         validate_compressed_stage_claim(claim)?;
     }
+    #[cfg(feature = "field-inline")]
+    validate_compressed_field_inline_stage_claim(&field_inc_claims)?;
     for claim in [
         &trusted_advice_claims,
         &untrusted_advice_claims,
@@ -215,6 +242,7 @@ where
 
     let public = |instruction_ra_gamma_powers: Vec<PCS::Field>,
                   inc_gamma: PCS::Field,
+                  #[cfg(feature = "field-inline")] field_inc_gamma: PCS::Field,
                   eta: Option<PCS::Field>,
                   address_phase_challenges: Vec<PCS::Field>,
                   address_phase_batching_coefficients: Vec<PCS::Field>,
@@ -235,6 +263,8 @@ where
         booleanity_gamma,
         instruction_ra_gamma_powers: instruction_ra_gamma_powers.clone(),
         inc_gamma,
+        #[cfg(feature = "field-inline")]
+        field_inline: super::outputs::FieldInlineStage6PublicOutput { field_inc_gamma },
         bytecode_reduction_eta: eta,
     };
 
@@ -256,6 +286,8 @@ where
                 .num_virtual_ra_polys(),
         );
         let inc_gamma = transcript.challenge_scalar();
+        #[cfg(feature = "field-inline")]
+        let field_inc_gamma = transcript.challenge_scalar();
         let eta = committed_program.then(|| transcript.challenge_scalar());
 
         let mut statements = vec![
@@ -278,6 +310,11 @@ where
             ),
             SumcheckStatement::new(inc_claims.sumcheck.rounds, inc_claims.sumcheck.degree),
         ];
+        #[cfg(feature = "field-inline")]
+        statements.push(SumcheckStatement::new(
+            field_inc_claims.sumcheck.rounds,
+            field_inc_claims.sumcheck.degree,
+        ));
         if let Some(claim) = &trusted_advice_claims {
             statements.push(SumcheckStatement::new(
                 claim.sumcheck.rounds,
@@ -430,6 +467,22 @@ where
                     stage: JoltRelationId::IncClaimReduction,
                     reason: error.to_string(),
                 })?;
+        #[cfg(feature = "field-inline")]
+        let (field_inc_point, field_inc_opening_point) = {
+            let field_inc_point = consistency
+                .try_instance_point(field_inc_claims.sumcheck.rounds)
+                .map_err(|error| VerifierError::StageClaimSumcheckFailed {
+                    stage: JoltRelationId::IncClaimReduction,
+                    reason: error.to_string(),
+                })?;
+            let field_inc_opening_point = trace_dimensions
+                .cycle_opening_point(&field_inc_point)
+                .map_err(|error| VerifierError::StageClaimPublicInputFailed {
+                    stage: JoltRelationId::IncClaimReduction,
+                    reason: error.to_string(),
+                })?;
+            (field_inc_point, field_inc_opening_point)
+        };
 
         let trusted_advice = if let (Some(layout), Some(claim)) =
             (trusted_advice_layout, trusted_advice_claims.as_ref())
@@ -514,6 +567,7 @@ where
             + ram_ra_output_openings.len()
             + flat_instruction_ra_output_openings.len()
             + 2
+            + field_inline_stage6_output_claim_count()
             + usize::from(trusted_advice_claims.is_some())
             + usize::from(untrusted_advice_claims.is_some())
             + bytecode_reduction_output_claims
@@ -531,6 +585,8 @@ where
             public: public(
                 instruction_ra_gamma_powers,
                 inc_gamma,
+                #[cfg(feature = "field-inline")]
+                field_inc_gamma,
                 eta,
                 stage6a.address_phase_consistency.challenges(),
                 stage6a
@@ -585,6 +641,13 @@ where
                 sumcheck_point: inc_point,
                 opening_point: inc_opening_point,
             },
+            #[cfg(feature = "field-inline")]
+            field_inline: super::outputs::FieldInlineStage6ZkOutput {
+                field_registers_inc_claim_reduction: Stage6SumcheckPublicOutput {
+                    sumcheck_point: field_inc_point,
+                    opening_point: field_inc_opening_point,
+                },
+            },
             trusted_advice_cycle_phase: trusted_advice,
             untrusted_advice_cycle_phase: untrusted_advice,
             bytecode_cycle_phase,
@@ -632,6 +695,9 @@ where
     );
     let [ram_inc_read_write, ram_inc_val_check, rd_inc_read_write, rd_inc_val_evaluation] =
         increments::claim_reduction_input_openings();
+    #[cfg(feature = "field-inline")]
+    let [field_rd_inc_read_write, field_rd_inc_val_evaluation] =
+        field_increments::claim_reduction_input_openings();
 
     let bytecode_read_raf_address_input = bytecode_address_claims.input.expression().try_evaluate(
         |id| {
@@ -832,6 +898,8 @@ where
         .copied()
         .unwrap_or_else(PCS::Field::one);
     let inc_gamma = transcript.challenge_scalar();
+    #[cfg(feature = "field-inline")]
+    let field_inc_gamma = transcript.challenge_scalar();
     let eta = committed_program.then(|| transcript.challenge_scalar());
 
     let input_claims = Stage6BatchInputClaims {
@@ -892,6 +960,37 @@ where
                 _ => Err(VerifierError::MissingStageClaimChallenge { id: *id }),
             },
             |id| Err(VerifierError::MissingStageClaimPublic { id: *id }),
+        )?,
+        #[cfg(feature = "field-inline")]
+        field_registers_inc_claim_reduction: field_inc_claims.input.expression().try_evaluate(
+            |id| match *id {
+                id if id == field_rd_inc_read_write => Ok(stage4
+                    .output_claims
+                    .field_inline
+                    .field_registers_read_write
+                    .field_rd_inc),
+                id if id == field_rd_inc_val_evaluation => Ok(stage5
+                    .output_claims
+                    .field_inline
+                    .field_registers_val_evaluation
+                    .field_rd_inc),
+                id => Err(VerifierError::MissingFieldInlineOpeningClaim { id }),
+            },
+            |id| match id {
+                FieldInlineChallengeId::FieldRegistersIncClaimReduction(
+                    FieldRegistersIncClaimReductionChallenge::Gamma,
+                ) => Ok(field_inc_gamma),
+                _ => Err(VerifierError::StageClaimPublicInputFailed {
+                    stage: JoltRelationId::IncClaimReduction,
+                    reason: format!("missing field-inline challenge input {id:?}"),
+                }),
+            },
+            |id| {
+                Err(VerifierError::StageClaimPublicInputFailed {
+                    stage: JoltRelationId::IncClaimReduction,
+                    reason: format!("missing field-inline public input {id:?}"),
+                })
+            },
         )?,
         trusted_advice_cycle_phase: trusted_advice_claims
             .as_ref()
@@ -997,6 +1096,12 @@ where
             input_claims.inc_claim_reduction,
         ),
     ];
+    #[cfg(feature = "field-inline")]
+    sumcheck_claims.push(SumcheckClaim::new(
+        field_inc_claims.sumcheck.rounds,
+        field_inc_claims.sumcheck.degree,
+        input_claims.field_registers_inc_claim_reduction,
+    ));
     if let (Some(claim), Some(input_claim)) = (
         &trusted_advice_claims,
         input_claims.trusted_advice_cycle_phase,
@@ -1532,6 +1637,96 @@ where
             _ => Err(VerifierError::MissingStageClaimPublic { id: *id }),
         },
     )?;
+    #[cfg(feature = "field-inline")]
+    let (field_inc_point, field_inc_opening_point, field_inc_output) = {
+        let field_inc_point = batch
+            .try_instance_point(field_inc_claims.sumcheck.rounds)
+            .map_err(|error| VerifierError::StageClaimSumcheckFailed {
+                stage: JoltRelationId::IncClaimReduction,
+                reason: error.to_string(),
+            })?;
+        let field_inc_opening_point = trace_dimensions
+            .cycle_opening_point(field_inc_point)
+            .map_err(|error| VerifierError::StageClaimPublicInputFailed {
+                stage: JoltRelationId::IncClaimReduction,
+                reason: error.to_string(),
+            })?;
+        let field_log_k = proof.protocol.field_inline.field_register_log_k;
+        if stage4.batch.field_registers_read_write.opening_point.len() < field_log_k {
+            return Err(VerifierError::StageClaimPublicInputFailed {
+                stage: JoltRelationId::IncClaimReduction,
+                reason: format!(
+                    "field-register read-write opening point is shorter than the field-register address: expected at least {field_log_k}, got {}",
+                    stage4.batch.field_registers_read_write.opening_point.len()
+                ),
+            });
+        }
+        if stage5
+            .batch
+            .field_registers_val_evaluation
+            .opening_point
+            .len()
+            < field_log_k
+        {
+            return Err(VerifierError::StageClaimPublicInputFailed {
+                stage: JoltRelationId::IncClaimReduction,
+                reason: format!(
+                    "field-register val-evaluation opening point is shorter than the field-register address: expected at least {field_log_k}, got {}",
+                    stage5.batch.field_registers_val_evaluation.opening_point.len()
+                ),
+            });
+        }
+        let (_, field_read_write_cycle) = stage4
+            .batch
+            .field_registers_read_write
+            .opening_point
+            .split_at(field_log_k);
+        let (_, field_val_evaluation_cycle) = stage5
+            .batch
+            .field_registers_val_evaluation
+            .opening_point
+            .split_at(field_log_k);
+        let eq_field_read_write = try_eq_mle(&field_inc_opening_point, field_read_write_cycle)
+            .map_err(|error| VerifierError::StageClaimPublicInputFailed {
+                stage: JoltRelationId::IncClaimReduction,
+                reason: error.to_string(),
+            })?;
+        let eq_field_val_evaluation =
+            try_eq_mle(&field_inc_opening_point, field_val_evaluation_cycle).map_err(|error| {
+                VerifierError::StageClaimPublicInputFailed {
+                    stage: JoltRelationId::IncClaimReduction,
+                    reason: error.to_string(),
+                }
+            })?;
+        let [field_rd_inc] = field_increments::claim_reduction_output_openings();
+        let output = field_inc_claims.output.expression().try_evaluate(
+            |id| match *id {
+                id if id == field_rd_inc => Ok(claims
+                    .field_inline
+                    .field_registers_inc_claim_reduction
+                    .field_rd_inc),
+                id => Err(VerifierError::MissingFieldInlineOpeningClaim { id }),
+            },
+            |id| match id {
+                FieldInlineChallengeId::FieldRegistersIncClaimReduction(
+                    FieldRegistersIncClaimReductionChallenge::Gamma,
+                ) => Ok(field_inc_gamma),
+                _ => Err(VerifierError::StageClaimPublicInputFailed {
+                    stage: JoltRelationId::IncClaimReduction,
+                    reason: format!("missing field-inline challenge input {id:?}"),
+                }),
+            },
+            |id| match id {
+                FieldInlinePublicId::FieldRegistersIncClaimReduction(
+                    FieldRegistersIncClaimReductionPublic::EqReadWrite,
+                ) => Ok(eq_field_read_write),
+                FieldInlinePublicId::FieldRegistersIncClaimReduction(
+                    FieldRegistersIncClaimReductionPublic::EqValEvaluation,
+                ) => Ok(eq_field_val_evaluation),
+            },
+        )?;
+        (field_inc_point.to_vec(), field_inc_opening_point, output)
+    };
 
     let trusted_advice = if let (Some(layout), Some(claim), Some(opening_claim)) = (
         trusted_advice_layout,
@@ -1668,6 +1863,8 @@ where
         ram_ra_virtualization: ram_ra_output,
         instruction_ra_virtualization: instruction_ra_output,
         inc_claim_reduction: inc_output,
+        #[cfg(feature = "field-inline")]
+        field_registers_inc_claim_reduction: field_inc_output,
         trusted_advice_cycle_phase: trusted_advice
             .as_ref()
             .map(|verified| verified.expected_output_claim),
@@ -1689,6 +1886,8 @@ where
         expected_outputs.instruction_ra_virtualization,
         expected_outputs.inc_claim_reduction,
     ];
+    #[cfg(feature = "field-inline")]
+    expected_outputs_in_order.push(expected_outputs.field_registers_inc_claim_reduction);
     if let Some(output_claim) = expected_outputs.trusted_advice_cycle_phase {
         expected_outputs_in_order.push(output_claim);
     }
@@ -1734,6 +1933,8 @@ where
         public: public(
             instruction_ra_gamma_powers,
             inc_gamma,
+            #[cfg(feature = "field-inline")]
+            field_inc_gamma,
             eta,
             address_batch.reduction.point.as_slice().to_vec(),
             address_batch.batching_coefficients.clone(),
@@ -1807,6 +2008,13 @@ where
                 opening_point: inc_opening_point,
                 expected_output_claim: expected_outputs.inc_claim_reduction,
             },
+            #[cfg(feature = "field-inline")]
+            field_registers_inc_claim_reduction: VerifiedStage6Sumcheck {
+                input_claim: input_claims.field_registers_inc_claim_reduction,
+                sumcheck_point: field_inc_point,
+                opening_point: field_inc_opening_point,
+                expected_output_claim: expected_outputs.field_registers_inc_claim_reduction,
+            },
             trusted_advice_cycle_phase: trusted_advice,
             untrusted_advice_cycle_phase: untrusted_advice,
             bytecode_cycle_phase,
@@ -1826,6 +2034,22 @@ fn validate_compressed_stage_claim<F: Field>(
     }
     if !matches!(claim.sumcheck.domain, JoltSumcheckDomain::BooleanHypercube) {
         return Err(VerifierError::CompressedStageClaimRequiresBooleanDomain { stage: claim.id });
+    }
+    Ok(())
+}
+
+#[cfg(feature = "field-inline")]
+fn validate_compressed_field_inline_stage_claim<F: Field>(
+    claim: &FieldInlineRelationClaims<F>,
+) -> Result<(), VerifierError> {
+    if claim.sumcheck.degree == 0 {
+        return Err(VerifierError::StageClaimPublicInputFailed {
+            stage: JoltRelationId::IncClaimReduction,
+            reason: format!(
+                "field-inline stage {:?} sumcheck degree is invalid: {}",
+                claim.id, claim.sumcheck.degree
+            ),
+        });
     }
     Ok(())
 }

--- a/crates/jolt-verifier/src/verifier.rs
+++ b/crates/jolt-verifier/src/verifier.rs
@@ -815,15 +815,7 @@ mod tests {
 
     fn proof_with_zk(is_zk: bool, claims: TestClaims) -> TestProof {
         JoltProof::new(
-            crate::proof::JoltCommitments::new(
-                TestCommitment,
-                TestCommitment,
-                crate::proof::JoltRaCommitments::new(
-                    Vec::<TestCommitment>::new(),
-                    Vec::<TestCommitment>::new(),
-                    Vec::<TestCommitment>::new(),
-                ),
-            ),
+            test_commitments(),
             stage_proofs(is_zk),
             (),
             None,
@@ -844,6 +836,35 @@ mod tests {
         )
     }
 
+    #[cfg(not(feature = "field-inline"))]
+    fn test_commitments() -> crate::proof::JoltCommitments<TestCommitment> {
+        crate::proof::JoltCommitments::new(
+            TestCommitment,
+            TestCommitment,
+            crate::proof::JoltRaCommitments::new(
+                Vec::<TestCommitment>::new(),
+                Vec::<TestCommitment>::new(),
+                Vec::<TestCommitment>::new(),
+            ),
+        )
+    }
+
+    #[cfg(feature = "field-inline")]
+    fn test_commitments() -> crate::proof::JoltCommitments<TestCommitment> {
+        crate::proof::JoltCommitments::new(
+            TestCommitment,
+            TestCommitment,
+            crate::proof::JoltRaCommitments::new(
+                Vec::<TestCommitment>::new(),
+                Vec::<TestCommitment>::new(),
+                Vec::<TestCommitment>::new(),
+            ),
+            crate::proof::FieldInlineCommitments::new(
+                crate::proof::FieldRegistersCommitments::new(TestCommitment),
+            ),
+        )
+    }
+
     fn clear_claims() -> TestClaims {
         let zero = Fr::zero();
 
@@ -851,6 +872,8 @@ mod tests {
             stage1: stage1::inputs::Stage1Claims {
                 uniskip_output_claim: zero,
                 outer: empty_spartan_outer_claims(),
+                #[cfg(feature = "field-inline")]
+                field_inline: zero_field_inline_stage1_claims(),
             },
             stage2: stage2::inputs::Stage2Claims {
                 product_uniskip_output_claim: zero,
@@ -870,6 +893,8 @@ mod tests {
                         next_is_noop: zero,
                         virtual_instruction: zero,
                     },
+                    #[cfg(feature = "field-inline")]
+                    field_inline: zero_field_inline_stage2_claims(),
                     instruction_claim_reduction:
                         stage2::inputs::InstructionClaimReductionOutputOpeningClaims {
                             lookup_output: None,
@@ -920,6 +945,8 @@ mod tests {
                     rd_wa: zero,
                     rd_inc: zero,
                 },
+                #[cfg(feature = "field-inline")]
+                field_inline: zero_field_inline_stage4_claims(),
                 ram_val_check: stage4::inputs::RamValCheckOutputOpeningClaims {
                     ram_ra: zero,
                     ram_inc: zero,
@@ -939,6 +966,8 @@ mod tests {
                         rd_inc: zero,
                         rd_wa: zero,
                     },
+                #[cfg(feature = "field-inline")]
+                field_inline: zero_field_inline_stage5_claims(),
             },
             stage6: stage6::inputs::Stage6Claims {
                 address_phase: stage6::inputs::Stage6AddressPhaseClaims {
@@ -968,6 +997,8 @@ mod tests {
                     ram_inc: zero,
                     rd_inc: zero,
                 },
+                #[cfg(feature = "field-inline")]
+                field_inline: zero_field_inline_stage6_claims(),
                 advice_cycle_phase: stage6::inputs::Stage6AdviceCyclePhaseClaims {
                     trusted: None,
                     untrusted: None,
@@ -990,6 +1021,61 @@ mod tests {
                 program_image_address_phase: None,
             },
         })
+    }
+
+    #[cfg(feature = "field-inline")]
+    fn zero_field_inline_stage1_claims() -> stage1::inputs::FieldInlineStage1Claims<Fr> {
+        stage1::inputs::FieldInlineStage1Claims::zero()
+    }
+
+    #[cfg(feature = "field-inline")]
+    fn zero_field_inline_stage2_claims() -> stage2::inputs::FieldInlineStage2OutputOpeningClaims<Fr>
+    {
+        let zero = Fr::zero();
+        stage2::inputs::FieldInlineStage2OutputOpeningClaims {
+            product: stage2::inputs::FieldInlineProductOutputOpeningClaims {
+                field_rs1_value: zero,
+                field_rs2_value: zero,
+                field_rd_value: zero,
+            },
+        }
+    }
+
+    #[cfg(feature = "field-inline")]
+    fn zero_field_inline_stage4_claims() -> stage4::inputs::FieldInlineStage4Claims<Fr> {
+        let zero = Fr::zero();
+        stage4::inputs::FieldInlineStage4Claims {
+            field_registers_read_write:
+                stage4::inputs::FieldRegistersReadWriteOutputOpeningClaims {
+                    field_registers_val: zero,
+                    field_rs1_ra: zero,
+                    field_rs2_ra: zero,
+                    field_rd_wa: zero,
+                    field_rd_inc: zero,
+                },
+        }
+    }
+
+    #[cfg(feature = "field-inline")]
+    fn zero_field_inline_stage5_claims() -> stage5::inputs::FieldInlineStage5Claims<Fr> {
+        let zero = Fr::zero();
+        stage5::inputs::FieldInlineStage5Claims {
+            field_registers_val_evaluation:
+                stage5::inputs::FieldRegistersValEvaluationOutputOpeningClaims {
+                    field_rd_inc: zero,
+                    field_rd_wa: zero,
+                },
+        }
+    }
+
+    #[cfg(feature = "field-inline")]
+    fn zero_field_inline_stage6_claims() -> stage6::inputs::FieldInlineStage6Claims<Fr> {
+        stage6::inputs::FieldInlineStage6Claims {
+            field_registers_inc_claim_reduction:
+                stage6::inputs::FieldRegistersIncClaimReductionOutputOpeningClaims {
+                    field_rd_inc: Fr::zero(),
+                },
+        }
     }
 
     fn empty_spartan_outer_claims() -> stage1::inputs::SpartanOuterClaims<Fr> {

--- a/crates/jolt-verifier/tests/support/tamper_manifest.rs
+++ b/crates/jolt-verifier/tests/support/tamper_manifest.rs
@@ -423,6 +423,14 @@ pub const STAGE1_TARGETS: &[TamperTarget] = &[
         TamperCoverage::Active,
         "core-fixture test offsets every Spartan outer variable opening claim",
     ),
+    checked_standard(
+        "stage1.claims.field_inline",
+        "claims.stage1.field_inline.*",
+        VerifierPhase::Stage1,
+        MutationStrategy::OffsetScalar,
+        TamperCoverage::IgnoredUntilFixture,
+        "field-inline claim tampering needs a field-inline core fixture; the feature matrix compiles and runs verifier/formula tests",
+    ),
 ];
 
 pub const STAGE2_TARGETS: &[TamperTarget] = &[
@@ -513,6 +521,14 @@ pub const STAGE2_TARGETS: &[TamperTarget] = &[
         MutationStrategy::OffsetScalar,
         TamperCoverage::Active,
         "Stage 6 bytecode read-RAF consumes this Stage 2 pass-through claim",
+    ),
+    checked_standard(
+        "stage2.claims.batch_outputs.field_inline.product",
+        "claims.stage2.batch_outputs.field_inline.product.*",
+        VerifierPhase::Stage4,
+        MutationStrategy::OffsetScalar,
+        TamperCoverage::IgnoredUntilFixture,
+        "field-inline claim tampering needs a field-inline core fixture; Stage 4 consumes these product output claims",
     ),
     checked_standard(
         "stage2.claims.batch_outputs.instruction_claim_reduction",
@@ -633,6 +649,14 @@ pub const STAGE4_TARGETS: &[TamperTarget] = &[
         "core-fixture test offsets each RAM value-check output claim",
     ),
     checked_standard(
+        "stage4.claims.field_inline.field_registers_read_write",
+        "claims.stage4.field_inline.field_registers_read_write.*",
+        VerifierPhase::Stage4,
+        MutationStrategy::OffsetScalar,
+        TamperCoverage::IgnoredUntilFixture,
+        "field-inline claim tampering needs a field-inline core fixture; Stage 4 checks these field-register read-write outputs",
+    ),
+    checked_standard(
         "stage4.claims.advice.untrusted",
         "claims.stage4.advice.untrusted",
         VerifierPhase::Stage4,
@@ -722,6 +746,14 @@ pub const STAGE5_TARGETS: &[TamperTarget] = &[
         MutationStrategy::OffsetScalar,
         TamperCoverage::Active,
         "core-fixture test offsets each register value-evaluation output claim",
+    ),
+    checked_standard(
+        "stage5.claims.field_inline.field_registers_val_evaluation",
+        "claims.stage5.field_inline.field_registers_val_evaluation.*",
+        VerifierPhase::Stage5,
+        MutationStrategy::OffsetScalar,
+        TamperCoverage::IgnoredUntilFixture,
+        "field-inline claim tampering needs a field-inline core fixture; Stage 5 checks these field-register value-evaluation outputs",
     ),
 ];
 
@@ -861,6 +893,14 @@ pub const STAGE6_TARGETS: &[TamperTarget] = &[
         MutationStrategy::OffsetScalar,
         TamperCoverage::Active,
         "core-fixture test offsets the register increment reduction output claim",
+    ),
+    checked_standard(
+        "stage6.claims.field_inline.field_registers_inc_claim_reduction",
+        "claims.stage6.field_inline.field_registers_inc_claim_reduction.*",
+        VerifierPhase::Stage6,
+        MutationStrategy::OffsetScalar,
+        TamperCoverage::IgnoredUntilFixture,
+        "field-inline claim tampering needs a field-inline core fixture; Stage 6 checks the field-register increment reduction output",
     ),
     checked_standard(
         "stage6.claims.advice_cycle_phase.trusted.opening_claim",
@@ -1198,10 +1238,30 @@ fn expand_manifest_path(target: TamperTarget) -> Vec<&'static str> {
             "claims.stage1.outer.flags.is_first_in_sequence",
             "claims.stage1.outer.flags.is_last_in_sequence",
         ],
+        "claims.stage1.field_inline.*" => vec![
+            "claims.stage1.field_inline.field_rs1_value",
+            "claims.stage1.field_inline.field_rs2_value",
+            "claims.stage1.field_inline.field_rd_value",
+            "claims.stage1.field_inline.field_product",
+            "claims.stage1.field_inline.field_inv_product",
+            "claims.stage1.field_inline.flags.add",
+            "claims.stage1.field_inline.flags.sub",
+            "claims.stage1.field_inline.flags.mul",
+            "claims.stage1.field_inline.flags.inv",
+            "claims.stage1.field_inline.flags.assert_eq",
+            "claims.stage1.field_inline.flags.load_from_x",
+            "claims.stage1.field_inline.flags.store_to_x",
+            "claims.stage1.field_inline.flags.load_imm",
+        ],
         "claims.stage2.batch_outputs.ram_read_write.*" => vec![
             "claims.stage2.batch_outputs.ram_read_write.val",
             "claims.stage2.batch_outputs.ram_read_write.ra",
             "claims.stage2.batch_outputs.ram_read_write.inc",
+        ],
+        "claims.stage2.batch_outputs.field_inline.product.*" => vec![
+            "claims.stage2.batch_outputs.field_inline.product.field_rs1_value",
+            "claims.stage2.batch_outputs.field_inline.product.field_rs2_value",
+            "claims.stage2.batch_outputs.field_inline.product.field_rd_value",
         ],
         "claims.stage2.batch_outputs.product_remainder.{left_instruction_input,right_instruction_input,jump_flag,lookup_output,branch_flag,next_is_noop}" => vec![
             "claims.stage2.batch_outputs.product_remainder.left_instruction_input",
@@ -1251,10 +1311,24 @@ fn expand_manifest_path(target: TamperTarget) -> Vec<&'static str> {
             "claims.stage4.ram_val_check.ram_ra",
             "claims.stage4.ram_val_check.ram_inc",
         ],
+        "claims.stage4.field_inline.field_registers_read_write.*" => vec![
+            "claims.stage4.field_inline.field_registers_read_write.field_registers_val",
+            "claims.stage4.field_inline.field_registers_read_write.field_rs1_ra",
+            "claims.stage4.field_inline.field_registers_read_write.field_rs2_ra",
+            "claims.stage4.field_inline.field_registers_read_write.field_rd_wa",
+            "claims.stage4.field_inline.field_registers_read_write.field_rd_inc",
+        ],
         "claims.stage5.registers_val_evaluation.*" => vec![
             "claims.stage5.registers_val_evaluation.rd_inc",
             "claims.stage5.registers_val_evaluation.rd_wa",
         ],
+        "claims.stage5.field_inline.field_registers_val_evaluation.*" => vec![
+            "claims.stage5.field_inline.field_registers_val_evaluation.field_rd_inc",
+            "claims.stage5.field_inline.field_registers_val_evaluation.field_rd_wa",
+        ],
+        "claims.stage6.field_inline.field_registers_inc_claim_reduction.*" => {
+            vec!["claims.stage6.field_inline.field_registers_inc_claim_reduction.field_rd_inc"]
+        }
         path => vec![path],
     }
 }
@@ -1317,6 +1391,8 @@ fn zero_clear_claims() -> ClearProofClaims<Fr> {
                     is_last_in_sequence: zero,
                 },
             },
+            #[cfg(feature = "field-inline")]
+            field_inline: zero_field_inline_stage1_claims(),
         },
         stage2: stage2::inputs::Stage2Claims {
             product_uniskip_output_claim: zero,
@@ -1336,6 +1412,8 @@ fn zero_clear_claims() -> ClearProofClaims<Fr> {
                     next_is_noop: zero,
                     virtual_instruction: zero,
                 },
+                #[cfg(feature = "field-inline")]
+                field_inline: zero_field_inline_stage2_claims(),
                 instruction_claim_reduction:
                     stage2::inputs::InstructionClaimReductionOutputOpeningClaims {
                         lookup_output: Some(zero),
@@ -1385,6 +1463,8 @@ fn zero_clear_claims() -> ClearProofClaims<Fr> {
                 rd_wa: zero,
                 rd_inc: zero,
             },
+            #[cfg(feature = "field-inline")]
+            field_inline: zero_field_inline_stage4_claims(),
             ram_val_check: stage4::inputs::RamValCheckOutputOpeningClaims {
                 ram_ra: zero,
                 ram_inc: zero,
@@ -1403,6 +1483,8 @@ fn zero_clear_claims() -> ClearProofClaims<Fr> {
                 rd_inc: zero,
                 rd_wa: zero,
             },
+            #[cfg(feature = "field-inline")]
+            field_inline: zero_field_inline_stage5_claims(),
         },
         stage6: stage6::inputs::Stage6Claims {
             address_phase: stage6::inputs::Stage6AddressPhaseClaims {
@@ -1432,6 +1514,8 @@ fn zero_clear_claims() -> ClearProofClaims<Fr> {
                 ram_inc: zero,
                 rd_inc: zero,
             },
+            #[cfg(feature = "field-inline")]
+            field_inline: zero_field_inline_stage6_claims(),
             advice_cycle_phase: stage6::inputs::Stage6AdviceCyclePhaseClaims {
                 trusted: Some(stage6::inputs::AdviceCyclePhaseOutputClaim {
                     opening_claim: zero,
@@ -1473,5 +1557,58 @@ fn zero_clear_claims() -> ClearProofClaims<Fr> {
                 },
             ),
         },
+    }
+}
+
+#[cfg(feature = "field-inline")]
+fn zero_field_inline_stage1_claims() -> stage1::inputs::FieldInlineStage1Claims<Fr> {
+    stage1::inputs::FieldInlineStage1Claims::zero()
+}
+
+#[cfg(feature = "field-inline")]
+fn zero_field_inline_stage2_claims() -> stage2::inputs::FieldInlineStage2OutputOpeningClaims<Fr> {
+    let zero = Fr::from_u64(0);
+    stage2::inputs::FieldInlineStage2OutputOpeningClaims {
+        product: stage2::inputs::FieldInlineProductOutputOpeningClaims {
+            field_rs1_value: zero,
+            field_rs2_value: zero,
+            field_rd_value: zero,
+        },
+    }
+}
+
+#[cfg(feature = "field-inline")]
+fn zero_field_inline_stage4_claims() -> stage4::inputs::FieldInlineStage4Claims<Fr> {
+    let zero = Fr::from_u64(0);
+    stage4::inputs::FieldInlineStage4Claims {
+        field_registers_read_write: stage4::inputs::FieldRegistersReadWriteOutputOpeningClaims {
+            field_registers_val: zero,
+            field_rs1_ra: zero,
+            field_rs2_ra: zero,
+            field_rd_wa: zero,
+            field_rd_inc: zero,
+        },
+    }
+}
+
+#[cfg(feature = "field-inline")]
+fn zero_field_inline_stage5_claims() -> stage5::inputs::FieldInlineStage5Claims<Fr> {
+    let zero = Fr::from_u64(0);
+    stage5::inputs::FieldInlineStage5Claims {
+        field_registers_val_evaluation:
+            stage5::inputs::FieldRegistersValEvaluationOutputOpeningClaims {
+                field_rd_inc: zero,
+                field_rd_wa: zero,
+            },
+    }
+}
+
+#[cfg(feature = "field-inline")]
+fn zero_field_inline_stage6_claims() -> stage6::inputs::FieldInlineStage6Claims<Fr> {
+    stage6::inputs::FieldInlineStage6Claims {
+        field_registers_inc_claim_reduction:
+            stage6::inputs::FieldRegistersIncClaimReductionOutputOpeningClaims {
+                field_rd_inc: Fr::from_u64(0),
+            },
     }
 }

--- a/specs/field-inline-protocol.md
+++ b/specs/field-inline-protocol.md
@@ -1,0 +1,1270 @@
+# Spec: Field Inline Protocol
+
+| Field | Value |
+|-------|-------|
+| Author(s) | Markos Georghiades, Codex |
+| Created | 2026-05-21 |
+| Status | draft |
+| PR | TBD |
+
+## Purpose
+
+Field inline adds native field operations to the Jolt VM. From the proof
+machinery perspective, it is a uniform extension of existing Jolt machinery:
+an FR register file is another memory-checking instance, field instructions add
+`field_constraints`, and multiplication uses an explicit FR-native product
+relation.
+
+This spec owns the field-inline protocol axis. Composition with Dory assist,
+wrapping, ZK, and proof-shape validation is specified in
+[selected-verifier-integration.md](selected-verifier-integration.md). Prover
+execution and witness construction concerns are tracked by
+[jolt-prover-model-crate.md](jolt-prover-model-crate.md).
+
+Reference implementation context:
+
+- Sagar's `sagar/fr-coprocessor-v2-port` PR/branch is the concrete reference
+  for the first modular port.
+- The v1 port should preserve the important protocol choices while moving the
+  protocol facts into modular crates.
+
+## Scope
+
+V1 scope:
+
+```text
+native field-inline arithmetic only
+FR register file with K = 16 slots
+explicit FieldProduct relation
+field_constraints
+x-register <-> FR bridge rows
+advice-style optionality when field inline is disabled
+```
+
+Out of scope:
+
+```text
+non-native field arithmetic q != modulus(F)
+limb modular-reduction gadgets
+one universal wrapper circuit for FR-on and FR-off verifier configs
+multi-width field arithmetic independent of the Jolt field
+```
+
+## Native-Field Invariant
+
+Field inline v1 is native-field only. For every supported instantiation:
+
+```text
+q = modulus(field-inline arithmetic)
+p = modulus(F: JoltField)
+q = p
+```
+
+The protocol is generic over `F: JoltField`, not over an independent modulus.
+A 254-bit target means Jolt itself is compiled over a 254-bit field such as
+BN254 Fr. A 128-bit target means Jolt itself is compiled over a 128-bit field.
+In both cases, FR register values are elements of `F`, and local field
+arithmetic is native R1CS arithmetic.
+
+This is why the FMUL relation is simple:
+
+```text
+FieldProduct = FieldRs1Value * FieldRs2Value
+FieldProduct = FieldRdValue
+```
+
+R1CS constraints over `F` already enforce equality modulo `modulus(F)`. Since
+the field-inline modulus is the same modulus, no quotient witness or modular
+reduction gadget is needed.
+
+If a future mode proves arithmetic modulo `q != modulus(F)`, the protocol must
+add explicit representation data:
+
+```text
+limb count
+limb bit width
+range checks
+carry constraints
+quotient witnesses
+canonical modular reduction
+conversion semantics
+```
+
+That is a separate project, not a field-inline v1 requirement.
+
+## Protocol Intuition
+
+Ordinary Jolt splits instruction semantics across several protocol components:
+
+```text
+Twist/read-write checking:
+  proves memory/register accesses are consistent over time
+
+instruction lookups and flags:
+  prove which instruction relation is active on each cycle
+
+Spartan/R1CS rows:
+  prove local per-cycle algebraic semantics
+
+product virtualization:
+  proves selected multiplication witness products used by local constraints
+```
+
+Field inline follows the same pattern:
+
+```text
+FR register Twist:
+  tracks reads and writes of field-register slots
+
+field instruction flags:
+  select FADD, FSUB, FMUL, FINV, ASSERT_EQ, MOV, bridge ops, etc.
+
+field_constraints:
+  enforce local field instruction semantics
+
+field-product relation:
+  proves FieldRs1Value * FieldRs2Value for FMUL/FINV-style rows
+
+conversion R1CS rows:
+  enforce movement between ordinary x-register values and field-register values
+```
+
+The important semantic split is:
+
+```text
+Twist:
+  proves the field register file is a consistent memory over cycles
+
+instruction flags/lookups:
+  prove which field instruction is active
+
+field_constraints:
+  prove local algebraic instruction semantics
+
+FieldProduct:
+  proves the FR-native multiplication witness used by local rows
+```
+
+Twist does not prove that a field multiplication is correct. It proves that the
+values read from and written to the FR register file are consistent over time.
+The multiplication equation is owned by the local R1CS/product relation.
+
+## Trace Semantics
+
+Pure field operations should use pure FR access in v1:
+
+```text
+pure field op:
+  FR metadata/events + FR Twist + field_constraints
+
+bridge op:
+  x-register Twist + FR Twist + bridge field_constraints
+```
+
+Example:
+
+```text
+cycle 10:
+  opcode = ADD
+  x-register reads/writes are active
+  normal register Twist is active
+  ordinary RV64 R1CS rows are active
+  FR register Twist is inactive
+
+cycle 11:
+  opcode = FMUL
+  FR register reads/writes are active
+  FieldProduct relation is active
+  field_constraints enforce FieldProduct = FieldRdValue
+  ordinary x-register accesses are suppressed
+
+cycle 12:
+  opcode = FIELD_MOV_FROM_X
+  x-register read is active
+  FR register write is active
+  bridge row enforces FieldRdValue = decode_x_register(Rs1Value, F)
+```
+
+Sagar's reference implementation treated incidental x-register accesses on
+field-op cycles as inert overhead. V1 should suppress them in the modular port
+unless the trace implementation makes suppression materially harder. If an
+implementation proves them inert instead, that must be an explicit trace-level
+compatibility choice, not an accidental side effect.
+
+## Field Register Memory
+
+V1 uses a small FR register file:
+
+```text
+field_register_log_k = 4
+K = 16 slots
+```
+
+The FR register file is a Twist/read-write memory instance. It has its own
+read/write events and value claims, analogous to normal registers and RAM:
+
+```text
+FieldRs1Value
+FieldRs2Value
+FieldRdValue
+FieldRegistersVal
+FieldRs1Ra
+FieldRs2Ra
+FieldRdWa
+FieldRdInc
+```
+
+The stage placement mirrors existing memory-checking work:
+
+```text
+stage 2:
+  field product lane in Spartan product virtualization
+  field-register claim reduction at the product remainder point
+
+stage 4:
+  field-register read/write checking over T * 16
+
+stage 5:
+  field-register val evaluation
+
+stage 6:
+  FieldRdInc claim reduction
+
+Spartan/product layer:
+  explicit field-register-native product relation for FMUL
+  optional inverse product relation for FINV
+```
+
+These relations are batched with the appropriate existing verifier stages in
+the same way register and RAM memory relations are batched with other protocol
+work.
+
+## Field Product
+
+`FieldProduct` is an explicit FR-native product relation:
+
+```text
+FieldProduct = FieldRs1Value * FieldRs2Value
+```
+
+Local FMUL rows then use:
+
+```text
+IsFieldMul * (FieldProduct - FieldRdValue) = 0
+```
+
+This relation is wired as another lane in Spartan product virtualization. The
+field-specific name remains important so the witness path stays FR-aware. It
+should not reuse an integer product witness unless that witness path is
+explicitly field-register aware.
+
+For FINV-style rows, the guarded inverse equation needs a separate product
+witness:
+
+```text
+FieldInvProduct = FieldRs1Value * FieldRdValue
+IsFieldInv * (FieldInvProduct - 1) = 0
+```
+
+This second product relation should batch with the same field-product machinery
+if FINV is included in v1. The protocol fact is that the inverse relation is
+over native `F`.
+
+## Protocol Composition And Points
+
+Field inline composes with the ordinary verifier by reusing the product
+virtualization point. The field-product relation should not introduce a
+separate field-product point.
+
+Notation:
+
+```text
+tau      = Spartan outer cycle point
+r_prod   = stage-2 product remainder point
+r_rw     = field-register read/write point = [field_addr, rw_cycle]
+r_val    = field-register val-eval point   = [field_addr, val_cycle]
+r_inc    = field increment-reduction cycle point
+r_final  = stage-8 final PCS opening point
+```
+
+With field inline enabled, product virtualization adds a field-product lane:
+
+```text
+existing product lanes:
+  Product = LeftInstructionInput * RightInstructionInput
+  ShouldBranch = LookupOutput * BranchFlag
+  ShouldJump = JumpFlag * (1 - NextIsNoop)
+
+field-inline lane:
+  FieldProduct = FieldRs1Value * FieldRs2Value
+```
+
+The product uniskip relation reduces `FieldProduct(tau)` into the same stage-2
+product remainder relation as the ordinary product lanes. The product
+remainder opens `FieldRs1Value(r_prod)` and `FieldRs2Value(r_prod)`.
+
+The field-register claim reduction is also batched in stage 2 and uses the
+same `r_prod` point:
+
+```text
+FieldRdValue(tau)
+  + gamma * FieldRs1Value(tau)
+  + gamma^2 * FieldRs2Value(tau)
+
+  ->
+
+Eq(tau, r_prod) * (
+  FieldRdValue(r_prod)
+    + gamma * FieldRs1Value(r_prod)
+    + gamma^2 * FieldRs2Value(r_prod)
+)
+```
+
+In the current batched sumcheck verifier, instances with the same number of
+rounds use the same suffix of the batched challenge vector. The field-product
+remainder and field-register claim reduction are both trace-domain claims, so
+placing them in the same stage-2 batch gives both relations the same
+`r_prod`.
+
+This is the important dependency: the `FieldRs1Value(r_prod)` and
+`FieldRs2Value(r_prod)` used by product virtualization are the same values
+that enter FR register memory checking. If field product and field-register
+claim reduction used different points, an extra equality/reduction protocol
+would be needed to connect them.
+
+The downstream memory path is:
+
+```text
+stage 4:
+  consumes FieldRd/Rs1/Rs2 values at r_prod
+  proves FR read/write consistency at r_rw
+  outputs FieldRegistersVal(r_rw), FieldRs1Ra(r_rw), FieldRs2Ra(r_rw),
+  FieldRdWa(r_rw), FieldRdInc(rw_cycle)
+
+stage 5:
+  consumes FieldRegistersVal(r_rw)
+  proves FR val evaluation at r_val
+  outputs FieldRdWa(r_val), FieldRdInc(val_cycle)
+
+stage 6 BytecodeReadRaf:
+  extends BytecodeReadRaf with field-inline instruction/access terms
+  proves FieldRs1Ra, FieldRs2Ra, FieldRdWa, FieldOpFlag(...)
+  match the field operands/opcode selected by BytecodeRa(i)
+
+stage 6 FieldRegistersIncClaimReduction:
+  reduces FieldRdInc(rw_cycle) and FieldRdInc(val_cycle)
+  to one FieldRdInc(r_inc) claim
+
+stage 8:
+  embeds FieldRdInc(r_inc) into the final PCS point
+  RLCs it with the ordinary final committed openings
+```
+
+For v1, the new committed field-inline surface is nested under
+`FieldInlineCommitments::field_registers` and includes `FieldRdInc`.
+`FieldRdInc` enters the stage-6 reduction and then the final PCS RLC.
+`FieldRs1Ra`, `FieldRs2Ra`, and `FieldRdWa` mirror ordinary register-Twist RA/WA
+columns: they are virtual openings inside the FR read/write relation, not
+committed PCS polynomials.
+
+Those virtual FR access columns are still anchored to committed data. The
+anchor is the existing bytecode RA commitment path:
+
+```text
+FieldRs1Ra / FieldRs2Ra / FieldRdWa
+  -> consumed by the field-inline extension of BytecodeReadRaf
+  -> checked against field operands in the selected bytecode row
+  -> reduced to BytecodeRa(i)@BytecodeReadRaf
+  -> reduced by HammingWeightClaimReduction
+  -> opened in the ordinary stage-8 PCS batch
+```
+
+Field op flags follow the same rule. They are virtual Spartan/R1CS inputs, but
+BytecodeReadRaf must check them against the decoded field opcode carried by the
+selected bytecode row. A field-inline verifier must not accept FR RA/WA claims
+that are only self-consistent under `FieldRegistersReadWriteChecking`; they must
+also be linked to `BytecodeRa(i)`.
+
+### Stage 2 Composition
+
+The selected product uniskip geometry lives with the selected R1CS constants in
+`jolt-r1cs::constraints::jolt`:
+
+```text
+FR off:
+  product lanes = 3
+  domain size   = 3
+
+FR on:
+  ordinary product lanes = 3
+  field product lanes    = 2
+  domain size            = 5
+```
+
+The two field lanes are:
+
+```text
+FieldProduct    = FieldRs1Value * FieldRs2Value
+FieldInvProduct = FieldRs1Value * FieldRdValue
+```
+
+The stage-2 batch order with field inline enabled is:
+
+```text
+1. RAM read/write
+2. Spartan product remainder
+3. instruction claim reduction
+4. FieldRegistersClaimReduction
+5. RAM RAF evaluation
+6. RAM output check
+```
+
+`FieldRegistersClaimReduction` uses the same `r_prod` suffix point as the
+product remainder. Its output openings are aliases into the field product
+remainder rows:
+
+```text
+FieldRs1Value@FieldRegistersClaimReduction -> FieldRs1Value@FieldRegistersProduct
+FieldRs2Value@FieldRegistersClaimReduction -> FieldRs2Value@FieldRegistersProduct
+FieldRdValue @FieldRegistersClaimReduction -> FieldRdValue @FieldRegistersProduct
+```
+
+The committed output-claim row order appends the three field product outputs
+after the ordinary product-remainder outputs and before the instruction
+claim-reduction non-aliased outputs. The transparent verifier appends those
+three values to the transcript in that order. The BlindFold builder uses the
+same output order and aliases so ZK mode binds the hidden values to the same
+stage-2 equations.
+
+The field-register claim-reduction gamma is pulled after the ordinary RAM
+read/write and instruction claim-reduction gammas, before RAM output address
+challenges. FR-off skips the field challenge and field sumcheck instance
+entirely.
+
+### Stage 4 Composition
+
+Stage 4 batches field-register read/write checking beside the ordinary
+register and RAM value-check work:
+
+```text
+FR off:
+  1. RegistersReadWriteChecking
+  2. RamValCheck
+
+FR on:
+  1. RegistersReadWriteChecking
+  2. FieldRegistersReadWriteChecking
+  3. RamValCheck
+```
+
+`FieldRegistersReadWriteChecking` uses the field-register read/write
+dimensions from `jolt-claims`:
+
+```text
+log_t = trace length log
+log_k = field_register_log_k = 4
+phase1 = log_t
+phase2 = field_register_log_k
+```
+
+The input claim consumes the stage-2 field-register claim-reduction values:
+
+```text
+FieldRdValue(r_prod)
+  + gamma * FieldRs1Value(r_prod)
+  + gamma^2 * FieldRs2Value(r_prod)
+```
+
+The output claim opens the FR register memory relation at `r_field_rw`:
+
+```text
+Eq(r_prod, r_field_rw.cycle) * (
+  FieldRdWa * FieldRdInc
+    + FieldRdWa * FieldRegistersVal
+    + gamma * FieldRs1Ra * FieldRegistersVal
+    + gamma^2 * FieldRs2Ra * FieldRegistersVal
+)
+```
+
+The committed output-claim row order appends the five field-register
+read/write outputs after ordinary register read/write outputs and before RAM
+value-check outputs:
+
+```text
+FieldRegistersVal
+FieldRs1Ra
+FieldRs2Ra
+FieldRdWa
+FieldRdInc
+```
+
+The transparent verifier appends those values to the Fiat-Shamir transcript in
+that order. The BlindFold builder uses the same order and the same
+`FieldRegistersReadWriteChecking` claim expression so ZK mode binds hidden
+outputs to the identical Stage 4 equations.
+
+### Stage 5 Composition
+
+Stage 5 batches field-register value evaluation beside the ordinary
+instruction read-RAF, RAM RA reduction, and register value-evaluation work:
+
+```text
+FR off:
+  1. InstructionReadRaf
+  2. RamRaClaimReduction
+  3. RegistersValEvaluation
+
+FR on:
+  1. InstructionReadRaf
+  2. RamRaClaimReduction
+  3. RegistersValEvaluation
+  4. FieldRegistersValEvaluation
+```
+
+`FieldRegistersValEvaluation` consumes the `FieldRegistersVal` output from
+Stage 4 at the field-register read/write point:
+
+```text
+input:
+  FieldRegistersVal(r_field_rw)
+```
+
+It opens the same field-register address at the Stage 5 value-evaluation
+cycle point and checks the write activation:
+
+```text
+output:
+  Lt(r_field_val.cycle, r_field_rw.cycle)
+    * FieldRdInc(r_field_val)
+    * FieldRdWa(r_field_val)
+```
+
+The committed output-claim row order appends the two field-register
+value-evaluation outputs after the ordinary register value-evaluation outputs:
+
+```text
+FieldRdInc
+FieldRdWa
+```
+
+The transparent verifier appends those values to the Fiat-Shamir transcript in
+that order. The BlindFold builder uses the same order and the same
+`FieldRegistersValEvaluation` claim expression so ZK mode binds hidden outputs
+to the identical Stage 5 equations.
+
+### Stage 6 Composition
+
+Stage 6 extends ordinary bytecode read-RAF and batches field-register increment
+reduction beside the ordinary Booleanity, RA virtualization, and
+increment-reduction work:
+
+```text
+FR off:
+  1. BytecodeReadRaf
+  2. Booleanity
+  3. RamHammingBooleanity
+  4. RamRaVirtualization
+  5. InstructionRaVirtualization
+  6. IncClaimReduction
+  7+. optional advice cycle-phase reductions
+
+FR on:
+  1. BytecodeReadRaf, with field-inline opcode/access terms enabled
+  2. Booleanity
+  3. RamHammingBooleanity
+  4. RamRaVirtualization
+  5. InstructionRaVirtualization
+  6. IncClaimReduction
+  7. FieldRegistersIncClaimReduction
+  8+. optional advice cycle-phase reductions
+```
+
+With field inline enabled, `BytecodeReadRaf` also consumes field-inline virtual
+openings produced by earlier stages:
+
+```text
+from stage 1 / selected Spartan outer:
+  FieldOpFlag(Add/Sub/Mul/Inv/AssertEq/LoadFromX/StoreToX/LoadImm)
+
+from stage 4 / FieldRegistersReadWriteChecking:
+  FieldRdWa
+  FieldRs1Ra
+  FieldRs2Ra
+
+from stage 5 / FieldRegistersValEvaluation:
+  FieldRdWa
+```
+
+The bytecode public-row evaluation computes the matching values from the field
+opcode and field operand columns in the selected bytecode row. The output
+remains the existing committed bytecode RA product:
+
+```text
+BytecodeRa(i)@BytecodeReadRaf
+```
+
+There is no `FieldRegistersRa(i)` commitment. FR register access selectors are
+valid only because `BytecodeReadRaf` links them to the committed `BytecodeRa(i)`
+path and the public/preprocessed bytecode table.
+
+The v1 modular verifier represents the field-inline bytecode facts as a
+preprocessed side table parallel to ordinary bytecode rows:
+
+```text
+FieldInlineBytecodeRow:
+  field op flags: Add/Sub/Mul/Inv/AssertEq/LoadFromX/StoreToX/LoadImm
+  field operands: rd, rs1, rs2 as FR register slots, each optional
+```
+
+When field inline is enabled, verifier preprocessing must supply this table.
+Stage 6 rejects a field-inline proof if the table is missing. This keeps the
+FR RA/WA openings soundly tied to the program being verified while the prover
+and tracer work is still landing in the modular crates.
+
+The field-inline `BytecodeReadRaf` extension appends terms to existing bytecode
+RLCs instead of creating another bytecode relation:
+
+```text
+Stage1Gamma powers:
+  ordinary powers 0..(1 + NUM_CIRCUIT_FLAGS)
+  then FieldOpFlag(Add/Sub/Mul/Inv/AssertEq/LoadFromX/StoreToX/LoadImm)
+
+Stage4Gamma powers:
+  ordinary powers: RdWa, Rs1Ra, Rs2Ra
+  then FieldRdWa, FieldRs1Ra, FieldRs2Ra
+
+Stage5Gamma powers:
+  ordinary powers: RdWa, InstructionRafFlag, lookup-table flags
+  then FieldRdWa@FieldRegistersValEvaluation
+```
+
+The input claim is the ordinary `BytecodeReadRaf` input claim plus those
+field-inline terms under the existing outer bytecode gamma. The output claim
+uses the same `BytecodeRa(i)@BytecodeReadRaf` product, with public stage values
+augmented by evaluating the field-inline side table at the bytecode point and
+the relevant stage cycle points.
+
+`FieldRegistersIncClaimReduction` consumes the two semantic openings of the
+committed `FieldRdInc` polynomial produced by Stage 4 and Stage 5:
+
+```text
+input:
+  FieldRdInc@FieldRegistersReadWriteChecking
+  + eta * FieldRdInc@FieldRegistersValEvaluation
+```
+
+It reduces them to one final `FieldRdInc` claim at the Stage 6 field increment
+point:
+
+```text
+output:
+  (Eq(r_field_inc, r_field_rw.cycle)
+    + eta * Eq(r_field_inc, r_field_val.cycle))
+    * FieldRdInc@FieldRegistersIncClaimReduction
+```
+
+The verifier pulls a separate field-inline increment-reduction challenge
+`eta` when field inline is enabled. FR-off skips this challenge and skips the
+field sumcheck instance entirely.
+
+The committed output-claim row order appends the reduced field `FieldRdInc`
+after ordinary `RamInc`/`RdInc` increment-reduction outputs and before optional
+advice cycle-phase outputs:
+
+```text
+FieldRdInc
+```
+
+The transparent verifier appends this value to the Fiat-Shamir transcript in
+that order. The BlindFold builder uses the same order and the same
+`FieldRegistersIncClaimReduction` claim expression so ZK mode binds the hidden
+field increment claim to the identical Stage 6 equation.
+
+Stage 8 then appends the same reduced `FieldRdInc` opening to the final PCS
+batch. The field-inline final-opening order is:
+
+```text
+RamInc@IncClaimReduction
+RdInc@IncClaimReduction
+FieldRdInc@FieldRegistersIncClaimReduction   // only with field-inline
+InstructionRa(i)@HammingWeightClaimReduction
+BytecodeRa(i)@HammingWeightClaimReduction
+RamRa(i)@HammingWeightClaimReduction
+TrustedAdvice / UntrustedAdvice              // if present
+```
+
+`FieldRdInc` uses the same dense embedding scale as ordinary `RdInc`; the
+stage-6 field reduction has already reduced the stage-4 and stage-5 claims to a
+single trace-domain opening. In ZK mode the Stage 8 output carries mixed final
+opening IDs, so the BlindFold final-opening equation can bind ordinary Jolt
+openings and field-inline openings in one RLC.
+
+## Field Constraints
+
+Target module:
+
+```text
+crates/jolt-r1cs/src/constraints/
+  mod.rs
+  rv64.rs
+  field_constraints.rs
+```
+
+`field_constraints.rs` owns the R1CS constraints for native field-inline
+instruction semantics. These constraints are flag-gated equalities over the
+field-register witness columns and, where needed, over product witnesses proven
+by the field-inline product protocol.
+
+Core wires:
+
+```text
+selectors:
+  IsFieldAdd
+  IsFieldSub
+  IsFieldMul
+  IsFieldInv
+  IsFieldAssertEq
+  IsFieldLoadFromX
+  IsFieldStoreToX
+  IsFieldLoadImm
+
+field values:
+  FieldRs1Value
+  FieldRs2Value
+  FieldRdValue
+  FieldProduct
+  FieldInvProduct
+
+ordinary values:
+  Rs1Value
+  RdWriteValue
+  Imm
+```
+
+Constraint sketch:
+
+```text
+FADD:
+  IsFieldAdd * (FieldRs1Value + FieldRs2Value - FieldRdValue) = 0
+
+FSUB:
+  IsFieldSub * (FieldRs1Value - FieldRs2Value - FieldRdValue) = 0
+
+FMUL:
+  IsFieldMul * (FieldProduct - FieldRdValue) = 0
+
+FINV:
+  FieldInvProduct = FieldRs1Value * FieldRdValue
+  IsFieldInv * (FieldInvProduct - 1) = 0
+
+ASSERT_EQ:
+  IsFieldAssertEq * (FieldRs1Value - FieldRs2Value) = 0
+
+x-register -> field-register:
+  IsFieldLoadFromX * (FieldRdValue - decode_x_register(Rs1Value, F)) = 0
+
+field-register -> x-register:
+  IsFieldStoreToX * (RdWriteValue - encode_field_register(FieldRs1Value, F)) = 0
+
+immediate/constant -> field-register:
+  IsFieldLoadImm * (FieldRdValue - decode_immediate(Imm, F)) = 0
+```
+
+The FINV relation cannot be represented as
+`IsFieldInv * (FieldRs1Value * FieldRdValue - 1) = 0` in one R1CS row because
+that is cubic. V1 includes `FieldInvProduct` as a second FR-native product
+witness batched with `FieldProduct`.
+
+These are constraints in Jolt's execution relation. They are separate from the
+wrapper R1CS, which proves a verifier computation.
+
+## Conversion Rows
+
+Conversion rows prove that ordinary Jolt data and FR register values agree at
+bridge instructions:
+
+```text
+x-register -> field-register:
+  IsFieldLoadFromX * (FieldRdValue - decode_x_register(Rs1Value, F)) = 0
+
+field-register -> x-register:
+  IsFieldStoreToX * (RdValue - encode_field_register(FieldRs1Value, F)) = 0
+
+immediate/constant -> field-register:
+  IsFieldLoadImm * (FieldRdValue - decode_immediate(imm, F)) = 0
+```
+
+These rows depend on canonical encoding for the active `F: JoltField`. For a
+254-bit Jolt field, host/guest encodings may use four 64-bit limbs. For a
+128-bit Jolt field, they may use two 64-bit limbs. This affects ABI,
+advice-tape encoding, and bridge/load/store row shape. It does not change the
+field arithmetic relation: FR values remain native elements of `F`.
+
+## Stage 1 Composition
+
+Field-inline stage-1 composition follows the same ownership rule as the rest
+of the protocol:
+
+```text
+jolt-claims::protocols::jolt:
+  ordinary RV64 Spartan outer opening semantics
+
+jolt-claims::protocols::field_inline:
+  field-inline-local Spartan outer opening semantics
+
+jolt-r1cs::constraints::jolt:
+  selected R1CS column layout and field-inline column remapping
+
+jolt-verifier::stages::stage1:
+  selected composition of openings, public coefficients, and expected claim
+```
+
+`jolt-claims` should not define a mixed selected Spartan protocol. It should
+only expose the protocol-local FR Spartan opening order for field-inline-local
+wires. The selected verifier then appends those FR-local openings after the
+ordinary RV64 openings when field inline is enabled.
+
+The selected R1CS layout reuses ordinary RV64 columns for bridge inputs:
+
+```text
+field local const       -> RV64 const
+field local Rs1Value    -> RV64 Rs1Value
+field local RdWriteValue -> RV64 RdWriteValue
+field local Imm         -> RV64 Imm
+```
+
+Those reused columns do not produce duplicate FR openings. They use the
+ordinary Jolt Spartan openings already present in the RV64 stage-1 list.
+
+The FR-local stage-1 openings are the true appended field-inline columns:
+
+```text
+FieldRs1Value
+FieldRs2Value
+FieldRdValue
+FieldProduct
+FieldInvProduct
+IsFieldAdd
+IsFieldSub
+IsFieldMul
+IsFieldInv
+IsFieldAssertEq
+IsFieldLoadFromX
+IsFieldStoreToX
+IsFieldLoadImm
+```
+
+`jolt-verifier` should compute the selected Spartan outer expected claim using
+a helper in `jolt-r1cs::constraints::jolt`, analogous to the RV64-only helper
+but parameterized by the selected equality constraints, selected row weights,
+and selected opening columns. FR-off must reduce exactly to the ordinary RV64
+helper.
+
+This stage-1 change must land for both verifier modes:
+
+```text
+transparent verifier:
+  checks the clear stage-1 remainder output against the composed Spartan outer
+  expected claim
+
+BlindFold verifier:
+  checks committed sumcheck consistency in stage1::verify, then lowers the same
+  composed Spartan outer relation inside stages::zk::blindfold::add_stage1
+```
+
+For ZK, changing only `stage1::verify` is insufficient. The committed
+sumcheck verifier only checks transcript consistency and output-claim
+commitments. The hidden equation tying those committed output claims to the
+Spartan outer formula is built in the BlindFold protocol assembly. When field
+inline is enabled, `add_stage1` must consume the same composed opening order,
+the same public coefficients, and the same expected-claim helper as the
+transparent verifier. Otherwise the verifier would either reject due to output
+claim shape mismatch or fail to bind the extra FR-local stage-1 claims.
+
+## `jolt-claims` Layout
+
+Field inline should be its own `jolt-claims` protocol module. Describing the
+FR register-file Twist semantics is protocol logic distinct from base Jolt,
+even though `jolt-verifier` later composes the resulting claims into the same
+linear verifier flow as ordinary Jolt stages.
+
+The module should mirror the organization of `protocols::jolt` instead of
+inventing a separate component hierarchy. The main v1 `jolt-claims` work is to
+describe the FR register-file Twist memory-checking formulas, FR-native product
+formula, and field-inline-local Spartan opening metadata. Composition with the
+ordinary Jolt Spartan opening list happens later in `jolt-verifier`.
+
+Target layout:
+
+```text
+crates/jolt-claims/src/protocols/field_inline/
+  mod.rs
+  config.rs
+  ids.rs
+  relation.rs
+  formulas/
+    mod.rs
+    dimensions.rs
+    product.rs
+    registers.rs
+    claim_reductions/
+      mod.rs
+      increments.rs
+      registers.rs
+```
+
+This intentionally mirrors existing ordinary-register ownership in
+`protocols::jolt`:
+
+```text
+ordinary registers:
+  formulas/registers.rs
+  formulas/claim_reductions/registers.rs
+
+field registers:
+  protocols/field_inline/formulas/registers.rs
+  protocols/field_inline/formulas/claim_reductions/registers.rs
+```
+
+Inside `protocols::field_inline`, `registers` means FR registers. The formulas
+should use the same generic claim-expression machinery as `protocols::jolt`,
+but with field-inline-specific relation IDs, challenge IDs, opening IDs, and
+dimension types. `jolt-verifier` owns the composition step that batches these
+field-inline claims into the appropriate verifier stages alongside ordinary
+Jolt claims.
+
+Initial protocol IDs:
+
+```rust
+pub enum FieldInlineRelationId {
+    FieldRegistersSpartanOuter,
+    FieldRegistersProduct,
+    FieldRegistersClaimReduction,
+    FieldRegistersReadWriteChecking,
+    FieldRegistersValEvaluation,
+    FieldRegistersIncClaimReduction,
+}
+
+pub enum FieldInlineChallengeId {
+    FieldRegistersClaimReduction(FieldRegistersClaimReductionChallenge),
+    FieldRegistersReadWrite(FieldRegistersReadWriteChallenge),
+    FieldRegistersValEvaluation(FieldRegistersValEvaluationChallenge),
+    FieldRegistersIncClaimReduction(FieldRegistersIncClaimReductionChallenge),
+}
+
+pub enum FieldRegistersClaimReductionChallenge {
+    Gamma,
+    EqSpartan,
+}
+
+pub enum FieldRegistersReadWriteChallenge {
+    Gamma,
+    EqCycle,
+}
+
+pub enum FieldRegistersValEvaluationChallenge {
+    LtCycle,
+}
+
+pub enum FieldRegistersIncClaimReductionChallenge {
+    Gamma,
+}
+
+pub enum FieldInlinePublicId {
+    FieldRegistersIncClaimReduction(FieldRegistersIncClaimReductionPublic),
+}
+
+pub enum FieldRegistersIncClaimReductionPublic {
+    EqReadWrite,
+    EqValEvaluation,
+}
+```
+
+The opening and polynomial IDs should mirror ordinary registers with
+field-register-specific names:
+
+```rust
+pub enum FieldInlineOpFlag {
+    Add,
+    Sub,
+    Mul,
+    Inv,
+    AssertEq,
+    LoadFromX,
+    StoreToX,
+    LoadImm,
+}
+
+pub enum FieldInlineVirtualPolynomial {
+    FieldRs1Value,
+    FieldRs2Value,
+    FieldRdValue,
+    FieldProduct,
+    FieldInvProduct,
+    FieldRegistersVal,
+    FieldRs1Ra,
+    FieldRs2Ra,
+    FieldRdWa,
+    FieldOpFlag(FieldInlineOpFlag),
+}
+
+pub enum FieldInlineCommittedPolynomial {
+    FieldRdInc,
+}
+```
+
+Exact committed vs virtual polynomial placement should follow the implemented
+FR witness layout. Conceptually, it mirrors ordinary registers:
+
+```text
+ordinary:
+  RdInc committed
+  RegistersVal/Rs1Ra/Rs2Ra/RdWa virtual
+
+field:
+  FieldRdInc committed and opened through the stage-6/stage-8 path
+  FieldRegistersVal/FieldRs1Ra/FieldRs2Ra/FieldRdWa virtual
+  FieldRs1Ra/FieldRs2Ra/FieldRdWa anchored by BytecodeReadRaf -> BytecodeRa(i)
+```
+
+### Field-Register Formulas
+
+The formulas mirror ordinary register Twist memory checking.
+The register read/write and val-evaluation formulas prove FR memory consistency;
+they do not by themselves prove that a given field instruction selected those
+FR registers. BytecodeReadRaf supplies that instruction-access binding by
+checking the same virtual FR RA/WA openings against committed bytecode rows.
+
+Claim reduction:
+
+```text
+input:
+  FieldRdValue@FieldRegistersSpartanOuter
+  + gamma * FieldRs1Value@FieldRegistersSpartanOuter
+  + gamma^2 * FieldRs2Value@FieldRegistersSpartanOuter
+
+output:
+  EqSpartan * (
+    FieldRdValue@FieldRegistersClaimReduction
+    + gamma * FieldRs1Value@FieldRegistersClaimReduction
+    + gamma^2 * FieldRs2Value@FieldRegistersClaimReduction
+  )
+```
+
+Read/write checking:
+
+```text
+input:
+  FieldRdValue@FieldRegistersClaimReduction
+  + gamma * FieldRs1Value@FieldRegistersClaimReduction
+  + gamma^2 * FieldRs2Value@FieldRegistersClaimReduction
+
+output:
+  EqCycle * FieldRdWa * FieldRdInc
+  + EqCycle * FieldRdWa * FieldRegistersVal
+  + EqCycle * gamma * FieldRs1Ra * FieldRegistersVal
+  + EqCycle * gamma^2 * FieldRs2Ra * FieldRegistersVal
+```
+
+Val evaluation:
+
+```text
+input:
+  FieldRegistersVal@FieldRegistersReadWriteChecking
+
+output:
+  LtCycle * FieldRdInc@FieldRegistersValEvaluation
+          * FieldRdWa@FieldRegistersValEvaluation
+```
+
+Increment reduction:
+
+```text
+input:
+  FieldRdInc@FieldRegistersReadWriteChecking
+  + eta * FieldRdInc@FieldRegistersValEvaluation
+
+output:
+  (EqReadWrite + eta * EqValEvaluation)
+    * FieldRdInc@FieldRegistersIncClaimReduction
+```
+
+Here `EqReadWrite = Eq(r_inc, rw_cycle)` and
+`EqValEvaluation = Eq(r_inc, val_cycle)`. This reduces the two semantic
+openings of the committed `FieldRdInc` polynomial to one final
+`FieldRdInc(r_inc)` claim for stage 8.
+
+Field product lanes:
+
+```text
+lane 0:
+  input  = FieldProduct@FieldRegistersProduct
+  output = FieldRs1Value@FieldRegistersProduct
+         * FieldRs2Value@FieldRegistersProduct
+
+lane 1:
+  input  = FieldInvProduct@FieldRegistersProduct
+  output = FieldRs1Value@FieldRegistersProduct
+         * FieldRdValue@FieldRegistersProduct
+```
+
+The `FieldRegistersProduct` lane is semantically distinct from the ordinary
+integer product lanes even though the verifier batches it through the same
+product-virtualization machinery. It proves the native-field multiplication
+witnesses used by field constraints; the local R1CS rows then check that
+`FieldProduct` is the FMUL destination value and that `FieldInvProduct` equals
+one when FINV is active.
+
+The module should also expose opening-order helpers matching the current
+`registers.rs` style:
+
+```text
+protocols::field_inline::formulas::product::field_product_input_openings()
+protocols::field_inline::formulas::product::field_product_output_openings()
+protocols::field_inline::formulas::registers::read_write_checking_input_openings()
+protocols::field_inline::formulas::registers::read_write_checking_output_openings()
+protocols::field_inline::formulas::registers::val_evaluation_input_openings()
+protocols::field_inline::formulas::registers::val_evaluation_output_openings()
+protocols::field_inline::formulas::claim_reductions::registers::claim_reduction_input_openings()
+protocols::field_inline::formulas::claim_reductions::registers::claim_reduction_output_openings()
+protocols::field_inline::formulas::claim_reductions::increments::claim_reduction_input_openings()
+protocols::field_inline::formulas::claim_reductions::increments::claim_reduction_output_openings()
+```
+
+`jolt-claims` should stay focused on these claim formulas and opening helpers.
+`field_constraints` and bridge constraints live in
+`jolt-r1cs::constraints::field_constraints`. The `jolt-claims` surface should
+stay as close as possible to the ordinary-register formula pattern.
+
+## Transcript And Optionality
+
+Field inline follows the advice optionality pattern:
+
+```text
+FR off:
+  no FR commitments
+  no FR opening claims
+  no FR sumcheck instances
+  no FR challenges
+  no dummy zero FR claims
+
+FR on:
+  FR commitments, claims, and challenges appear in fixed order
+  the configured verifier flow includes FR stage additions
+```
+
+`JOLT_VERIFIER_CONFIG` determines whether FR payloads are accepted. The
+verifier binds the configured protocol before Fiat-Shamir challenge derivation.
+Detailed proof-shape validation and transcript ordering live in
+[selected-verifier-integration.md](selected-verifier-integration.md).
+
+## Interaction With Dory Assist And Wrapper
+
+Dory assist sees field inline only through the configured verifier outputs. If
+field inline is enabled, the composed verifier stages already include FR claims
+and openings where relevant. Dory assist consumes those configured outputs
+without needing separate field-inline awareness.
+
+The wrapper proves the configured verifier computation. If field inline is off,
+the wrapper R1CS excludes FR checks. If field inline is on, the wrapper includes
+the FR verifier work by lowering the configured verifier flow through the
+generic claim, sumcheck, transcript, and opening R1CS helpers.
+
+## Implementation Steps
+
+Each step should be reviewed before continuing to the next.
+
+1. Add `jolt-claims::protocols::field_inline`.
+   - Add field-register relation IDs, challenge IDs, opening IDs, dimensions, and
+     opening helpers in a layout that mirrors `protocols::jolt`.
+   - Keep the module focused on FR Twist protocol semantics. Composition with
+     ordinary Jolt happens in `jolt-verifier`.
+   - Review gate: API shape mirrors ordinary registers and does not expose
+     non-native modulus configuration.
+
+2. Add field-register claim formulas.
+   - Add FR claim reduction, read/write, val-evaluation, and increment
+     reduction formulas.
+   - Add canonical opening-order helpers.
+   - Review gate: formula tests cover small synthetic FR traces.
+
+3. Add explicit field product-virtualization lanes.
+   - Add `FieldRegistersProduct` relation IDs and `FieldProduct` /
+     `FieldInvProduct` opening metadata.
+   - Add the native-field relations
+     `FieldProduct = FieldRs1Value * FieldRs2Value` and
+     `FieldInvProduct = FieldRs1Value * FieldRdValue`.
+   - Compose it with the stage-2 product uniskip/remainder point so it shares
+     `r_prod` with field-register claim reduction.
+   - Review gate: tests cover dependency ordering, point sharing, and formula
+     evaluation.
+
+4. Add `field_constraints`.
+   - Implement `jolt-r1cs::constraints::field_constraints`.
+   - Cover FADD, FSUB, FMUL, FINV, ASSERT_EQ, and bridge rows.
+   - Review gate: constraint tests prove native-field arithmetic and reject bad
+     FieldProduct witnesses.
+
+5. Add conversion row semantics.
+   - Define `decode_x_register`, `encode_field_register`, and immediate
+     encoding for the active `F`.
+   - Keep 128-bit and 254-bit handling as field-instantiation encoding, not
+     non-native arithmetic.
+   - Review gate: bridge-row fixtures cover two-limb and four-limb field
+     encodings when both field instantiations exist.
+
+6. Wire verifier support one stage slice at a time.
+   - Proof/config gate: require `proof.protocol.field_inline` to match the
+     compile-time verifier config before any stage logic runs.
+   - Commitment absorption: absorb the nested FieldRegisters commitment,
+     currently `FieldRdInc`, only when field inline is enabled.
+   - Selected R1CS composition: add `jolt-r1cs::constraints::jolt` so the
+     compile-time selected R1CS is RV64 alone when FR is off and RV64 plus
+     field-inline rows when FR is on. The composition keeps protocol semantics
+     separate and performs the mixing only in the selected R1CS layout: it
+     reuses the RV64 constant, `Rs1Value`, `RdWriteValue`, and `Imm` columns for
+     bridge rows, then appends true FR-local columns after the RV64 layout.
+   - Stage 1 selected Spartan outer composition: compose ordinary Jolt Spartan
+     openings with field-inline-local Spartan openings in `jolt-verifier`.
+     Reused bridge columns use ordinary Jolt openings; only true FR-local
+     columns are appended as field-inline openings.
+     This slice must update both transparent verification and the ZK/BlindFold
+     stage-1 relation assembly. The transparent path checks clear output
+     claims directly; the BlindFold path must lower the same composed Spartan
+     outer relation over committed output-claim rows.
+   - Stage 2 product virtualization: add `FieldRegistersProduct` as explicit
+     product lanes sharing `r_prod`.
+   - Stage 2 claim reduction: add `FieldRegistersClaimReduction` at the same
+     product point and consume its consistency claims explicitly.
+   - Stage 4: batch `FieldRegistersReadWriteChecking` with the existing
+     read/write work.
+   - Stage 5: batch `FieldRegistersValEvaluation` with the existing
+     val-evaluation work.
+   - Stage 6 bytecode read-RAF: extend `BytecodeReadRaf` to consume the
+     field-inline op flags plus `FieldRs1Ra`, `FieldRs2Ra`, and `FieldRdWa`
+     openings, and to check them against the field opcode/operands in the
+     selected bytecode row. The output remains `BytecodeRa(i)@BytecodeReadRaf`;
+     no `FieldRegistersRa(i)` commitment is introduced.
+   - Stage 6: reduce the stage-4/stage-5 `FieldRdInc` claims to one final
+     committed claim.
+   - Stage 8: include the reduced `FieldRdInc` claim in the ordinary joint PCS
+     RLC using an explicit polynomial-to-relation mapping.
+   - Review gate for every slice: FR-off ordering, transcript pulls, and
+     opening accumulator entries remain unchanged.
+   - Final review gate before prover work: standard and ZK tests pass with
+     field inline disabled.
+   - Final review gate once the prover path for a slice exists: field-inline
+     proofs verify in both transparent and ZK/BlindFold modes, or the
+     unsupported mode is explicitly unavailable behind config/feature gating.
+
+7. Add prover/trace wiring.
+   - Trace pure field ops through FR accesses.
+   - Suppress incidental x-register accesses for pure field ops.
+   - Review gate: trace-level fixtures show ordinary, pure field, and bridge
+     cycles.
+
+8. Add end-to-end fixtures.
+   - Add a small field-inline guest.
+   - Keep existing `muldiv` tests passing in standard and ZK modes.
+   - Review gate: field-inline proof verifies natively and with the configured
+     verifier path.

--- a/specs/selected-verifier-integration.md
+++ b/specs/selected-verifier-integration.md
@@ -1,0 +1,820 @@
+# Spec: Selected Verifier Integration
+
+| Field | Value |
+|-------|-------|
+| Author(s) | Markos Georghiades, Codex |
+| Created | 2026-05-21 |
+| Status | draft |
+| PR | TBD |
+
+## Purpose
+
+Selected verifier integration defines how optional protocol axes fit into the
+linear Jolt verifier. The verifier should stay close to today's flow:
+
+```text
+validate proof/config
+initialize transcript
+absorb preamble and commitments
+run stages in order
+verify openings
+return accept/reject
+```
+
+Protocol-axis specs:
+
+- [field-inline-protocol.md](field-inline-protocol.md)
+- [dory-assist-protocol.md](dory-assist-protocol.md)
+- [wrapper-protocol.md](wrapper-protocol.md)
+
+This spec owns:
+
+```text
+JoltProtocolConfig
+compile-time feature-derived verifier configuration
+linear JoltProof shape with optional payload slots
+validate_proof_config
+stage-local field-inline checks inside ordinary stage folders
+PCS-assist verification in the opening phase
+wrapper verifier entry point
+ZK/BlindFold composition
+```
+
+## Core Model
+
+The verifier config is fixed by compile-time feature flags. Optional proof
+fields are payload slots only; they do not choose verifier behavior.
+
+```text
+compile-time features:
+  determine JOLT_VERIFIER_CONFIG
+  include zk, field-inline, and pcs-assist axes
+
+JOLT_VERIFIER_CONFIG:
+  authoritative verifier behavior
+
+JoltProof::protocol:
+  self-description that must equal JOLT_VERIFIER_CONFIG
+
+Option<T> fields:
+  payload slots for proof axes that are genuinely separate artifacts
+
+PCS assist:
+  generic PcsAssist implementation with an associated proof payload
+  no Dory-specific proof field or verifier stage in jolt-verifier
+  `pcs-assist` feature determines whether the verifier requires the payload
+
+Field inline:
+  no top-level payload slot
+  cfg-gated stage-local proof data and commitments
+  stage folders own the corresponding presence checks
+```
+
+The verifier never does this:
+
+```rust
+if proof.pcs_assist.is_some() {
+    skip_native_pcs_verification();
+}
+```
+
+It always does this:
+
+```rust
+let config = JOLT_VERIFIER_CONFIG;
+validate_proof_config(&config, proof)?;
+run_linear_verifier(&config, proof)?;
+```
+
+This removes runtime Cartesian-product ambiguity. A verifier binary checks one
+configured path. Proof options are accepted or rejected against that path before
+any stage logic runs.
+
+## Protocol Config
+
+`JoltProtocolConfig` records the configured verifier behavior:
+
+```rust
+pub struct JoltProtocolConfig<PcsAssistConfig = NoPcsAssistConfig> {
+    pub zk: ZkConfig,
+    pub field_inline: FieldInlineConfig,
+    pub pcs_assist: Option<PcsAssistConfig>,
+}
+
+pub enum ZkConfig {
+    Transparent,
+    BlindFold,
+}
+
+pub struct FieldInlineConfig {
+    pub enabled: bool,
+    pub field_register_log_k: usize,
+    pub representation: FieldInlineRepresentation,
+}
+
+pub enum FieldInlineRepresentation {
+    NativeFieldElement,
+}
+
+pub struct NoPcsAssistConfig;
+```
+
+The crate exposes a config derived from feature flags:
+
+```rust
+pub const JOLT_VERIFIER_CONFIG: JoltProtocolConfig<SelectedPcsAssistConfig> =
+    /* cfg-gated */;
+```
+
+The exact construction can use `#[cfg(...)]` blocks rather than a single
+literal. The important rule is that the verifier's accepted protocol shape is
+not selected by proof contents. A Dory-assisted build selects the Dory PCS,
+`jolt_dory_assist_verifier::DoryAssistConfig` as
+`SelectedPcsAssistConfig`, and the matching Dory-assist proof payload type.
+`jolt-verifier` does not need a Dory-specific PCS-assist enum variant.
+
+The `pcs-assist` Cargo feature is the compile-time switch for this axis. With
+the feature disabled, the selected config has `pcs_assist = None` and proofs
+with assist payloads reject. With the feature enabled, the selected config uses
+`Some(PcsAssist::selected_config())` and proofs without the associated assist
+payload reject.
+
+## Linear Proof Shape
+
+The proof should remain a single linear artifact. Do not nest a separate
+`BaseJoltProof`; keep ordinary proof fields where they already live and add
+optional extension payloads.
+
+Sketch:
+
+```rust
+pub trait PcsProofAssist<PCS: CommitmentScheme> {
+    type Proof;
+    type Config;
+    type Error;
+
+    fn verify_clear<T>(
+        config: &Self::Config,
+        input: PcsAssistClearInput<'_, PCS>,
+        proof: &Self::Proof,
+        transcript: &mut T,
+    ) -> Result<(), Self::Error>
+    where
+        T: Transcript<Challenge = PCS::Field>;
+
+    fn verify_zk<T>(
+        config: &Self::Config,
+        input: PcsAssistZkInput<'_, PCS>,
+        proof: &Self::Proof,
+        transcript: &mut T,
+    ) -> Result<<PCS as ZkOpeningScheme>::HidingCommitment, Self::Error>
+    where
+        PCS: ZkOpeningScheme,
+        T: Transcript<Challenge = PCS::Field>;
+}
+
+pub struct PcsAssistClearInput<'a, PCS: CommitmentScheme> {
+    pub setup: &'a PCS::VerifierSetup,
+    pub pcs_proof: &'a PCS::Proof,
+    pub commitment: &'a PCS::Output,
+    pub point: &'a [PCS::Field],
+    pub eval: PCS::Field,
+}
+
+pub struct PcsAssistZkInput<'a, PCS: CommitmentScheme> {
+    pub setup: &'a PCS::VerifierSetup,
+    pub pcs_proof: &'a PCS::Proof,
+    pub commitment: &'a PCS::Output,
+    pub point: &'a [PCS::Field],
+}
+
+pub struct JoltProof<PCS, VC, ZkProof, PcsAssist>
+where
+    PCS: CommitmentScheme,
+    PcsAssist: PcsProofAssist<PCS>,
+{
+    pub protocol: JoltProtocolConfig<PcsAssist::Config>,
+
+    pub commitments: JoltCommitments<PCS>,
+    pub stages: JoltStageProofs<PCS::Field, VC, ZkProof>,
+    pub joint_opening_proof: PCS::Proof,
+
+    pub pcs_assist: Option<PcsAssist::Proof>,
+}
+```
+
+`joint_opening_proof` stays structurally present. When PCS assist is disabled,
+the verifier checks it with the ordinary PCS verifier. When PCS assist is
+enabled, the assist proof certifies the relevant PCS verifier work over this
+same `joint_opening_proof` and the same reduced opening statement.
+
+The assist implementation type, config type, and proof payload type are selected
+by the verifier build. For Dory assist those types come from
+`jolt-dory-assist-verifier`; `jolt-verifier` only sees the generic
+`PcsProofAssist<PCS>` boundary. A no-assist build can use a `NoPcsAssist`
+marker implementation whose payload slot is validated to be `None`.
+
+The assist input is deliberately the reduced PCS opening statement plus the
+entire `PCS::Proof`. `jolt-verifier` must not parse Dory proof internals. For
+Dory, `jolt-dory-assist-verifier` consumes the full Dory PCS proof and uses the
+fields it needs internally.
+
+If ZK/BlindFold data is already nested in `JoltStageProofs`, it does not need a
+separate top-level field. The same validation principle applies: the transparent
+or BlindFold proof payload shape must match `JOLT_VERIFIER_CONFIG.zk`.
+
+## `validate_proof_config`
+
+`validate_proof_config` is the first verifier gate:
+
+```rust
+pub fn validate_proof_config<PCS, VC, ZkProof, PcsAssist>(
+    config: &JoltProtocolConfig<PcsAssist::Config>,
+    proof: &JoltProof<PCS, VC, ZkProof, PcsAssist>,
+) -> Result<(), VerifierError>
+where
+    PcsAssist: PcsProofAssist<PCS>,
+{
+    /* shape checks only */
+}
+```
+
+It checks:
+
+```text
+proof.protocol == JOLT_VERIFIER_CONFIG
+pcs_assist payload is present iff config.pcs_assist.is_some()
+stage proof payloads match config.zk
+unsupported feature combinations are impossible or rejected
+```
+
+It does not assemble field-inline verifier logic. After this config check, the
+appropriate `jolt-verifier::stages/*` modules own the cfg-gated field-inline
+payload checks they batch with their stage.
+
+Shape rule:
+
+```rust
+match config.pcs_assist {
+    None => reject_some(&proof.pcs_assist)?,
+    Some(_) => require_some(&proof.pcs_assist)?,
+}
+```
+
+There is no fallback. If `config.pcs_assist` requires an assist proof and
+`proof.pcs_assist` is missing, the verifier rejects. If config disables PCS
+assist and `proof.pcs_assist` is present, the verifier rejects.
+
+## Linear Verifier Flow
+
+The verifier remains a linear function:
+
+```rust
+pub fn verify<PCS, VC, ZkProof, PcsAssist>(
+    preprocessing: &JoltVerifierPreprocessing<PCS, VC>,
+    public_io: &JoltDevice,
+    proof: &JoltProof<PCS, VC, ZkProof, PcsAssist>,
+    trusted_advice_commitment: Option<&PCS::Output>,
+) -> Result<(), VerifierError>
+where
+    PcsAssist: PcsProofAssist<PCS>,
+{
+    let config = JOLT_VERIFIER_CONFIG;
+    validate_proof_config(&config, proof)?;
+
+    let mut transcript = Transcript::new(b"Jolt");
+    absorb_protocol_config(&config, &mut transcript);
+    absorb_preamble(preprocessing, public_io, proof, &mut transcript);
+    absorb_commitments(&config, proof, trusted_advice_commitment, &mut transcript);
+
+    let stage1 = verify_stage1(&config, ...)?;
+    let stage2 = verify_stage2(&config, ...)?;
+    let stage3 = verify_stage3(&config, ...)?;
+    let stage4 = verify_stage4(&config, ...)?;
+    let stage5 = verify_stage5(&config, ...)?;
+    let stage6 = verify_stage6(&config, ...)?;
+    let stage7 = verify_stage7(&config, ...)?;
+
+    let opening_statement = build_reduced_opening_statement(&config, ...)?;
+    verify_opening_phase(&config, proof, opening_statement, &mut transcript)
+}
+```
+
+The config parameter is not a runtime selector supplied by the prover. It is the
+compile-time-derived verifier config passed to stage helpers so each stage
+folder can run the additions it owns.
+
+## Transcript Binding
+
+The verifier absorbs the configured protocol before any challenge that depends
+on optional protocol shape:
+
+```text
+domain separator
+JOLT_VERIFIER_CONFIG / proof.protocol
+field / curve / transcript identifiers
+public IO / preprocessing digest
+commitments selected by the configured proof shape
+```
+
+Optionality follows the advice pattern:
+
+```text
+component absent:
+  no commitment
+  no opening claim
+  no sumcheck instance
+  no transcript challenge
+  no dummy zero claim
+
+component present:
+  payload is required
+  claims and challenges appear in fixed order
+```
+
+For field inline:
+
+```text
+config.field_inline.enabled = false:
+  skip FR commitments, claims, reductions, and challenges
+
+config.field_inline.enabled = true:
+  require FR payloads and insert FR transcript messages in fixed order
+```
+
+For advice, keep the existing advice-driven optionality. For field inline and
+PCS assist, optionality is verifier-config driven.
+
+## ZK / BlindFold
+
+ZK stays close to the current pattern:
+
+```text
+config.zk = Transparent:
+  verifier runs clear sumcheck/opening-claim checks
+  BlindFold payloads are rejected
+
+config.zk = BlindFold:
+  verifier runs committed consistency checks and BlindFold verification
+  clear-only payloads are rejected where applicable
+```
+
+The ZK choice is part of `JOLT_VERIFIER_CONFIG`. Stage helpers can keep the
+existing `cfg(feature = "zk")` structure while validating the proof payload
+shape up front.
+
+Field-inline verifier changes must preserve this two-mode contract. Every
+field-inline stage slice that changes a verifier relation has two obligations:
+
+```text
+transparent mode:
+  check the clear claims directly in the ordinary stage verifier
+
+BlindFold mode:
+  check committed sumcheck consistency in the ordinary stage verifier and lower
+  the same relation into the BlindFold protocol builder
+```
+
+For stage 1 specifically, field inline changes the Spartan outer relation. The
+transparent path computes the composed expected remainder claim from clear
+RV64-plus-FR openings. The ZK path must also update
+`stages::zk::blindfold::add_stage1` so the committed output-claim rows are
+bound to the same composed Spartan outer formula. Updating only
+`stages::stage1::verify` is not sound for ZK because committed consistency
+does not by itself prove the hidden output claims satisfy the composed Spartan
+outer formula.
+
+## Field Inline
+
+Field inline is gated inside the appropriate ordinary stage folders. It should
+not require a separate selected-schedule abstraction or top-level field-inline
+router in `jolt-verifier`.
+
+When enabled:
+
+```text
+validate_proof_config requires proof.protocol.field_inline to match verifier config
+commitment absorption includes the FieldRdInc field-register commitment
+jolt-r1cs selected constraints compose RV64 rows with field-inline rows
+stage 1 composes selected Spartan outer openings and public coefficients
+stage 2 extends product virtualization with field product lanes
+stage 2 batches field-register claim reduction at the product point
+stage 4 batches FR read/write checking
+stage 5 batches FR val evaluation
+stage 6 extends BytecodeReadRaf to anchor FR RA/WA and field op flags to BytecodeRa(i)
+stage 6 batches FieldRdInc reduction
+stage 8 includes reduced FieldRdInc in the joint opening RLC
+```
+
+When disabled:
+
+```text
+validate_proof_config requires proof.protocol.field_inline to match verifier config
+ordinary stages run without FR additions
+FR transcript rounds are skipped entirely
+```
+
+Field-inline arithmetic details are specified in
+[field-inline-protocol.md](field-inline-protocol.md).
+
+### Field-Inline Verifier Slices
+
+Field-inline verifier support should land one verifier-stage slice at a time.
+Each slice has a small review gate and must preserve the FR-off path.
+
+0. Proof/config gate.
+   - Add the compile-time field-inline config and require `proof.protocol` to
+     match it.
+   - No stage logic changes yet.
+   - Review gate: a proof declaring a different field-inline config is rejected.
+
+1. Commitment and preamble absorption.
+   - Absorb FR commitments only when field inline is enabled.
+   - For v1 this includes the nested `FieldInlineCommitments {
+     field_registers: FieldRegistersCommitments { rd_inc } }` payload.
+   - The `jolt-core` compatibility converter is unavailable for
+     `field-inline` builds until the prover path can supply this nested
+     payload.
+   - Review gate: FR-off transcript matches ordinary Jolt through the first
+     config-dependent challenge.
+
+2. Compose selected R1CS constraints.
+   - Add `jolt-r1cs::constraints::jolt` as the compile-time selected R1CS
+     composition point.
+   - FR-off selected constraints are exactly the RV64 constraints.
+   - FR-on selected constraints append `field_constraints` rows while keeping
+     protocol semantics separate. The selected layout reuses the RV64 constant,
+     `Rs1Value`, `RdWriteValue`, and `Imm` columns for bridge constraints, then
+     appends true FR-local columns after the RV64 layout.
+   - Review gate: FR-off selected matrices equal RV64 matrices; FR-on exposes
+     deterministic composed row/column layout.
+
+3. Stage 1 selected Spartan outer composition.
+   - Keep `jolt-claims::protocols::jolt` and
+     `jolt-claims::protocols::field_inline` semantically separate.
+     `jolt-claims` should expose protocol-local opening-order helpers; it
+     should not expose a mixed selected Spartan protocol.
+   - In `jolt-verifier::stages::stage1`, compose the selected opening list at
+     the last point: ordinary RV64 Spartan openings first, then FR-local
+     Spartan openings only when field inline is enabled.
+   - Do not duplicate bridge openings for RV64 columns reused by
+     `jolt-r1cs::constraints::jolt`: `Rs1Value`, `RdWriteValue`, and `Imm`
+     remain ordinary Jolt openings.
+   - FR-local Spartan openings follow the selected appended-column order:
+     field register operand values, field product witnesses, and field-inline
+     selector flags.
+   - Add a selected Spartan outer remainder helper in `jolt-r1cs` that mirrors
+     the existing RV64 helper but uses the selected equality constraints,
+     selected row weights, and selected opening columns.
+   - Transparent path: `jolt-verifier::stages::stage1::verify` uses the
+     composed opening list, composed output-claim count, and composed expected
+     remainder helper.
+   - ZK path: `jolt-verifier::stages::zk::blindfold::add_stage1` uses the same
+     composed opening list and public coefficients when constructing the
+     BlindFold relation for committed output claims.
+   - The verifier ID layer must be able to name both ordinary Jolt and
+     field-inline openings/publics in ZK relation assembly. This can be a
+     small verifier-local enum or an equivalent adapter; it should not collapse
+     field-inline protocol IDs into ordinary Jolt IDs.
+   - Review gate: FR-off expected output claims and public coefficient order
+     match RV64 exactly; FR-on has deterministic selected opening order and
+     does not introduce a mixed `jolt-claims` protocol namespace. Both
+     transparent and ZK verifier tests pass for FR-off. Once field-inline prover
+     fixtures exist, both transparent and ZK field-inline proofs must verify, or
+     the unsupported mode must be rejected by config/feature gating.
+
+4. Stage 2 product virtualization.
+   - Add `FieldRegistersProduct` as explicit product lanes.
+   - Use the existing stage-2 product point `r_prod`; do not introduce a
+     separate `r_field`.
+   - Review gate: FR-off product lane ordering is unchanged; FR-on includes the
+     `FieldProduct = FieldRs1Value * FieldRs2Value` and
+     `FieldInvProduct = FieldRs1Value * FieldRdValue` lanes.
+
+5. Stage 2 field-register claim reduction.
+   - Batch `FieldRegistersClaimReduction` into the same stage-2 verifier flow.
+   - Share `r_prod` with the product virtualization output where the formulas
+     require point agreement.
+   - Review gate: required FR openings/challenges are present and consistency
+     claims are explicit.
+
+6. Stage 4 field-register read/write checking.
+   - Add the FR Twist read/write instance over `T * 16`.
+   - Batch it with the existing stage-4 read/write work.
+   - Output `FieldRegistersVal`, `FieldRs1Ra`, `FieldRs2Ra`, `FieldRdWa`,
+     and `FieldRdInc`; the FR RA/WA outputs are later consumed by
+     `BytecodeReadRaf`.
+   - Review gate: FR-off stage 4 transcript and accumulator entries are
+     unchanged; FR-on rejects missing FR read/write payload.
+
+7. Stage 5 field-register val evaluation.
+   - Add `FieldRegistersValEvaluation` using the stage-5 batching pattern.
+   - Review gate: FR-off stage 5 is unchanged; FR-on produces the expected
+     `FieldRdWa` and `FieldRdInc` opening claims.
+
+8. Stage 6 bytecode read-RAF field-inline anchoring.
+   - Extend `BytecodeReadRaf` when field inline is enabled, rather than adding
+     a separate field-bytecode verifier route.
+   - Consume field-inline op flags from selected Spartan outer, FR RA/WA claims
+     from stage 4, and `FieldRdWa` from stage 5.
+   - Check those virtual openings against the field opcode and field operands
+     encoded in the selected bytecode row.
+   - Require verifier preprocessing to carry the field-inline bytecode side
+     table when field inline is enabled; missing metadata is a verifier error.
+   - Extend the existing Stage1/Stage4/Stage5 bytecode RLC powers by appending
+     the field op flags and field-register access terms. FR-off keeps the
+     ordinary challenge counts and transcript order.
+   - In BlindFold mode, lower the same mixed `BytecodeReadRaf` input
+     expression: Jolt openings stay `JoltOpeningId`, FR openings stay
+     `FieldInlineOpeningId`, and the shared bytecode challenges remain
+     `JoltChallengeId`.
+   - Keep the committed output as `BytecodeRa(i)@BytecodeReadRaf`, so the
+     existing hamming/final-opening path anchors the field access selectors.
+   - Review gate: there is no `FieldRegistersRa(i)` commitment or transcript
+     absorption; tampering with FR access selectors fails through
+     `BytecodeReadRaf`.
+
+9. Stage 6 `FieldRdInc` reduction.
+   - Reduce the stage-4 and stage-5 semantic openings of `FieldRdInc` to one
+     final committed claim.
+   - Review gate: the reduced claim is the only `FieldRdInc` claim handed to
+     the final opening planner.
+
+10. Stage 8 joint opening inclusion.
+   - Add the reduced `FieldRdInc` opening to the joint opening RLC with an
+     explicit polynomial-to-relation mapping.
+   - Review gate: FR-off final opening order is unchanged; FR-on order is
+     deterministic and covered by tests.
+
+11. FR-off regression checkpoint.
+   - Run the ordinary standard and ZK verifier tests with field inline disabled.
+   - No prover-side field-inline work starts before this checkpoint is green.
+
+## PCS Assist
+
+PCS assist is the opening-phase extension. The `jolt-verifier` boundary is
+generic over a `PcsAssist` implementation of `PcsProofAssist<PCS>`, whose
+associated `Proof` type is the optional payload. V1 concrete assist is Dory
+assist, supplied by the `jolt-dory-assist-verifier` crate.
+
+`joint_opening_proof` is always present:
+
+```text
+config.pcs_assist = None:
+  proof.pcs_assist must be None
+  verifier checks joint_opening_proof through the ordinary PCS verifier
+
+config.pcs_assist = Some(...):
+  proof.pcs_assist must be Some(PcsAssist::Proof)
+  verifier calls PcsAssist::verify_clear / verify_zk
+  joint_opening_proof is public input to the assist verification
+  verifier does not also run the expensive native PCS verifier path
+```
+
+The assist path must bind to the exact same data as ordinary opening
+verification:
+
+```text
+joint_opening_proof
+commitments
+opening points
+opening claims
+transcript-derived challenges
+preprocessing/public IO values used by opening verification
+```
+
+The safe implementation pattern is:
+
+```rust
+let opening_statement = build_reduced_opening_statement(&config, stage_outputs)?;
+
+match config.pcs_assist {
+    None => {
+        verify_joint_opening_proof_natively(
+            &proof.joint_opening_proof,
+            &opening_statement,
+            &mut transcript,
+        )?;
+        bind_joint_opening_inputs(&opening_statement, &mut transcript)
+    }
+    Some(ref assist_config) => {
+        let assist_proof = proof.pcs_assist.as_ref().ok_or(MissingPayload)?;
+        PcsAssist::verify_clear(
+            assist_config,
+            PcsAssistClearInput {
+                setup: &preprocessing.pcs_setup,
+                pcs_proof: &proof.joint_opening_proof,
+                commitment: &opening_statement.joint_commitment,
+                point: opening_statement.pcs_opening_point.as_slice(),
+                eval: opening_statement.joint_claim,
+            },
+            assist_proof,
+            &mut transcript,
+        )?;
+        bind_joint_opening_inputs(&opening_statement, &mut transcript)
+    }
+}
+```
+
+The ZK path follows the same shape but calls `PcsAssist::verify_zk`, receives the
+PCS hiding/evaluation commitment, and then performs the same
+`bind_zk_opening_inputs` step as the ordinary `PCS::verify_zk` path. The binding
+step remains owned by `jolt-verifier`; the assist implementation replaces only
+the expensive PCS verifier computation in that slot.
+
+The assist implementation may also absorb an assist-local checked-input
+preamble before its own stage challenges. For Dory assist that preamble includes
+the Dory verifier setup, the full `joint_opening_proof`, the reduced opening
+commitment/point, and the clear evaluation when present. This is not a
+Dory-specific responsibility in `jolt-verifier`; it is the selected assist's
+internal transcript binding for the auxiliary proof. The common
+`bind_joint_opening_inputs` / `bind_zk_opening_inputs` step still remains in
+the generic verifier flow so the surrounding Jolt opening-phase transcript
+shape stays uniform.
+
+For a Dory-assisted build, `PCS = DoryScheme` and the selected assist
+implementation is `jolt_dory_assist_verifier::DoryAssist`. Its proof payload is
+`jolt_dory_assist_verifier::DoryAssistProof`, and its implementation owns the
+three Dory-assist stages, checked input normalization, Hyrax opening,
+Fr-to-Fq challenge injection, and native final pairing check. Dory-assist
+details are specified in
+[dory-assist-protocol.md](dory-assist-protocol.md).
+
+## Wrapper
+
+Wrapper verification is a separate outer entry point. A wrapper verifier checks
+a wrapper proof for a fixed inner verifier config; it does not run the remaining
+native Jolt verifier stages.
+
+```text
+native Jolt verifier:
+  validates and runs the configured linear verifier flow
+
+wrapper prover / assembly:
+  encodes the configured linear verifier flow into R1CS
+  proves that R1CS with ZK Spartan + HyperKZG
+
+wrapper verifier:
+  verifies the wrapper proof against wrapper public inputs and verifying key
+  does not re-run inner Jolt stages
+```
+
+The wrapper verifying key or public statement must bind the inner
+`JOLT_VERIFIER_CONFIG` so a proof for one configured verifier cannot be checked
+as another. Wrapper protocol details are specified in
+[wrapper-protocol.md](wrapper-protocol.md).
+
+For the primary v1 wrapped-ZK path, the inner configured verifier is the
+transparent verifier and the transparent Jolt proof is private wrapper witness
+data. Base-layer BlindFold is still the standalone Jolt ZK path, but wrapping
+the BlindFold verifier is not the primary wrapper composition.
+
+## End-To-End Flows
+
+Ordinary Jolt:
+
+```text
+JOLT_VERIFIER_CONFIG:
+  zk = Transparent or BlindFold
+  field_inline.enabled = false
+  pcs_assist = None
+
+verify:
+  validate_proof_config
+  run ordinary linear verifier
+  verify joint_opening_proof natively
+```
+
+Field-inline Jolt:
+
+```text
+JOLT_VERIFIER_CONFIG:
+  field_inline.enabled = true
+
+verify:
+  validate_proof_config requires the selected field_inline config
+  absorb the nested FieldRdInc commitment
+  run ordinary stages with FR additions
+  verify opening phase according to pcs_assist config
+```
+
+Dory-assisted Jolt:
+
+```text
+JOLT_VERIFIER_CONFIG:
+  PCS = DoryScheme
+  pcs_assist = Some(DoryAssistConfig)
+  PcsAssist = jolt_dory_assist_verifier::DoryAssist
+  PcsAssist::Proof = jolt_dory_assist_verifier::DoryAssistProof
+
+verify:
+  validate_proof_config requires pcs_assist payload
+  run ordinary stages through reduced opening statement construction
+  call PcsProofAssist::verify_clear / verify_zk with joint_opening_proof and
+  the reduced opening statement as public input
+```
+
+Wrapped Jolt:
+
+```text
+inner proof:
+  transparent Jolt proof as private wrapper witness
+
+wrapper verifier:
+  verifies wrapper proof for a fixed inner JOLT_VERIFIER_CONFIG
+  skips native inner verifier execution
+```
+
+## Testing And Acceptance
+
+Config validation tests:
+
+```text
+proof.protocol must equal JOLT_VERIFIER_CONFIG
+FR-off verifier rejects proof.protocol.field_inline.enabled = true
+FR-on verifier rejects proof.protocol.field_inline.enabled = false
+PCS-assist-off verifier rejects pcs_assist = Some(...)
+PCS-assist-on verifier rejects pcs_assist = None
+Transparent verifier rejects BlindFold-only payloads
+BlindFold verifier rejects transparent-only payloads where applicable
+```
+
+Transcript tests:
+
+```text
+config is absorbed before config-dependent challenges
+FR-off transcript matches ordinary Jolt transcript
+FR-on transcript inserts FR messages in fixed order
+advice absent follows existing skip behavior
+PCS-assist-on binds the same reduced opening statement as native PCS verification
+PCS-assist-on passes the whole PCS::Proof without jolt-verifier parsing it
+Dory-assist challenges are squeezed from the continued Fr transcript and then
+injected into Fq on both prover and verifier sides
+```
+
+Flow tests:
+
+```text
+muldiv passes in standard and ZK modes
+existing advice fixtures continue to pass
+field-inline fixtures pass when compiled with field-inline config
+PCS-assist fixtures pass when compiled with assist config
+wrapper verifier rejects proofs built for the wrong inner config
+```
+
+## Implementation Steps
+
+Each step should be reviewed before continuing to the next.
+
+1. Add `JoltProtocolConfig` and the PCS-assist boundary.
+   - Define ZK, field-inline, and generic PCS-assist config types.
+   - Define the verifier-facing `PcsProofAssist<PCS>` trait or equivalent
+     abstraction with associated `Proof` and `Config` types.
+   - Define clear and ZK assist input structs that carry the whole
+     `PCS::Proof` plus the reduced opening statement.
+   - Derive `JOLT_VERIFIER_CONFIG` from feature flags.
+   - Review gate: config constants match expected feature combinations.
+
+2. Linearize proof optional payloads.
+   - Add `protocol` and `pcs_assist: Option<_>` to the linear proof artifact.
+   - Do not add a top-level field-inline proof object; field-inline data is
+     stage-local.
+   - Keep `joint_opening_proof: PCS::Proof` structurally present.
+   - Review gate: serialization round trips all payload shapes.
+
+3. Add `validate_proof_config`.
+   - Check proof config equality and exact `Option<T>` shape.
+   - Reject extra and missing payloads before stage verification.
+   - Review gate: tests cover every Some/None mismatch.
+
+4. Bind config into transcript.
+   - Absorb canonical config encoding before config-dependent challenges.
+   - Review gate: changing config changes the challenge stream.
+
+5. Wire field-inline verifier slices.
+   - Implement the stage-by-stage slices from "Field-Inline Verifier Slices".
+   - Review every stage slice before moving to the next one.
+   - Review gate: the FR-off regression checkpoint passes before prover-side
+     field-inline work begins.
+
+6. Wire PCS assist in the opening phase.
+   - Build a typed reduced opening statement once.
+   - Dispatch to ordinary PCS verify or the selected `PcsProofAssist`
+     implementation based on config.
+   - Preserve common transcript binding after either native or assist
+     verification.
+   - Keep Dory-specific stage organization outside `jolt-verifier`.
+   - Review gate: assist proof is bound to the exact `joint_opening_proof` and
+     reduced opening statement.
+
+7. Keep ZK/BlindFold linear.
+   - Preserve the current cfg-gated ZK flow.
+   - Route proof-shape validation through `validate_proof_config`.
+   - Review gate: standard and ZK `muldiv` pass.
+
+8. Add wrapper verifier entry point.
+   - Verify wrapper proofs against a fixed inner `JOLT_VERIFIER_CONFIG`.
+   - Treat the transparent inner Jolt proof as private wrapper witness in the
+     primary v1 wrapped-ZK flow.
+   - Do not run native inner Jolt stages in wrapper verification.
+   - Review gate: wrapper proof for one inner config is rejected under another.

--- a/src/main.rs
+++ b/src/main.rs
@@ -535,6 +535,9 @@ edition = "2021"
 [workspace]
 members = ["guest"]
 
+[features]
+field-inline = ["jolt-sdk/field-inline", "guest/field-inline"]
+
 [profile.release]
 debug = 1
 codegen-units = 1
@@ -588,6 +591,9 @@ edition = "2021"
 
 [workspace]
 members = ["guest"]
+
+[features]
+field-inline = ["jolt-sdk/field-inline", "guest/field-inline"]
 
 [profile.release]
 debug = 1


### PR DESCRIPTION
Part of the draft Jolt prover stack.

Base: `prover-stack/01-field-inline-tracing`
Head: `prover-stack/02-jolt-claims-protocol-formulas`

Extends the Jolt claim formulas, including field-inline protocol formulas and supporting specs.

Validation before submission:
- `cargo fmt -q -- --check`
- `cargo metadata --no-deps --format-version 1`
- local `gh stack push` simulation against a temporary bare remote
- forbidden-path scan for `handoffs/`, old `STACK.md`, `stack/`, and old stack workflow