### PR TITLE
feat: add Hyrax row commitments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2989,6 +2989,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "jolt-hyrax"
+version = "0.1.0"
+dependencies = [
+ "jolt-crypto",
+ "jolt-dory",
+ "jolt-field",
+ "jolt-openings",
+ "jolt-poly",
+ "jolt-r1cs",
+ "jolt-transcript",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "jolt-inlines-bigint"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ members = [
   "crates/jolt-openings",
   "crates/jolt-verifier",
   "crates/jolt-dory",
+  "crates/jolt-hyrax",
   "crates/jolt-hyperkzg",
   "crates/jolt-riscv",
   "crates/jolt-transcript",
@@ -388,6 +389,7 @@ jolt-claims = { path = "./crates/jolt-claims" }
 jolt-crypto = { path = "./crates/jolt-crypto" }
 jolt-field = { path = "./crates/jolt-field" }
 jolt-openings = { path = "./crates/jolt-openings" }
+jolt-hyrax = { path = "./crates/jolt-hyrax" }
 jolt-verifier = { path = "./crates/jolt-verifier" }
 jolt-poly = { path = "./crates/jolt-poly" }
 jolt-r1cs = { path = "./crates/jolt-r1cs" }

--- a/crates/jolt-hyrax/Cargo.toml
+++ b/crates/jolt-hyrax/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "jolt-hyrax"
+version = "0.1.0"
+edition = "2021"
+license = "MIT"
+description = "Hyrax multilinear polynomial commitment adapter for Jolt"
+
+[lints]
+workspace = true
+
+[features]
+r1cs = ["dep:jolt-r1cs", "jolt-crypto/r1cs", "jolt-poly/r1cs"]
+
+[dependencies]
+jolt-crypto = { workspace = true }
+jolt-field = { workspace = true }
+jolt-openings = { workspace = true }
+jolt-poly = { workspace = true }
+jolt-r1cs = { workspace = true, optional = true }
+jolt-transcript = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+thiserror = { workspace = true }
+
+[dev-dependencies]
+jolt-crypto = { workspace = true, features = ["grumpkin"] }
+jolt-dory = { path = "../jolt-dory" }
+jolt-field = { workspace = true, features = ["bn254"] }
+rand_chacha = { workspace = true }
+rand_core = { workspace = true }
+serde_json = { workspace = true, features = ["std"] }

--- a/crates/jolt-hyrax/src/commitment.rs
+++ b/crates/jolt-hyrax/src/commitment.rs
@@ -1,0 +1,78 @@
+use jolt_crypto::HomomorphicCommitment;
+use jolt_field::Field;
+use jolt_transcript::{AppendToTranscript, LabelWithCount, Transcript};
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(bound(serialize = "C: Serialize", deserialize = "C: for<'a> Deserialize<'a>"))]
+pub struct HyraxCommitment<C> {
+    pub rows: Vec<C>,
+}
+
+impl<C: AppendToTranscript> AppendToTranscript for HyraxCommitment<C> {
+    fn append_to_transcript<T: Transcript>(&self, transcript: &mut T) {
+        transcript.append(&LabelWithCount(
+            b"hyrax_commitment_rows",
+            self.rows.len() as u64,
+        ));
+        for row in &self.rows {
+            row.append_to_transcript(transcript);
+        }
+    }
+}
+
+impl<F, C> HomomorphicCommitment<F> for HyraxCommitment<C>
+where
+    F: Field,
+    C: HomomorphicCommitment<F>,
+{
+    fn add(c1: &Self, c2: &Self) -> Self {
+        match (c1.rows.is_empty(), c2.rows.is_empty()) {
+            (true, true) => Self::default(),
+            (true, false) => c2.clone(),
+            (false, true) => c1.clone(),
+            (false, false) => {
+                assert_eq!(
+                    c1.rows.len(),
+                    c2.rows.len(),
+                    "Hyrax commitment row count mismatch",
+                );
+                let rows = c1
+                    .rows
+                    .iter()
+                    .zip(c2.rows.iter())
+                    .map(|(left, right)| C::add(left, right))
+                    .collect();
+                Self { rows }
+            }
+        }
+    }
+
+    fn linear_combine(c1: &Self, c2: &Self, scalar: &F) -> Self {
+        if c2.rows.is_empty() {
+            return c1.clone();
+        }
+
+        if c1.rows.is_empty() {
+            let rows = c2
+                .rows
+                .iter()
+                .map(|right| C::linear_combine(&C::default(), right, scalar))
+                .collect();
+            return Self { rows };
+        }
+
+        assert_eq!(
+            c1.rows.len(),
+            c2.rows.len(),
+            "Hyrax commitment row count mismatch",
+        );
+        let rows = c1
+            .rows
+            .iter()
+            .zip(c2.rows.iter())
+            .map(|(left, right)| C::linear_combine(left, right, scalar))
+            .collect();
+        Self { rows }
+    }
+}

--- a/crates/jolt-hyrax/src/dimensions.rs
+++ b/crates/jolt-hyrax/src/dimensions.rs
@@ -1,0 +1,65 @@
+use serde::{Deserialize, Serialize};
+
+use crate::HyraxError;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct HyraxDimensions {
+    pub num_vars: usize,
+    pub row_vars: usize,
+    pub col_vars: usize,
+}
+
+impl HyraxDimensions {
+    pub fn new(num_vars: usize, row_vars: usize, col_vars: usize) -> Result<Self, HyraxError> {
+        let dimensions = Self {
+            num_vars,
+            row_vars,
+            col_vars,
+        };
+        dimensions.validate()?;
+        Ok(dimensions)
+    }
+
+    pub fn validate(&self) -> Result<(), HyraxError> {
+        if self.row_vars.checked_add(self.col_vars) != Some(self.num_vars) {
+            return Err(HyraxError::InvalidDimensions {
+                num_vars: self.num_vars,
+                row_vars: self.row_vars,
+                col_vars: self.col_vars,
+            });
+        }
+        let _ = Self::dimension_len(self.num_vars)?;
+        let _ = Self::dimension_len(self.row_vars)?;
+        let _ = Self::dimension_len(self.col_vars)?;
+        Ok(())
+    }
+
+    pub fn row_count(&self) -> Result<usize, HyraxError> {
+        Self::dimension_len(self.row_vars)
+    }
+
+    pub fn row_len(&self) -> Result<usize, HyraxError> {
+        Self::dimension_len(self.col_vars)
+    }
+
+    pub fn polynomial_len(&self) -> Result<usize, HyraxError> {
+        Self::dimension_len(self.num_vars)
+    }
+
+    pub fn split_point<'a, F>(&self, point: &'a [F]) -> Result<(&'a [F], &'a [F]), HyraxError> {
+        if point.len() != self.num_vars {
+            return Err(HyraxError::PointLengthMismatch {
+                expected: self.num_vars,
+                got: point.len(),
+            });
+        }
+        Ok(point.split_at(self.row_vars))
+    }
+
+    fn dimension_len(dimension: usize) -> Result<usize, HyraxError> {
+        if dimension >= usize::BITS as usize {
+            return Err(HyraxError::DimensionTooLarge { dimension });
+        }
+        Ok(1usize << dimension)
+    }
+}

