### PR TITLE
Mitigate proof-deserialization DOS vector

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3324,6 +3324,7 @@ version = "0.1.0"
 dependencies = [
  "ark-bn254 0.5.0 (git+https://github.com/a16z/arkworks-algebra?branch=dev%2Ftwist-shout)",
  "ark-serialize 0.5.0 (git+https://github.com/a16z/arkworks-algebra?branch=dev%2Ftwist-shout)",
+ "bincode 2.0.1",
  "common",
  "jolt-blindfold",
  "jolt-claims",

--- a/crates/jolt-verifier/Cargo.toml
+++ b/crates/jolt-verifier/Cargo.toml
@@ -24,6 +24,7 @@ transcript-poseidon = []
 [dependencies]
 ark-bn254 = { workspace = true, optional = true }
 ark-serialize.workspace = true
+bincode.workspace = true
 common.workspace = true
 jolt-core = { workspace = true, features = ["minimal"], optional = true }
 jolt-blindfold.workspace = true

--- a/crates/jolt-verifier/src/decode.rs
+++ b/crates/jolt-verifier/src/decode.rs
@@ -1,0 +1,121 @@
+//! Canonical, size-bounded (de)serialization for [`JoltProof`].
+//!
+//! A standalone proof arrives as untrusted bytes from a prover. Two properties
+//! matter at this boundary:
+//!
+//! 1. **Bounded work.** A malformed length prefix must not drive an unbounded
+//!    allocation. The proof contains many length-prefixed `Vec`s (RA commitment
+//!    vectors, per-round sumcheck vectors, the BlindFold row/commitment
+//!    vectors); without a ceiling, a prover can claim astronomically long
+//!    vectors. (One specific inner allocation — the Dory proof round count — is
+//!    already capped at the element level by `MAX_SERIALIZED_PROOF_ROUNDS` in
+//!    `jolt-dory`; this is the systematic outer bound covering every other
+//!    `Vec`.)
+//! 2. **A single accepted encoding.** Pinning one wire format and rejecting
+//!    trailing bytes removes proof malleability.
+//!
+//! Element-level validation (curve points in-subgroup, field elements reduced)
+//! is enforced independently by the `serde` implementations of the field and
+//! group types, which route through `CanonicalDeserialize` with validation.
+
+use serde::{de::DeserializeOwned, Serialize};
+
+use jolt_crypto::VectorCommitment;
+use jolt_openings::CommitmentScheme;
+
+use crate::{proof::JoltProof, VerifierError};
+
+/// Hard ceiling on accepted serialized proof size, enforced both before
+/// decoding (input length) and during decoding (the bincode read limit).
+///
+/// Jolt proofs are succinct — polylogarithmic in the trace length — so even
+/// large executions serialize well under this bound; it exists only to cap the
+/// deserialization work a malicious proof can induce. Callers that can compute
+/// a tighter bound from their preprocessing may pass it to
+/// [`JoltProof::from_canonical_bytes_bounded`].
+pub const MAX_PROOF_BYTES: usize = 1 << 27; // 128 MiB
+
+impl<PCS, VC, ZkProof> JoltProof<PCS, VC, ZkProof>
+where
+    PCS: CommitmentScheme,
+    VC: VectorCommitment<Field = PCS::Field>,
+{
+    /// Decodes a proof from its canonical byte encoding.
+    ///
+    /// Rejects inputs larger than [`MAX_PROOF_BYTES`] before allocating, caps
+    /// allocation during decoding at the same bound, and rejects any trailing
+    /// bytes after a complete proof.
+    pub fn from_canonical_bytes(bytes: &[u8]) -> Result<Self, VerifierError>
+    where
+        Self: DeserializeOwned,
+    {
+        Self::from_canonical_bytes_bounded(bytes, MAX_PROOF_BYTES)
+    }
+
+    /// Like [`from_canonical_bytes`](Self::from_canonical_bytes) but with a
+    /// caller-supplied upper bound on the input length. The bound is clamped to
+    /// [`MAX_PROOF_BYTES`], which always remains the absolute allocation ceiling
+    /// enforced during decoding.
+    pub fn from_canonical_bytes_bounded(
+        bytes: &[u8],
+        max_bytes: usize,
+    ) -> Result<Self, VerifierError>
+    where
+        Self: DeserializeOwned,
+    {
+        let max_bytes = max_bytes.min(MAX_PROOF_BYTES);
+        if bytes.len() > max_bytes {
+            return Err(VerifierError::ProofTooLarge {
+                got: bytes.len(),
+                max: max_bytes,
+            });
+        }
+
+        let config = bincode::config::standard().with_limit::<MAX_PROOF_BYTES>();
+        let (proof, consumed) = bincode::serde::decode_from_slice::<Self, _>(bytes, config)
+            .map_err(|error| VerifierError::ProofDeserializationFailed {
+                reason: error.to_string(),
+            })?;
+        if consumed != bytes.len() {
+            return Err(VerifierError::TrailingProofBytes {
+                consumed,
+                total: bytes.len(),
+            });
+        }
+        Ok(proof)
+    }
+
+    /// Encodes the proof to its canonical byte form, the inverse of
+    /// [`from_canonical_bytes`](Self::from_canonical_bytes).
+    pub fn to_canonical_bytes(&self) -> Result<Vec<u8>, VerifierError>
+    where
+        Self: Serialize,
+    {
+        let config = bincode::config::standard().with_limit::<MAX_PROOF_BYTES>();
+        bincode::serde::encode_to_vec(self, config).map_err(|error| {
+            VerifierError::ProofSerializationFailed {
+                reason: error.to_string(),
+            }
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use jolt_crypto::{Bn254G1, Pedersen};
+    use jolt_dory::DoryScheme;
+
+    use crate::proof::JoltProof;
+
+    fn assert_canonical_bytes_capable<T: serde::Serialize + serde::de::DeserializeOwned>() {}
+
+    #[test]
+    fn dory_pedersen_proof_supports_canonical_bytes() {
+        // Compile-time assurance that the production (Dory PCS, Pedersen VC)
+        // instantiation satisfies the `serde` bounds that `from_canonical_bytes`
+        // and `to_canonical_bytes` require, so the canonical decode boundary is
+        // usable for real proofs (the `core-fixtures` integration round-trip
+        // exercises it dynamically once the compat layer compiles).
+        assert_canonical_bytes_capable::<JoltProof<DoryScheme, Pedersen<Bn254G1>>>();
+    }
+}

--- a/crates/jolt-verifier/src/error.rs
+++ b/crates/jolt-verifier/src/error.rs
@@ -128,4 +128,16 @@ pub enum VerifierError {
 
     #[error("BlindFold proof verification failed: {reason}")]
     BlindFoldVerificationFailed { reason: String },
+
+    #[error("serialized proof length {got} exceeds maximum {max}")]
+    ProofTooLarge { got: usize, max: usize },
+
+    #[error("serialized proof has trailing bytes: consumed {consumed} of {total}")]
+    TrailingProofBytes { consumed: usize, total: usize },
+
+    #[error("proof deserialization failed: {reason}")]
+    ProofDeserializationFailed { reason: String },
+
+    #[error("proof serialization failed: {reason}")]
+    ProofSerializationFailed { reason: String },
 }

--- a/crates/jolt-verifier/src/lib.rs
+++ b/crates/jolt-verifier/src/lib.rs
@@ -2,6 +2,7 @@
 
 pub mod compat;
 pub mod config;
+pub mod decode;
 pub mod error;
 pub mod preprocessing;
 pub mod proof;
@@ -12,6 +13,7 @@ pub use config::{
     validate_proof_config, JoltProtocolConfig, ZkConfig, JOLT_VERIFIER_CONFIG,
     SELECTED_FIELD_INLINE_CONFIG,
 };
+pub use decode::MAX_PROOF_BYTES;
 pub use error::VerifierError;
 pub use preprocessing::JoltVerifierPreprocessing;
 pub use proof::{ClearProofClaims, JoltProof, JoltProofClaims};

--- a/crates/jolt-verifier/src/verifier.rs
+++ b/crates/jolt-verifier/src/verifier.rs
@@ -751,6 +751,45 @@ mod tests {
         ));
     }
 
+    #[test]
+    fn proof_roundtrips_through_canonical_bytes() {
+        let proof = proof_with_zk(false, clear_claims());
+        let bytes = proof.to_canonical_bytes();
+        assert!(bytes.is_ok(), "proof must encode");
+        let Ok(bytes) = bytes else { return };
+        let decoded = TestProof::from_canonical_bytes(&bytes);
+        assert!(decoded.is_ok(), "proof must decode");
+        let Ok(decoded) = decoded else { return };
+        assert_eq!(decoded, proof);
+    }
+
+    #[test]
+    fn from_canonical_bytes_rejects_trailing_bytes() {
+        let proof = proof_with_zk(false, clear_claims());
+        let bytes = proof.to_canonical_bytes();
+        assert!(bytes.is_ok(), "proof must encode");
+        let Ok(mut bytes) = bytes else { return };
+        bytes.push(0);
+        assert!(matches!(
+            TestProof::from_canonical_bytes(&bytes),
+            Err(VerifierError::TrailingProofBytes { .. })
+        ));
+    }
+
+    #[test]
+    fn from_canonical_bytes_rejects_oversized_input() {
+        let proof = proof_with_zk(false, clear_claims());
+        let bytes = proof.to_canonical_bytes();
+        assert!(bytes.is_ok(), "proof must encode");
+        let Ok(bytes) = bytes else { return };
+        let max = bytes.len().saturating_sub(1);
+        assert!(matches!(
+            TestProof::from_canonical_bytes_bounded(&bytes, max),
+            Err(VerifierError::ProofTooLarge { got, max: bound })
+                if got == bytes.len() && bound == max
+        ));
+    }
+
     fn proof_with_zk(is_zk: bool, claims: TestClaims) -> TestProof {
         JoltProof::new(
             crate::proof::JoltCommitments::new(

--- a/crates/jolt-verifier/tests/completeness/standard.rs
+++ b/crates/jolt-verifier/tests/completeness/standard.rs
@@ -9,6 +9,12 @@ fn standard_muldiv_core_proof_is_accepted() {
 
 #[test]
 #[cfg(all(feature = "core-fixtures", not(feature = "zk")))]
+fn standard_muldiv_proof_canonical_bytes_roundtrip() {
+    crate::support::core_fixtures::standard_muldiv_case().assert_canonical_bytes_roundtrip();
+}
+
+#[test]
+#[cfg(all(feature = "core-fixtures", not(feature = "zk")))]
 fn standard_fibonacci_small_core_proof_is_accepted() {
     support::assert_accepts(
         crate::support::core_fixtures::standard_fibonacci_small_case().verify(),

--- a/crates/jolt-verifier/tests/support/core_fixtures.rs
+++ b/crates/jolt-verifier/tests/support/core_fixtures.rs
@@ -218,6 +218,38 @@ impl CoreVerifierCase {
             false,
         )
     }
+
+    /// Round-trips the verifier-model proof through its canonical byte encoding
+    /// and checks the size-cap and trailing/truncation rejections on a real
+    /// Dory proof (exercising the curve/field `serde` paths end to end).
+    pub fn assert_canonical_bytes_roundtrip(&self) {
+        let bytes = self.proof.to_canonical_bytes().expect("encode proof");
+        let decoded = ConvertedProof::from_canonical_bytes(&bytes).expect("decode proof");
+        assert_eq!(decoded, self.proof, "decoded proof must equal the original");
+
+        let mut trailing = bytes.clone();
+        trailing.push(0);
+        assert!(
+            matches!(
+                ConvertedProof::from_canonical_bytes(&trailing),
+                Err(VerifierError::TrailingProofBytes { .. })
+            ),
+            "trailing bytes must be rejected"
+        );
+
+        assert!(
+            matches!(
+                ConvertedProof::from_canonical_bytes_bounded(&bytes, bytes.len().saturating_sub(1)),
+                Err(VerifierError::ProofTooLarge { .. })
+            ),
+            "oversized input must be rejected before allocation"
+        );
+
+        assert!(
+            ConvertedProof::from_canonical_bytes(&bytes[..bytes.len() - 1]).is_err(),
+            "truncated input must be rejected"
+        );
+    }
 }
 
 #[cfg(not(feature = "zk"))]


### PR DESCRIPTION
## Summary

<!-- What does this PR do and why? Link to relevant issues. -->

## Changes

<!-- Bulleted list of key changes. -->

-

## Testing

<!-- How was this tested? Which tests cover this change? -->

- [ ] Ran tests for modified crates
- [ ] `cargo clippy` and `cargo fmt` pass

## Security Considerations

<!-- Every change to a zkVM has security implications. Describe them.
     Does this affect proof soundness? Verifier correctness? Private inputs? -->

## Breaking Changes

<!-- List any breaking changes to public APIs, proof formats, or serialization. Write "None" if not applicable. -->

None