--- a/crates/jolt-hyrax/src/error.rs
+++ b/crates/jolt-hyrax/src/error.rs
@@ -1,0 +1,41 @@
+use jolt_crypto::VectorOpeningError;
+
+#[derive(Clone, Debug, PartialEq, Eq, thiserror::Error)]
+pub enum HyraxError {
+    #[error("invalid Hyrax dimensions: num_vars ({num_vars}) != row_vars ({row_vars}) + col_vars ({col_vars})")]
+    InvalidDimensions {
+        num_vars: usize,
+        row_vars: usize,
+        col_vars: usize,
+    },
+
+    #[error("dimension {dimension} is too large to fit in usize")]
+    DimensionTooLarge { dimension: usize },
+
+    #[error("point length mismatch: expected {expected}, got {got}")]
+    PointLengthMismatch { expected: usize, got: usize },
+
+    #[error("polynomial variable mismatch: expected {expected}, got {got}")]
+    PolynomialVariableMismatch { expected: usize, got: usize },
+
+    #[error("row length {row_len} exceeds vector commitment capacity {capacity}")]
+    CommitmentCapacityExceeded { capacity: usize, row_len: usize },
+
+    #[error("row commitment count mismatch: expected {expected}, got {got}")]
+    RowCommitmentCountMismatch { expected: usize, got: usize },
+
+    #[error("row iteration skipped row {expected}; got row {got}")]
+    RowIterationOutOfOrder { expected: usize, got: usize },
+
+    #[error("row iteration count mismatch: expected {expected}, got {got}")]
+    RowIterationCountMismatch { expected: usize, got: usize },
+
+    #[error("row length mismatch: expected {expected}, got {got}")]
+    RowLengthMismatch { expected: usize, got: usize },
+
+    #[error("vector opening failed: {0}")]
+    VectorOpening(#[from] VectorOpeningError),
+
+    #[error("evaluation mismatch")]
+    EvaluationMismatch,
+}

--- a/crates/jolt-hyrax/src/lib.rs
+++ b/crates/jolt-hyrax/src/lib.rs
@@ -1,0 +1,21 @@
+//! Hyrax multilinear polynomial commitment adapter.
+//!
+//! This crate implements Hyrax as a thin row-commitment layer over
+//! [`jolt_crypto::VectorCommitment`]. V1 is transparent: row commitments use
+//! zero blinding and the opening hint is `()`.
+
+mod commitment;
+mod dimensions;
+mod error;
+mod proof;
+#[cfg(feature = "r1cs")]
+pub mod r1cs;
+mod scheme;
+mod setup;
+
+pub use commitment::HyraxCommitment;
+pub use dimensions::HyraxDimensions;
+pub use error::HyraxError;
+pub use proof::HyraxOpeningProof;
+pub use scheme::HyraxScheme;
+pub use setup::{HyraxProverSetup, HyraxSetupParams, HyraxVerifierSetup};

--- a/crates/jolt-hyrax/src/proof.rs
+++ b/crates/jolt-hyrax/src/proof.rs
@@ -1,0 +1,23 @@
+use jolt_transcript::{AppendToTranscript, Label, LabelWithCount, Transcript};
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(bound(serialize = "F: Serialize", deserialize = "F: for<'a> Deserialize<'a>"))]
+pub struct HyraxOpeningProof<F> {
+    pub combined_row: Vec<F>,
+    pub combined_row_opening_scalar: F,
+}
+
+impl<F: AppendToTranscript> AppendToTranscript for HyraxOpeningProof<F> {
+    fn append_to_transcript<T: Transcript>(&self, transcript: &mut T) {
+        transcript.append(&LabelWithCount(
+            b"hyrax_opening_row",
+            self.combined_row.len() as u64,
+        ));
+        for row_coordinate in &self.combined_row {
+            transcript.append(row_coordinate);
+        }
+        transcript.append(&Label(b"hyrax_opening_scalar"));
+        transcript.append(&self.combined_row_opening_scalar);
+    }
+}

--- a/crates/jolt-hyrax/src/r1cs.rs
+++ b/crates/jolt-hyrax/src/r1cs.rs
@@ -1,0 +1,375 @@
+use jolt_crypto::r1cs::{VectorCommitmentOpeningVar, VectorCommitmentR1cs};
+use jolt_poly::r1cs::{self as poly_r1cs, PolyR1csError};
+use jolt_r1cs::{R1csBuilder, ScalarGadget};
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct HyraxOpeningR1csInput<S, C> {
+    pub row_commitments: Vec<C>,
+    pub row_point: Vec<S>,
+    pub entry_point: Vec<S>,
+    pub combined_row: Vec<S>,
+    pub combined_blinding: S,
+    pub claimed_eval: S,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, thiserror::Error)]
+pub enum HyraxR1csError<VCError> {
+    #[error("dimension {dimension} is too large to fit in usize")]
+    DimensionTooLarge { dimension: usize },
+    #[error("row commitment count mismatch: expected {expected}, got {got}")]
+    RowCommitmentCountMismatch { expected: usize, got: usize },
+    #[error("combined row length mismatch: expected {expected}, got {got}")]
+    CombinedRowLengthMismatch { expected: usize, got: usize },
+    #[error("polynomial R1CS failed: {0}")]
+    Polynomial(#[from] PolyR1csError),
+    #[error("vector commitment R1CS failed: {0}")]
+    VectorCommitment(VCError),
+}
+
+pub fn verify_opening<VC>(
+    builder: &mut R1csBuilder<VC::BuilderField>,
+    setup: &VC::SetupVar,
+    input: &HyraxOpeningR1csInput<VC::ScalarVar, VC::OutputVar>,
+) -> Result<(), HyraxR1csError<VC::Error>>
+where
+    VC: VectorCommitmentR1cs,
+    VC::ScalarVar: ScalarGadget<BuilderField = VC::BuilderField>,
+{
+    let expected_rows = hypercube_len::<VC::Error>(input.row_point.len())?;
+    if input.row_commitments.len() != expected_rows {
+        return Err(HyraxR1csError::RowCommitmentCountMismatch {
+            expected: expected_rows,
+            got: input.row_commitments.len(),
+        });
+    }
+
+    let expected_row_len = hypercube_len::<VC::Error>(input.entry_point.len())?;
+    if input.combined_row.len() != expected_row_len {
+        return Err(HyraxR1csError::CombinedRowLengthMismatch {
+            expected: expected_row_len,
+            got: input.combined_row.len(),
+        });
+    }
+
+    let row_weights = poly_r1cs::eq_evals(builder, &input.row_point);
+    let combined_commitment =
+        VC::linear_combine_commitments(builder, &input.row_commitments, &row_weights)
+            .map_err(HyraxR1csError::VectorCommitment)?;
+
+    VC::verify_opening(
+        builder,
+        setup,
+        &combined_commitment,
+        &VectorCommitmentOpeningVar::new(
+            input.combined_row.clone(),
+            input.combined_blinding.clone(),
+        ),
+    )
+    .map_err(HyraxR1csError::VectorCommitment)?;
+
+    let entry_weights = poly_r1cs::eq_evals(builder, &input.entry_point);
+    let opened_eval = poly_r1cs::inner_product(builder, &input.combined_row, &entry_weights)?;
+    opened_eval.assert_equal(builder, &input.claimed_eval);
+
+    Ok(())
+}
+
+fn hypercube_len<VCError>(dimension: usize) -> Result<usize, HyraxR1csError<VCError>> {
+    if dimension >= usize::BITS as usize {
+        return Err(HyraxR1csError::DimensionTooLarge { dimension });
+    }
+    Ok(1usize << dimension)
+}
+
+#[cfg(test)]
+#[expect(clippy::expect_used, reason = "tests may panic on assertion failures")]
+mod tests {
+    use jolt_crypto::{
+        r1cs::{CryptoR1csError, GrumpkinPointWithIdentityVar},
+        Grumpkin, GrumpkinPoint, JoltGroup, Pedersen, PedersenSetup, VectorCommitment,
+    };
+    use jolt_field::{Fq, Fr, FromPrimitiveInt};
+    use jolt_poly::EqPolynomial;
+    use jolt_r1cs::{AssignedScalar, FqVar, Variable};
+
+    use super::*;
+
+    type TestVc = Pedersen<GrumpkinPoint>;
+    type TestError = HyraxR1csError<CryptoR1csError>;
+
+    #[derive(Clone)]
+    struct NativeCase {
+        setup: PedersenSetup<GrumpkinPoint>,
+        row_commitments: Vec<GrumpkinPoint>,
+        row_point: Vec<Fq>,
+        entry_point: Vec<Fq>,
+        combined_row: Vec<Fq>,
+        combined_blinding: Fq,
+        claimed_eval: Fq,
+    }
+
+    struct AllocatedCase {
+        input: HyraxOpeningR1csInput<FqVar, GrumpkinPointWithIdentityVar>,
+    }
+
+    #[test]
+    fn hyrax_r1cs_accepts_valid_opening() {
+        let mut builder = R1csBuilder::<Fr>::new();
+        let case = native_case();
+        let allocated = allocate_case(&mut builder, &case);
+
+        verify_opening::<TestVc>(&mut builder, &case.setup, &allocated.input)
+            .expect("valid Hyrax opening");
+
+        assert!(builder_accepts(builder));
+    }
+
+    #[test]
+    fn hyrax_r1cs_rejects_tampered_row_commitment() {
+        let mut builder = R1csBuilder::<Fr>::new();
+        let case = native_case();
+        let allocated = allocate_case(&mut builder, &case);
+        let targets = [(
+            "row commitment x-coordinate",
+            variable(&allocated.input.row_commitments[0].x),
+        )];
+
+        verify_opening::<TestVc>(&mut builder, &case.setup, &allocated.input)
+            .expect("valid Hyrax opening before tampering");
+
+        assert_tampering_rejected(builder, targets);
+    }
+
+    #[test]
+    fn hyrax_r1cs_rejects_tampered_row_point() {
+        let mut builder = R1csBuilder::<Fr>::new();
+        let case = native_case();
+        let allocated = allocate_case(&mut builder, &case);
+        let targets = [(
+            "row point limb",
+            variable(&allocated.input.row_point[0].limbs()[0]),
+        )];
+
+        verify_opening::<TestVc>(&mut builder, &case.setup, &allocated.input)
+            .expect("valid Hyrax opening before tampering");
+
+        assert_tampering_rejected(builder, targets);
+    }
+
+    #[test]
+    fn hyrax_r1cs_rejects_tampered_entry_point() {
+        let mut builder = R1csBuilder::<Fr>::new();
+        let case = native_case();
+        let allocated = allocate_case(&mut builder, &case);
+        let targets = [(
+            "entry point limb",
+            variable(&allocated.input.entry_point[0].limbs()[0]),
+        )];
+
+        verify_opening::<TestVc>(&mut builder, &case.setup, &allocated.input)
+            .expect("valid Hyrax opening before tampering");
+
+        assert_tampering_rejected(builder, targets);
+    }
+
+    #[test]
+    fn hyrax_r1cs_rejects_tampered_combined_row() {
+        let mut builder = R1csBuilder::<Fr>::new();
+        let case = native_case();
+        let allocated = allocate_case(&mut builder, &case);
+        let targets = [(
+            "combined row limb",
+            variable(&allocated.input.combined_row[0].limbs()[0]),
+        )];
+
+        verify_opening::<TestVc>(&mut builder, &case.setup, &allocated.input)
+            .expect("valid Hyrax opening before tampering");
+
+        assert_tampering_rejected(builder, targets);
+    }
+
+    #[test]
+    fn hyrax_r1cs_rejects_tampered_combined_blinding() {
+        let mut builder = R1csBuilder::<Fr>::new();
+        let case = native_case();
+        let allocated = allocate_case(&mut builder, &case);
+        let targets = [(
+            "combined blinding limb",
+            variable(&allocated.input.combined_blinding.limbs()[0]),
+        )];
+
+        verify_opening::<TestVc>(&mut builder, &case.setup, &allocated.input)
+            .expect("valid Hyrax opening before tampering");
+
+        assert_tampering_rejected(builder, targets);
+    }
+
+    #[test]
+    fn hyrax_r1cs_rejects_tampered_claimed_eval() {
+        let mut builder = R1csBuilder::<Fr>::new();
+        let case = native_case();
+        let allocated = allocate_case(&mut builder, &case);
+        let targets = [(
+            "claimed eval limb",
+            variable(&allocated.input.claimed_eval.limbs()[0]),
+        )];
+
+        verify_opening::<TestVc>(&mut builder, &case.setup, &allocated.input)
+            .expect("valid Hyrax opening before tampering");
+
+        assert_tampering_rejected(builder, targets);
+    }
+
+    #[test]
+    fn hyrax_r1cs_rejects_row_commitment_count_mismatch() {
+        let mut builder = R1csBuilder::<Fr>::new();
+        let case = native_case();
+        let mut allocated = allocate_case(&mut builder, &case);
+        let _ = allocated.input.row_commitments.pop();
+
+        assert_eq!(
+            verify_opening::<TestVc>(&mut builder, &case.setup, &allocated.input),
+            Err(TestError::RowCommitmentCountMismatch {
+                expected: 4,
+                got: 3,
+            })
+        );
+    }
+
+    #[test]
+    fn hyrax_r1cs_rejects_combined_row_length_mismatch() {
+        let mut builder = R1csBuilder::<Fr>::new();
+        let case = native_case();
+        let mut allocated = allocate_case(&mut builder, &case);
+        let _ = allocated.input.combined_row.pop();
+
+        assert_eq!(
+            verify_opening::<TestVc>(&mut builder, &case.setup, &allocated.input),
+            Err(TestError::CombinedRowLengthMismatch {
+                expected: 4,
+                got: 3,
+            })
+        );
+    }
+
+    fn native_case() -> NativeCase {
+        let generator = Grumpkin::generator();
+        let setup = PedersenSetup::new(
+            (1..=4)
+                .map(|index| generator.scalar_mul(&Fq::from_u64(10 + index)))
+                .collect(),
+            generator.scalar_mul(&Fq::from_u64(99)),
+        );
+        let rows = [
+            [2, 3, 5, 7],
+            [11, 13, 17, 19],
+            [23, 29, 31, 37],
+            [41, 43, 47, 53],
+        ]
+        .map(|row| row.map(Fq::from_u64).to_vec());
+        let row_point = vec![Fq::from_u64(3), Fq::from_u64(5)];
+        let entry_point = vec![Fq::from_u64(7), Fq::from_u64(11)];
+        let row_blindings = [
+            Fq::from_u64(101),
+            Fq::from_u64(103),
+            Fq::from_u64(107),
+            Fq::from_u64(109),
+        ];
+
+        let row_commitments = rows
+            .iter()
+            .zip(row_blindings)
+            .map(|(row, blinding)| TestVc::commit(&setup, row, &blinding))
+            .collect::<Vec<_>>();
+        let row_weights = EqPolynomial::new(row_point.clone()).evaluations();
+        let entry_weights = EqPolynomial::new(entry_point.clone()).evaluations();
+        let zero = Fq::from_u64(0);
+        let mut combined_row = vec![zero; 4];
+        for (row, row_weight) in rows.iter().zip(&row_weights) {
+            for (combined, row_entry) in combined_row.iter_mut().zip(row) {
+                *combined += *row_weight * *row_entry;
+            }
+        }
+        let combined_blinding = row_blindings
+            .iter()
+            .zip(&row_weights)
+            .fold(zero, |acc, (blinding, row_weight)| {
+                acc + *blinding * *row_weight
+            });
+        let claimed_eval = combined_row
+            .iter()
+            .zip(&entry_weights)
+            .fold(zero, |acc, (entry, entry_weight)| {
+                acc + *entry * *entry_weight
+            });
+
+        NativeCase {
+            setup,
+            row_commitments,
+            row_point,
+            entry_point,
+            combined_row,
+            combined_blinding,
+            claimed_eval,
+        }
+    }
+
+    fn allocate_case(builder: &mut R1csBuilder<Fr>, case: &NativeCase) -> AllocatedCase {
+        AllocatedCase {
+            input: HyraxOpeningR1csInput {
+                row_commitments: case
+                    .row_commitments
+                    .iter()
+                    .map(|commitment| GrumpkinPointWithIdentityVar::alloc(builder, commitment))
+                    .collect(),
+                row_point: alloc_fq_vec(builder, &case.row_point),
+                entry_point: alloc_fq_vec(builder, &case.entry_point),
+                combined_row: alloc_fq_vec(builder, &case.combined_row),
+                combined_blinding: FqVar::alloc(builder, case.combined_blinding),
+                claimed_eval: FqVar::alloc(builder, case.claimed_eval),
+            },
+        }
+    }
+
+    fn alloc_fq_vec(builder: &mut R1csBuilder<Fr>, values: &[Fq]) -> Vec<FqVar> {
+        values
+            .iter()
+            .copied()
+            .map(|value| FqVar::alloc(builder, value))
+            .collect()
+    }
+
+    fn builder_accepts(builder: R1csBuilder<Fr>) -> bool {
+        let witness = builder.witness().expect("witness is assigned");
+        builder.into_matrices().check_witness(&witness).is_ok()
+    }
+
+    fn assert_tampering_rejected(
+        builder: R1csBuilder<Fr>,
+        targets: impl IntoIterator<Item = (&'static str, Variable)>,
+    ) {
+        let witness = builder.witness().expect("witness is assigned");
+        let matrices = builder.into_matrices();
+        assert!(matrices.check_witness(&witness).is_ok());
+
+        for (label, variable) in targets {
+            let mut tampered = witness.clone();
+            tampered[variable.index()] += Fr::from_u64(1);
+            assert!(
+                matrices.check_witness(&tampered).is_err(),
+                "{label} accepted after tampering variable {}",
+                variable.index()
+            );
+        }
+    }
+
+    fn variable(scalar: &AssignedScalar<Fr>) -> Variable {
+        scalar
+            .lc
+            .terms
+            .first()
+            .copied()
+            .expect("expected scalar backed by one variable")
+            .0
+    }
+}

--- a/crates/jolt-hyrax/src/scheme.rs
+++ b/crates/jolt-hyrax/src/scheme.rs
@@ -1,0 +1,525 @@
+use std::marker::PhantomData;
+
+use jolt_crypto::VectorCommitmentOpening;
+use jolt_crypto::{Commitment, HomomorphicCommitment, VectorCommitment};
+use jolt_openings::{AdditivelyHomomorphic, CommitmentScheme, OpeningsError};
+use jolt_poly::{MultilinearPoly, Polynomial};
+use jolt_transcript::{AppendToTranscript, Label, LabelWithCount, Transcript};
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
+
+use crate::{
+    HyraxCommitment, HyraxDimensions, HyraxError, HyraxOpeningProof, HyraxProverSetup,
+    HyraxSetupParams, HyraxVerifierSetup,
+};
+
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(bound = "")]
+pub struct HyraxScheme<VC: VectorCommitment> {
+    _marker: PhantomData<VC>,
+}
+
+impl<VC> HyraxScheme<VC>
+where
+    VC: VectorCommitment,
+    VC::Output: HomomorphicCommitment<VC::Field>,
+{
+    pub fn opening_proof(
+        setup: &HyraxProverSetup<VC>,
+        poly: &Polynomial<VC::Field>,
+        point: &[VC::Field],
+    ) -> Result<(HyraxOpeningProof<VC::Field>, VC::Field), HyraxError> {
+        validate_dimensions_for_poly(&setup.dimensions, poly.num_vars())?;
+        validate_capacity::<VC>(setup)?;
+        let (row_point, col_point) = setup.dimensions.split_point(point)?;
+        let row_opening_scalars = zero_row_opening_scalars::<VC>(&setup.dimensions)?;
+        let (row_opening, opened_eval) = VC::open_committed_rows(
+            poly.evaluations(),
+            &row_opening_scalars,
+            setup.dimensions.row_len()?,
+            row_point,
+            col_point,
+        )?;
+        Ok((
+            HyraxOpeningProof {
+                combined_row: row_opening.combined_vector,
+                combined_row_opening_scalar: row_opening.combined_blinding,
+            },
+            opened_eval,
+        ))
+    }
+
+    pub fn verify_opening_proof(
+        setup: &HyraxVerifierSetup<VC>,
+        commitment: &HyraxCommitment<VC::Output>,
+        point: &[VC::Field],
+        eval: VC::Field,
+        proof: &HyraxOpeningProof<VC::Field>,
+    ) -> Result<(), HyraxError> {
+        setup.dimensions.validate()?;
+        validate_verifier_capacity::<VC>(setup)?;
+        let row_count = setup.dimensions.row_count()?;
+        if commitment.rows.len() != row_count {
+            return Err(HyraxError::RowCommitmentCountMismatch {
+                expected: row_count,
+                got: commitment.rows.len(),
+            });
+        }
+        let (row_point, col_point) = setup.dimensions.split_point(point)?;
+        let opened_eval = VC::verify_committed_rows(
+            &setup.vc_setup,
+            &commitment.rows,
+            row_point,
+            col_point,
+            &VectorCommitmentOpening {
+                combined_vector: proof.combined_row.clone(),
+                combined_blinding: proof.combined_row_opening_scalar,
+            },
+        )?;
+        if opened_eval != eval {
+            return Err(HyraxError::EvaluationMismatch);
+        }
+        Ok(())
+    }
+}
+
+impl<VC> Commitment for HyraxScheme<VC>
+where
+    VC: VectorCommitment,
+{
+    type Output = HyraxCommitment<VC::Output>;
+}
+
+impl<VC> CommitmentScheme for HyraxScheme<VC>
+where
+    VC: VectorCommitment,
+    VC::Field: AppendToTranscript,
+    VC::Output: HomomorphicCommitment<VC::Field>,
+    VC::Setup: Serialize + DeserializeOwned,
+{
+    type Field = VC::Field;
+    type Proof = HyraxOpeningProof<VC::Field>;
+    type ProverSetup = HyraxProverSetup<VC>;
+    type VerifierSetup = HyraxVerifierSetup<VC>;
+    type Polynomial = Polynomial<VC::Field>;
+    type OpeningHint = ();
+    type SetupParams = HyraxSetupParams<VC>;
+
+    fn setup(params: Self::SetupParams) -> (Self::ProverSetup, Self::VerifierSetup) {
+        assert_valid_dimensions(&params.dimensions);
+        let prover = HyraxProverSetup {
+            dimensions: params.dimensions,
+            vc_setup: params.vc_setup,
+        };
+        let verifier = Self::verifier_setup(&prover);
+        (prover, verifier)
+    }
+
+    fn verifier_setup(prover_setup: &Self::ProverSetup) -> Self::VerifierSetup {
+        prover_setup.into()
+    }
+
+    fn commit<P: MultilinearPoly<Self::Field> + ?Sized>(
+        poly: &P,
+        setup: &Self::ProverSetup,
+    ) -> (Self::Output, Self::OpeningHint) {
+        assert_valid_dimensions(&setup.dimensions);
+        assert_valid_poly(&setup.dimensions, poly.num_vars());
+        assert_valid_capacity::<VC>(setup);
+
+        let row_len = setup.dimensions.row_len().unwrap_or_default();
+        let row_count = setup.dimensions.row_count().unwrap_or_default();
+        let zero_opening_scalar = VC::Field::default();
+        let mut rows = Vec::with_capacity(row_count);
+
+        poly.for_each_row(setup.dimensions.col_vars, &mut |row_index, row| {
+            assert_eq!(
+                row_index,
+                rows.len(),
+                "Hyrax row iterator produced rows out of order",
+            );
+            assert_eq!(row.len(), row_len, "Hyrax row length mismatch");
+            rows.push(VC::commit(&setup.vc_setup, row, &zero_opening_scalar));
+        });
+
+        assert_eq!(rows.len(), row_count, "Hyrax row count mismatch");
+        (HyraxCommitment { rows }, ())
+    }
+
+    fn open(
+        poly: &Self::Polynomial,
+        point: &[Self::Field],
+        _eval: Self::Field,
+        setup: &Self::ProverSetup,
+        _hint: Option<Self::OpeningHint>,
+        _transcript: &mut impl Transcript<Challenge = Self::Field>,
+    ) -> Self::Proof {
+        let result = Self::opening_proof(setup, poly, point);
+        assert!(result.is_ok(), "Hyrax open failed");
+        match result {
+            Ok((proof, _)) => proof,
+            Err(_) => HyraxOpeningProof {
+                combined_row: Vec::new(),
+                combined_row_opening_scalar: Self::Field::default(),
+            },
+        }
+    }
+
+    fn verify(
+        commitment: &Self::Output,
+        point: &[Self::Field],
+        eval: Self::Field,
+        proof: &Self::Proof,
+        setup: &Self::VerifierSetup,
+        _transcript: &mut impl Transcript<Challenge = Self::Field>,
+    ) -> Result<(), OpeningsError> {
+        Self::verify_opening_proof(setup, commitment, point, eval, proof)
+            .map_err(|_| OpeningsError::VerificationFailed)
+    }
+
+    fn bind_opening_inputs(
+        transcript: &mut impl Transcript<Challenge = Self::Field>,
+        point: &[Self::Field],
+        eval: &Self::Field,
+    ) {
+        transcript.append(&LabelWithCount(b"hyrax_opening_point", point.len() as u64));
+        for scalar in point {
+            scalar.append_to_transcript(transcript);
+        }
+        transcript.append(&Label(b"hyrax_opening_eval"));
+        eval.append_to_transcript(transcript);
+    }
+}
+
+impl<VC> AdditivelyHomomorphic for HyraxScheme<VC>
+where
+    VC: VectorCommitment,
+    VC::Field: AppendToTranscript,
+    VC::Output: HomomorphicCommitment<VC::Field>,
+    VC::Setup: Serialize + DeserializeOwned,
+{
+    fn combine(commitments: &[Self::Output], scalars: &[Self::Field]) -> Self::Output {
+        assert_eq!(commitments.len(), scalars.len());
+        commitments
+            .iter()
+            .zip(scalars.iter())
+            .fold(HyraxCommitment::default(), |acc, (commitment, scalar)| {
+                HyraxCommitment::linear_combine(&acc, commitment, scalar)
+            })
+    }
+}
+
+fn validate_dimensions_for_poly(
+    dimensions: &HyraxDimensions,
+    poly_num_vars: usize,
+) -> Result<(), HyraxError> {
+    dimensions.validate()?;
+    if poly_num_vars != dimensions.num_vars {
+        return Err(HyraxError::PolynomialVariableMismatch {
+            expected: dimensions.num_vars,
+            got: poly_num_vars,
+        });
+    }
+    Ok(())
+}
+
+fn validate_capacity<VC: VectorCommitment>(setup: &HyraxProverSetup<VC>) -> Result<(), HyraxError> {
+    let row_len = setup.dimensions.row_len()?;
+    let capacity = VC::capacity(&setup.vc_setup);
+    if row_len > capacity {
+        return Err(HyraxError::CommitmentCapacityExceeded { capacity, row_len });
+    }
+    Ok(())
+}
+
+fn validate_verifier_capacity<VC: VectorCommitment>(
+    setup: &HyraxVerifierSetup<VC>,
+) -> Result<(), HyraxError> {
+    let row_len = setup.dimensions.row_len()?;
+    let capacity = VC::capacity(&setup.vc_setup);
+    if row_len > capacity {
+        return Err(HyraxError::CommitmentCapacityExceeded { capacity, row_len });
+    }
+    Ok(())
+}
+
+fn zero_row_opening_scalars<VC: VectorCommitment>(
+    dimensions: &HyraxDimensions,
+) -> Result<Vec<VC::Field>, HyraxError> {
+    Ok(vec![VC::Field::default(); dimensions.row_count()?])
+}
+
+fn assert_valid_dimensions(dimensions: &HyraxDimensions) {
+    assert!(dimensions.validate().is_ok(), "invalid Hyrax dimensions");
+}
+
+fn assert_valid_poly(dimensions: &HyraxDimensions, poly_num_vars: usize) {
+    assert!(
+        validate_dimensions_for_poly(dimensions, poly_num_vars).is_ok(),
+        "invalid Hyrax polynomial",
+    );
+}
+
+fn assert_valid_capacity<VC: VectorCommitment>(setup: &HyraxProverSetup<VC>) {
+    assert!(
+        validate_capacity::<VC>(setup).is_ok(),
+        "invalid Hyrax setup",
+    );
+}
+
+#[cfg(test)]
+#[expect(clippy::expect_used, reason = "tests may panic on assertion failures")]
+mod tests {
+    use jolt_crypto::{Bn254, Bn254G1, Pedersen, PedersenSetup};
+    use jolt_field::{Fr, FromPrimitiveInt};
+    use jolt_openings::{AdditivelyHomomorphic, CommitmentScheme};
+    use jolt_poly::Polynomial;
+    use jolt_transcript::Blake2bTranscript;
+    use rand_chacha::ChaCha20Rng;
+    use rand_core::SeedableRng;
+
+    use super::*;
+
+    type TestHyrax = HyraxScheme<Pedersen<Bn254G1>>;
+
+    fn setup(
+        row_vars: usize,
+        col_vars: usize,
+    ) -> (
+        HyraxProverSetup<Pedersen<Bn254G1>>,
+        HyraxVerifierSetup<Pedersen<Bn254G1>>,
+    ) {
+        let mut rng = ChaCha20Rng::seed_from_u64(10 + row_vars as u64 * 100 + col_vars as u64);
+        let row_len = 1usize << col_vars;
+        let generators = (0..row_len).map(|_| Bn254::random_g1(&mut rng)).collect();
+        let blinding_generator = Bn254::random_g1(&mut rng);
+        let vc_setup = PedersenSetup::new(generators, blinding_generator);
+        let dimensions = HyraxDimensions::new(row_vars + col_vars, row_vars, col_vars)
+            .expect("valid dimensions");
+        TestHyrax::setup(HyraxSetupParams {
+            dimensions,
+            vc_setup,
+        })
+    }
+
+    fn polynomial(num_vars: usize) -> Polynomial<Fr> {
+        let evals: Vec<Fr> = (0..(1usize << num_vars))
+            .map(|index| Fr::from_u64((index as u64 + 3) * 7))
+            .collect();
+        Polynomial::from(evals)
+    }
+
+    fn point(num_vars: usize) -> Vec<Fr> {
+        (0..num_vars)
+            .map(|index| Fr::from_u64(index as u64 + 2))
+            .collect()
+    }
+
+    fn prove_and_verify(row_vars: usize, col_vars: usize) {
+        let (prover_setup, verifier_setup) = setup(row_vars, col_vars);
+        let poly = polynomial(row_vars + col_vars);
+        let point = point(poly.num_vars());
+        let eval = poly.evaluate(&point);
+        let (commitment, hint) = TestHyrax::commit(&poly, &prover_setup);
+
+        let mut prover_transcript = Blake2bTranscript::new(b"hyrax-test");
+        let proof = TestHyrax::open(
+            &poly,
+            &point,
+            eval,
+            &prover_setup,
+            Some(hint),
+            &mut prover_transcript,
+        );
+
+        let mut verifier_transcript = Blake2bTranscript::new(b"hyrax-test");
+        TestHyrax::verify(
+            &commitment,
+            &point,
+            eval,
+            &proof,
+            &verifier_setup,
+            &mut verifier_transcript,
+        )
+        .expect("valid opening verifies");
+    }
+
+    #[test]
+    fn round_trip_small_dimensions() {
+        prove_and_verify(0, 1);
+        prove_and_verify(1, 1);
+        prove_and_verify(2, 3);
+        prove_and_verify(3, 2);
+    }
+
+    #[test]
+    fn wrong_evaluation_rejects() {
+        let (prover_setup, verifier_setup) = setup(2, 2);
+        let poly = polynomial(4);
+        let point = point(4);
+        let eval = poly.evaluate(&point);
+        let (commitment, hint) = TestHyrax::commit(&poly, &prover_setup);
+        let mut prover_transcript = Blake2bTranscript::new(b"hyrax-wrong-eval");
+        let proof = TestHyrax::open(
+            &poly,
+            &point,
+            eval,
+            &prover_setup,
+            Some(hint),
+            &mut prover_transcript,
+        );
+
+        let mut verifier_transcript = Blake2bTranscript::new(b"hyrax-wrong-eval");
+        let err = TestHyrax::verify(
+            &commitment,
+            &point,
+            eval + Fr::from_u64(1),
+            &proof,
+            &verifier_setup,
+            &mut verifier_transcript,
+        )
+        .expect_err("wrong evaluation must reject");
+        assert!(matches!(err, OpeningsError::VerificationFailed));
+    }
+
+    #[test]
+    fn wrong_point_rejects() {
+        let (prover_setup, verifier_setup) = setup(2, 2);
+        let poly = polynomial(4);
+        let point = point(4);
+        let eval = poly.evaluate(&point);
+        let (commitment, hint) = TestHyrax::commit(&poly, &prover_setup);
+        let mut prover_transcript = Blake2bTranscript::new(b"hyrax-wrong-point");
+        let proof = TestHyrax::open(
+            &poly,
+            &point,
+            eval,
+            &prover_setup,
+            Some(hint),
+            &mut prover_transcript,
+        );
+
+        let mut wrong_point = point;
+        wrong_point[0] += Fr::from_u64(5);
+        let mut verifier_transcript = Blake2bTranscript::new(b"hyrax-wrong-point");
+        let err = TestHyrax::verify(
+            &commitment,
+            &wrong_point,
+            eval,
+            &proof,
+            &verifier_setup,
+            &mut verifier_transcript,
+        )
+        .expect_err("wrong point must reject");
+        assert!(matches!(err, OpeningsError::VerificationFailed));
+    }
+
+    #[test]
+    fn wrong_row_commitment_rejects() {
+        let (prover_setup, verifier_setup) = setup(2, 2);
+        let poly = polynomial(4);
+        let point = point(4);
+        let eval = poly.evaluate(&point);
+        let (mut commitment, hint) = TestHyrax::commit(&poly, &prover_setup);
+        commitment.rows[0] += Bn254::g1_generator();
+        let mut prover_transcript = Blake2bTranscript::new(b"hyrax-wrong-commitment");
+        let proof = TestHyrax::open(
+            &poly,
+            &point,
+            eval,
+            &prover_setup,
+            Some(hint),
+            &mut prover_transcript,
+        );
+
+        let mut verifier_transcript = Blake2bTranscript::new(b"hyrax-wrong-commitment");
+        let err = TestHyrax::verify(
+            &commitment,
+            &point,
+            eval,
+            &proof,
+            &verifier_setup,
+            &mut verifier_transcript,
+        )
+        .expect_err("wrong commitment must reject");
+        assert!(matches!(err, OpeningsError::VerificationFailed));
+    }
+
+    #[test]
+    fn additive_homomorphic_combines_rows() {
+        let (prover_setup, _) = setup(2, 2);
+        let poly_a = polynomial(4);
+        let evals_b: Vec<Fr> = (0..poly_a.len())
+            .map(|index| Fr::from_u64(index as u64 * 11 + 9))
+            .collect();
+        let poly_b = Polynomial::from(evals_b);
+        let scalar_a = Fr::from_u64(3);
+        let scalar_b = Fr::from_u64(5);
+
+        let (commitment_a, ()) = TestHyrax::commit(&poly_a, &prover_setup);
+        let (commitment_b, ()) = TestHyrax::commit(&poly_b, &prover_setup);
+        let combined = TestHyrax::combine(&[commitment_a, commitment_b], &[scalar_a, scalar_b]);
+
+        let combined_evals: Vec<Fr> = poly_a
+            .evaluations()
+            .iter()
+            .zip(poly_b.evaluations().iter())
+            .map(|(left, right)| scalar_a * *left + scalar_b * *right)
+            .collect();
+        let combined_poly = Polynomial::from(combined_evals);
+        let (expected, ()) = TestHyrax::commit(&combined_poly, &prover_setup);
+        assert_eq!(combined, expected);
+    }
+
+    #[test]
+    fn verifier_setup_serializes() {
+        let (_, verifier_setup) = setup(2, 2);
+        let json = serde_json::to_vec(&verifier_setup).expect("serialize verifier setup");
+        let recovered: HyraxVerifierSetup<Pedersen<Bn254G1>> =
+            serde_json::from_slice(&json).expect("deserialize verifier setup");
+        assert_eq!(recovered.dimensions, verifier_setup.dimensions);
+        assert_eq!(
+            recovered.vc_setup.message_generators,
+            verifier_setup.vc_setup.message_generators,
+        );
+        assert_eq!(
+            recovered.vc_setup.blinding_generator,
+            verifier_setup.vc_setup.blinding_generator,
+        );
+    }
+
+    #[test]
+    fn derives_pedersen_hyrax_setup_from_dory_setup() {
+        let dory_setup = jolt_dory::DoryScheme::setup_prover(8);
+        let dimensions = HyraxDimensions::new(4, 2, 2).expect("valid dimensions");
+        let prover_setup =
+            HyraxProverSetup::<Pedersen<Bn254G1>>::derive_from(&dory_setup, dimensions)
+                .expect("derive Hyrax setup from Dory setup");
+        let verifier_setup = TestHyrax::verifier_setup(&prover_setup);
+
+        let poly = polynomial(4);
+        let point = point(4);
+        let eval = poly.evaluate(&point);
+        let (commitment, hint) = TestHyrax::commit(&poly, &prover_setup);
+
+        let mut prover_transcript = Blake2bTranscript::new(b"hyrax-dory-derived");
+        let proof = TestHyrax::open(
+            &poly,
+            &point,
+            eval,
+            &prover_setup,
+            Some(hint),
+            &mut prover_transcript,
+        );
+
+        let mut verifier_transcript = Blake2bTranscript::new(b"hyrax-dory-derived");
+        TestHyrax::verify(
+            &commitment,
+            &point,
+            eval,
+            &proof,
+            &verifier_setup,
+            &mut verifier_transcript,
+        )
+        .expect("Dory-derived Hyrax setup verifies");
+    }
+}

--- a/crates/jolt-hyrax/src/setup.rs
+++ b/crates/jolt-hyrax/src/setup.rs
@@ -1,0 +1,112 @@
+use jolt_crypto::{DeriveSetup, VectorCommitment};
+use serde::{Deserialize, Serialize};
+
+use crate::{HyraxDimensions, HyraxError};
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(bound(
+    serialize = "VC::Setup: Serialize",
+    deserialize = "VC::Setup: for<'a> Deserialize<'a>"
+))]
+pub struct HyraxSetupParams<VC: VectorCommitment> {
+    pub dimensions: HyraxDimensions,
+    pub vc_setup: VC::Setup,
+}
+
+impl<VC: VectorCommitment> HyraxSetupParams<VC> {
+    pub fn new(dimensions: HyraxDimensions, vc_setup: VC::Setup) -> Result<Self, HyraxError> {
+        validate_capacity::<VC>(&dimensions, &vc_setup)?;
+        Ok(Self {
+            dimensions,
+            vc_setup,
+        })
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(bound(
+    serialize = "VC::Setup: Serialize",
+    deserialize = "VC::Setup: for<'a> Deserialize<'a>"
+))]
+pub struct HyraxProverSetup<VC: VectorCommitment> {
+    pub dimensions: HyraxDimensions,
+    pub vc_setup: VC::Setup,
+}
+
+impl<VC: VectorCommitment> HyraxProverSetup<VC> {
+    pub fn new(dimensions: HyraxDimensions, vc_setup: VC::Setup) -> Result<Self, HyraxError> {
+        validate_capacity::<VC>(&dimensions, &vc_setup)?;
+        Ok(Self {
+            dimensions,
+            vc_setup,
+        })
+    }
+
+    pub fn derive_from<Source>(
+        source: &Source,
+        dimensions: HyraxDimensions,
+    ) -> Result<Self, HyraxError>
+    where
+        VC::Setup: DeriveSetup<Source>,
+    {
+        dimensions.validate()?;
+        let row_len = dimensions.row_len()?;
+        let vc_setup = VC::Setup::derive(source, row_len);
+        Self::new(dimensions, vc_setup)
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(bound(
+    serialize = "VC::Setup: Serialize",
+    deserialize = "VC::Setup: for<'a> Deserialize<'a>"
+))]
+pub struct HyraxVerifierSetup<VC: VectorCommitment> {
+    pub dimensions: HyraxDimensions,
+    pub vc_setup: VC::Setup,
+}
+
+impl<VC: VectorCommitment> HyraxVerifierSetup<VC> {
+    pub fn new(dimensions: HyraxDimensions, vc_setup: VC::Setup) -> Result<Self, HyraxError> {
+        validate_capacity::<VC>(&dimensions, &vc_setup)?;
+        Ok(Self {
+            dimensions,
+            vc_setup,
+        })
+    }
+
+    pub fn derive_from<Source>(
+        source: &Source,
+        dimensions: HyraxDimensions,
+    ) -> Result<Self, HyraxError>
+    where
+        VC::Setup: DeriveSetup<Source>,
+    {
+        dimensions.validate()?;
+        let row_len = dimensions.row_len()?;
+        let vc_setup = VC::Setup::derive(source, row_len);
+        Self::new(dimensions, vc_setup)
+    }
+}
+
+impl<VC: VectorCommitment> From<&HyraxProverSetup<VC>> for HyraxVerifierSetup<VC> {
+    fn from(prover_setup: &HyraxProverSetup<VC>) -> Self {
+        Self {
+            dimensions: prover_setup.dimensions,
+            vc_setup: prover_setup.vc_setup.clone(),
+        }
+    }
+}
+
+fn validate_capacity<VC: VectorCommitment>(
+    dimensions: &HyraxDimensions,
+    vc_setup: &VC::Setup,
+) -> Result<(), HyraxError> {
+    dimensions.validate()?;
+    let row_len = dimensions.row_len()?;
+    let capacity = VC::capacity(vc_setup);
+    if row_len > capacity {
+        return Err(HyraxError::CommitmentCapacityExceeded { capacity, row_len });
+    }
+    Ok(())
+}

--- a/crates/jolt-hyrax/tests/opening_soundness.rs
+++ b/crates/jolt-hyrax/tests/opening_soundness.rs
@@ -1,0 +1,432 @@
+#![expect(
+    clippy::expect_used,
+    reason = "integration tests may panic on setup failures"
+)]
+
+use jolt_crypto::{Bn254, Bn254G1, Grumpkin, GrumpkinPoint, JoltGroup, Pedersen, PedersenSetup};
+use jolt_field::{Fq, Fr, FromPrimitiveInt};
+use jolt_hyrax::{
+    HyraxCommitment, HyraxDimensions, HyraxOpeningProof, HyraxProverSetup, HyraxScheme,
+    HyraxSetupParams, HyraxVerifierSetup,
+};
+use jolt_openings::{AdditivelyHomomorphic, CommitmentScheme, OpeningsError};
+use jolt_poly::{EqPolynomial, Polynomial};
+use jolt_transcript::{Blake2bTranscript, Transcript};
+use rand_chacha::ChaCha20Rng;
+use rand_core::SeedableRng;
+
+type TestVc = Pedersen<Bn254G1>;
+type TestHyrax = HyraxScheme<TestVc>;
+type GrumpkinHyrax = HyraxScheme<Pedersen<GrumpkinPoint>>;
+
+struct OpeningCase {
+    verifier_setup: HyraxVerifierSetup<TestVc>,
+    commitment: HyraxCommitment<Bn254G1>,
+    proof: HyraxOpeningProof<Fr>,
+    eval: Fr,
+}
+
+fn setup(
+    row_vars: usize,
+    col_vars: usize,
+) -> (HyraxProverSetup<TestVc>, HyraxVerifierSetup<TestVc>) {
+    let mut rng = ChaCha20Rng::seed_from_u64(10_000 + row_vars as u64 * 131 + col_vars as u64);
+    let row_len = 1usize << col_vars;
+    let generators = (0..row_len).map(|_| Bn254::random_g1(&mut rng)).collect();
+    let blinding_generator = Bn254::random_g1(&mut rng);
+    let vc_setup = PedersenSetup::new(generators, blinding_generator);
+    let dimensions =
+        HyraxDimensions::new(row_vars + col_vars, row_vars, col_vars).expect("valid dimensions");
+    TestHyrax::setup(HyraxSetupParams {
+        dimensions,
+        vc_setup,
+    })
+}
+
+fn grumpkin_setup(
+    row_vars: usize,
+    col_vars: usize,
+) -> (
+    HyraxProverSetup<Pedersen<GrumpkinPoint>>,
+    HyraxVerifierSetup<Pedersen<GrumpkinPoint>>,
+) {
+    let generator = Grumpkin::generator();
+    let row_len = 1usize << col_vars;
+    let generators = (1..=row_len)
+        .map(|index| generator.scalar_mul(&Fq::from_u64(index as u64)))
+        .collect();
+    let opening_generator = generator.scalar_mul(&Fq::from_u64(99));
+    let vc_setup = PedersenSetup::new(generators, opening_generator);
+    let dimensions =
+        HyraxDimensions::new(row_vars + col_vars, row_vars, col_vars).expect("valid dimensions");
+    GrumpkinHyrax::setup(HyraxSetupParams {
+        dimensions,
+        vc_setup,
+    })
+}
+
+fn polynomial(num_vars: usize, salt: u64) -> Polynomial<Fr> {
+    let evals: Vec<Fr> = (0..(1usize << num_vars))
+        .map(|index| {
+            let x = index as u64 + 1;
+            Fr::from_u64((x * x * 17) + (x * (salt + 29)) + salt * 41 + 5)
+        })
+        .collect();
+    Polynomial::from(evals)
+}
+
+fn point(num_vars: usize, salt: u64) -> Vec<Fr> {
+    (0..num_vars)
+        .map(|index| Fr::from_u64((index as u64 + 3) * (salt + 11)))
+        .collect()
+}
+
+fn fq_polynomial(num_vars: usize, salt: u64) -> Polynomial<Fq> {
+    let evals: Vec<Fq> = (0..(1usize << num_vars))
+        .map(|index| {
+            let x = index as u64 + 1;
+            Fq::from_u64((x * x * 23) + (x * (salt + 31)) + salt * 43 + 7)
+        })
+        .collect();
+    Polynomial::from(evals)
+}
+
+fn fq_point(num_vars: usize, salt: u64) -> Vec<Fq> {
+    (0..num_vars)
+        .map(|index| Fq::from_u64((index as u64 + 5) * (salt + 13)))
+        .collect()
+}
+
+fn open_case(row_vars: usize, col_vars: usize, salt: u64) -> OpeningCase {
+    let (prover_setup, verifier_setup) = setup(row_vars, col_vars);
+    let poly = polynomial(row_vars + col_vars, salt);
+    let point = point(poly.num_vars(), salt);
+    let eval = poly.evaluate(&point);
+    let (commitment, hint) = TestHyrax::commit(&poly, &prover_setup);
+    let mut transcript = Blake2bTranscript::new(b"hyrax-integration-open");
+    let proof = TestHyrax::open(
+        &poly,
+        &point,
+        eval,
+        &prover_setup,
+        Some(hint),
+        &mut transcript,
+    );
+    OpeningCase {
+        verifier_setup,
+        commitment,
+        proof,
+        eval,
+    }
+}
+
+fn verify(
+    verifier_setup: &HyraxVerifierSetup<TestVc>,
+    commitment: &HyraxCommitment<Bn254G1>,
+    point: &[Fr],
+    eval: Fr,
+    proof: &HyraxOpeningProof<Fr>,
+) -> Result<(), OpeningsError> {
+    let mut transcript = Blake2bTranscript::new(b"hyrax-integration-open");
+    TestHyrax::verify(
+        commitment,
+        point,
+        eval,
+        proof,
+        verifier_setup,
+        &mut transcript,
+    )
+}
+
+fn column_eval(combined_row: &[Fr], col_point: &[Fr]) -> Fr {
+    EqPolynomial::new(col_point.to_vec())
+        .evaluations()
+        .iter()
+        .zip(combined_row.iter())
+        .map(|(weight, value)| *weight * *value)
+        .sum()
+}
+
+fn expected_combined_row(
+    poly: &Polynomial<Fr>,
+    dimensions: HyraxDimensions,
+    row_point: &[Fr],
+) -> Vec<Fr> {
+    let row_weights = EqPolynomial::new(row_point.to_vec()).evaluations();
+    let row_len = dimensions.row_len().expect("valid row len");
+    let mut combined = vec![Fr::from_u64(0); row_len];
+    for (row, weight) in poly.evaluations().chunks(row_len).zip(row_weights.iter()) {
+        for (dst, value) in combined.iter_mut().zip(row.iter()) {
+            *dst += *weight * *value;
+        }
+    }
+    combined
+}
+
+fn assert_rejects(result: Result<(), OpeningsError>) {
+    let err = result.expect_err("tampered opening must reject");
+    assert!(matches!(err, OpeningsError::VerificationFailed));
+}
+
+#[test]
+fn trait_and_native_openings_verify_across_dimension_splits() {
+    for (row_vars, col_vars, salt) in [(0, 0, 1), (0, 3, 2), (3, 0, 3), (1, 4, 4), (4, 1, 5)] {
+        let (prover_setup, verifier_setup) = setup(row_vars, col_vars);
+        let dimensions = prover_setup.dimensions;
+        let poly = polynomial(row_vars + col_vars, salt);
+        let point = point(poly.num_vars(), salt);
+        let eval = poly.evaluate(&point);
+        let (commitment, hint) = TestHyrax::commit(&poly, &prover_setup);
+
+        let (native_proof, native_eval) =
+            TestHyrax::opening_proof(&prover_setup, &poly, &point).expect("native opening proof");
+        assert_eq!(native_eval, eval);
+        TestHyrax::verify_opening_proof(&verifier_setup, &commitment, &point, eval, &native_proof)
+            .expect("native opening verifies");
+
+        let mut prover_transcript = Blake2bTranscript::new(b"hyrax-integration-open");
+        let trait_proof = TestHyrax::open(
+            &poly,
+            &point,
+            eval,
+            &prover_setup,
+            Some(hint),
+            &mut prover_transcript,
+        );
+        verify(&verifier_setup, &commitment, &point, eval, &trait_proof)
+            .expect("trait opening verifies");
+
+        let (row_point, _) = dimensions.split_point(&point).expect("valid point");
+        assert_eq!(
+            trait_proof.combined_row,
+            expected_combined_row(&poly, dimensions, row_point),
+        );
+        assert_eq!(trait_proof.combined_row_opening_scalar, Fr::from_u64(0));
+    }
+}
+
+#[test]
+fn wrong_evaluation_rejects() {
+    let case = open_case(3, 2, 20);
+    let point = point(5, 20);
+    assert_rejects(verify(
+        &case.verifier_setup,
+        &case.commitment,
+        &point,
+        case.eval + Fr::from_u64(1),
+        &case.proof,
+    ));
+}
+
+#[test]
+fn tampered_combined_row_rejects_even_with_matching_evaluation() {
+    let case = open_case(3, 2, 30);
+    let point = point(5, 30);
+    let (_, col_point) = case
+        .verifier_setup
+        .dimensions
+        .split_point(&point)
+        .expect("valid point");
+    let mut proof = case.proof;
+    proof.combined_row[0] += Fr::from_u64(9);
+    let matching_tampered_eval = column_eval(&proof.combined_row, col_point);
+
+    assert_rejects(verify(
+        &case.verifier_setup,
+        &case.commitment,
+        &point,
+        matching_tampered_eval,
+        &proof,
+    ));
+}
+
+#[test]
+fn tampered_combined_row_opening_scalar_rejects() {
+    let case = open_case(2, 3, 40);
+    let point = point(5, 40);
+    let mut proof = case.proof;
+    proof.combined_row_opening_scalar += Fr::from_u64(1);
+
+    assert_rejects(verify(
+        &case.verifier_setup,
+        &case.commitment,
+        &point,
+        case.eval,
+        &proof,
+    ));
+}
+
+#[test]
+fn truncated_combined_row_rejects() {
+    let case = open_case(2, 3, 50);
+    let point = point(5, 50);
+    let mut proof = case.proof;
+    let _ = proof.combined_row.pop();
+
+    assert_rejects(verify(
+        &case.verifier_setup,
+        &case.commitment,
+        &point,
+        case.eval,
+        &proof,
+    ));
+}
+
+#[test]
+fn proof_for_one_commitment_rejects_against_another_commitment() {
+    let (prover_setup, verifier_setup) = setup(3, 2);
+    let point = point(5, 60);
+    let poly_a = polynomial(5, 60);
+    let poly_b = polynomial(5, 61);
+    let eval_a = poly_a.evaluate(&point);
+    let (_, hint_a) = TestHyrax::commit(&poly_a, &prover_setup);
+    let (commitment_b, ()) = TestHyrax::commit(&poly_b, &prover_setup);
+    let mut transcript = Blake2bTranscript::new(b"hyrax-integration-open");
+    let proof_a = TestHyrax::open(
+        &poly_a,
+        &point,
+        eval_a,
+        &prover_setup,
+        Some(hint_a),
+        &mut transcript,
+    );
+
+    assert_rejects(verify(
+        &verifier_setup,
+        &commitment_b,
+        &point,
+        eval_a,
+        &proof_a,
+    ));
+}
+
+#[test]
+fn proof_for_one_row_point_rejects_at_another_row_point() {
+    let case = open_case(3, 2, 70);
+    let mut wrong_point = point(5, 70);
+    wrong_point[0] += Fr::from_u64(5);
+    let wrong_eval = polynomial(5, 70).evaluate(&wrong_point);
+
+    assert_rejects(verify(
+        &case.verifier_setup,
+        &case.commitment,
+        &wrong_point,
+        wrong_eval,
+        &case.proof,
+    ));
+}
+
+#[test]
+fn tampered_row_commitment_rejects() {
+    let mut case = open_case(3, 2, 80);
+    let point = point(5, 80);
+    case.commitment.rows[1] += Bn254::g1_generator();
+
+    assert_rejects(verify(
+        &case.verifier_setup,
+        &case.commitment,
+        &point,
+        case.eval,
+        &case.proof,
+    ));
+}
+
+#[test]
+fn row_commitment_count_mismatch_rejects() {
+    let mut case = open_case(3, 2, 90);
+    let point = point(5, 90);
+    let _ = case.commitment.rows.pop();
+
+    assert_rejects(verify(
+        &case.verifier_setup,
+        &case.commitment,
+        &point,
+        case.eval,
+        &case.proof,
+    ));
+}
+
+#[test]
+fn additive_homomorphic_combination_verifies_against_combined_polynomial() {
+    let (prover_setup, verifier_setup) = setup(3, 2);
+    let point = point(5, 100);
+    let poly_a = polynomial(5, 100);
+    let poly_b = polynomial(5, 101);
+    let scalar_a = Fr::from_u64(7);
+    let scalar_b = Fr::from_u64(13);
+    let (commitment_a, ()) = TestHyrax::commit(&poly_a, &prover_setup);
+    let (commitment_b, ()) = TestHyrax::commit(&poly_b, &prover_setup);
+    let combined_commitment =
+        TestHyrax::combine(&[commitment_a, commitment_b], &[scalar_a, scalar_b]);
+    let combined_poly = Polynomial::from(
+        poly_a
+            .evaluations()
+            .iter()
+            .zip(poly_b.evaluations().iter())
+            .map(|(a, b)| scalar_a * *a + scalar_b * *b)
+            .collect::<Vec<_>>(),
+    );
+    let combined_eval = combined_poly.evaluate(&point);
+    let (_, hint) = TestHyrax::commit(&combined_poly, &prover_setup);
+    let mut transcript = Blake2bTranscript::new(b"hyrax-integration-open");
+    let proof = TestHyrax::open(
+        &combined_poly,
+        &point,
+        combined_eval,
+        &prover_setup,
+        Some(hint),
+        &mut transcript,
+    );
+
+    verify(
+        &verifier_setup,
+        &combined_commitment,
+        &point,
+        combined_eval,
+        &proof,
+    )
+    .expect("opening verifies against homomorphically combined commitment");
+}
+
+#[test]
+fn grumpkin_backed_hyrax_verifies_and_rejects_tampering() {
+    let (prover_setup, verifier_setup) = grumpkin_setup(2, 3);
+    let poly = fq_polynomial(5, 110);
+    let point = fq_point(5, 110);
+    let eval = poly.evaluate(&point);
+    let (commitment, hint) = GrumpkinHyrax::commit(&poly, &prover_setup);
+    let mut prover_transcript = Blake2bTranscript::new(b"hyrax-grumpkin-open");
+    let proof = GrumpkinHyrax::open(
+        &poly,
+        &point,
+        eval,
+        &prover_setup,
+        Some(hint),
+        &mut prover_transcript,
+    );
+
+    let mut verifier_transcript = Blake2bTranscript::new(b"hyrax-grumpkin-open");
+    GrumpkinHyrax::verify(
+        &commitment,
+        &point,
+        eval,
+        &proof,
+        &verifier_setup,
+        &mut verifier_transcript,
+    )
+    .expect("Grumpkin-backed Hyrax verifies");
+
+    let mut tampered_proof = proof;
+    tampered_proof.combined_row[0] += Fq::from_u64(1);
+    let mut verifier_transcript = Blake2bTranscript::new(b"hyrax-grumpkin-open");
+    let err = GrumpkinHyrax::verify(
+        &commitment,
+        &point,
+        eval,
+        &tampered_proof,
+        &verifier_setup,
+        &mut verifier_transcript,
+    )
+    .expect_err("tampered Grumpkin-backed opening rejects");
+    assert!(matches!(err, OpeningsError::VerificationFailed));
+}


### PR DESCRIPTION
Part of the draft Jolt prover stack.

Base: `prover-stack/03-r1cs-extensions`
Head: `prover-stack/04-hyrax`

Adds the Hyrax row commitment crate used by later assist and wrapper protocols.

Validation before submission:
- `cargo fmt -q -- --check`
- `cargo metadata --no-deps --format-version 1`
- local `gh stack push` simulation against a temporary bare remote
- forbidden-path scan for `handoffs/`, old `STACK.md`, `stack/`, and old stack workflow