### PR TITLE
feat: port precommitted polynomial reductions to modular verifier

### DIFF
--- a/.claude/skills/ci-code-review/SKILL.md
+++ b/.claude/skills/ci-code-review/SKILL.md
@@ -9,12 +9,12 @@ Follow these steps:
 
 1. **Eligibility Check** (Sonnet): Check if the PR (a) is closed, (b) is automated/trivial. If so, stop.
 
-2. **PR Analysis** (Opus): View the PR and return:
+2. **PR Analysis** (Fable): View the PR and return:
    - Summary of the change and its purpose
    - List of new functions, types, enums, or abstractions introduced
    - For each new abstraction: its name, stated purpose (from comments/docs), and intended usage contract
 
-3. **Parallel Deep Review** (4 Opus agents):
+3. **Parallel Deep Review** (4 Fable agents):
 
    Pass the PR summary and new abstractions list to each agent.
 

--- a/crates/jolt-claims/src/protocols/jolt/formulas/claim_reductions/advice.rs
+++ b/crates/jolt-claims/src/protocols/jolt/formulas/claim_reductions/advice.rs
@@ -1,4 +1,4 @@
-use std::{cmp::min, ops::Range};
+//! Two-phase advice claim reduction (Stage 6 cycle -> Stage 7 address).
 
 use jolt_field::{Field, RingCore};
 use jolt_poly::EqPolynomial;
@@ -11,129 +11,79 @@ use super::super::super::{
 };
 use super::super::dimensions::{CommitmentMatrixShape, JoltSumcheckSpec, TracePolynomialOrder};
 use super::super::error::JoltFormulaPointError;
+use super::precommitted::{
+    precommitted_skip_round_scale, PrecommittedClaimReduction, PrecommittedSchedulingReference,
+};
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct AdviceClaimReductionLayout {
-    trace_order: TracePolynomialOrder,
-    log_t: usize,
-    log_k_chunk: usize,
-    main_shape: CommitmentMatrixShape,
     advice_shape: CommitmentMatrixShape,
-    cycle_phase_col_rounds: Range<usize>,
-    cycle_phase_row_rounds: Range<usize>,
+    precommitted: PrecommittedClaimReduction,
+}
+
+/// Total-var counts of the present advice polynomials, in the order core feeds
+/// them to the shared precommitted scheduling reference (trusted first).
+pub fn precommitted_candidates(
+    trusted_max_advice_size_bytes: Option<usize>,
+    untrusted_max_advice_size_bytes: Option<usize>,
+) -> Vec<usize> {
+    trusted_max_advice_size_bytes
+        .into_iter()
+        .chain(untrusted_max_advice_size_bytes)
+        .map(|max_bytes| CommitmentMatrixShape::advice_from_max_bytes(max_bytes).total_vars())
+        .collect()
 }
 
 impl AdviceClaimReductionLayout {
     pub fn balanced(
         trace_order: TracePolynomialOrder,
         log_t: usize,
-        log_k_chunk: usize,
+        scheduling_reference: PrecommittedSchedulingReference,
         max_advice_size_bytes: usize,
     ) -> Self {
-        Self::new(
+        let advice_shape = CommitmentMatrixShape::advice_from_max_bytes(max_advice_size_bytes);
+        let precommitted = PrecommittedClaimReduction::new(
+            advice_shape.row_vars(),
+            advice_shape.column_vars(),
+            scheduling_reference,
             trace_order,
             log_t,
-            log_k_chunk,
-            CommitmentMatrixShape::balanced(log_k_chunk + log_t),
-            CommitmentMatrixShape::advice_from_max_bytes(max_advice_size_bytes),
-        )
-    }
-
-    pub fn new(
-        trace_order: TracePolynomialOrder,
-        log_t: usize,
-        log_k_chunk: usize,
-        main_shape: CommitmentMatrixShape,
-        advice_shape: CommitmentMatrixShape,
-    ) -> Self {
-        let (cycle_phase_col_rounds, cycle_phase_row_rounds) =
-            cycle_phase_round_schedule(trace_order, log_t, log_k_chunk, main_shape, advice_shape);
+        );
         Self {
-            trace_order,
-            log_t,
-            log_k_chunk,
-            main_shape,
             advice_shape,
-            cycle_phase_col_rounds,
-            cycle_phase_row_rounds,
+            precommitted,
         }
-    }
-
-    pub const fn trace_order(&self) -> TracePolynomialOrder {
-        self.trace_order
-    }
-
-    pub const fn log_t(&self) -> usize {
-        self.log_t
-    }
-
-    pub const fn log_k_chunk(&self) -> usize {
-        self.log_k_chunk
-    }
-
-    pub const fn main_shape(&self) -> CommitmentMatrixShape {
-        self.main_shape
     }
 
     pub const fn advice_shape(&self) -> CommitmentMatrixShape {
         self.advice_shape
     }
 
-    pub fn cycle_phase_col_rounds(&self) -> Range<usize> {
-        self.cycle_phase_col_rounds.clone()
-    }
-
-    pub fn cycle_phase_row_rounds(&self) -> Range<usize> {
-        self.cycle_phase_row_rounds.clone()
-    }
-
-    pub fn active_cycle_phase_rounds(&self) -> usize {
-        self.cycle_phase_col_rounds.len() + self.cycle_phase_row_rounds.len()
-    }
-
-    pub fn cycle_phase_rounds(&self) -> usize {
-        if !self.cycle_phase_row_rounds.is_empty() {
-            self.cycle_phase_row_rounds.end - self.cycle_phase_col_rounds.start
-        } else {
-            self.cycle_phase_col_rounds.len()
-        }
-    }
-
-    pub fn address_phase_rounds(&self) -> usize {
-        self.advice_shape
-            .total_vars()
-            .saturating_sub(self.active_cycle_phase_rounds())
+    pub const fn precommitted(&self) -> &PrecommittedClaimReduction {
+        &self.precommitted
     }
 
     pub fn dimensions(&self) -> AdviceClaimReductionDimensions {
-        AdviceClaimReductionDimensions::new(self.cycle_phase_rounds(), self.address_phase_rounds())
+        AdviceClaimReductionDimensions::new(
+            self.precommitted.cycle_phase_total_rounds(),
+            self.precommitted.address_phase_total_rounds(),
+            self.precommitted.num_address_phase_rounds() > 0,
+        )
     }
 
     pub fn cycle_phase_opening_point<F: Field>(
         &self,
         challenges: &[F],
     ) -> Result<Vec<F>, JoltFormulaPointError> {
-        let mut advice_var_challenges = self.cycle_phase_variable_challenges(challenges)?;
-        advice_var_challenges.reverse();
-        Ok(advice_var_challenges)
+        self.precommitted.cycle_phase_opening_point(challenges)
     }
 
     pub fn cycle_phase_variable_challenges<F: Field>(
         &self,
         challenges: &[F],
     ) -> Result<Vec<F>, JoltFormulaPointError> {
-        let expected = self.cycle_phase_rounds();
-        if challenges.len() != expected {
-            return Err(JoltFormulaPointError::ChallengeLengthMismatch {
-                expected,
-                got: challenges.len(),
-            });
-        }
-
-        let mut advice_var_challenges = Vec::with_capacity(self.active_cycle_phase_rounds());
-        advice_var_challenges.extend_from_slice(&challenges[self.cycle_phase_col_rounds.clone()]);
-        advice_var_challenges.extend_from_slice(&challenges[self.cycle_phase_row_rounds.clone()]);
-        Ok(advice_var_challenges)
+        self.precommitted
+            .cycle_phase_variable_challenges(challenges)
     }
 
     pub fn address_phase_opening_point<F: Field>(
@@ -141,114 +91,72 @@ impl AdviceClaimReductionLayout {
         cycle_var_challenges: &[F],
         challenges: &[F],
     ) -> Result<Vec<F>, JoltFormulaPointError> {
-        let expected_cycle = self.active_cycle_phase_rounds();
-        if cycle_var_challenges.len() != expected_cycle {
-            return Err(JoltFormulaPointError::ChallengeLengthMismatch {
-                expected: expected_cycle,
-                got: cycle_var_challenges.len(),
-            });
-        }
-        let expected_address = self.address_phase_rounds();
-        if challenges.len() != expected_address {
-            return Err(JoltFormulaPointError::ChallengeLengthMismatch {
-                expected: expected_address,
-                got: challenges.len(),
-            });
-        }
-
-        let mut point = match self.trace_order {
-            TracePolynomialOrder::CycleMajor => [cycle_var_challenges, challenges].concat(),
-            TracePolynomialOrder::AddressMajor => [challenges, cycle_var_challenges].concat(),
-        };
-        point.reverse();
-        Ok(point)
+        self.precommitted
+            .address_phase_opening_point(cycle_var_challenges, challenges)
     }
 
+    /// `FinalScale` value when the reduction completes in the cycle phase
+    /// (i.e. no active address-phase rounds remain).
     pub fn cycle_phase_final_output_scale<F: Field>(
         &self,
         reference_opening_point: &[F],
         challenges: &[F],
     ) -> Result<F, JoltFormulaPointError> {
-        let opening_point = self.cycle_phase_opening_point(challenges)?;
-        self.final_output_scale_at(reference_opening_point, &opening_point)
+        let opening_point = self
+            .precommitted
+            .cycle_phase_permuted_opening_point(challenges)?;
+        let eq_eval = final_advice_eq_eval(reference_opening_point, &opening_point)?;
+        Ok(eq_eval * self.precommitted.cycle_phase_skip_scale::<F>())
     }
 
+    /// `FinalScale` value when the reduction completes in the address phase.
     pub fn address_phase_final_output_scale<F: Field>(
         &self,
         reference_opening_point: &[F],
         cycle_var_challenges: &[F],
         challenges: &[F],
     ) -> Result<F, JoltFormulaPointError> {
-        let opening_point = self.address_phase_opening_point(cycle_var_challenges, challenges)?;
-        self.final_output_scale_at(reference_opening_point, &opening_point)
-    }
-
-    fn final_output_scale_at<F: Field>(
-        &self,
-        reference_opening_point: &[F],
-        opening_point: &[F],
-    ) -> Result<F, JoltFormulaPointError> {
-        if reference_opening_point.len() != opening_point.len() {
-            return Err(JoltFormulaPointError::OpeningPointLengthMismatch {
-                expected: reference_opening_point.len(),
-                got: opening_point.len(),
-            });
-        }
-
-        Ok(
-            EqPolynomial::<F>::mle(opening_point, reference_opening_point)
-                * self.dummy_cycle_phase_scale::<F>(),
-        )
-    }
-
-    fn dummy_cycle_phase_scale<F: Field>(&self) -> F {
-        let two_inv = F::from_u64(2).inv_or_zero();
-        (0..self.dummy_cycle_phase_rounds()).fold(F::one(), |scale, _| scale * two_inv)
-    }
-
-    pub fn dummy_cycle_phase_rounds(&self) -> usize {
-        self.cycle_phase_rounds()
-            .saturating_sub(self.active_cycle_phase_rounds())
+        let opening_point = self
+            .precommitted
+            .address_phase_opening_point(cycle_var_challenges, challenges)?;
+        let eq_eval = final_advice_eq_eval(reference_opening_point, &opening_point)?;
+        Ok(eq_eval * precommitted_skip_round_scale::<F>(&self.precommitted))
     }
 }
 
-fn cycle_phase_round_schedule(
-    trace_order: TracePolynomialOrder,
-    log_t: usize,
-    log_k_chunk: usize,
-    main_shape: CommitmentMatrixShape,
-    advice_shape: CommitmentMatrixShape,
-) -> (Range<usize>, Range<usize>) {
-    match trace_order {
-        TracePolynomialOrder::CycleMajor => {
-            let col_binding_rounds = 0..min(log_t, advice_shape.column_vars());
-            let row_binding_rounds = min(log_t, main_shape.column_vars())
-                ..min(log_t, main_shape.column_vars() + advice_shape.row_vars());
-            (col_binding_rounds, row_binding_rounds)
-        }
-        TracePolynomialOrder::AddressMajor => {
-            let col_binding_rounds = 0..advice_shape.column_vars().saturating_sub(log_k_chunk);
-            let row_binding_rounds = main_shape.column_vars().saturating_sub(log_k_chunk)
-                ..min(
-                    log_t,
-                    main_shape.column_vars().saturating_sub(log_k_chunk) + advice_shape.row_vars(),
-                );
-            (col_binding_rounds, row_binding_rounds)
-        }
+fn final_advice_eq_eval<F: Field>(
+    reference_opening_point: &[F],
+    opening_point: &[F],
+) -> Result<F, JoltFormulaPointError> {
+    if reference_opening_point.len() != opening_point.len() {
+        return Err(JoltFormulaPointError::OpeningPointLengthMismatch {
+            expected: reference_opening_point.len(),
+            got: opening_point.len(),
+        });
     }
+    Ok(EqPolynomial::<F>::mle(
+        opening_point,
+        reference_opening_point,
+    ))
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct AdviceClaimReductionDimensions {
     cycle_phase_rounds: usize,
     address_phase_rounds: usize,
+    has_address_phase: bool,
 }
 
 impl AdviceClaimReductionDimensions {
-    pub const fn new(cycle_phase_rounds: usize, address_phase_rounds: usize) -> Self {
+    pub const fn new(
+        cycle_phase_rounds: usize,
+        address_phase_rounds: usize,
+        has_address_phase: bool,
+    ) -> Self {
         Self {
             cycle_phase_rounds,
             address_phase_rounds,
+            has_address_phase,
         }
     }
 
@@ -260,8 +168,11 @@ impl AdviceClaimReductionDimensions {
         self.address_phase_rounds
     }
 
+    /// The address phase only runs for this advice polynomial when it has
+    /// active address-phase rounds; otherwise the reduction finalizes at the
+    /// cycle-phase handoff.
     pub const fn has_address_phase(self) -> bool {
-        self.address_phase_rounds > 0
+        self.has_address_phase
     }
 
     pub const fn cycle_sumcheck(self) -> JoltSumcheckSpec {
@@ -353,11 +264,11 @@ mod tests {
     use jolt_field::{Fr, FromPrimitiveInt};
 
     fn with_address_phase() -> AdviceClaimReductionDimensions {
-        AdviceClaimReductionDimensions::new(4, 3)
+        AdviceClaimReductionDimensions::new(4, 3, true)
     }
 
     fn without_address_phase() -> AdviceClaimReductionDimensions {
-        AdviceClaimReductionDimensions::new(4, 0)
+        AdviceClaimReductionDimensions::new(4, 3, false)
     }
 
     #[test]

--- a/crates/jolt-claims/src/protocols/jolt/formulas/claim_reductions/advice.rs
+++ b/crates/jolt-claims/src/protocols/jolt/formulas/claim_reductions/advice.rs
@@ -41,7 +41,7 @@ impl AdviceClaimReductionLayout {
         log_t: usize,
         scheduling_reference: PrecommittedSchedulingReference,
         max_advice_size_bytes: usize,
-    ) -> Self {
+    ) -> Result<Self, JoltFormulaPointError> {
         let advice_shape = CommitmentMatrixShape::advice_from_max_bytes(max_advice_size_bytes);
         let precommitted = PrecommittedClaimReduction::new(
             advice_shape.row_vars(),
@@ -49,11 +49,11 @@ impl AdviceClaimReductionLayout {
             scheduling_reference,
             trace_order,
             log_t,
-        );
-        Self {
+        )?;
+        Ok(Self {
             advice_shape,
             precommitted,
-        }
+        })
     }
 
     pub const fn advice_shape(&self) -> CommitmentMatrixShape {

--- a/crates/jolt-claims/src/protocols/jolt/formulas/claim_reductions/advice.rs
+++ b/crates/jolt-claims/src/protocols/jolt/formulas/claim_reductions/advice.rs
@@ -13,6 +13,7 @@ use super::super::dimensions::{CommitmentMatrixShape, JoltSumcheckSpec, TracePol
 use super::super::error::JoltFormulaPointError;
 use super::precommitted::{
     precommitted_skip_round_scale, PrecommittedClaimReduction, PrecommittedSchedulingReference,
+    TWO_PHASE_DEGREE_BOUND,
 };
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -23,7 +24,7 @@ pub struct AdviceClaimReductionLayout {
 
 /// Total-var counts of the present advice polynomials, in the order core feeds
 /// them to the shared precommitted scheduling reference (trusted first).
-pub fn precommitted_candidates(
+pub fn candidate_total_vars(
     trusted_max_advice_size_bytes: Option<usize>,
     untrusted_max_advice_size_bytes: Option<usize>,
 ) -> Vec<usize> {
@@ -142,30 +143,34 @@ fn final_advice_eq_eval<F: Field>(
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct AdviceClaimReductionDimensions {
-    cycle_phase_rounds: usize,
-    address_phase_rounds: usize,
+    cycle_phase_total_rounds: usize,
+    address_phase_total_rounds: usize,
     has_address_phase: bool,
 }
 
 impl AdviceClaimReductionDimensions {
     pub const fn new(
-        cycle_phase_rounds: usize,
-        address_phase_rounds: usize,
+        cycle_phase_total_rounds: usize,
+        address_phase_total_rounds: usize,
         has_address_phase: bool,
     ) -> Self {
         Self {
-            cycle_phase_rounds,
-            address_phase_rounds,
+            cycle_phase_total_rounds,
+            address_phase_total_rounds,
             has_address_phase,
         }
     }
 
-    pub const fn cycle_phase_rounds(self) -> usize {
-        self.cycle_phase_rounds
+    /// Full cycle-phase sumcheck round count, including rounds this advice
+    /// polynomial skips.
+    pub const fn cycle_phase_total_rounds(self) -> usize {
+        self.cycle_phase_total_rounds
     }
 
-    pub const fn address_phase_rounds(self) -> usize {
-        self.address_phase_rounds
+    /// Full address-phase sumcheck round count, including rounds this advice
+    /// polynomial skips.
+    pub const fn address_phase_total_rounds(self) -> usize {
+        self.address_phase_total_rounds
     }
 
     /// The address phase only runs for this advice polynomial when it has
@@ -176,11 +181,11 @@ impl AdviceClaimReductionDimensions {
     }
 
     pub const fn cycle_sumcheck(self) -> JoltSumcheckSpec {
-        JoltSumcheckSpec::boolean(self.cycle_phase_rounds, 2)
+        JoltSumcheckSpec::boolean(self.cycle_phase_total_rounds, TWO_PHASE_DEGREE_BOUND)
     }
 
     pub const fn address_sumcheck(self) -> JoltSumcheckSpec {
-        JoltSumcheckSpec::boolean(self.address_phase_rounds, 2)
+        JoltSumcheckSpec::boolean(self.address_phase_total_rounds, TWO_PHASE_DEGREE_BOUND)
     }
 }
 

--- a/crates/jolt-claims/src/protocols/jolt/formulas/claim_reductions/mod.rs
+++ b/crates/jolt-claims/src/protocols/jolt/formulas/claim_reductions/mod.rs
@@ -2,4 +2,5 @@ pub mod advice;
 pub mod hamming_weight;
 pub mod increments;
 pub mod instruction;
+pub mod precommitted;
 pub mod registers;

--- a/crates/jolt-claims/src/protocols/jolt/formulas/claim_reductions/precommitted.rs
+++ b/crates/jolt-claims/src/protocols/jolt/formulas/claim_reductions/precommitted.rs
@@ -186,14 +186,6 @@ impl PrecommittedClaimReduction {
         (cycle_phase_rounds, address_phase_rounds)
     }
 
-    pub const fn scheduling_reference_dimensions(&self) -> PrecommittedSchedulingReference {
-        self.scheduling_reference
-    }
-
-    pub fn num_active_cycle_phase_rounds(&self) -> usize {
-        self.cycle_phase_rounds.len()
-    }
-
     pub fn num_address_phase_rounds(&self) -> usize {
         self.address_phase_rounds.len()
     }
@@ -222,10 +214,6 @@ impl PrecommittedClaimReduction {
         self.scheduling_reference.cycle_alignment_rounds
     }
 
-    pub const fn address_alignment_rounds(&self) -> usize {
-        self.scheduling_reference.address_rounds
-    }
-
     /// Total cycle-phase sumcheck rounds, including rounds this polynomial
     /// skips.
     pub const fn cycle_phase_total_rounds(&self) -> usize {
@@ -251,12 +239,10 @@ impl PrecommittedClaimReduction {
         cycle_var_challenges: &[F],
         round: usize,
     ) -> Result<F, JoltFormulaPointError> {
-        let idx = self.cycle_phase_rounds.binary_search(&round).map_err(|_| {
-            JoltFormulaPointError::ChallengeLengthMismatch {
-                expected: self.cycle_phase_rounds.len(),
-                got: cycle_var_challenges.len(),
-            }
-        })?;
+        let idx = self
+            .cycle_phase_rounds
+            .binary_search(&round)
+            .map_err(|_| JoltFormulaPointError::InactiveCycleRound { round })?;
         cycle_var_challenges.get(idx).copied().ok_or(
             JoltFormulaPointError::ChallengeLengthMismatch {
                 expected: self.cycle_phase_rounds.len(),
@@ -314,9 +300,8 @@ impl PrecommittedClaimReduction {
                 if global_round < cycle_round_limit {
                     Ok(challenges[global_round])
                 } else {
-                    Err(JoltFormulaPointError::ChallengeLengthMismatch {
-                        expected: 0,
-                        got: self.num_address_phase_rounds(),
+                    Err(JoltFormulaPointError::CyclePhaseNotFinal {
+                        active_address_rounds: self.num_address_phase_rounds(),
                     })
                 }
             })

--- a/crates/jolt-claims/src/protocols/jolt/formulas/claim_reductions/precommitted.rs
+++ b/crates/jolt-claims/src/protocols/jolt/formulas/claim_reductions/precommitted.rs
@@ -1,0 +1,467 @@
+//! Shared two-phase scheduling for precommitted polynomial claim reductions.
+//!
+//! Precommitted polynomials (trusted/untrusted advice today; committed bytecode
+//! chunks and the program image in committed program mode) are smaller or larger
+//! than the main trace-domain polynomials. All of them are reduced over a shared
+//! reference domain so their final openings embed consistently into the stage 8
+//! batched PCS opening. Mirrors `jolt-core`'s
+//! `zkvm/claim_reductions/precommitted.rs`, with the Dory globals
+//! (`main_k`, `main_t`, layout, configured column count) parameter-passed.
+
+use jolt_field::Field;
+
+use super::super::dimensions::{CommitmentMatrixShape, TracePolynomialOrder};
+use super::super::error::JoltFormulaPointError;
+
+/// Degree bound shared by all two-phase precommitted reduction sumchecks.
+pub const TWO_PHASE_DEGREE_BOUND: usize = 2;
+
+/// Shared scheduling dimensions derived from the main trace domain and all
+/// precommitted candidate domains.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct PrecommittedSchedulingReference {
+    pub main_total_vars: usize,
+    pub reference_total_vars: usize,
+    pub cycle_alignment_rounds: usize,
+    pub address_rounds: usize,
+    pub joint_col_vars: usize,
+}
+
+/// Per-polynomial two-phase round schedule projected from the shared reference
+/// domain.
+///
+/// Unlike core's stateful counterpart, this layout is pure: the verifier passes
+/// the recorded cycle-phase challenges explicitly when completing the address
+/// phase.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct PrecommittedClaimReduction {
+    scheduling_reference: PrecommittedSchedulingReference,
+    poly_opening_round_permutation_be: Vec<usize>,
+    cycle_phase_rounds: Vec<usize>,
+    cycle_phase_total_rounds: usize,
+    address_phase_rounds: Vec<usize>,
+    address_phase_total_rounds: usize,
+}
+
+impl PrecommittedClaimReduction {
+    /// Compute shared scheduling dimensions from the main trace domain and
+    /// precommitted candidate total-var counts.
+    ///
+    /// `joint_col_vars` mirrors core's
+    /// `max(configured_main_num_columns().log_2(), reference_sigma)`: after the
+    /// stage 6 Dory re-embedding the main matrix is balanced over
+    /// `reference_total_vars`, so both operands equal
+    /// `ceil(reference_total_vars / 2)`.
+    pub fn scheduling_reference(
+        main_total_vars: usize,
+        candidates: &[usize],
+        log_k_chunk: usize,
+    ) -> PrecommittedSchedulingReference {
+        let address_rounds = log_k_chunk;
+        let max_precommitted = candidates.iter().copied().max().unwrap_or(0);
+        let reference_total_vars = main_total_vars.max(max_precommitted);
+        let cycle_alignment_rounds = reference_total_vars.saturating_sub(address_rounds);
+        let joint_col_vars = CommitmentMatrixShape::balanced(reference_total_vars).column_vars();
+        PrecommittedSchedulingReference {
+            main_total_vars,
+            reference_total_vars,
+            cycle_alignment_rounds,
+            address_rounds,
+            joint_col_vars,
+        }
+    }
+
+    pub fn new(
+        poly_row_vars: usize,
+        poly_col_vars: usize,
+        scheduling_reference: PrecommittedSchedulingReference,
+        trace_order: TracePolynomialOrder,
+        log_t: usize,
+    ) -> Self {
+        let has_precommitted_dominance =
+            scheduling_reference.reference_total_vars > scheduling_reference.main_total_vars;
+        let dense_cycle_prefix_rounds = if has_precommitted_dominance { log_t } else { 0 };
+        let dory_opening_round_permutation_be = Self::reference_dory_opening_round_permutation_be(
+            &scheduling_reference,
+            trace_order,
+            has_precommitted_dominance,
+            dense_cycle_prefix_rounds,
+        );
+        let poly_opening_round_permutation_be = Self::project_dory_round_permutation_for_poly(
+            &dory_opening_round_permutation_be,
+            &scheduling_reference,
+            poly_row_vars,
+            poly_col_vars,
+        );
+        let (cycle_phase_rounds, address_phase_rounds) = Self::active_rounds_from_poly_permutation(
+            &poly_opening_round_permutation_be,
+            scheduling_reference.cycle_alignment_rounds,
+        );
+        Self {
+            scheduling_reference,
+            poly_opening_round_permutation_be,
+            cycle_phase_rounds,
+            cycle_phase_total_rounds: scheduling_reference.cycle_alignment_rounds,
+            address_phase_rounds,
+            address_phase_total_rounds: scheduling_reference.address_rounds,
+        }
+    }
+
+    fn reference_dory_opening_round_permutation_be(
+        reference: &PrecommittedSchedulingReference,
+        trace_order: TracePolynomialOrder,
+        has_precommitted_dominance: bool,
+        dense_cycle_prefix_rounds: usize,
+    ) -> Vec<usize> {
+        let cycle_rounds = reference.cycle_alignment_rounds;
+        let address_rounds = reference.address_rounds;
+        let total_rounds = cycle_rounds + address_rounds;
+        if has_precommitted_dominance {
+            let address_rev = (cycle_rounds..total_rounds).rev();
+            let t = dense_cycle_prefix_rounds.min(cycle_rounds);
+            let prefix_rev = (0..cycle_rounds.saturating_sub(t)).rev();
+            let dense_rev = (cycle_rounds.saturating_sub(t)..cycle_rounds).rev();
+            return match trace_order {
+                TracePolynomialOrder::CycleMajor => {
+                    prefix_rev.chain(address_rev).chain(dense_rev).collect()
+                }
+                TracePolynomialOrder::AddressMajor => {
+                    dense_rev.chain(address_rev).chain(prefix_rev).collect()
+                }
+            };
+        }
+
+        match trace_order {
+            TracePolynomialOrder::CycleMajor => (0..total_rounds).rev().collect(),
+            TracePolynomialOrder::AddressMajor => {
+                let cycle_rev = (0..cycle_rounds).rev();
+                let address_rev = (cycle_rounds..total_rounds).rev();
+                cycle_rev.chain(address_rev).collect()
+            }
+        }
+    }
+
+    fn project_dory_round_permutation_for_poly(
+        dory_opening_round_permutation_be: &[usize],
+        reference: &PrecommittedSchedulingReference,
+        poly_row_vars: usize,
+        poly_col_vars: usize,
+    ) -> Vec<usize> {
+        let total_full = reference.reference_total_vars;
+        let sigma_full = reference.joint_col_vars;
+        let nu_full = total_full.saturating_sub(sigma_full);
+        assert_eq!(
+            dory_opening_round_permutation_be.len(),
+            total_full,
+            "reference dory round permutation length mismatch",
+        );
+        assert!(
+            poly_row_vars <= nu_full && poly_col_vars <= sigma_full,
+            "top-left projection requires poly dims <= full dims (poly row/col vars={poly_row_vars}/{poly_col_vars}, full row/col vars={nu_full}/{sigma_full})"
+        );
+        let row_be = &dory_opening_round_permutation_be[..nu_full];
+        let col_be = &dory_opening_round_permutation_be[nu_full..nu_full + sigma_full];
+        let row_tail = &row_be[nu_full - poly_row_vars..];
+        let col_tail = &col_be[sigma_full - poly_col_vars..];
+        [row_tail, col_tail].concat()
+    }
+
+    fn active_rounds_from_poly_permutation(
+        poly_opening_round_permutation_be: &[usize],
+        cycle_alignment_rounds: usize,
+    ) -> (Vec<usize>, Vec<usize>) {
+        let mut cycle_phase_rounds = Vec::new();
+        let mut address_phase_rounds = Vec::new();
+        for &global_round in poly_opening_round_permutation_be {
+            if global_round < cycle_alignment_rounds {
+                cycle_phase_rounds.push(global_round);
+            } else {
+                address_phase_rounds.push(global_round - cycle_alignment_rounds);
+            }
+        }
+        cycle_phase_rounds.sort_unstable();
+        cycle_phase_rounds.dedup();
+        address_phase_rounds.sort_unstable();
+        address_phase_rounds.dedup();
+        (cycle_phase_rounds, address_phase_rounds)
+    }
+
+    pub const fn scheduling_reference_dimensions(&self) -> PrecommittedSchedulingReference {
+        self.scheduling_reference
+    }
+
+    pub fn num_active_cycle_phase_rounds(&self) -> usize {
+        self.cycle_phase_rounds.len()
+    }
+
+    pub fn num_address_phase_rounds(&self) -> usize {
+        self.address_phase_rounds.len()
+    }
+
+    /// Indices of the cycle-phase rounds this polynomial actively participates
+    /// in (sorted ascending, deduplicated). Inactive rounds contribute a `1/2`
+    /// factor instead.
+    pub fn cycle_phase_rounds(&self) -> &[usize] {
+        &self.cycle_phase_rounds
+    }
+
+    /// Indices of the address-phase rounds this polynomial actively
+    /// participates in. Same conventions as [`Self::cycle_phase_rounds`].
+    pub fn address_phase_rounds(&self) -> &[usize] {
+        &self.address_phase_rounds
+    }
+
+    /// Big-endian Dory opening-round permutation projected onto this
+    /// polynomial's `(row_vars, col_vars)` rectangle: the first `row_vars`
+    /// entries describe the row-side rounds, the rest the column-side rounds.
+    pub fn poly_opening_round_permutation_be(&self) -> &[usize] {
+        &self.poly_opening_round_permutation_be
+    }
+
+    pub const fn cycle_alignment_rounds(&self) -> usize {
+        self.scheduling_reference.cycle_alignment_rounds
+    }
+
+    pub const fn address_alignment_rounds(&self) -> usize {
+        self.scheduling_reference.address_rounds
+    }
+
+    /// Total cycle-phase sumcheck rounds, including rounds this polynomial
+    /// skips.
+    pub const fn cycle_phase_total_rounds(&self) -> usize {
+        self.cycle_phase_total_rounds
+    }
+
+    /// Total address-phase sumcheck rounds, including rounds this polynomial
+    /// skips.
+    pub const fn address_phase_total_rounds(&self) -> usize {
+        self.address_phase_total_rounds
+    }
+
+    /// The `(1/2)^cycle_gap` factor contributed by inactive cycle-phase
+    /// rounds. This is the cycle-only counterpart of
+    /// [`precommitted_skip_round_scale`], used when the reduction finishes in
+    /// the cycle phase.
+    pub fn cycle_phase_skip_scale<F: Field>(&self) -> F {
+        skip_round_scale(self.cycle_phase_total_rounds - self.cycle_phase_rounds.len())
+    }
+
+    fn cycle_challenge_for_round<F: Field>(
+        &self,
+        cycle_var_challenges: &[F],
+        round: usize,
+    ) -> Result<F, JoltFormulaPointError> {
+        let idx = self.cycle_phase_rounds.binary_search(&round).map_err(|_| {
+            JoltFormulaPointError::ChallengeLengthMismatch {
+                expected: self.cycle_phase_rounds.len(),
+                got: cycle_var_challenges.len(),
+            }
+        })?;
+        cycle_var_challenges.get(idx).copied().ok_or(
+            JoltFormulaPointError::ChallengeLengthMismatch {
+                expected: self.cycle_phase_rounds.len(),
+                got: cycle_var_challenges.len(),
+            },
+        )
+    }
+
+    /// Cycle-phase challenges this polynomial actively binds, in ascending
+    /// round order. The verifier carries these into the address phase.
+    pub fn cycle_phase_variable_challenges<F: Field>(
+        &self,
+        challenges: &[F],
+    ) -> Result<Vec<F>, JoltFormulaPointError> {
+        if challenges.len() != self.cycle_phase_total_rounds {
+            return Err(JoltFormulaPointError::ChallengeLengthMismatch {
+                expected: self.cycle_phase_total_rounds,
+                got: challenges.len(),
+            });
+        }
+        Ok(self
+            .cycle_phase_rounds
+            .iter()
+            .map(|&round| challenges[round])
+            .collect())
+    }
+
+    /// Big-endian opening point cached at the cycle-phase handoff.
+    pub fn cycle_phase_opening_point<F: Field>(
+        &self,
+        challenges: &[F],
+    ) -> Result<Vec<F>, JoltFormulaPointError> {
+        let mut point = self.cycle_phase_variable_challenges(challenges)?;
+        point.reverse();
+        Ok(point)
+    }
+
+    /// Big-endian permutation-ordered point for a reduction that completes in
+    /// the cycle phase. Errors if the polynomial still has active
+    /// address-phase rounds.
+    pub fn cycle_phase_permuted_opening_point<F: Field>(
+        &self,
+        challenges: &[F],
+    ) -> Result<Vec<F>, JoltFormulaPointError> {
+        if challenges.len() != self.cycle_phase_total_rounds {
+            return Err(JoltFormulaPointError::ChallengeLengthMismatch {
+                expected: self.cycle_phase_total_rounds,
+                got: challenges.len(),
+            });
+        }
+        let cycle_round_limit = self.cycle_alignment_rounds();
+        self.poly_opening_round_permutation_be
+            .iter()
+            .map(|&global_round| {
+                if global_round < cycle_round_limit {
+                    Ok(challenges[global_round])
+                } else {
+                    Err(JoltFormulaPointError::ChallengeLengthMismatch {
+                        expected: 0,
+                        got: self.num_address_phase_rounds(),
+                    })
+                }
+            })
+            .collect()
+    }
+
+    /// Big-endian final opening point in Dory opening-round order, assembled
+    /// from the recorded cycle-phase challenges and the address-phase
+    /// sumcheck challenges.
+    pub fn address_phase_opening_point<F: Field>(
+        &self,
+        cycle_var_challenges: &[F],
+        challenges: &[F],
+    ) -> Result<Vec<F>, JoltFormulaPointError> {
+        if cycle_var_challenges.len() != self.cycle_phase_rounds.len() {
+            return Err(JoltFormulaPointError::ChallengeLengthMismatch {
+                expected: self.cycle_phase_rounds.len(),
+                got: cycle_var_challenges.len(),
+            });
+        }
+        if challenges.len() != self.address_phase_total_rounds {
+            return Err(JoltFormulaPointError::ChallengeLengthMismatch {
+                expected: self.address_phase_total_rounds,
+                got: challenges.len(),
+            });
+        }
+        let cycle_round_limit = self.cycle_alignment_rounds();
+        self.poly_opening_round_permutation_be
+            .iter()
+            .map(|&global_round| {
+                if global_round < cycle_round_limit {
+                    self.cycle_challenge_for_round(cycle_var_challenges, global_round)
+                } else {
+                    Ok(challenges[global_round - cycle_round_limit])
+                }
+            })
+            .collect()
+    }
+}
+
+/// The `(1/2)^gap` factor contributed by all rounds (cycle and address) this
+/// polynomial skips across both phases. Used for the final output claim when
+/// the reduction completes in the address phase.
+pub fn precommitted_skip_round_scale<F: Field>(precommitted: &PrecommittedClaimReduction) -> F {
+    let gap = (precommitted.cycle_phase_total_rounds - precommitted.cycle_phase_rounds.len())
+        + (precommitted.address_phase_total_rounds - precommitted.address_phase_rounds.len());
+    skip_round_scale(gap)
+}
+
+fn skip_round_scale<F: Field>(gap: usize) -> F {
+    if gap == 0 {
+        return F::one();
+    }
+    let two_inv = F::from_u64(2).inv_or_zero();
+    (0..gap).fold(F::one(), |scale, _| scale * two_inv)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::protocols::jolt::formulas::dimensions::TracePolynomialOrder;
+    use jolt_field::{Fr, FromPrimitiveInt, Invertible};
+
+    #[test]
+    fn cycle_skip_scale_counts_inactive_cycle_rounds() {
+        let scheduling_reference = PrecommittedSchedulingReference {
+            main_total_vars: 3,
+            reference_total_vars: 3,
+            cycle_alignment_rounds: 3,
+            address_rounds: 0,
+            joint_col_vars: 0,
+        };
+        let precommitted = PrecommittedClaimReduction::new(
+            1,
+            0,
+            scheduling_reference,
+            TracePolynomialOrder::CycleMajor,
+            3,
+        );
+
+        let two_inv = Fr::from_u64(2).inv_or_zero();
+        assert_eq!(precommitted.cycle_phase_rounds(), &[0]);
+        assert_eq!(precommitted.num_address_phase_rounds(), 0);
+        assert_eq!(
+            precommitted.cycle_phase_skip_scale::<Fr>(),
+            two_inv * two_inv
+        );
+    }
+
+    #[test]
+    fn cycle_skip_scale_ignores_unrun_address_dummy_rounds() {
+        let scheduling_reference = PrecommittedSchedulingReference {
+            main_total_vars: 4,
+            reference_total_vars: 4,
+            cycle_alignment_rounds: 2,
+            address_rounds: 2,
+            joint_col_vars: 0,
+        };
+        let precommitted = PrecommittedClaimReduction::new(
+            1,
+            0,
+            scheduling_reference,
+            TracePolynomialOrder::CycleMajor,
+            4,
+        );
+
+        let two_inv = Fr::from_u64(2).inv_or_zero();
+        assert_eq!(precommitted.cycle_phase_rounds(), &[0]);
+        assert_eq!(precommitted.num_address_phase_rounds(), 0);
+        // The cycle-phase handoff scale excludes the address rounds this
+        // polynomial never participates in...
+        assert_eq!(precommitted.cycle_phase_skip_scale::<Fr>(), two_inv);
+        // ...while the full final scale counts both phase gaps.
+        assert_eq!(
+            precommitted_skip_round_scale::<Fr>(&precommitted),
+            two_inv * two_inv * two_inv
+        );
+    }
+
+    #[test]
+    fn dominant_precommitted_permutation_reorders_dense_cycle_prefix() {
+        let scheduling_reference = PrecommittedClaimReduction::scheduling_reference(4, &[6, 3], 2);
+        assert_eq!(
+            scheduling_reference,
+            PrecommittedSchedulingReference {
+                main_total_vars: 4,
+                reference_total_vars: 6,
+                cycle_alignment_rounds: 4,
+                address_rounds: 2,
+                joint_col_vars: 3,
+            }
+        );
+
+        let precommitted = PrecommittedClaimReduction::new(
+            3,
+            3,
+            scheduling_reference,
+            TracePolynomialOrder::CycleMajor,
+            2,
+        );
+        assert_eq!(
+            precommitted.poly_opening_round_permutation_be(),
+            &[1, 0, 5, 4, 3, 2]
+        );
+        assert_eq!(precommitted.cycle_phase_rounds(), &[0, 1, 2, 3]);
+        assert_eq!(precommitted.address_phase_rounds(), &[0, 1]);
+    }
+}

--- a/crates/jolt-claims/src/protocols/jolt/formulas/claim_reductions/precommitted.rs
+++ b/crates/jolt-claims/src/protocols/jolt/formulas/claim_reductions/precommitted.rs
@@ -77,7 +77,7 @@ impl PrecommittedClaimReduction {
         scheduling_reference: PrecommittedSchedulingReference,
         trace_order: TracePolynomialOrder,
         log_t: usize,
-    ) -> Self {
+    ) -> Result<Self, JoltFormulaPointError> {
         let has_precommitted_dominance =
             scheduling_reference.reference_total_vars > scheduling_reference.main_total_vars;
         let dense_cycle_prefix_rounds = if has_precommitted_dominance { log_t } else { 0 };
@@ -92,19 +92,19 @@ impl PrecommittedClaimReduction {
             &scheduling_reference,
             poly_row_vars,
             poly_col_vars,
-        );
+        )?;
         let (cycle_phase_rounds, address_phase_rounds) = Self::active_rounds_from_poly_permutation(
             &poly_opening_round_permutation_be,
             scheduling_reference.cycle_alignment_rounds,
         );
-        Self {
+        Ok(Self {
             scheduling_reference,
             poly_opening_round_permutation_be,
             cycle_phase_rounds,
             cycle_phase_total_rounds: scheduling_reference.cycle_alignment_rounds,
             address_phase_rounds,
             address_phase_total_rounds: scheduling_reference.address_rounds,
-        }
+        })
     }
 
     fn reference_dory_opening_round_permutation_be(
@@ -146,24 +146,29 @@ impl PrecommittedClaimReduction {
         reference: &PrecommittedSchedulingReference,
         poly_row_vars: usize,
         poly_col_vars: usize,
-    ) -> Vec<usize> {
+    ) -> Result<Vec<usize>, JoltFormulaPointError> {
         let total_full = reference.reference_total_vars;
         let sigma_full = reference.joint_col_vars;
         let nu_full = total_full.saturating_sub(sigma_full);
-        assert_eq!(
-            dory_opening_round_permutation_be.len(),
-            total_full,
-            "reference dory round permutation length mismatch",
-        );
-        assert!(
-            poly_row_vars <= nu_full && poly_col_vars <= sigma_full,
-            "top-left projection requires poly dims <= full dims (poly row/col vars={poly_row_vars}/{poly_col_vars}, full row/col vars={nu_full}/{sigma_full})"
-        );
+        if dory_opening_round_permutation_be.len() != total_full {
+            return Err(JoltFormulaPointError::OpeningPointLengthMismatch {
+                expected: total_full,
+                got: dory_opening_round_permutation_be.len(),
+            });
+        }
+        if poly_row_vars > nu_full || poly_col_vars > sigma_full {
+            return Err(JoltFormulaPointError::PolyDimsExceedReference {
+                poly_row_vars,
+                poly_col_vars,
+                reference_row_vars: nu_full,
+                reference_col_vars: sigma_full,
+            });
+        }
         let row_be = &dory_opening_round_permutation_be[..nu_full];
         let col_be = &dory_opening_round_permutation_be[nu_full..nu_full + sigma_full];
         let row_tail = &row_be[nu_full - poly_row_vars..];
         let col_tail = &col_be[sigma_full - poly_col_vars..];
-        [row_tail, col_tail].concat()
+        Ok([row_tail, col_tail].concat())
     }
 
     fn active_rounds_from_poly_permutation(
@@ -361,6 +366,8 @@ fn skip_round_scale<F: Field>(gap: usize) -> F {
 
 #[cfg(test)]
 mod tests {
+    #![expect(clippy::panic, reason = "tests fail loudly on unexpected errors")]
+
     use super::*;
     use crate::protocols::jolt::formulas::dimensions::TracePolynomialOrder;
     use jolt_field::{Fr, FromPrimitiveInt, Invertible};
@@ -380,7 +387,8 @@ mod tests {
             scheduling_reference,
             TracePolynomialOrder::CycleMajor,
             3,
-        );
+        )
+        .unwrap_or_else(|error| panic!("schedule should build: {error}"));
 
         let two_inv = Fr::from_u64(2).inv_or_zero();
         assert_eq!(precommitted.cycle_phase_rounds(), &[0]);
@@ -406,7 +414,8 @@ mod tests {
             scheduling_reference,
             TracePolynomialOrder::CycleMajor,
             4,
-        );
+        )
+        .unwrap_or_else(|error| panic!("schedule should build: {error}"));
 
         let two_inv = Fr::from_u64(2).inv_or_zero();
         assert_eq!(precommitted.cycle_phase_rounds(), &[0]);
@@ -441,7 +450,8 @@ mod tests {
             scheduling_reference,
             TracePolynomialOrder::CycleMajor,
             2,
-        );
+        )
+        .unwrap_or_else(|error| panic!("schedule should build: {error}"));
         assert_eq!(
             precommitted.poly_opening_round_permutation_be(),
             &[1, 0, 5, 4, 3, 2]

--- a/crates/jolt-claims/src/protocols/jolt/formulas/committed_openings.rs
+++ b/crates/jolt-claims/src/protocols/jolt/formulas/committed_openings.rs
@@ -3,6 +3,8 @@
 use jolt_field::Field;
 
 use super::super::{JoltCommittedPolynomial, JoltOpeningId, JoltRelationId};
+use super::dimensions::TracePolynomialOrder;
+use super::error::JoltFormulaPointError;
 use super::ra::JoltRaPolynomialLayout;
 
 pub fn proof_commitment_order(layout: JoltRaPolynomialLayout) -> Vec<JoltCommittedPolynomial> {
@@ -72,20 +74,111 @@ pub fn final_opening_relation(polynomial: JoltCommittedPolynomial) -> JoltRelati
     }
 }
 
-pub fn advice_commitment_embedding_scale<F: Field>(
+/// Lagrange factor for embedding a smaller polynomial's opening into the
+/// top-left block of the unified final opening point: `1` on variables the
+/// embedded point binds, `1 - r` on the rest.
+pub fn commitment_embedding_scale<F: Field>(
     opening_point: &[F],
-    advice_opening_point: &[F],
+    embedded_opening_point: &[F],
 ) -> F {
     opening_point
         .iter()
         .map(|challenge| {
-            if advice_opening_point.contains(challenge) {
+            if embedded_opening_point.contains(challenge) {
                 F::one()
             } else {
                 F::one() - challenge
             }
         })
         .product()
+}
+
+/// Inputs to [`final_opening_point`], gathered from earlier verification
+/// stages.
+pub struct FinalOpeningPointInputs<'a, F: Field> {
+    /// `log_T + log_k_chunk` for the native trace domain.
+    pub native_main_vars: usize,
+    pub log_k_chunk: usize,
+    pub trace_order: TracePolynomialOrder,
+    /// Stage 7 hamming-weight claim-reduction opening point.
+    pub hamming_weight_opening_point: &'a [F],
+    /// Stage 6 increment claim-reduction opening point (the stage 6 cycle
+    /// challenges).
+    pub inc_claim_reduction_opening_point: &'a [F],
+    /// Final opening points of present precommitted polynomials, in stage 8
+    /// batch order (trusted advice, untrusted advice).
+    pub precommitted_anchor_points: &'a [&'a [F]],
+}
+
+/// Unified big-endian opening point for the stage 8 batched PCS opening.
+///
+/// When a precommitted polynomial spans more variables than the native trace
+/// domain, its opening point anchors the batch (all dominant anchors must
+/// agree). Otherwise the point is assembled from the stage 6 cycle challenges
+/// and the stage 7 address challenges in the order the active trace layout
+/// expects.
+pub fn final_opening_point<F: Field>(
+    inputs: FinalOpeningPointInputs<'_, F>,
+) -> Result<Vec<F>, JoltFormulaPointError> {
+    let max_anchor_len = inputs
+        .precommitted_anchor_points
+        .iter()
+        .map(|point| point.len())
+        .max()
+        .unwrap_or(0);
+    if max_anchor_len > inputs.native_main_vars {
+        let mut dominant: Option<(usize, &[F])> = None;
+        for (index, point) in inputs.precommitted_anchor_points.iter().enumerate() {
+            if point.len() != max_anchor_len {
+                continue;
+            }
+            match dominant {
+                None => dominant = Some((index, point)),
+                Some((first, dominant_point)) => {
+                    if *point != dominant_point {
+                        return Err(JoltFormulaPointError::IncompatibleDominantAnchors {
+                            first,
+                            second: index,
+                        });
+                    }
+                }
+            }
+        }
+        let (_, dominant_point) =
+            dominant.ok_or(JoltFormulaPointError::OpeningPointLengthMismatch {
+                expected: max_anchor_len,
+                got: 0,
+            })?;
+        return Ok(dominant_point.to_vec());
+    }
+
+    if inputs.hamming_weight_opening_point.len() < inputs.log_k_chunk {
+        return Err(JoltFormulaPointError::OpeningPointLengthMismatch {
+            expected: inputs.log_k_chunk,
+            got: inputs.hamming_weight_opening_point.len(),
+        });
+    }
+    let r_address_stage7 = &inputs.hamming_weight_opening_point[..inputs.log_k_chunk];
+    let r_cycle_stage6 = inputs.inc_claim_reduction_opening_point;
+    match inputs.trace_order {
+        TracePolynomialOrder::AddressMajor => Ok([r_cycle_stage6, r_address_stage7].concat()),
+        TracePolynomialOrder::CycleMajor => {
+            let native_cycle = &inputs.hamming_weight_opening_point[inputs.log_k_chunk..];
+            if r_cycle_stage6.len() < native_cycle.len() {
+                return Err(
+                    JoltFormulaPointError::CycleChallengesShorterThanNativeCycle {
+                        expected: native_cycle.len(),
+                        got: r_cycle_stage6.len(),
+                    },
+                );
+            }
+            if &r_cycle_stage6[..native_cycle.len()] != native_cycle {
+                return Err(JoltFormulaPointError::CycleMajorCyclePrefixMismatch);
+            }
+            let cycle_extra = &r_cycle_stage6[native_cycle.len()..];
+            Ok([cycle_extra, r_address_stage7, native_cycle].concat())
+        }
+    }
 }
 
 #[cfg(test)]
@@ -174,13 +267,88 @@ mod tests {
     }
 
     #[test]
-    fn advice_embedding_scale_selects_variables_outside_advice_point() {
+    fn embedding_scale_selects_variables_outside_embedded_point() {
         let opening_point = [Fr::from_u64(2), Fr::from_u64(3), Fr::from_u64(5)];
-        let advice_point = [Fr::from_u64(3)];
+        let embedded_point = [Fr::from_u64(3)];
 
         assert_eq!(
-            advice_commitment_embedding_scale(&opening_point, &advice_point),
+            commitment_embedding_scale(&opening_point, &embedded_point),
             (Fr::from_u64(1) - Fr::from_u64(2)) * (Fr::from_u64(1) - Fr::from_u64(5))
+        );
+    }
+
+    #[test]
+    fn final_opening_point_passes_through_hamming_point_for_cycle_major() {
+        let hamming_point: Vec<Fr> = (1..=6).map(Fr::from_u64).collect();
+        let inc_point: Vec<Fr> = hamming_point[2..].to_vec();
+
+        let point = final_opening_point(FinalOpeningPointInputs {
+            native_main_vars: 6,
+            log_k_chunk: 2,
+            trace_order: TracePolynomialOrder::CycleMajor,
+            hamming_weight_opening_point: &hamming_point,
+            inc_claim_reduction_opening_point: &inc_point,
+            precommitted_anchor_points: &[],
+        })
+        .unwrap_or_else(|error| panic!("final opening point should assemble: {error}"));
+
+        assert_eq!(point, hamming_point);
+    }
+
+    #[test]
+    fn final_opening_point_orders_cycle_before_address_for_address_major() {
+        let hamming_point: Vec<Fr> = (1..=6).map(Fr::from_u64).collect();
+        let inc_point: Vec<Fr> = (11..=14).map(Fr::from_u64).collect();
+
+        let point = final_opening_point(FinalOpeningPointInputs {
+            native_main_vars: 6,
+            log_k_chunk: 2,
+            trace_order: TracePolynomialOrder::AddressMajor,
+            hamming_weight_opening_point: &hamming_point,
+            inc_claim_reduction_opening_point: &inc_point,
+            precommitted_anchor_points: &[],
+        })
+        .unwrap_or_else(|error| panic!("final opening point should assemble: {error}"));
+
+        let expected: Vec<Fr> = inc_point
+            .iter()
+            .chain(&hamming_point[..2])
+            .copied()
+            .collect();
+        assert_eq!(point, expected);
+    }
+
+    #[test]
+    fn final_opening_point_anchors_on_dominant_precommitted_opening() {
+        let hamming_point: Vec<Fr> = (1..=6).map(Fr::from_u64).collect();
+        let inc_point: Vec<Fr> = hamming_point[2..].to_vec();
+        let dominant: Vec<Fr> = (21..=28).map(Fr::from_u64).collect();
+        let conflicting: Vec<Fr> = (31..=38).map(Fr::from_u64).collect();
+
+        let point = final_opening_point(FinalOpeningPointInputs {
+            native_main_vars: 6,
+            log_k_chunk: 2,
+            trace_order: TracePolynomialOrder::CycleMajor,
+            hamming_weight_opening_point: &hamming_point,
+            inc_claim_reduction_opening_point: &inc_point,
+            precommitted_anchor_points: &[&dominant, &dominant],
+        })
+        .unwrap_or_else(|error| panic!("final opening point should assemble: {error}"));
+        assert_eq!(point, dominant);
+
+        assert_eq!(
+            final_opening_point(FinalOpeningPointInputs {
+                native_main_vars: 6,
+                log_k_chunk: 2,
+                trace_order: TracePolynomialOrder::CycleMajor,
+                hamming_weight_opening_point: &hamming_point,
+                inc_claim_reduction_opening_point: &inc_point,
+                precommitted_anchor_points: &[&dominant, &conflicting],
+            }),
+            Err(JoltFormulaPointError::IncompatibleDominantAnchors {
+                first: 0,
+                second: 1
+            })
         );
     }
 }

--- a/crates/jolt-claims/src/protocols/jolt/formulas/committed_openings.rs
+++ b/crates/jolt-claims/src/protocols/jolt/formulas/committed_openings.rs
@@ -81,6 +81,12 @@ pub fn commitment_embedding_scale<F: Field>(
     opening_point: &[F],
     embedded_opening_point: &[F],
 ) -> F {
+    debug_assert!(
+        embedded_opening_point
+            .iter()
+            .all(|challenge| opening_point.contains(challenge)),
+        "embedded opening point must be a subset of the unified opening point"
+    );
     opening_point
         .iter()
         .map(|challenge| {
@@ -96,8 +102,7 @@ pub fn commitment_embedding_scale<F: Field>(
 /// Inputs to [`final_opening_point`], gathered from earlier verification
 /// stages.
 pub struct FinalOpeningPointInputs<'a, F: Field> {
-    /// `log_T + log_k_chunk` for the native trace domain.
-    pub native_main_vars: usize,
+    pub log_t: usize,
     pub log_k_chunk: usize,
     pub trace_order: TracePolynomialOrder,
     /// Stage 7 hamming-weight claim-reduction opening point.
@@ -120,36 +125,25 @@ pub struct FinalOpeningPointInputs<'a, F: Field> {
 pub fn final_opening_point<F: Field>(
     inputs: FinalOpeningPointInputs<'_, F>,
 ) -> Result<Vec<F>, JoltFormulaPointError> {
-    let max_anchor_len = inputs
-        .precommitted_anchor_points
-        .iter()
-        .map(|point| point.len())
-        .max()
-        .unwrap_or(0);
-    if max_anchor_len > inputs.native_main_vars {
-        let mut dominant: Option<(usize, &[F])> = None;
-        for (index, point) in inputs.precommitted_anchor_points.iter().enumerate() {
-            if point.len() != max_anchor_len {
-                continue;
-            }
-            match dominant {
-                None => dominant = Some((index, point)),
-                Some((first, dominant_point)) => {
-                    if *point != dominant_point {
-                        return Err(JoltFormulaPointError::IncompatibleDominantAnchors {
-                            first,
-                            second: index,
-                        });
-                    }
+    let native_main_vars = inputs.log_t + inputs.log_k_chunk;
+    let mut dominant: Option<(usize, &[F])> = None;
+    for (index, point) in inputs.precommitted_anchor_points.iter().enumerate() {
+        if dominant.is_none_or(|(_, dominant_point)| point.len() > dominant_point.len()) {
+            dominant = Some((index, point));
+        }
+    }
+    if let Some((first, dominant_point)) = dominant {
+        if dominant_point.len() > native_main_vars {
+            for (index, point) in inputs.precommitted_anchor_points.iter().enumerate() {
+                if point.len() == dominant_point.len() && *point != dominant_point {
+                    return Err(JoltFormulaPointError::IncompatibleDominantAnchors {
+                        first,
+                        second: index,
+                    });
                 }
             }
+            return Ok(dominant_point.to_vec());
         }
-        let (_, dominant_point) =
-            dominant.ok_or(JoltFormulaPointError::OpeningPointLengthMismatch {
-                expected: max_anchor_len,
-                got: 0,
-            })?;
-        return Ok(dominant_point.to_vec());
     }
 
     if inputs.hamming_weight_opening_point.len() < inputs.log_k_chunk {
@@ -283,7 +277,7 @@ mod tests {
         let inc_point: Vec<Fr> = hamming_point[2..].to_vec();
 
         let point = final_opening_point(FinalOpeningPointInputs {
-            native_main_vars: 6,
+            log_t: 4,
             log_k_chunk: 2,
             trace_order: TracePolynomialOrder::CycleMajor,
             hamming_weight_opening_point: &hamming_point,
@@ -301,7 +295,7 @@ mod tests {
         let inc_point: Vec<Fr> = (11..=14).map(Fr::from_u64).collect();
 
         let point = final_opening_point(FinalOpeningPointInputs {
-            native_main_vars: 6,
+            log_t: 4,
             log_k_chunk: 2,
             trace_order: TracePolynomialOrder::AddressMajor,
             hamming_weight_opening_point: &hamming_point,
@@ -326,7 +320,7 @@ mod tests {
         let conflicting: Vec<Fr> = (31..=38).map(Fr::from_u64).collect();
 
         let point = final_opening_point(FinalOpeningPointInputs {
-            native_main_vars: 6,
+            log_t: 4,
             log_k_chunk: 2,
             trace_order: TracePolynomialOrder::CycleMajor,
             hamming_weight_opening_point: &hamming_point,
@@ -338,7 +332,7 @@ mod tests {
 
         assert_eq!(
             final_opening_point(FinalOpeningPointInputs {
-                native_main_vars: 6,
+                log_t: 4,
                 log_k_chunk: 2,
                 trace_order: TracePolynomialOrder::CycleMajor,
                 hamming_weight_opening_point: &hamming_point,

--- a/crates/jolt-claims/src/protocols/jolt/formulas/dimensions.rs
+++ b/crates/jolt-claims/src/protocols/jolt/formulas/dimensions.rs
@@ -62,27 +62,6 @@ impl TracePolynomialOrder {
         }
     }
 
-    pub fn commitment_opening_point<F: Field>(
-        self,
-        opening_point: &[F],
-        log_t: usize,
-    ) -> Result<Vec<F>, JoltFormulaPointError> {
-        match self {
-            Self::CycleMajor => Ok(opening_point.to_vec()),
-            Self::AddressMajor => {
-                if opening_point.len() < log_t {
-                    return Err(JoltFormulaPointError::ChallengeLengthMismatch {
-                        expected: log_t,
-                        got: opening_point.len(),
-                    });
-                }
-                let log_k = opening_point.len() - log_t;
-                let (r_address, r_cycle) = opening_point.split_at(log_k);
-                Ok([r_cycle, r_address].concat())
-            }
-        }
-    }
-
     pub const fn address_cycle_to_index(
         self,
         address: usize,
@@ -686,8 +665,8 @@ mod tests {
         assert_eq!(layout.advice_shape(), CommitmentMatrixShape::new(2, 1));
         assert_eq!(layout.precommitted().cycle_phase_rounds(), &[0, 1, 6]);
         assert_eq!(layout.precommitted().num_address_phase_rounds(), 0);
-        assert_eq!(layout.dimensions().cycle_phase_rounds(), 8);
-        assert_eq!(layout.dimensions().address_phase_rounds(), 4);
+        assert_eq!(layout.dimensions().cycle_phase_total_rounds(), 8);
+        assert_eq!(layout.dimensions().address_phase_total_rounds(), 4);
         assert!(!layout.dimensions().has_address_phase());
         assert_eq!(
             layout
@@ -758,8 +737,8 @@ mod tests {
 
         assert_eq!(layout.precommitted().cycle_phase_rounds(), &[2]);
         assert_eq!(layout.precommitted().address_phase_rounds(), &[0, 1]);
-        assert_eq!(layout.dimensions().cycle_phase_rounds(), 8);
-        assert_eq!(layout.dimensions().address_phase_rounds(), 4);
+        assert_eq!(layout.dimensions().cycle_phase_total_rounds(), 8);
+        assert_eq!(layout.dimensions().address_phase_total_rounds(), 4);
         assert!(layout.dimensions().has_address_phase());
         assert_eq!(cycle_vars, vec![Fr::from_u64(3)]);
         assert_eq!(

--- a/crates/jolt-claims/src/protocols/jolt/formulas/dimensions.rs
+++ b/crates/jolt-claims/src/protocols/jolt/formulas/dimensions.rs
@@ -655,6 +655,7 @@ mod tests {
             scheduling_reference,
             max_advice_size_bytes,
         )
+        .unwrap_or_else(|error| panic!("advice layout should build: {error}"))
     }
 
     #[test]

--- a/crates/jolt-claims/src/protocols/jolt/formulas/dimensions.rs
+++ b/crates/jolt-claims/src/protocols/jolt/formulas/dimensions.rs
@@ -543,8 +543,10 @@ mod tests {
     #![expect(clippy::panic, reason = "tests fail loudly on unexpected errors")]
 
     use super::super::claim_reductions::advice::AdviceClaimReductionLayout;
+    use super::super::claim_reductions::precommitted::PrecommittedClaimReduction;
     use super::*;
     use jolt_field::{Fr, FromPrimitiveInt, Invertible};
+    use jolt_poly::EqPolynomial;
 
     fn dimensions() -> JoltOneHotDimensions {
         JoltOneHotDimensions {
@@ -655,20 +657,38 @@ mod tests {
         );
     }
 
+    fn advice_layout(
+        trace_order: TracePolynomialOrder,
+        log_t: usize,
+        log_k_chunk: usize,
+        max_advice_size_bytes: usize,
+    ) -> AdviceClaimReductionLayout {
+        let advice_vars =
+            CommitmentMatrixShape::advice_from_max_bytes(max_advice_size_bytes).total_vars();
+        let scheduling_reference = PrecommittedClaimReduction::scheduling_reference(
+            log_t + log_k_chunk,
+            &[advice_vars],
+            log_k_chunk,
+        );
+        AdviceClaimReductionLayout::balanced(
+            trace_order,
+            log_t,
+            scheduling_reference,
+            max_advice_size_bytes,
+        )
+    }
+
     #[test]
     fn advice_layout_extracts_cycle_phase_variables_without_dory_globals() {
-        let layout =
-            AdviceClaimReductionLayout::balanced(TracePolynomialOrder::CycleMajor, 8, 4, 64);
-        let challenges = (1..=7).map(Fr::from_u64).collect::<Vec<_>>();
+        let layout = advice_layout(TracePolynomialOrder::CycleMajor, 8, 4, 64);
+        let challenges = (1..=8).map(Fr::from_u64).collect::<Vec<_>>();
 
-        assert_eq!(layout.main_shape(), CommitmentMatrixShape::new(6, 6));
         assert_eq!(layout.advice_shape(), CommitmentMatrixShape::new(2, 1));
-        assert_eq!(layout.cycle_phase_col_rounds(), 0..2);
-        assert_eq!(layout.cycle_phase_row_rounds(), 6..7);
-        assert_eq!(layout.cycle_phase_rounds(), 7);
-        assert_eq!(layout.active_cycle_phase_rounds(), 3);
-        assert_eq!(layout.address_phase_rounds(), 0);
-        assert_eq!(layout.dummy_cycle_phase_rounds(), 4);
+        assert_eq!(layout.precommitted().cycle_phase_rounds(), &[0, 1, 6]);
+        assert_eq!(layout.precommitted().num_address_phase_rounds(), 0);
+        assert_eq!(layout.dimensions().cycle_phase_rounds(), 8);
+        assert_eq!(layout.dimensions().address_phase_rounds(), 4);
+        assert!(!layout.dimensions().has_address_phase());
         assert_eq!(
             layout
                 .cycle_phase_variable_challenges(&challenges)
@@ -685,23 +705,26 @@ mod tests {
 
     #[test]
     fn advice_layout_extracts_address_phase_point_without_dory_globals() {
-        let layout = AdviceClaimReductionLayout::new(
-            TracePolynomialOrder::CycleMajor,
-            8,
-            4,
-            CommitmentMatrixShape::balanced(12),
-            CommitmentMatrixShape::balanced(8),
-        );
+        // 2048 bytes = 256 words: an 8-variable advice polynomial with shape (4, 4).
+        let layout = advice_layout(TracePolynomialOrder::CycleMajor, 8, 4, 2048);
         let cycle_challenges = (1..=8).map(Fr::from_u64).collect::<Vec<_>>();
         let cycle_vars = layout
             .cycle_phase_variable_challenges(&cycle_challenges)
             .unwrap_or_else(|error| panic!("cycle variables should extract: {error}"));
-        let address_challenges = [Fr::from_u64(101), Fr::from_u64(102)];
+        let address_challenges = [
+            Fr::from_u64(101),
+            Fr::from_u64(102),
+            Fr::from_u64(103),
+            Fr::from_u64(104),
+        ];
 
-        assert_eq!(layout.cycle_phase_col_rounds(), 0..4);
-        assert_eq!(layout.cycle_phase_row_rounds(), 6..8);
-        assert_eq!(layout.active_cycle_phase_rounds(), 6);
-        assert_eq!(layout.address_phase_rounds(), 2);
+        assert_eq!(layout.advice_shape(), CommitmentMatrixShape::new(4, 4));
+        assert_eq!(
+            layout.precommitted().cycle_phase_rounds(),
+            &[0, 1, 2, 3, 6, 7]
+        );
+        assert_eq!(layout.precommitted().address_phase_rounds(), &[0, 1]);
+        assert!(layout.dimensions().has_address_phase());
         assert_eq!(
             layout
                 .address_phase_opening_point(&cycle_vars, &address_challenges)
@@ -721,43 +744,48 @@ mod tests {
 
     #[test]
     fn advice_layout_tracks_address_major_cycle_gap() {
-        let layout =
-            AdviceClaimReductionLayout::balanced(TracePolynomialOrder::AddressMajor, 8, 4, 64);
-        let challenges = (1..=3).map(Fr::from_u64).collect::<Vec<_>>();
+        let layout = advice_layout(TracePolynomialOrder::AddressMajor, 8, 4, 64);
+        let challenges = (1..=8).map(Fr::from_u64).collect::<Vec<_>>();
         let cycle_vars = layout
             .cycle_phase_variable_challenges(&challenges)
             .unwrap_or_else(|error| panic!("cycle variables should extract: {error}"));
+        let address_challenges = [
+            Fr::from_u64(101),
+            Fr::from_u64(102),
+            Fr::from_u64(103),
+            Fr::from_u64(104),
+        ];
 
-        assert_eq!(layout.cycle_phase_col_rounds(), 0..0);
-        assert_eq!(layout.cycle_phase_row_rounds(), 2..3);
-        assert_eq!(layout.cycle_phase_rounds(), 3);
-        assert_eq!(layout.active_cycle_phase_rounds(), 1);
-        assert_eq!(layout.address_phase_rounds(), 2);
-        assert_eq!(layout.dummy_cycle_phase_rounds(), 2);
+        assert_eq!(layout.precommitted().cycle_phase_rounds(), &[2]);
+        assert_eq!(layout.precommitted().address_phase_rounds(), &[0, 1]);
+        assert_eq!(layout.dimensions().cycle_phase_rounds(), 8);
+        assert_eq!(layout.dimensions().address_phase_rounds(), 4);
+        assert!(layout.dimensions().has_address_phase());
         assert_eq!(cycle_vars, vec![Fr::from_u64(3)]);
         assert_eq!(
             layout
-                .address_phase_opening_point(&cycle_vars, &[Fr::from_u64(101), Fr::from_u64(102)])
+                .address_phase_opening_point(&cycle_vars, &address_challenges)
                 .unwrap_or_else(|error| panic!("address phase point should normalize: {error}")),
             vec![Fr::from_u64(3), Fr::from_u64(102), Fr::from_u64(101)]
         );
     }
 
     #[test]
-    fn advice_final_output_scale_includes_cycle_phase_dummy_rounds() {
-        let layout =
-            AdviceClaimReductionLayout::balanced(TracePolynomialOrder::AddressMajor, 8, 4, 64);
-        let challenges = [Fr::from_u64(11), Fr::from_u64(12), Fr::from_u64(1)];
-        let opening_point = layout
-            .cycle_phase_opening_point(&challenges)
-            .unwrap_or_else(|error| panic!("cycle phase point should normalize: {error}"));
+    fn advice_final_output_scale_includes_cycle_phase_skip_rounds() {
+        let layout = advice_layout(TracePolynomialOrder::CycleMajor, 8, 4, 64);
+        let challenges = (1..=8).map(Fr::from_u64).collect::<Vec<_>>();
+        // Permutation order for the active cycle rounds is [6, 1, 0].
+        let permuted_point = [Fr::from_u64(7), Fr::from_u64(2), Fr::from_u64(1)];
+        let reference_point = [Fr::from_u64(101), Fr::from_u64(102), Fr::from_u64(103)];
         let two_inv = Fr::from_u64(2).inv_or_zero();
+        let skip_scale = (0..5).fold(Fr::from_u64(1), |scale, _| scale * two_inv);
+        let expected = EqPolynomial::<Fr>::mle(&permuted_point, &reference_point) * skip_scale;
 
         assert_eq!(
             layout
-                .cycle_phase_final_output_scale(&opening_point, &challenges)
+                .cycle_phase_final_output_scale(&reference_point, &challenges)
                 .unwrap_or_else(|error| panic!("final output scale should compute: {error}")),
-            two_inv * two_inv
+            expected
         );
     }
 

--- a/crates/jolt-claims/src/protocols/jolt/formulas/error.rs
+++ b/crates/jolt-claims/src/protocols/jolt/formulas/error.rs
@@ -31,6 +31,15 @@ pub enum JoltFormulaPointError {
     CyclePhaseNotFinal { active_address_rounds: usize },
     #[error("cycle round {round} is not active for this polynomial")]
     InactiveCycleRound { round: usize },
+    #[error(
+        "polynomial dims ({poly_row_vars}x{poly_col_vars}) exceed reference dims ({reference_row_vars}x{reference_col_vars})"
+    )]
+    PolyDimsExceedReference {
+        poly_row_vars: usize,
+        poly_col_vars: usize,
+        reference_row_vars: usize,
+        reference_col_vars: usize,
+    },
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Error)]

--- a/crates/jolt-claims/src/protocols/jolt/formulas/error.rs
+++ b/crates/jolt-claims/src/protocols/jolt/formulas/error.rs
@@ -17,6 +17,14 @@ pub enum JoltFormulaPointError {
     OpeningPointLengthMismatch { expected: usize, got: usize },
     #[error("evaluation domain length mismatch: expected {expected}, got {got}")]
     EvaluationDomainLengthMismatch { expected: usize, got: usize },
+    #[error("incompatible dominant precommitted anchors: {first} and {second} disagree")]
+    IncompatibleDominantAnchors { first: usize, second: usize },
+    #[error("stage 6 cycle challenges ({got}) shorter than native cycle vars ({expected})")]
+    CycleChallengesShorterThanNativeCycle { expected: usize, got: usize },
+    #[error(
+        "cycle-major final opening expects the stage 6 cycle prefix to equal the native cycle vars"
+    )]
+    CycleMajorCyclePrefixMismatch,
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Error)]

--- a/crates/jolt-claims/src/protocols/jolt/formulas/error.rs
+++ b/crates/jolt-claims/src/protocols/jolt/formulas/error.rs
@@ -25,6 +25,12 @@ pub enum JoltFormulaPointError {
         "cycle-major final opening expects the stage 6 cycle prefix to equal the native cycle vars"
     )]
     CycleMajorCyclePrefixMismatch,
+    #[error(
+        "cycle-phase final opening requested with {active_address_rounds} active address-phase rounds remaining"
+    )]
+    CyclePhaseNotFinal { active_address_rounds: usize },
+    #[error("cycle round {round} is not active for this polynomial")]
+    InactiveCycleRound { round: usize },
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Error)]

--- a/crates/jolt-claims/src/protocols/jolt/mod.rs
+++ b/crates/jolt-claims/src/protocols/jolt/mod.rs
@@ -5,6 +5,7 @@ mod relation;
 
 pub use formulas::{
     claim_reductions::advice::{AdviceClaimReductionDimensions, AdviceClaimReductionLayout},
+    claim_reductions::precommitted::{PrecommittedClaimReduction, PrecommittedSchedulingReference},
     dimensions::{
         CommitmentMatrixShape, JoltFormulaDimensions, JoltOneHotConfig, JoltOneHotDimensions,
         JoltReadWriteConfig, JoltSumcheckDomain, JoltSumcheckSpec, ReadWriteDimensions,

--- a/crates/jolt-verifier/src/error.rs
+++ b/crates/jolt-verifier/src/error.rs
@@ -68,6 +68,9 @@ pub enum VerifierError {
     #[error("invalid verifier memory layout: {reason}")]
     InvalidMemoryLayout { reason: String },
 
+    #[error("invalid precommitted claim-reduction schedule: {reason}")]
+    InvalidPrecommittedSchedule { reason: String },
+
     #[error("missing stage claim opening input {id:?}")]
     MissingStageClaimOpening { id: JoltOpeningId },
 

--- a/crates/jolt-verifier/src/stages/mod.rs
+++ b/crates/jolt-verifier/src/stages/mod.rs
@@ -1,9 +1,8 @@
 //! Typed verifier stage entry points.
 
-use common::jolt_device::MemoryLayout;
 use jolt_claims::protocols::jolt::{
-    formulas::claim_reductions::advice, AdviceClaimReductionLayout, JoltAdviceKind,
-    PrecommittedClaimReduction, TracePolynomialOrder,
+    formulas::claim_reductions::advice, formulas::error::JoltFormulaPointError,
+    AdviceClaimReductionLayout, JoltAdviceKind, PrecommittedClaimReduction, TracePolynomialOrder,
 };
 
 pub mod stage1;
@@ -33,34 +32,32 @@ impl PrecommittedSchedule {
         trace_order: TracePolynomialOrder,
         log_t: usize,
         log_k_chunk: usize,
-        memory_layout: &MemoryLayout,
-        trusted_advice_present: bool,
-        untrusted_advice_present: bool,
-    ) -> Self {
-        let trusted_max_bytes =
-            trusted_advice_present.then_some(memory_layout.max_trusted_advice_size as usize);
-        let untrusted_max_bytes =
-            untrusted_advice_present.then_some(memory_layout.max_untrusted_advice_size as usize);
-        let candidates = advice::candidate_total_vars(trusted_max_bytes, untrusted_max_bytes);
+        trusted_max_advice_bytes: Option<usize>,
+        untrusted_max_advice_bytes: Option<usize>,
+    ) -> Result<Self, JoltFormulaPointError> {
+        let candidates =
+            advice::candidate_total_vars(trusted_max_advice_bytes, untrusted_max_advice_bytes);
         let scheduling_reference = PrecommittedClaimReduction::scheduling_reference(
             log_t + log_k_chunk,
             &candidates,
             log_k_chunk,
         );
         let layout = |max_bytes: Option<usize>| {
-            max_bytes.map(|max_bytes| {
-                AdviceClaimReductionLayout::balanced(
-                    trace_order,
-                    log_t,
-                    scheduling_reference,
-                    max_bytes,
-                )
-            })
+            max_bytes
+                .map(|max_bytes| {
+                    AdviceClaimReductionLayout::balanced(
+                        trace_order,
+                        log_t,
+                        scheduling_reference,
+                        max_bytes,
+                    )
+                })
+                .transpose()
         };
-        Self {
-            trusted_advice: layout(trusted_max_bytes),
-            untrusted_advice: layout(untrusted_max_bytes),
-        }
+        Ok(Self {
+            trusted_advice: layout(trusted_max_advice_bytes)?,
+            untrusted_advice: layout(untrusted_max_advice_bytes)?,
+        })
     }
 
     pub fn advice(&self, kind: JoltAdviceKind) -> Option<&AdviceClaimReductionLayout> {

--- a/crates/jolt-verifier/src/stages/mod.rs
+++ b/crates/jolt-verifier/src/stages/mod.rs
@@ -2,8 +2,8 @@
 
 use common::jolt_device::MemoryLayout;
 use jolt_claims::protocols::jolt::{
-    formulas::claim_reductions::advice, AdviceClaimReductionLayout, PrecommittedClaimReduction,
-    TracePolynomialOrder,
+    formulas::claim_reductions::advice, AdviceClaimReductionLayout, JoltAdviceKind,
+    PrecommittedClaimReduction, TracePolynomialOrder,
 };
 
 pub mod stage1;
@@ -16,48 +16,57 @@ pub mod stage7;
 pub mod stage8;
 pub(crate) mod zk;
 
-pub(crate) struct AdviceLayouts {
-    pub trusted: Option<AdviceClaimReductionLayout>,
-    pub untrusted: Option<AdviceClaimReductionLayout>,
+/// Per-polynomial claim-reduction layouts over the shared precommitted
+/// scheduling reference, derived once during input validation.
+///
+/// The reference spans all present precommitted polynomials, so the layouts
+/// must be built together; stages read them from `CheckedInputs` instead of
+/// re-deriving the schedule.
+#[derive(Clone, Debug, PartialEq)]
+pub struct PrecommittedSchedule {
+    pub trusted_advice: Option<AdviceClaimReductionLayout>,
+    pub untrusted_advice: Option<AdviceClaimReductionLayout>,
 }
 
-/// Builds the per-kind advice claim-reduction layouts over the shared
-/// precommitted scheduling reference. The reference spans all present advice
-/// polynomials, so both layouts must be derived together.
-pub(crate) fn advice_layouts(
-    trace_order: TracePolynomialOrder,
-    log_t: usize,
-    log_k_chunk: usize,
-    memory_layout: &MemoryLayout,
-    trusted_advice_present: bool,
-    untrusted_advice_present: bool,
-) -> AdviceLayouts {
-    let trusted_max_bytes =
-        trusted_advice_present.then_some(memory_layout.max_trusted_advice_size as usize);
-    let untrusted_max_bytes =
-        untrusted_advice_present.then_some(memory_layout.max_untrusted_advice_size as usize);
-    let candidates = advice::precommitted_candidates(trusted_max_bytes, untrusted_max_bytes);
-    let scheduling_reference = PrecommittedClaimReduction::scheduling_reference(
-        log_t + log_k_chunk,
-        &candidates,
-        log_k_chunk,
-    );
-    AdviceLayouts {
-        trusted: trusted_max_bytes.map(|max_bytes| {
-            AdviceClaimReductionLayout::balanced(
-                trace_order,
-                log_t,
-                scheduling_reference,
-                max_bytes,
-            )
-        }),
-        untrusted: untrusted_max_bytes.map(|max_bytes| {
-            AdviceClaimReductionLayout::balanced(
-                trace_order,
-                log_t,
-                scheduling_reference,
-                max_bytes,
-            )
-        }),
+impl PrecommittedSchedule {
+    pub fn new(
+        trace_order: TracePolynomialOrder,
+        log_t: usize,
+        log_k_chunk: usize,
+        memory_layout: &MemoryLayout,
+        trusted_advice_present: bool,
+        untrusted_advice_present: bool,
+    ) -> Self {
+        let trusted_max_bytes =
+            trusted_advice_present.then_some(memory_layout.max_trusted_advice_size as usize);
+        let untrusted_max_bytes =
+            untrusted_advice_present.then_some(memory_layout.max_untrusted_advice_size as usize);
+        let candidates = advice::precommitted_candidates(trusted_max_bytes, untrusted_max_bytes);
+        let scheduling_reference = PrecommittedClaimReduction::scheduling_reference(
+            log_t + log_k_chunk,
+            &candidates,
+            log_k_chunk,
+        );
+        let layout = |max_bytes: Option<usize>| {
+            max_bytes.map(|max_bytes| {
+                AdviceClaimReductionLayout::balanced(
+                    trace_order,
+                    log_t,
+                    scheduling_reference,
+                    max_bytes,
+                )
+            })
+        };
+        Self {
+            trusted_advice: layout(trusted_max_bytes),
+            untrusted_advice: layout(untrusted_max_bytes),
+        }
+    }
+
+    pub fn advice(&self, kind: JoltAdviceKind) -> Option<&AdviceClaimReductionLayout> {
+        match kind {
+            JoltAdviceKind::Trusted => self.trusted_advice.as_ref(),
+            JoltAdviceKind::Untrusted => self.untrusted_advice.as_ref(),
+        }
     }
 }

--- a/crates/jolt-verifier/src/stages/mod.rs
+++ b/crates/jolt-verifier/src/stages/mod.rs
@@ -1,5 +1,11 @@
 //! Typed verifier stage entry points.
 
+use common::jolt_device::MemoryLayout;
+use jolt_claims::protocols::jolt::{
+    formulas::claim_reductions::advice, AdviceClaimReductionLayout, PrecommittedClaimReduction,
+    TracePolynomialOrder,
+};
+
 pub mod stage1;
 pub mod stage2;
 pub mod stage3;
@@ -9,3 +15,49 @@ pub mod stage6;
 pub mod stage7;
 pub mod stage8;
 pub(crate) mod zk;
+
+pub(crate) struct AdviceLayouts {
+    pub trusted: Option<AdviceClaimReductionLayout>,
+    pub untrusted: Option<AdviceClaimReductionLayout>,
+}
+
+/// Builds the per-kind advice claim-reduction layouts over the shared
+/// precommitted scheduling reference. The reference spans all present advice
+/// polynomials, so both layouts must be derived together.
+pub(crate) fn advice_layouts(
+    trace_order: TracePolynomialOrder,
+    log_t: usize,
+    log_k_chunk: usize,
+    memory_layout: &MemoryLayout,
+    trusted_advice_present: bool,
+    untrusted_advice_present: bool,
+) -> AdviceLayouts {
+    let trusted_max_bytes =
+        trusted_advice_present.then_some(memory_layout.max_trusted_advice_size as usize);
+    let untrusted_max_bytes =
+        untrusted_advice_present.then_some(memory_layout.max_untrusted_advice_size as usize);
+    let candidates = advice::precommitted_candidates(trusted_max_bytes, untrusted_max_bytes);
+    let scheduling_reference = PrecommittedClaimReduction::scheduling_reference(
+        log_t + log_k_chunk,
+        &candidates,
+        log_k_chunk,
+    );
+    AdviceLayouts {
+        trusted: trusted_max_bytes.map(|max_bytes| {
+            AdviceClaimReductionLayout::balanced(
+                trace_order,
+                log_t,
+                scheduling_reference,
+                max_bytes,
+            )
+        }),
+        untrusted: untrusted_max_bytes.map(|max_bytes| {
+            AdviceClaimReductionLayout::balanced(
+                trace_order,
+                log_t,
+                scheduling_reference,
+                max_bytes,
+            )
+        }),
+    }
+}

--- a/crates/jolt-verifier/src/stages/mod.rs
+++ b/crates/jolt-verifier/src/stages/mod.rs
@@ -41,7 +41,7 @@ impl PrecommittedSchedule {
             trusted_advice_present.then_some(memory_layout.max_trusted_advice_size as usize);
         let untrusted_max_bytes =
             untrusted_advice_present.then_some(memory_layout.max_untrusted_advice_size as usize);
-        let candidates = advice::precommitted_candidates(trusted_max_bytes, untrusted_max_bytes);
+        let candidates = advice::candidate_total_vars(trusted_max_bytes, untrusted_max_bytes);
         let scheduling_reference = PrecommittedClaimReduction::scheduling_reference(
             log_t + log_k_chunk,
             &candidates,

--- a/crates/jolt-verifier/src/stages/stage6/verify.rs
+++ b/crates/jolt-verifier/src/stages/stage6/verify.rs
@@ -124,20 +124,12 @@ where
     );
     let inc_claims = increments::claim_reduction::<PCS::Field>(trace_dimensions);
 
-    let advice_layouts = crate::stages::advice_layouts(
-        proof.trace_polynomial_order,
-        log_t,
-        proof.one_hot_config.committed_chunk_bits(),
-        &checked.public_io.memory_layout,
-        checked.trusted_advice_commitment_present,
-        proof.untrusted_advice_commitment.is_some(),
-    );
-    let trusted_advice_layout = advice_layouts.trusted;
-    let untrusted_advice_layout = advice_layouts.untrusted;
-    let trusted_advice_claims = trusted_advice_layout.as_ref().map(|layout| {
+    let trusted_advice_layout = checked.precommitted.trusted_advice.as_ref();
+    let untrusted_advice_layout = checked.precommitted.untrusted_advice.as_ref();
+    let trusted_advice_claims = trusted_advice_layout.map(|layout| {
         advice::cycle_phase::<PCS::Field>(JoltAdviceKind::Trusted, layout.dimensions())
     });
-    let untrusted_advice_claims = untrusted_advice_layout.as_ref().map(|layout| {
+    let untrusted_advice_claims = untrusted_advice_layout.map(|layout| {
         advice::cycle_phase::<PCS::Field>(JoltAdviceKind::Untrusted, layout.dimensions())
     });
 
@@ -400,10 +392,9 @@ where
                     reason: error.to_string(),
                 })?;
 
-        let trusted_advice = if let (Some(layout), Some(claim)) = (
-            trusted_advice_layout.as_ref(),
-            trusted_advice_claims.as_ref(),
-        ) {
+        let trusted_advice = if let (Some(layout), Some(claim)) =
+            (trusted_advice_layout, trusted_advice_claims.as_ref())
+        {
             Some(verify_b::advice_cycle_phase_public(
                 &consistency,
                 claim,
@@ -413,10 +404,9 @@ where
         } else {
             None
         };
-        let untrusted_advice = if let (Some(layout), Some(claim)) = (
-            untrusted_advice_layout.as_ref(),
-            untrusted_advice_claims.as_ref(),
-        ) {
+        let untrusted_advice = if let (Some(layout), Some(claim)) =
+            (untrusted_advice_layout, untrusted_advice_claims.as_ref())
+        {
             Some(verify_b::advice_cycle_phase_public(
                 &consistency,
                 claim,
@@ -1321,7 +1311,7 @@ where
     )?;
 
     let trusted_advice = if let (Some(layout), Some(claim), Some(opening_claim)) = (
-        trusted_advice_layout.as_ref(),
+        trusted_advice_layout,
         trusted_advice_claims.as_ref(),
         claims.advice_cycle_phase.trusted.as_ref(),
     ) {
@@ -1337,7 +1327,7 @@ where
         None
     };
     let untrusted_advice = if let (Some(layout), Some(claim), Some(opening_claim)) = (
-        untrusted_advice_layout.as_ref(),
+        untrusted_advice_layout,
         untrusted_advice_claims.as_ref(),
         claims.advice_cycle_phase.untrusted.as_ref(),
     ) {
@@ -1353,10 +1343,7 @@ where
         None
     };
 
-    if let (Some(layout), Some(_)) = (
-        trusted_advice_layout.as_ref(),
-        trusted_advice_claims.as_ref(),
-    ) {
+    if let (Some(layout), Some(_)) = (trusted_advice_layout, trusted_advice_claims.as_ref()) {
         if trusted_advice.is_none() {
             return Err(VerifierError::MissingOpeningClaim {
                 id: advice::cycle_phase_output_openings(
@@ -1366,10 +1353,7 @@ where
             });
         }
     }
-    if let (Some(layout), Some(_)) = (
-        untrusted_advice_layout.as_ref(),
-        untrusted_advice_claims.as_ref(),
-    ) {
+    if let (Some(layout), Some(_)) = (untrusted_advice_layout, untrusted_advice_claims.as_ref()) {
         if untrusted_advice.is_none() {
             return Err(VerifierError::MissingOpeningClaim {
                 id: advice::cycle_phase_output_openings(

--- a/crates/jolt-verifier/src/stages/stage6/verify.rs
+++ b/crates/jolt-verifier/src/stages/stage6/verify.rs
@@ -6,11 +6,10 @@ use jolt_claims::protocols::jolt::{
         dimensions::{JoltFormulaDimensions, REGISTER_ADDRESS_BITS},
         instruction, ram,
     },
-    AdviceClaimReductionLayout, BooleanityChallenge, BooleanityPublic, BytecodeReadRafChallenge,
-    IncClaimReductionChallenge, IncClaimReductionPublic, InstructionRaVirtualizationChallenge,
-    JoltAdviceKind, JoltChallengeId, JoltPublicId, JoltRelationClaims, JoltRelationId,
-    JoltSumcheckDomain, JoltVirtualPolynomial, RamHammingBooleanityChallenge,
-    RamRaVirtualizationChallenge,
+    BooleanityChallenge, BooleanityPublic, BytecodeReadRafChallenge, IncClaimReductionChallenge,
+    IncClaimReductionPublic, InstructionRaVirtualizationChallenge, JoltAdviceKind, JoltChallengeId,
+    JoltPublicId, JoltRelationClaims, JoltRelationId, JoltSumcheckDomain, JoltVirtualPolynomial,
+    RamHammingBooleanityChallenge, RamRaVirtualizationChallenge,
 };
 use jolt_crypto::VectorCommitment;
 use jolt_field::Field;
@@ -125,22 +124,16 @@ where
     );
     let inc_claims = increments::claim_reduction::<PCS::Field>(trace_dimensions);
 
-    let trusted_advice_layout = checked.trusted_advice_commitment_present.then(|| {
-        AdviceClaimReductionLayout::balanced(
-            proof.trace_polynomial_order,
-            log_t,
-            proof.one_hot_config.committed_chunk_bits(),
-            checked.public_io.memory_layout.max_trusted_advice_size as usize,
-        )
-    });
-    let untrusted_advice_layout = proof.untrusted_advice_commitment.as_ref().map(|_| {
-        AdviceClaimReductionLayout::balanced(
-            proof.trace_polynomial_order,
-            log_t,
-            proof.one_hot_config.committed_chunk_bits(),
-            checked.public_io.memory_layout.max_untrusted_advice_size as usize,
-        )
-    });
+    let advice_layouts = crate::stages::advice_layouts(
+        proof.trace_polynomial_order,
+        log_t,
+        proof.one_hot_config.committed_chunk_bits(),
+        &checked.public_io.memory_layout,
+        checked.trusted_advice_commitment_present,
+        proof.untrusted_advice_commitment.is_some(),
+    );
+    let trusted_advice_layout = advice_layouts.trusted;
+    let untrusted_advice_layout = advice_layouts.untrusted;
     let trusted_advice_claims = trusted_advice_layout.as_ref().map(|layout| {
         advice::cycle_phase::<PCS::Field>(JoltAdviceKind::Trusted, layout.dimensions())
     });

--- a/crates/jolt-verifier/src/stages/stage7/outputs.rs
+++ b/crates/jolt-verifier/src/stages/stage7/outputs.rs
@@ -1,6 +1,6 @@
 //! Typed outputs produced by stage 7 verification.
 
-use jolt_claims::protocols::jolt::{JoltAdviceKind, JoltCommittedPolynomial, JoltOpeningId};
+use jolt_claims::protocols::jolt::{JoltAdviceKind, JoltCommittedPolynomial};
 use jolt_field::Field;
 use jolt_poly::{Point, HIGH_TO_LOW};
 use jolt_sumcheck::BatchedCommittedSumcheckConsistency;
@@ -16,7 +16,6 @@ use super::inputs::Stage7Claims;
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct PrecommittedFinalOpening<F: Field> {
     pub polynomial: JoltCommittedPolynomial,
-    pub id: JoltOpeningId,
     pub point: Vec<F>,
     /// `None` in ZK mode, where opening claims stay committed.
     pub opening_claim: Option<F>,

--- a/crates/jolt-verifier/src/stages/stage7/outputs.rs
+++ b/crates/jolt-verifier/src/stages/stage7/outputs.rs
@@ -1,6 +1,6 @@
 //! Typed outputs produced by stage 7 verification.
 
-use jolt_claims::protocols::jolt::JoltAdviceKind;
+use jolt_claims::protocols::jolt::{JoltAdviceKind, JoltCommittedPolynomial, JoltOpeningId};
 use jolt_field::Field;
 use jolt_poly::{Point, HIGH_TO_LOW};
 use jolt_sumcheck::BatchedCommittedSumcheckConsistency;
@@ -8,6 +8,19 @@ use jolt_sumcheck::BatchedCommittedSumcheckConsistency;
 use crate::stages::zk::outputs::CommittedOutputClaimOutput;
 
 use super::inputs::Stage7Claims;
+
+/// Final opening of a precommitted polynomial, resolved from whichever stage
+/// completed its claim reduction (stage 6b cycle phase or stage 7 address
+/// phase). Stage 8 consumes these as anchors and batch members of the final
+/// PCS opening.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct PrecommittedFinalOpening<F: Field> {
+    pub polynomial: JoltCommittedPolynomial,
+    pub id: JoltOpeningId,
+    pub point: Vec<F>,
+    /// `None` in ZK mode, where opening claims stay committed.
+    pub opening_claim: Option<F>,
+}
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Stage7PublicOutput<F: Field> {
@@ -21,6 +34,7 @@ pub struct Stage7ClearOutput<F: Field> {
     pub public: Stage7PublicOutput<F>,
     pub output_claims: Stage7Claims<F>,
     pub batch: VerifiedStage7Batch<F>,
+    pub precommitted_final_openings: Vec<PrecommittedFinalOpening<F>>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -31,6 +45,7 @@ pub struct Stage7ZkOutput<F: Field, C> {
     pub hamming_weight_claim_reduction: HammingWeightClaimReductionPublicOutput<F>,
     pub trusted_advice_address_phase: Option<AdviceAddressPhasePublicOutput<F>>,
     pub untrusted_advice_address_phase: Option<AdviceAddressPhasePublicOutput<F>>,
+    pub precommitted_final_openings: Vec<PrecommittedFinalOpening<F>>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/crates/jolt-verifier/src/stages/stage7/verify.rs
+++ b/crates/jolt-verifier/src/stages/stage7/verify.rs
@@ -228,22 +228,22 @@ where
                 trusted_advice_layout,
                 trusted_advice
                     .as_ref()
-                    .map(|public| (public.opening_point.as_slice(), None)),
+                    .map(|public| AdviceFinalSource::zk(&public.opening_point)),
                 stage6
                     .trusted_advice_cycle_phase
                     .as_ref()
-                    .map(|public| (public.opening_point.as_slice(), None)),
+                    .map(|public| AdviceFinalSource::zk(&public.opening_point)),
             ),
             (
                 JoltAdviceKind::Untrusted,
                 untrusted_advice_layout,
                 untrusted_advice
                     .as_ref()
-                    .map(|public| (public.opening_point.as_slice(), None)),
+                    .map(|public| AdviceFinalSource::zk(&public.opening_point)),
                 stage6
                     .untrusted_advice_cycle_phase
                     .as_ref()
-                    .map(|public| (public.opening_point.as_slice(), None)),
+                    .map(|public| AdviceFinalSource::zk(&public.opening_point)),
             ),
         ] {
             if let Some(layout) = layout {
@@ -465,40 +465,38 @@ where
         (
             JoltAdviceKind::Trusted,
             trusted_advice_layout,
-            match (&trusted_advice, &claims.advice_address_phase.trusted) {
-                (Some(verified), Some(claim)) => {
-                    Some((verified.opening_point.as_slice(), Some(claim.opening_claim)))
-                }
-                _ => None,
-            },
-            match (
-                &stage6.batch.trusted_advice_cycle_phase,
-                &stage6.output_claims.advice_cycle_phase.trusted,
-            ) {
-                (Some(verified), Some(claim)) => {
-                    Some((verified.opening_point.as_slice(), Some(claim.opening_claim)))
-                }
-                _ => None,
-            },
+            trusted_advice
+                .as_ref()
+                .zip(claims.advice_address_phase.trusted.as_ref())
+                .map(|(verified, claim)| {
+                    AdviceFinalSource::clear(&verified.opening_point, claim.opening_claim)
+                }),
+            stage6
+                .batch
+                .trusted_advice_cycle_phase
+                .as_ref()
+                .zip(stage6.output_claims.advice_cycle_phase.trusted.as_ref())
+                .map(|(verified, claim)| {
+                    AdviceFinalSource::clear(&verified.opening_point, claim.opening_claim)
+                }),
         ),
         (
             JoltAdviceKind::Untrusted,
             untrusted_advice_layout,
-            match (&untrusted_advice, &claims.advice_address_phase.untrusted) {
-                (Some(verified), Some(claim)) => {
-                    Some((verified.opening_point.as_slice(), Some(claim.opening_claim)))
-                }
-                _ => None,
-            },
-            match (
-                &stage6.batch.untrusted_advice_cycle_phase,
-                &stage6.output_claims.advice_cycle_phase.untrusted,
-            ) {
-                (Some(verified), Some(claim)) => {
-                    Some((verified.opening_point.as_slice(), Some(claim.opening_claim)))
-                }
-                _ => None,
-            },
+            untrusted_advice
+                .as_ref()
+                .zip(claims.advice_address_phase.untrusted.as_ref())
+                .map(|(verified, claim)| {
+                    AdviceFinalSource::clear(&verified.opening_point, claim.opening_claim)
+                }),
+            stage6
+                .batch
+                .untrusted_advice_cycle_phase
+                .as_ref()
+                .zip(stage6.output_claims.advice_cycle_phase.untrusted.as_ref())
+                .map(|(verified, claim)| {
+                    AdviceFinalSource::clear(&verified.opening_point, claim.opening_claim)
+                }),
         ),
     ] {
         if let Some(layout) = layout {
@@ -846,33 +844,54 @@ fn hamming_opening_points<F: Field>(
     }
 }
 
+/// Opening point and (clear-mode) claim recorded by the stage that completed
+/// an advice claim reduction.
+struct AdviceFinalSource<'a, F> {
+    point: &'a [F],
+    opening_claim: Option<F>,
+}
+
+impl<'a, F> AdviceFinalSource<'a, F> {
+    fn zk(point: &'a [F]) -> Self {
+        Self {
+            point,
+            opening_claim: None,
+        }
+    }
+
+    fn clear(point: &'a [F], opening_claim: F) -> Self {
+        Self {
+            point,
+            opening_claim: Some(opening_claim),
+        }
+    }
+}
+
 /// Resolves the final opening of an advice polynomial from whichever phase
 /// completed its reduction: this stage's address phase, or the stage 6b cycle
 /// phase when no active address rounds remain.
 fn advice_final_opening<F: Field>(
     kind: JoltAdviceKind,
     layout: &AdviceClaimReductionLayout,
-    address_phase: Option<(&[F], Option<F>)>,
-    cycle_phase: Option<(&[F], Option<F>)>,
+    address_phase: Option<AdviceFinalSource<'_, F>>,
+    cycle_phase: Option<AdviceFinalSource<'_, F>>,
 ) -> Result<PrecommittedFinalOpening<F>, VerifierError> {
-    let (point, opening_claim) = if layout.dimensions().has_address_phase() {
-        address_phase.ok_or(VerifierError::MissingOpeningClaim {
-            id: advice::final_advice_opening(kind),
-        })?
+    let source = if layout.dimensions().has_address_phase() {
+        address_phase
     } else {
-        cycle_phase.ok_or(VerifierError::MissingOpeningClaim {
-            id: advice::cycle_phase_advice_opening(kind),
-        })?
+        cycle_phase
     };
+    let source = source.ok_or(VerifierError::MissingOpeningClaim {
+        id: advice::final_advice_opening(kind),
+    })?;
     let polynomial = match kind {
         JoltAdviceKind::Trusted => JoltCommittedPolynomial::TrustedAdvice,
         JoltAdviceKind::Untrusted => JoltCommittedPolynomial::UntrustedAdvice,
     };
     Ok(PrecommittedFinalOpening {
         polynomial,
-        id: advice::final_advice_opening(kind),
-        point: point.to_vec(),
-        opening_claim,
+        point: source.point.to_vec(),
+        opening_claim: source.opening_claim,
     })
 }
 

--- a/crates/jolt-verifier/src/stages/stage7/verify.rs
+++ b/crates/jolt-verifier/src/stages/stage7/verify.rs
@@ -4,8 +4,8 @@ use jolt_claims::protocols::jolt::{
         dimensions::JoltFormulaDimensions,
     },
     AdviceClaimReductionLayout, AdviceClaimReductionPublic, HammingWeightClaimReductionChallenge,
-    HammingWeightClaimReductionPublic, JoltAdviceKind, JoltChallengeId, JoltOpeningId,
-    JoltPublicId, JoltRelationClaims, JoltRelationId, JoltSumcheckDomain,
+    HammingWeightClaimReductionPublic, JoltAdviceKind, JoltChallengeId, JoltCommittedPolynomial,
+    JoltOpeningId, JoltPublicId, JoltRelationClaims, JoltRelationId, JoltSumcheckDomain,
 };
 use jolt_crypto::VectorCommitment;
 use jolt_field::Field;
@@ -20,8 +20,9 @@ use jolt_transcript::Transcript;
 use super::{
     inputs::{AdviceAddressPhaseOutputClaim, Deps, Stage7Claims},
     outputs::{
-        AdviceAddressPhasePublicOutput, HammingWeightClaimReductionPublicOutput, Stage7ClearOutput,
-        Stage7Output, Stage7PublicOutput, Stage7ZkOutput, VerifiedAdviceAddressPhaseSumcheck,
+        AdviceAddressPhasePublicOutput, HammingWeightClaimReductionPublicOutput,
+        PrecommittedFinalOpening, Stage7ClearOutput, Stage7Output, Stage7PublicOutput,
+        Stage7ZkOutput, VerifiedAdviceAddressPhaseSumcheck,
         VerifiedHammingWeightClaimReductionSumcheck, VerifiedStage7Batch,
     },
 };
@@ -93,17 +94,9 @@ where
     );
     let hamming_claims = hamming_weight::claim_reduction::<PCS::Field>(hamming_dimensions);
 
-    let advice_layouts = crate::stages::advice_layouts(
-        proof.trace_polynomial_order,
-        log_t,
-        proof.one_hot_config.committed_chunk_bits(),
-        &checked.public_io.memory_layout,
-        checked.trusted_advice_commitment_present,
-        proof.untrusted_advice_commitment.is_some(),
-    );
-    let trusted_advice_layout = advice_layouts.trusted;
-    let untrusted_advice_layout = advice_layouts.untrusted;
-    let trusted_advice_claims = trusted_advice_layout.as_ref().and_then(|layout| {
+    let trusted_advice_layout = checked.precommitted.trusted_advice.as_ref();
+    let untrusted_advice_layout = checked.precommitted.untrusted_advice.as_ref();
+    let trusted_advice_claims = trusted_advice_layout.and_then(|layout| {
         if layout.dimensions().has_address_phase() {
             Some(advice::address_phase::<PCS::Field>(
                 JoltAdviceKind::Trusted,
@@ -113,7 +106,7 @@ where
             None
         }
     });
-    let untrusted_advice_claims = untrusted_advice_layout.as_ref().and_then(|layout| {
+    let untrusted_advice_claims = untrusted_advice_layout.and_then(|layout| {
         if layout.dimensions().has_address_phase() {
             Some(advice::address_phase::<PCS::Field>(
                 JoltAdviceKind::Untrusted,
@@ -201,10 +194,9 @@ where
         let hamming_opening_points =
             hamming_opening_points(hamming_dimensions, &hamming_opening_point);
 
-        let trusted_advice = if let (Some(layout), Some(claim)) = (
-            trusted_advice_layout.as_ref(),
-            trusted_advice_claims.as_ref(),
-        ) {
+        let trusted_advice = if let (Some(layout), Some(claim)) =
+            (trusted_advice_layout, trusted_advice_claims.as_ref())
+        {
             Some(advice_address_phase_public(
                 &batch_consistency,
                 claim,
@@ -215,10 +207,9 @@ where
         } else {
             None
         };
-        let untrusted_advice = if let (Some(layout), Some(claim)) = (
-            untrusted_advice_layout.as_ref(),
-            untrusted_advice_claims.as_ref(),
-        ) {
+        let untrusted_advice = if let (Some(layout), Some(claim)) =
+            (untrusted_advice_layout, untrusted_advice_claims.as_ref())
+        {
             Some(advice_address_phase_public(
                 &batch_consistency,
                 claim,
@@ -229,6 +220,41 @@ where
         } else {
             None
         };
+
+        let mut precommitted_final_openings = Vec::new();
+        for (kind, layout, address_phase, cycle_phase) in [
+            (
+                JoltAdviceKind::Trusted,
+                trusted_advice_layout,
+                trusted_advice
+                    .as_ref()
+                    .map(|public| (public.opening_point.as_slice(), None)),
+                stage6
+                    .trusted_advice_cycle_phase
+                    .as_ref()
+                    .map(|public| (public.opening_point.as_slice(), None)),
+            ),
+            (
+                JoltAdviceKind::Untrusted,
+                untrusted_advice_layout,
+                untrusted_advice
+                    .as_ref()
+                    .map(|public| (public.opening_point.as_slice(), None)),
+                stage6
+                    .untrusted_advice_cycle_phase
+                    .as_ref()
+                    .map(|public| (public.opening_point.as_slice(), None)),
+            ),
+        ] {
+            if let Some(layout) = layout {
+                precommitted_final_openings.push(advice_final_opening(
+                    kind,
+                    layout,
+                    address_phase,
+                    cycle_phase,
+                )?);
+            }
+        }
 
         return Ok(Stage7Output::Zk(Stage7ZkOutput {
             public: public(
@@ -246,6 +272,7 @@ where
             },
             trusted_advice_address_phase: trusted_advice,
             untrusted_advice_address_phase: untrusted_advice,
+            precommitted_final_openings,
         }));
     }
 
@@ -348,7 +375,7 @@ where
     let hamming_opening_points = hamming_opening_points(hamming_dimensions, &hamming_opening_point);
 
     let trusted_advice = if let (Some(layout), Some(claim), Some(opening_claim)) = (
-        trusted_advice_layout.as_ref(),
+        trusted_advice_layout,
         trusted_advice_claims.as_ref(),
         claims.advice_address_phase.trusted.as_ref(),
     ) {
@@ -365,7 +392,7 @@ where
         None
     };
     let untrusted_advice = if let (Some(layout), Some(claim), Some(opening_claim)) = (
-        untrusted_advice_layout.as_ref(),
+        untrusted_advice_layout,
         untrusted_advice_claims.as_ref(),
         claims.advice_address_phase.untrusted.as_ref(),
     ) {
@@ -433,6 +460,57 @@ where
 
     append_stage7_opening_claims(transcript, claims);
 
+    let mut precommitted_final_openings = Vec::new();
+    for (kind, layout, address_phase, cycle_phase) in [
+        (
+            JoltAdviceKind::Trusted,
+            trusted_advice_layout,
+            match (&trusted_advice, &claims.advice_address_phase.trusted) {
+                (Some(verified), Some(claim)) => {
+                    Some((verified.opening_point.as_slice(), Some(claim.opening_claim)))
+                }
+                _ => None,
+            },
+            match (
+                &stage6.batch.trusted_advice_cycle_phase,
+                &stage6.output_claims.advice_cycle_phase.trusted,
+            ) {
+                (Some(verified), Some(claim)) => {
+                    Some((verified.opening_point.as_slice(), Some(claim.opening_claim)))
+                }
+                _ => None,
+            },
+        ),
+        (
+            JoltAdviceKind::Untrusted,
+            untrusted_advice_layout,
+            match (&untrusted_advice, &claims.advice_address_phase.untrusted) {
+                (Some(verified), Some(claim)) => {
+                    Some((verified.opening_point.as_slice(), Some(claim.opening_claim)))
+                }
+                _ => None,
+            },
+            match (
+                &stage6.batch.untrusted_advice_cycle_phase,
+                &stage6.output_claims.advice_cycle_phase.untrusted,
+            ) {
+                (Some(verified), Some(claim)) => {
+                    Some((verified.opening_point.as_slice(), Some(claim.opening_claim)))
+                }
+                _ => None,
+            },
+        ),
+    ] {
+        if let Some(layout) = layout {
+            precommitted_final_openings.push(advice_final_opening(
+                kind,
+                layout,
+                address_phase,
+                cycle_phase,
+            )?);
+        }
+    }
+
     Ok(Stage7Output::Clear(Stage7ClearOutput {
         public: public(
             batch.reduction.point.as_slice().to_vec(),
@@ -456,6 +534,7 @@ where
             trusted_advice_address_phase: trusted_advice,
             untrusted_advice_address_phase: untrusted_advice,
         },
+        precommitted_final_openings,
     }))
 }
 
@@ -765,6 +844,36 @@ fn hamming_opening_points<F: Field>(
         bytecode: vec![opening_point.to_vec(); dimensions.layout.bytecode()],
         ram: vec![opening_point.to_vec(); dimensions.layout.ram()],
     }
+}
+
+/// Resolves the final opening of an advice polynomial from whichever phase
+/// completed its reduction: this stage's address phase, or the stage 6b cycle
+/// phase when no active address rounds remain.
+fn advice_final_opening<F: Field>(
+    kind: JoltAdviceKind,
+    layout: &AdviceClaimReductionLayout,
+    address_phase: Option<(&[F], Option<F>)>,
+    cycle_phase: Option<(&[F], Option<F>)>,
+) -> Result<PrecommittedFinalOpening<F>, VerifierError> {
+    let (point, opening_claim) = if layout.dimensions().has_address_phase() {
+        address_phase.ok_or(VerifierError::MissingOpeningClaim {
+            id: advice::final_advice_opening(kind),
+        })?
+    } else {
+        cycle_phase.ok_or(VerifierError::MissingOpeningClaim {
+            id: advice::cycle_phase_advice_opening(kind),
+        })?
+    };
+    let polynomial = match kind {
+        JoltAdviceKind::Trusted => JoltCommittedPolynomial::TrustedAdvice,
+        JoltAdviceKind::Untrusted => JoltCommittedPolynomial::UntrustedAdvice,
+    };
+    Ok(PrecommittedFinalOpening {
+        polynomial,
+        id: advice::final_advice_opening(kind),
+        point: point.to_vec(),
+        opening_claim,
+    })
 }
 
 fn advice_address_phase_input<F: Field>(

--- a/crates/jolt-verifier/src/stages/stage7/verify.rs
+++ b/crates/jolt-verifier/src/stages/stage7/verify.rs
@@ -93,22 +93,16 @@ where
     );
     let hamming_claims = hamming_weight::claim_reduction::<PCS::Field>(hamming_dimensions);
 
-    let trusted_advice_layout = checked.trusted_advice_commitment_present.then(|| {
-        AdviceClaimReductionLayout::balanced(
-            proof.trace_polynomial_order,
-            log_t,
-            proof.one_hot_config.committed_chunk_bits(),
-            checked.public_io.memory_layout.max_trusted_advice_size as usize,
-        )
-    });
-    let untrusted_advice_layout = proof.untrusted_advice_commitment.as_ref().map(|_| {
-        AdviceClaimReductionLayout::balanced(
-            proof.trace_polynomial_order,
-            log_t,
-            proof.one_hot_config.committed_chunk_bits(),
-            checked.public_io.memory_layout.max_untrusted_advice_size as usize,
-        )
-    });
+    let advice_layouts = crate::stages::advice_layouts(
+        proof.trace_polynomial_order,
+        log_t,
+        proof.one_hot_config.committed_chunk_bits(),
+        &checked.public_io.memory_layout,
+        checked.trusted_advice_commitment_present,
+        proof.untrusted_advice_commitment.is_some(),
+    );
+    let trusted_advice_layout = advice_layouts.trusted;
+    let untrusted_advice_layout = advice_layouts.untrusted;
     let trusted_advice_claims = trusted_advice_layout.as_ref().and_then(|layout| {
         if layout.dimensions().has_address_phase() {
             Some(advice::address_phase::<PCS::Field>(

--- a/crates/jolt-verifier/src/stages/stage8/outputs.rs
+++ b/crates/jolt-verifier/src/stages/stage8/outputs.rs
@@ -30,7 +30,6 @@ pub struct Stage8ClearOutput<F: Field, C> {
     pub opening_claims: Vec<VerifierOpeningClaim<F, C>>,
     pub opening_ids: Vec<Stage8OpeningId>,
     pub constraint_coefficients: Vec<F>,
-    pub opening_point: Point<HIGH_TO_LOW, F>,
     pub pcs_opening_point: Point<HIGH_TO_LOW, F>,
     pub joint_claim: F,
     pub joint_commitment: C,
@@ -40,7 +39,6 @@ pub struct Stage8ClearOutput<F: Field, C> {
 pub struct Stage8ZkOutput<F: Field, C, H> {
     pub opening_ids: Vec<Stage8OpeningId>,
     pub constraint_coefficients: Vec<F>,
-    pub opening_point: Point<HIGH_TO_LOW, F>,
     pub pcs_opening_point: Point<HIGH_TO_LOW, F>,
     pub joint_commitment: C,
     pub hiding_evaluation_commitment: H,

--- a/crates/jolt-verifier/src/stages/stage8/verify.rs
+++ b/crates/jolt-verifier/src/stages/stage8/verify.rs
@@ -121,7 +121,7 @@ where
         .map(|opening| opening.point.as_slice())
         .collect();
     let opening_point = final_opening_point(FinalOpeningPointInputs {
-        native_main_vars: log_t + proof.one_hot_config.committed_chunk_bits(),
+        log_t,
         log_k_chunk: proof.one_hot_config.committed_chunk_bits(),
         trace_order: proof.trace_polynomial_order,
         hamming_weight_opening_point: hamming_opening_point,

--- a/crates/jolt-verifier/src/stages/stage8/verify.rs
+++ b/crates/jolt-verifier/src/stages/stage8/verify.rs
@@ -34,9 +34,9 @@ use jolt_openings::{
 use jolt_poly::Point;
 use jolt_transcript::{AppendToTranscript, LabelWithCount, Transcript};
 
-struct Stage8BatchEntry<F: Field, C> {
+struct Stage8BatchEntry<'a, F: Field, C> {
     id: Stage8OpeningId,
-    commitment: C,
+    commitment: &'a C,
     /// `None` in ZK mode, where opening claims stay committed.
     opening_claim: Option<F>,
     /// Lagrange factor embedding this polynomial's own opening point into the
@@ -133,11 +133,6 @@ where
     })?;
     let pcs_opening_point = Point::high_to_low(opening_point.clone());
 
-    let advice_final = |polynomial: JoltCommittedPolynomial| {
-        precommitted_finals
-            .iter()
-            .find(|opening| opening.polynomial == polynomial)
-    };
     let entries = batch_entries(
         proof,
         layout,
@@ -145,7 +140,7 @@ where
         &opening_point,
         hamming_opening_point,
         inc_opening_point,
-        &advice_final,
+        precommitted_finals,
         clear_claims,
     )?;
     let opening_ids: Vec<Stage8OpeningId> = entries.iter().map(|entry| entry.id).collect();
@@ -182,7 +177,6 @@ where
         return Ok(Stage8Output::Zk(Stage8ZkOutput {
             opening_ids,
             constraint_coefficients,
-            opening_point: pcs_opening_point.clone(),
             pcs_opening_point,
             joint_commitment,
             hiding_evaluation_commitment,
@@ -248,7 +242,6 @@ where
         opening_claims,
         opening_ids,
         constraint_coefficients,
-        opening_point: pcs_opening_point.clone(),
         pcs_opening_point,
         joint_claim,
         joint_commitment,
@@ -269,15 +262,19 @@ fn batch_entries<'a, F, PCS, VC, ZkProof>(
     opening_point: &[F],
     hamming_opening_point: &[F],
     inc_opening_point: &[F],
-    advice_final: &dyn Fn(JoltCommittedPolynomial) -> Option<&'a PrecommittedFinalOpening<F>>,
+    precommitted_finals: &'a [PrecommittedFinalOpening<F>],
     clear_claims: Option<(&Stage6Claims<F>, &Stage7Claims<F>)>,
-) -> Result<Vec<Stage8BatchEntry<F, PCS::Output>>, VerifierError>
+) -> Result<Vec<Stage8BatchEntry<'a, F, PCS::Output>>, VerifierError>
 where
     F: Field,
     PCS: CommitmentScheme<Field = F>,
-    PCS::Output: Clone,
     VC: VectorCommitment<Field = F>,
 {
+    let advice_final = |polynomial: JoltCommittedPolynomial| {
+        precommitted_finals
+            .iter()
+            .find(|opening| opening.polynomial == polynomial)
+    };
     let include_trusted = advice_final(JoltCommittedPolynomial::TrustedAdvice).is_some();
     let include_untrusted = advice_final(JoltCommittedPolynomial::UntrustedAdvice).is_some();
     let order = final_opening_polynomial_order(layout, include_trusted, include_untrusted);
@@ -383,7 +380,7 @@ where
             };
         entries.push(Stage8BatchEntry {
             id: id.into(),
-            commitment: commitment.clone(),
+            commitment,
             opening_claim,
             scale: commitment_embedding_scale(opening_point, own_point),
         });
@@ -391,12 +388,7 @@ where
         if polynomial == JoltCommittedPolynomial::RdInc {
             entries.push(Stage8BatchEntry {
                 id: field_increments::field_rd_inc_reduced_opening().into(),
-                commitment: proof
-                    .commitments
-                    .field_inline
-                    .field_registers
-                    .rd_inc
-                    .clone(),
+                commitment: &proof.commitments.field_inline.field_registers.rd_inc,
                 opening_claim: clear_claims.map(|(stage6, _)| {
                     stage6
                         .field_inline

--- a/crates/jolt-verifier/src/stages/stage8/verify.rs
+++ b/crates/jolt-verifier/src/stages/stage8/verify.rs
@@ -6,8 +6,8 @@ use crate::{
     preprocessing::JoltVerifierPreprocessing,
     proof::{JoltCommitments, JoltProof},
     stages::{
-        stage6::{Stage6ClearOutput, Stage6ZkOutput},
-        stage7::{Stage7ClearOutput, Stage7ZkOutput},
+        stage6::inputs::Stage6Claims,
+        stage7::{inputs::Stage7Claims, outputs::PrecommittedFinalOpening},
     },
     verifier::CheckedInputs,
     VerifierError,
@@ -16,14 +16,14 @@ use crate::{
 use jolt_claims::protocols::field_inline::formulas::claim_reductions::increments as field_increments;
 use jolt_claims::protocols::jolt::{
     formulas::{
-        claim_reductions::advice,
         committed_openings::{
-            commitment_embedding_scale, final_opening_point, FinalOpeningPointInputs,
+            commitment_embedding_scale, final_opening_id, final_opening_point,
+            final_opening_polynomial_order, FinalOpeningPointInputs,
         },
         dimensions::JoltFormulaDimensions,
         ra::JoltRaPolynomialLayout,
     },
-    JoltAdviceKind, JoltCommittedPolynomial, JoltOpeningId, JoltRelationId,
+    JoltCommittedPolynomial,
 };
 use jolt_crypto::{HomomorphicCommitment, VectorCommitment};
 use jolt_field::Field;
@@ -34,13 +34,14 @@ use jolt_openings::{
 use jolt_poly::Point;
 use jolt_transcript::{AppendToTranscript, LabelWithCount, Transcript};
 
-struct AdviceFinalOpening<F: Field> {
-    point: Vec<F>,
-    opening_claim: F,
-}
-
-struct AdviceFinalOpeningPoint<F: Field> {
-    point: Vec<F>,
+struct Stage8BatchEntry<F: Field, C> {
+    id: Stage8OpeningId,
+    commitment: C,
+    /// `None` in ZK mode, where opening claims stay committed.
+    opening_claim: Option<F>,
+    /// Lagrange factor embedding this polynomial's own opening point into the
+    /// unified opening point.
+    scale: F,
 }
 
 #[cfg(feature = "field-inline")]
@@ -92,7 +93,7 @@ where
     })?;
     let layout = formula_dimensions.ra_layout;
 
-    let (hamming_opening_point, inc_opening_point) = match deps {
+    let (hamming_opening_point, inc_opening_point, precommitted_finals, clear_claims) = match deps {
         Deps::Clear { stage6, stage7 } => (
             stage7
                 .batch
@@ -100,6 +101,8 @@ where
                 .opening_point
                 .as_slice(),
             stage6.batch.inc_claim_reduction.opening_point.as_slice(),
+            stage7.precommitted_final_openings.as_slice(),
+            Some((&stage6.output_claims, &stage7.output_claims)),
         ),
         Deps::Zk { stage6, stage7 } => (
             stage7
@@ -107,190 +110,57 @@ where
                 .opening_point
                 .as_slice(),
             stage6.inc_claim_reduction.opening_point.as_slice(),
+            stage7.precommitted_final_openings.as_slice(),
+            None,
         ),
     };
     require_commitment_layout(&proof.commitments, layout)?;
 
-    if checked.zk {
-        let Deps::Zk { stage6, stage7 } = deps else {
-            return Err(VerifierError::ExpectedCommittedProof { field: "stage8" });
-        };
+    let anchor_points: Vec<&[F]> = precommitted_finals
+        .iter()
+        .map(|opening| opening.point.as_slice())
+        .collect();
+    let opening_point = final_opening_point(FinalOpeningPointInputs {
+        native_main_vars: log_t + proof.one_hot_config.committed_chunk_bits(),
+        log_k_chunk: proof.one_hot_config.committed_chunk_bits(),
+        trace_order: proof.trace_polynomial_order,
+        hamming_weight_opening_point: hamming_opening_point,
+        inc_claim_reduction_opening_point: inc_opening_point,
+        precommitted_anchor_points: &anchor_points,
+    })
+    .map_err(|error| VerifierError::FinalOpeningBatchFailed {
+        reason: error.to_string(),
+    })?;
+    let pcs_opening_point = Point::high_to_low(opening_point.clone());
 
-        let trusted_advice = if checked.trusted_advice_commitment_present {
-            Some(final_advice_opening_point(
-                JoltAdviceKind::Trusted,
-                checked,
-                proof,
-                stage6,
-                stage7,
-            )?)
-        } else {
-            None
-        };
-        let untrusted_advice = if proof.untrusted_advice_commitment.is_some() {
-            Some(final_advice_opening_point(
-                JoltAdviceKind::Untrusted,
-                checked,
-                proof,
-                stage6,
-                stage7,
-            )?)
-        } else {
-            None
-        };
-        let precommitted_anchor_points: Vec<&[PCS::Field]> = trusted_advice
+    let advice_final = |polynomial: JoltCommittedPolynomial| {
+        precommitted_finals
             .iter()
-            .map(|opening| opening.point.as_slice())
-            .chain(
-                untrusted_advice
-                    .iter()
-                    .map(|opening| opening.point.as_slice()),
-            )
+            .find(|opening| opening.polynomial == polynomial)
+    };
+    let entries = batch_entries(
+        proof,
+        layout,
+        trusted_advice_commitment,
+        &opening_point,
+        hamming_opening_point,
+        inc_opening_point,
+        &advice_final,
+        clear_claims,
+    )?;
+    let opening_ids: Vec<Stage8OpeningId> = entries.iter().map(|entry| entry.id).collect();
+
+    if checked.zk {
+        let gamma_powers = transcript.challenge_scalar_powers(entries.len());
+        let commitments: Vec<PCS::Output> = entries
+            .iter()
+            .map(|entry| entry.commitment.clone())
             .collect();
-        let opening_point = final_opening_point(FinalOpeningPointInputs {
-            native_main_vars: log_t + proof.one_hot_config.committed_chunk_bits(),
-            log_k_chunk: proof.one_hot_config.committed_chunk_bits(),
-            trace_order: proof.trace_polynomial_order,
-            hamming_weight_opening_point: hamming_opening_point,
-            inc_claim_reduction_opening_point: inc_opening_point,
-            precommitted_anchor_points: &precommitted_anchor_points,
-        })
-        .map_err(|error| VerifierError::FinalOpeningBatchFailed {
-            reason: error.to_string(),
-        })?;
-        let pcs_opening_point = Point::high_to_low(opening_point.clone());
-        let common_point = pcs_opening_point.clone();
-        let final_opening_count = 2
-            + field_inline_final_opening_count()
-            + layout.total()
-            + usize::from(trusted_advice.is_some())
-            + usize::from(untrusted_advice.is_some());
-        let trusted_advice_commitment = match (trusted_advice.is_some(), trusted_advice_commitment)
-        {
-            (true, Some(commitment)) => Some(commitment),
-            (true, None) => {
-                return Err(VerifierError::MissingFinalOpeningCommitment {
-                    polynomial: JoltCommittedPolynomial::TrustedAdvice,
-                });
-            }
-            (false, _) => None,
-        };
-        let untrusted_advice_commitment = match (
-            untrusted_advice.is_some(),
-            proof.untrusted_advice_commitment.as_ref(),
-        ) {
-            (true, Some(commitment)) => Some(commitment),
-            (true, None) => {
-                return Err(VerifierError::MissingFinalOpeningCommitment {
-                    polynomial: JoltCommittedPolynomial::UntrustedAdvice,
-                });
-            }
-            (false, _) => None,
-        };
-
-        let mut opening_ids = Vec::with_capacity(final_opening_count);
-        let mut commitments = Vec::with_capacity(final_opening_count);
-        let mut scaling_factors = Vec::with_capacity(final_opening_count);
-        {
-            let mut push_opening =
-                |id: Stage8OpeningId, commitment: &PCS::Output, scale: PCS::Field| {
-                    scaling_factors.push(scale);
-                    opening_ids.push(id);
-                    commitments.push(commitment.clone());
-                };
-
-            // Core's final PCS batch order intentionally differs from proof payload order.
-            push_opening(
-                JoltOpeningId::committed(
-                    JoltCommittedPolynomial::RamInc,
-                    JoltRelationId::IncClaimReduction,
-                )
-                .into(),
-                &proof.commitments.ram_inc,
-                commitment_embedding_scale(&opening_point, inc_opening_point),
-            );
-            push_opening(
-                JoltOpeningId::committed(
-                    JoltCommittedPolynomial::RdInc,
-                    JoltRelationId::IncClaimReduction,
-                )
-                .into(),
-                &proof.commitments.rd_inc,
-                commitment_embedding_scale(&opening_point, inc_opening_point),
-            );
-            #[cfg(feature = "field-inline")]
-            push_opening(
-                field_increments::field_rd_inc_reduced_opening().into(),
-                &proof.commitments.field_inline.field_registers.rd_inc,
-                commitment_embedding_scale(&opening_point, inc_opening_point),
-            );
-            for (index, commitment) in proof.commitments.ra.instruction.iter().enumerate() {
-                push_opening(
-                    JoltOpeningId::committed(
-                        JoltCommittedPolynomial::InstructionRa(index),
-                        JoltRelationId::HammingWeightClaimReduction,
-                    )
-                    .into(),
-                    commitment,
-                    commitment_embedding_scale(&opening_point, hamming_opening_point),
-                );
-            }
-            for (index, commitment) in proof.commitments.ra.bytecode.iter().enumerate() {
-                push_opening(
-                    JoltOpeningId::committed(
-                        JoltCommittedPolynomial::BytecodeRa(index),
-                        JoltRelationId::HammingWeightClaimReduction,
-                    )
-                    .into(),
-                    commitment,
-                    commitment_embedding_scale(&opening_point, hamming_opening_point),
-                );
-            }
-            for (index, commitment) in proof.commitments.ra.ram.iter().enumerate() {
-                push_opening(
-                    JoltOpeningId::committed(
-                        JoltCommittedPolynomial::RamRa(index),
-                        JoltRelationId::HammingWeightClaimReduction,
-                    )
-                    .into(),
-                    commitment,
-                    commitment_embedding_scale(&opening_point, hamming_opening_point),
-                );
-            }
-            if let Some(commitment) = trusted_advice_commitment {
-                let final_opening =
-                    trusted_advice
-                        .as_ref()
-                        .ok_or(VerifierError::MissingOpeningClaim {
-                            id: advice::final_advice_opening(JoltAdviceKind::Trusted),
-                        })?;
-                push_opening(
-                    advice::final_advice_opening(JoltAdviceKind::Trusted).into(),
-                    commitment,
-                    commitment_embedding_scale(&opening_point, &final_opening.point),
-                );
-            }
-            if let Some(commitment) = untrusted_advice_commitment {
-                let final_opening =
-                    untrusted_advice
-                        .as_ref()
-                        .ok_or(VerifierError::MissingOpeningClaim {
-                            id: advice::final_advice_opening(JoltAdviceKind::Untrusted),
-                        })?;
-                push_opening(
-                    advice::final_advice_opening(JoltAdviceKind::Untrusted).into(),
-                    commitment,
-                    commitment_embedding_scale(&opening_point, &final_opening.point),
-                );
-            }
-        }
-
-        let gamma_powers = transcript.challenge_scalar_powers(opening_ids.len());
         let joint_commitment = PCS::combine(&commitments, &gamma_powers);
         let constraint_coefficients = gamma_powers
             .iter()
-            .zip(scaling_factors)
-            .map(|(gamma, scale)| *gamma * scale)
+            .zip(&entries)
+            .map(|(gamma, entry)| *gamma * entry.scale)
             .collect::<Vec<_>>();
 
         let hiding_evaluation_commitment = PCS::verify_zk(
@@ -305,228 +175,38 @@ where
         })?;
         PCS::bind_zk_opening_inputs(
             transcript,
-            common_point.as_slice(),
+            pcs_opening_point.as_slice(),
             &hiding_evaluation_commitment,
         );
 
         return Ok(Stage8Output::Zk(Stage8ZkOutput {
             opening_ids,
             constraint_coefficients,
-            opening_point: common_point,
+            opening_point: pcs_opening_point.clone(),
             pcs_opening_point,
             joint_commitment,
             hiding_evaluation_commitment,
         }));
     }
 
-    let Deps::Clear { stage6, stage7 } = deps else {
-        return Err(VerifierError::ExpectedClearProof { field: "stage8" });
-    };
-    let trusted_advice = if checked.trusted_advice_commitment_present {
-        Some(final_advice_opening(
-            JoltAdviceKind::Trusted,
-            checked,
-            proof,
-            stage6,
-            stage7,
-        )?)
-    } else {
-        None
-    };
-    let untrusted_advice = if proof.untrusted_advice_commitment.is_some() {
-        Some(final_advice_opening(
-            JoltAdviceKind::Untrusted,
-            checked,
-            proof,
-            stage6,
-            stage7,
-        )?)
-    } else {
-        None
-    };
-    let precommitted_anchor_points: Vec<&[PCS::Field]> = trusted_advice
+    let opening_claims = entries
         .iter()
-        .map(|opening| opening.point.as_slice())
-        .chain(
-            untrusted_advice
-                .iter()
-                .map(|opening| opening.point.as_slice()),
-        )
-        .collect();
-    let opening_point = final_opening_point(FinalOpeningPointInputs {
-        native_main_vars: log_t + proof.one_hot_config.committed_chunk_bits(),
-        log_k_chunk: proof.one_hot_config.committed_chunk_bits(),
-        trace_order: proof.trace_polynomial_order,
-        hamming_weight_opening_point: hamming_opening_point,
-        inc_claim_reduction_opening_point: inc_opening_point,
-        precommitted_anchor_points: &precommitted_anchor_points,
-    })
-    .map_err(|error| VerifierError::FinalOpeningBatchFailed {
-        reason: error.to_string(),
-    })?;
-    let pcs_opening_point = Point::high_to_low(opening_point.clone());
-    let common_point = pcs_opening_point.clone();
-
-    let final_opening_count = 2
-        + field_inline_final_opening_count()
-        + layout.total()
-        + usize::from(trusted_advice.is_some())
-        + usize::from(untrusted_advice.is_some());
-    let trusted_advice_commitment = match (trusted_advice.is_some(), trusted_advice_commitment) {
-        (true, Some(commitment)) => Some(commitment),
-        (true, None) => {
-            return Err(VerifierError::MissingFinalOpeningCommitment {
-                polynomial: JoltCommittedPolynomial::TrustedAdvice,
-            });
-        }
-        (false, _) => None,
-    };
-    let untrusted_advice_commitment = match (
-        untrusted_advice.is_some(),
-        proof.untrusted_advice_commitment.as_ref(),
-    ) {
-        (true, Some(commitment)) => Some(commitment),
-        (true, None) => {
-            return Err(VerifierError::MissingFinalOpeningCommitment {
-                polynomial: JoltCommittedPolynomial::UntrustedAdvice,
-            });
-        }
-        (false, _) => None,
-    };
-    let mut opening_ids = Vec::with_capacity(final_opening_count);
-    let mut opening_claims = Vec::with_capacity(final_opening_count);
-    let mut constraint_coefficients = Vec::with_capacity(final_opening_count);
-    let mut scaling_factors = Vec::with_capacity(final_opening_count);
-
-    {
-        let mut push_opening = |id: Stage8OpeningId,
-                                commitment: &PCS::Output,
-                                opening_claim: PCS::Field,
-                                scale: PCS::Field| {
-            scaling_factors.push(scale);
-            opening_ids.push(id);
-            opening_claims.push(VerifierOpeningClaim {
-                commitment: commitment.clone(),
-                evaluation: EvaluationClaim::new(pcs_opening_point.clone(), opening_claim * scale),
-            });
-        };
-
-        // Core's final PCS batch order intentionally differs from proof payload order.
-        push_opening(
-            JoltOpeningId::committed(
-                JoltCommittedPolynomial::RamInc,
-                JoltRelationId::IncClaimReduction,
-            )
-            .into(),
-            &proof.commitments.ram_inc,
-            stage6.output_claims.inc_claim_reduction.ram_inc,
-            commitment_embedding_scale(&opening_point, inc_opening_point),
-        );
-        push_opening(
-            JoltOpeningId::committed(
-                JoltCommittedPolynomial::RdInc,
-                JoltRelationId::IncClaimReduction,
-            )
-            .into(),
-            &proof.commitments.rd_inc,
-            stage6.output_claims.inc_claim_reduction.rd_inc,
-            commitment_embedding_scale(&opening_point, inc_opening_point),
-        );
-        #[cfg(feature = "field-inline")]
-        push_opening(
-            field_increments::field_rd_inc_reduced_opening().into(),
-            &proof.commitments.field_inline.field_registers.rd_inc,
-            stage6
-                .output_claims
-                .field_inline
-                .field_registers_inc_claim_reduction
-                .field_rd_inc,
-            commitment_embedding_scale(&opening_point, inc_opening_point),
-        );
-
-        for (index, commitment) in proof.commitments.ra.instruction.iter().enumerate() {
-            let id = JoltOpeningId::committed(
-                JoltCommittedPolynomial::InstructionRa(index),
-                JoltRelationId::HammingWeightClaimReduction,
-            );
-            let opening_claim = *stage7
-                .output_claims
-                .hamming_weight_claim_reduction
-                .instruction_ra
-                .get(index)
-                .ok_or(VerifierError::MissingOpeningClaim { id })?;
-            push_opening(
-                id.into(),
-                commitment,
-                opening_claim,
-                commitment_embedding_scale(&opening_point, hamming_opening_point),
-            );
-        }
-
-        for (index, commitment) in proof.commitments.ra.bytecode.iter().enumerate() {
-            let id = JoltOpeningId::committed(
-                JoltCommittedPolynomial::BytecodeRa(index),
-                JoltRelationId::HammingWeightClaimReduction,
-            );
-            let opening_claim = *stage7
-                .output_claims
-                .hamming_weight_claim_reduction
-                .bytecode_ra
-                .get(index)
-                .ok_or(VerifierError::MissingOpeningClaim { id })?;
-            push_opening(
-                id.into(),
-                commitment,
-                opening_claim,
-                commitment_embedding_scale(&opening_point, hamming_opening_point),
-            );
-        }
-
-        for (index, commitment) in proof.commitments.ra.ram.iter().enumerate() {
-            let id = JoltOpeningId::committed(
-                JoltCommittedPolynomial::RamRa(index),
-                JoltRelationId::HammingWeightClaimReduction,
-            );
-            let opening_claim = *stage7
-                .output_claims
-                .hamming_weight_claim_reduction
-                .ram_ra
-                .get(index)
-                .ok_or(VerifierError::MissingOpeningClaim { id })?;
-            push_opening(
-                id.into(),
-                commitment,
-                opening_claim,
-                commitment_embedding_scale(&opening_point, hamming_opening_point),
-            );
-        }
-
-        if let Some(commitment) = trusted_advice_commitment {
-            let id = advice::final_advice_opening(JoltAdviceKind::Trusted);
-            let final_opening = trusted_advice
-                .as_ref()
-                .ok_or(VerifierError::MissingOpeningClaim { id })?;
-            push_opening(
-                id.into(),
-                commitment,
-                final_opening.opening_claim,
-                commitment_embedding_scale(&opening_point, &final_opening.point),
-            );
-        }
-
-        if let Some(commitment) = untrusted_advice_commitment {
-            let id = advice::final_advice_opening(JoltAdviceKind::Untrusted);
-            let final_opening = untrusted_advice
-                .as_ref()
-                .ok_or(VerifierError::MissingOpeningClaim { id })?;
-            push_opening(
-                id.into(),
-                commitment,
-                final_opening.opening_claim,
-                commitment_embedding_scale(&opening_point, &final_opening.point),
-            );
-        }
-    }
+        .map(|entry| {
+            let opening_claim =
+                entry
+                    .opening_claim
+                    .ok_or_else(|| VerifierError::FinalOpeningBatchFailed {
+                        reason: "missing clear opening claim in final batch".to_string(),
+                    })?;
+            Ok(VerifierOpeningClaim {
+                commitment: entry.commitment.clone(),
+                evaluation: EvaluationClaim::new(
+                    pcs_opening_point.clone(),
+                    opening_claim * entry.scale,
+                ),
+            })
+        })
+        .collect::<Result<Vec<_>, VerifierError>>()?;
 
     transcript.append(&LabelWithCount(b"rlc_claims", opening_claims.len() as u64));
     for claim in &opening_claims {
@@ -545,12 +225,11 @@ where
         .map(|claim| claim.commitment.clone())
         .collect::<Vec<_>>();
     let joint_commitment = PCS::combine(&commitments, &gamma_powers);
-    constraint_coefficients.extend(
-        gamma_powers
-            .iter()
-            .zip(scaling_factors)
-            .map(|(gamma, scale)| *gamma * scale),
-    );
+    let constraint_coefficients = gamma_powers
+        .iter()
+        .zip(&entries)
+        .map(|(gamma, entry)| *gamma * entry.scale)
+        .collect::<Vec<_>>();
 
     PCS::verify(
         &joint_commitment,
@@ -563,17 +242,172 @@ where
     .map_err(|error| VerifierError::FinalOpeningVerificationFailed {
         reason: error.to_string(),
     })?;
-    PCS::bind_opening_inputs(transcript, common_point.as_slice(), &joint_claim);
+    PCS::bind_opening_inputs(transcript, pcs_opening_point.as_slice(), &joint_claim);
 
     Ok(Stage8Output::Clear(Stage8ClearOutput {
         opening_claims,
         opening_ids,
         constraint_coefficients,
-        opening_point: common_point,
+        opening_point: pcs_opening_point.clone(),
         pcs_opening_point,
         joint_claim,
         joint_commitment,
     }))
+}
+
+/// Builds the final PCS batch in the canonical order from
+/// [`final_opening_polynomial_order`], resolving each polynomial's commitment,
+/// opening claim (clear mode only), and unified-point embedding scale.
+#[expect(
+    clippy::too_many_arguments,
+    reason = "gathers per-polynomial sources from several stages"
+)]
+fn batch_entries<'a, F, PCS, VC, ZkProof>(
+    proof: &'a JoltProof<PCS, VC, ZkProof>,
+    layout: JoltRaPolynomialLayout,
+    trusted_advice_commitment: Option<&'a PCS::Output>,
+    opening_point: &[F],
+    hamming_opening_point: &[F],
+    inc_opening_point: &[F],
+    advice_final: &dyn Fn(JoltCommittedPolynomial) -> Option<&'a PrecommittedFinalOpening<F>>,
+    clear_claims: Option<(&Stage6Claims<F>, &Stage7Claims<F>)>,
+) -> Result<Vec<Stage8BatchEntry<F, PCS::Output>>, VerifierError>
+where
+    F: Field,
+    PCS: CommitmentScheme<Field = F>,
+    PCS::Output: Clone,
+    VC: VectorCommitment<Field = F>,
+{
+    let include_trusted = advice_final(JoltCommittedPolynomial::TrustedAdvice).is_some();
+    let include_untrusted = advice_final(JoltCommittedPolynomial::UntrustedAdvice).is_some();
+    let order = final_opening_polynomial_order(layout, include_trusted, include_untrusted);
+
+    let mut entries = Vec::with_capacity(order.len() + field_inline_final_opening_count());
+    // Core's final PCS batch order intentionally differs from proof payload order.
+    for polynomial in order {
+        let id = final_opening_id(polynomial);
+        let (commitment, own_point, opening_claim): (&PCS::Output, &[F], Option<F>) =
+            match polynomial {
+                JoltCommittedPolynomial::RamInc => (
+                    &proof.commitments.ram_inc,
+                    inc_opening_point,
+                    clear_claims.map(|(stage6, _)| stage6.inc_claim_reduction.ram_inc),
+                ),
+                JoltCommittedPolynomial::RdInc => (
+                    &proof.commitments.rd_inc,
+                    inc_opening_point,
+                    clear_claims.map(|(stage6, _)| stage6.inc_claim_reduction.rd_inc),
+                ),
+                JoltCommittedPolynomial::InstructionRa(index) => (
+                    proof
+                        .commitments
+                        .ra
+                        .instruction
+                        .get(index)
+                        .ok_or(VerifierError::MissingFinalOpeningCommitment { polynomial })?,
+                    hamming_opening_point,
+                    match clear_claims {
+                        Some((_, stage7)) => Some(
+                            *stage7
+                                .hamming_weight_claim_reduction
+                                .instruction_ra
+                                .get(index)
+                                .ok_or(VerifierError::MissingOpeningClaim { id })?,
+                        ),
+                        None => None,
+                    },
+                ),
+                JoltCommittedPolynomial::BytecodeRa(index) => (
+                    proof
+                        .commitments
+                        .ra
+                        .bytecode
+                        .get(index)
+                        .ok_or(VerifierError::MissingFinalOpeningCommitment { polynomial })?,
+                    hamming_opening_point,
+                    match clear_claims {
+                        Some((_, stage7)) => Some(
+                            *stage7
+                                .hamming_weight_claim_reduction
+                                .bytecode_ra
+                                .get(index)
+                                .ok_or(VerifierError::MissingOpeningClaim { id })?,
+                        ),
+                        None => None,
+                    },
+                ),
+                JoltCommittedPolynomial::RamRa(index) => (
+                    proof
+                        .commitments
+                        .ra
+                        .ram
+                        .get(index)
+                        .ok_or(VerifierError::MissingFinalOpeningCommitment { polynomial })?,
+                    hamming_opening_point,
+                    match clear_claims {
+                        Some((_, stage7)) => Some(
+                            *stage7
+                                .hamming_weight_claim_reduction
+                                .ram_ra
+                                .get(index)
+                                .ok_or(VerifierError::MissingOpeningClaim { id })?,
+                        ),
+                        None => None,
+                    },
+                ),
+                JoltCommittedPolynomial::TrustedAdvice => {
+                    let opening = advice_final(polynomial)
+                        .ok_or(VerifierError::MissingOpeningClaim { id })?;
+                    let commitment = trusted_advice_commitment
+                        .ok_or(VerifierError::MissingFinalOpeningCommitment { polynomial })?;
+                    (commitment, opening.point.as_slice(), opening.opening_claim)
+                }
+                JoltCommittedPolynomial::UntrustedAdvice => {
+                    let opening = advice_final(polynomial)
+                        .ok_or(VerifierError::MissingOpeningClaim { id })?;
+                    let commitment = proof
+                        .untrusted_advice_commitment
+                        .as_ref()
+                        .ok_or(VerifierError::MissingFinalOpeningCommitment { polynomial })?;
+                    (commitment, opening.point.as_slice(), opening.opening_claim)
+                }
+                // Committed-program polynomials (bytecode chunks, program
+                // image) are not wired into the final batch yet.
+                polynomial => {
+                    return Err(VerifierError::FinalOpeningBatchFailed {
+                        reason: format!(
+                            "unsupported polynomial in final opening batch: {polynomial:?}"
+                        ),
+                    });
+                }
+            };
+        entries.push(Stage8BatchEntry {
+            id: id.into(),
+            commitment: commitment.clone(),
+            opening_claim,
+            scale: commitment_embedding_scale(opening_point, own_point),
+        });
+        #[cfg(feature = "field-inline")]
+        if polynomial == JoltCommittedPolynomial::RdInc {
+            entries.push(Stage8BatchEntry {
+                id: field_increments::field_rd_inc_reduced_opening().into(),
+                commitment: proof
+                    .commitments
+                    .field_inline
+                    .field_registers
+                    .rd_inc
+                    .clone(),
+                opening_claim: clear_claims.map(|(stage6, _)| {
+                    stage6
+                        .field_inline
+                        .field_registers_inc_claim_reduction
+                        .field_rd_inc
+                }),
+                scale: commitment_embedding_scale(opening_point, inc_opening_point),
+            });
+        }
+    }
+    Ok(entries)
 }
 
 fn require_commitment_layout<C>(
@@ -605,170 +439,4 @@ fn require_commitment_layout<C>(
         });
     }
     Ok(())
-}
-
-fn final_advice_opening<PCS, VC, ZkProof>(
-    kind: JoltAdviceKind,
-    checked: &CheckedInputs,
-    proof: &JoltProof<PCS, VC, ZkProof>,
-    stage6: &Stage6ClearOutput<PCS::Field>,
-    stage7: &Stage7ClearOutput<PCS::Field>,
-) -> Result<AdviceFinalOpening<PCS::Field>, VerifierError>
-where
-    PCS: CommitmentScheme,
-    VC: VectorCommitment<Field = PCS::Field>,
-{
-    let log_t = checked.trace_length.ilog2() as usize;
-    let advice_layouts = crate::stages::advice_layouts(
-        proof.trace_polynomial_order,
-        log_t,
-        proof.one_hot_config.committed_chunk_bits(),
-        &checked.public_io.memory_layout,
-        checked.trusted_advice_commitment_present,
-        proof.untrusted_advice_commitment.is_some(),
-    );
-    let id = advice::final_advice_opening(kind);
-    let layout = match kind {
-        JoltAdviceKind::Trusted => advice_layouts.trusted,
-        JoltAdviceKind::Untrusted => advice_layouts.untrusted,
-    }
-    .ok_or(VerifierError::MissingOpeningClaim { id })?;
-
-    match (kind, layout.dimensions().has_address_phase()) {
-        (JoltAdviceKind::Trusted, true) => {
-            let verified = stage7
-                .batch
-                .trusted_advice_address_phase
-                .as_ref()
-                .ok_or(VerifierError::MissingOpeningClaim { id })?;
-            let claim = stage7
-                .output_claims
-                .advice_address_phase
-                .trusted
-                .as_ref()
-                .ok_or(VerifierError::MissingOpeningClaim { id })?;
-            Ok(AdviceFinalOpening {
-                point: verified.opening_point.clone(),
-                opening_claim: claim.opening_claim,
-            })
-        }
-        (JoltAdviceKind::Untrusted, true) => {
-            let verified = stage7
-                .batch
-                .untrusted_advice_address_phase
-                .as_ref()
-                .ok_or(VerifierError::MissingOpeningClaim { id })?;
-            let claim = stage7
-                .output_claims
-                .advice_address_phase
-                .untrusted
-                .as_ref()
-                .ok_or(VerifierError::MissingOpeningClaim { id })?;
-            Ok(AdviceFinalOpening {
-                point: verified.opening_point.clone(),
-                opening_claim: claim.opening_claim,
-            })
-        }
-        (JoltAdviceKind::Trusted, false) => {
-            let verified = stage6
-                .batch
-                .trusted_advice_cycle_phase
-                .as_ref()
-                .ok_or(VerifierError::MissingOpeningClaim { id })?;
-            let claim = stage6
-                .output_claims
-                .advice_cycle_phase
-                .trusted
-                .as_ref()
-                .ok_or(VerifierError::MissingOpeningClaim { id })?;
-            Ok(AdviceFinalOpening {
-                point: verified.opening_point.clone(),
-                opening_claim: claim.opening_claim,
-            })
-        }
-        (JoltAdviceKind::Untrusted, false) => {
-            let verified = stage6
-                .batch
-                .untrusted_advice_cycle_phase
-                .as_ref()
-                .ok_or(VerifierError::MissingOpeningClaim { id })?;
-            let claim = stage6
-                .output_claims
-                .advice_cycle_phase
-                .untrusted
-                .as_ref()
-                .ok_or(VerifierError::MissingOpeningClaim { id })?;
-            Ok(AdviceFinalOpening {
-                point: verified.opening_point.clone(),
-                opening_claim: claim.opening_claim,
-            })
-        }
-    }
-}
-
-fn final_advice_opening_point<PCS, VC, ZkProof>(
-    kind: JoltAdviceKind,
-    checked: &CheckedInputs,
-    proof: &JoltProof<PCS, VC, ZkProof>,
-    stage6: &Stage6ZkOutput<PCS::Field, VC::Output>,
-    stage7: &Stage7ZkOutput<PCS::Field, VC::Output>,
-) -> Result<AdviceFinalOpeningPoint<PCS::Field>, VerifierError>
-where
-    PCS: CommitmentScheme,
-    VC: VectorCommitment<Field = PCS::Field>,
-{
-    let log_t = checked.trace_length.ilog2() as usize;
-    let advice_layouts = crate::stages::advice_layouts(
-        proof.trace_polynomial_order,
-        log_t,
-        proof.one_hot_config.committed_chunk_bits(),
-        &checked.public_io.memory_layout,
-        checked.trusted_advice_commitment_present,
-        proof.untrusted_advice_commitment.is_some(),
-    );
-    let id = advice::final_advice_opening(kind);
-    let layout = match kind {
-        JoltAdviceKind::Trusted => advice_layouts.trusted,
-        JoltAdviceKind::Untrusted => advice_layouts.untrusted,
-    }
-    .ok_or(VerifierError::MissingOpeningClaim { id })?;
-
-    match (kind, layout.dimensions().has_address_phase()) {
-        (JoltAdviceKind::Trusted, true) => {
-            let verified = stage7
-                .trusted_advice_address_phase
-                .as_ref()
-                .ok_or(VerifierError::MissingOpeningClaim { id })?;
-            Ok(AdviceFinalOpeningPoint {
-                point: verified.opening_point.clone(),
-            })
-        }
-        (JoltAdviceKind::Untrusted, true) => {
-            let verified = stage7
-                .untrusted_advice_address_phase
-                .as_ref()
-                .ok_or(VerifierError::MissingOpeningClaim { id })?;
-            Ok(AdviceFinalOpeningPoint {
-                point: verified.opening_point.clone(),
-            })
-        }
-        (JoltAdviceKind::Trusted, false) => {
-            let verified = stage6
-                .trusted_advice_cycle_phase
-                .as_ref()
-                .ok_or(VerifierError::MissingOpeningClaim { id })?;
-            Ok(AdviceFinalOpeningPoint {
-                point: verified.opening_point.clone(),
-            })
-        }
-        (JoltAdviceKind::Untrusted, false) => {
-            let verified = stage6
-                .untrusted_advice_cycle_phase
-                .as_ref()
-                .ok_or(VerifierError::MissingOpeningClaim { id })?;
-            Ok(AdviceFinalOpeningPoint {
-                point: verified.opening_point.clone(),
-            })
-        }
-    }
 }

--- a/crates/jolt-verifier/src/stages/stage8/verify.rs
+++ b/crates/jolt-verifier/src/stages/stage8/verify.rs
@@ -16,11 +16,14 @@ use crate::{
 use jolt_claims::protocols::field_inline::formulas::claim_reductions::increments as field_increments;
 use jolt_claims::protocols::jolt::{
     formulas::{
-        claim_reductions::advice, committed_openings::advice_commitment_embedding_scale,
-        dimensions::JoltFormulaDimensions, ra::JoltRaPolynomialLayout,
+        claim_reductions::advice,
+        committed_openings::{
+            commitment_embedding_scale, final_opening_point, FinalOpeningPointInputs,
+        },
+        dimensions::JoltFormulaDimensions,
+        ra::JoltRaPolynomialLayout,
     },
-    AdviceClaimReductionLayout, JoltAdviceKind, JoltCommittedPolynomial, JoltOpeningId,
-    JoltRelationId,
+    JoltAdviceKind, JoltCommittedPolynomial, JoltOpeningId, JoltRelationId,
 };
 use jolt_crypto::{HomomorphicCommitment, VectorCommitment};
 use jolt_field::Field;
@@ -28,7 +31,7 @@ use jolt_lookup_tables::XLEN as RISCV_XLEN;
 use jolt_openings::{
     AdditivelyHomomorphic, CommitmentScheme, EvaluationClaim, VerifierOpeningClaim, ZkOpeningScheme,
 };
-use jolt_poly::{EqPolynomial, Point};
+use jolt_poly::Point;
 use jolt_transcript::{AppendToTranscript, LabelWithCount, Transcript};
 
 struct AdviceFinalOpening<F: Field> {
@@ -89,36 +92,24 @@ where
     })?;
     let layout = formula_dimensions.ra_layout;
 
-    let opening_point = match deps {
-        Deps::Clear { stage7, .. } => stage7
-            .batch
-            .hamming_weight_claim_reduction
-            .opening_point
-            .clone(),
-        Deps::Zk { stage7, .. } => stage7.hamming_weight_claim_reduction.opening_point.clone(),
+    let (hamming_opening_point, inc_opening_point) = match deps {
+        Deps::Clear { stage6, stage7 } => (
+            stage7
+                .batch
+                .hamming_weight_claim_reduction
+                .opening_point
+                .as_slice(),
+            stage6.batch.inc_claim_reduction.opening_point.as_slice(),
+        ),
+        Deps::Zk { stage6, stage7 } => (
+            stage7
+                .hamming_weight_claim_reduction
+                .opening_point
+                .as_slice(),
+            stage6.inc_claim_reduction.opening_point.as_slice(),
+        ),
     };
-    let committed_chunk_bits = proof.one_hot_config.committed_chunk_bits();
-    if opening_point.len() < committed_chunk_bits {
-        return Err(VerifierError::FinalOpeningBatchFailed {
-            reason: format!(
-                "final opening point has {} variables, expected at least {committed_chunk_bits}",
-                opening_point.len()
-            ),
-        });
-    }
-    let r_address_stage7 = &opening_point[..committed_chunk_bits];
-    let dense_embedding_scale = EqPolynomial::<PCS::Field>::zero_selector(r_address_stage7);
     require_commitment_layout(&proof.commitments, layout)?;
-
-    let pcs_opening_point = Point::high_to_low(
-        proof
-            .trace_polynomial_order
-            .commitment_opening_point(&opening_point, log_t)
-            .map_err(|error| VerifierError::FinalOpeningBatchFailed {
-                reason: error.to_string(),
-            })?,
-    );
-    let common_point = Point::high_to_low(opening_point.clone());
 
     if checked.zk {
         let Deps::Zk { stage6, stage7 } = deps else {
@@ -147,6 +138,28 @@ where
         } else {
             None
         };
+        let precommitted_anchor_points: Vec<&[PCS::Field]> = trusted_advice
+            .iter()
+            .map(|opening| opening.point.as_slice())
+            .chain(
+                untrusted_advice
+                    .iter()
+                    .map(|opening| opening.point.as_slice()),
+            )
+            .collect();
+        let opening_point = final_opening_point(FinalOpeningPointInputs {
+            native_main_vars: log_t + proof.one_hot_config.committed_chunk_bits(),
+            log_k_chunk: proof.one_hot_config.committed_chunk_bits(),
+            trace_order: proof.trace_polynomial_order,
+            hamming_weight_opening_point: hamming_opening_point,
+            inc_claim_reduction_opening_point: inc_opening_point,
+            precommitted_anchor_points: &precommitted_anchor_points,
+        })
+        .map_err(|error| VerifierError::FinalOpeningBatchFailed {
+            reason: error.to_string(),
+        })?;
+        let pcs_opening_point = Point::high_to_low(opening_point.clone());
+        let common_point = pcs_opening_point.clone();
         let final_opening_count = 2
             + field_inline_final_opening_count()
             + layout.total()
@@ -194,7 +207,7 @@ where
                 )
                 .into(),
                 &proof.commitments.ram_inc,
-                dense_embedding_scale,
+                commitment_embedding_scale(&opening_point, inc_opening_point),
             );
             push_opening(
                 JoltOpeningId::committed(
@@ -203,13 +216,13 @@ where
                 )
                 .into(),
                 &proof.commitments.rd_inc,
-                dense_embedding_scale,
+                commitment_embedding_scale(&opening_point, inc_opening_point),
             );
             #[cfg(feature = "field-inline")]
             push_opening(
                 field_increments::field_rd_inc_reduced_opening().into(),
                 &proof.commitments.field_inline.field_registers.rd_inc,
-                dense_embedding_scale,
+                commitment_embedding_scale(&opening_point, inc_opening_point),
             );
             for (index, commitment) in proof.commitments.ra.instruction.iter().enumerate() {
                 push_opening(
@@ -219,7 +232,7 @@ where
                     )
                     .into(),
                     commitment,
-                    PCS::Field::one(),
+                    commitment_embedding_scale(&opening_point, hamming_opening_point),
                 );
             }
             for (index, commitment) in proof.commitments.ra.bytecode.iter().enumerate() {
@@ -230,7 +243,7 @@ where
                     )
                     .into(),
                     commitment,
-                    PCS::Field::one(),
+                    commitment_embedding_scale(&opening_point, hamming_opening_point),
                 );
             }
             for (index, commitment) in proof.commitments.ra.ram.iter().enumerate() {
@@ -241,7 +254,7 @@ where
                     )
                     .into(),
                     commitment,
-                    PCS::Field::one(),
+                    commitment_embedding_scale(&opening_point, hamming_opening_point),
                 );
             }
             if let Some(commitment) = trusted_advice_commitment {
@@ -254,7 +267,7 @@ where
                 push_opening(
                     advice::final_advice_opening(JoltAdviceKind::Trusted).into(),
                     commitment,
-                    advice_commitment_embedding_scale(&opening_point, &final_opening.point),
+                    commitment_embedding_scale(&opening_point, &final_opening.point),
                 );
             }
             if let Some(commitment) = untrusted_advice_commitment {
@@ -267,7 +280,7 @@ where
                 push_opening(
                     advice::final_advice_opening(JoltAdviceKind::Untrusted).into(),
                     commitment,
-                    advice_commitment_embedding_scale(&opening_point, &final_opening.point),
+                    commitment_embedding_scale(&opening_point, &final_opening.point),
                 );
             }
         }
@@ -331,6 +344,28 @@ where
     } else {
         None
     };
+    let precommitted_anchor_points: Vec<&[PCS::Field]> = trusted_advice
+        .iter()
+        .map(|opening| opening.point.as_slice())
+        .chain(
+            untrusted_advice
+                .iter()
+                .map(|opening| opening.point.as_slice()),
+        )
+        .collect();
+    let opening_point = final_opening_point(FinalOpeningPointInputs {
+        native_main_vars: log_t + proof.one_hot_config.committed_chunk_bits(),
+        log_k_chunk: proof.one_hot_config.committed_chunk_bits(),
+        trace_order: proof.trace_polynomial_order,
+        hamming_weight_opening_point: hamming_opening_point,
+        inc_claim_reduction_opening_point: inc_opening_point,
+        precommitted_anchor_points: &precommitted_anchor_points,
+    })
+    .map_err(|error| VerifierError::FinalOpeningBatchFailed {
+        reason: error.to_string(),
+    })?;
+    let pcs_opening_point = Point::high_to_low(opening_point.clone());
+    let common_point = pcs_opening_point.clone();
 
     let final_opening_count = 2
         + field_inline_final_opening_count()
@@ -385,7 +420,7 @@ where
             .into(),
             &proof.commitments.ram_inc,
             stage6.output_claims.inc_claim_reduction.ram_inc,
-            dense_embedding_scale,
+            commitment_embedding_scale(&opening_point, inc_opening_point),
         );
         push_opening(
             JoltOpeningId::committed(
@@ -395,7 +430,7 @@ where
             .into(),
             &proof.commitments.rd_inc,
             stage6.output_claims.inc_claim_reduction.rd_inc,
-            dense_embedding_scale,
+            commitment_embedding_scale(&opening_point, inc_opening_point),
         );
         #[cfg(feature = "field-inline")]
         push_opening(
@@ -406,7 +441,7 @@ where
                 .field_inline
                 .field_registers_inc_claim_reduction
                 .field_rd_inc,
-            dense_embedding_scale,
+            commitment_embedding_scale(&opening_point, inc_opening_point),
         );
 
         for (index, commitment) in proof.commitments.ra.instruction.iter().enumerate() {
@@ -420,7 +455,12 @@ where
                 .instruction_ra
                 .get(index)
                 .ok_or(VerifierError::MissingOpeningClaim { id })?;
-            push_opening(id.into(), commitment, opening_claim, PCS::Field::one());
+            push_opening(
+                id.into(),
+                commitment,
+                opening_claim,
+                commitment_embedding_scale(&opening_point, hamming_opening_point),
+            );
         }
 
         for (index, commitment) in proof.commitments.ra.bytecode.iter().enumerate() {
@@ -434,7 +474,12 @@ where
                 .bytecode_ra
                 .get(index)
                 .ok_or(VerifierError::MissingOpeningClaim { id })?;
-            push_opening(id.into(), commitment, opening_claim, PCS::Field::one());
+            push_opening(
+                id.into(),
+                commitment,
+                opening_claim,
+                commitment_embedding_scale(&opening_point, hamming_opening_point),
+            );
         }
 
         for (index, commitment) in proof.commitments.ra.ram.iter().enumerate() {
@@ -448,7 +493,12 @@ where
                 .ram_ra
                 .get(index)
                 .ok_or(VerifierError::MissingOpeningClaim { id })?;
-            push_opening(id.into(), commitment, opening_claim, PCS::Field::one());
+            push_opening(
+                id.into(),
+                commitment,
+                opening_claim,
+                commitment_embedding_scale(&opening_point, hamming_opening_point),
+            );
         }
 
         if let Some(commitment) = trusted_advice_commitment {
@@ -460,7 +510,7 @@ where
                 id.into(),
                 commitment,
                 final_opening.opening_claim,
-                advice_commitment_embedding_scale(&opening_point, &final_opening.point),
+                commitment_embedding_scale(&opening_point, &final_opening.point),
             );
         }
 
@@ -473,7 +523,7 @@ where
                 id.into(),
                 commitment,
                 final_opening.opening_claim,
-                advice_commitment_embedding_scale(&opening_point, &final_opening.point),
+                commitment_embedding_scale(&opening_point, &final_opening.point),
             );
         }
     }
@@ -569,17 +619,20 @@ where
     VC: VectorCommitment<Field = PCS::Field>,
 {
     let log_t = checked.trace_length.ilog2() as usize;
-    let max_advice_size = match kind {
-        JoltAdviceKind::Trusted => checked.public_io.memory_layout.max_trusted_advice_size,
-        JoltAdviceKind::Untrusted => checked.public_io.memory_layout.max_untrusted_advice_size,
-    } as usize;
-    let layout = AdviceClaimReductionLayout::balanced(
+    let advice_layouts = crate::stages::advice_layouts(
         proof.trace_polynomial_order,
         log_t,
         proof.one_hot_config.committed_chunk_bits(),
-        max_advice_size,
+        &checked.public_io.memory_layout,
+        checked.trusted_advice_commitment_present,
+        proof.untrusted_advice_commitment.is_some(),
     );
     let id = advice::final_advice_opening(kind);
+    let layout = match kind {
+        JoltAdviceKind::Trusted => advice_layouts.trusted,
+        JoltAdviceKind::Untrusted => advice_layouts.untrusted,
+    }
+    .ok_or(VerifierError::MissingOpeningClaim { id })?;
 
     match (kind, layout.dimensions().has_address_phase()) {
         (JoltAdviceKind::Trusted, true) => {
@@ -665,17 +718,20 @@ where
     VC: VectorCommitment<Field = PCS::Field>,
 {
     let log_t = checked.trace_length.ilog2() as usize;
-    let max_advice_size = match kind {
-        JoltAdviceKind::Trusted => checked.public_io.memory_layout.max_trusted_advice_size,
-        JoltAdviceKind::Untrusted => checked.public_io.memory_layout.max_untrusted_advice_size,
-    } as usize;
-    let layout = AdviceClaimReductionLayout::balanced(
+    let advice_layouts = crate::stages::advice_layouts(
         proof.trace_polynomial_order,
         log_t,
         proof.one_hot_config.committed_chunk_bits(),
-        max_advice_size,
+        &checked.public_io.memory_layout,
+        checked.trusted_advice_commitment_present,
+        proof.untrusted_advice_commitment.is_some(),
     );
     let id = advice::final_advice_opening(kind);
+    let layout = match kind {
+        JoltAdviceKind::Trusted => advice_layouts.trusted,
+        JoltAdviceKind::Untrusted => advice_layouts.untrusted,
+    }
+    .ok_or(VerifierError::MissingOpeningClaim { id })?;
 
     match (kind, layout.dimensions().has_address_phase()) {
         (JoltAdviceKind::Trusted, true) => {

--- a/crates/jolt-verifier/src/stages/zk/blindfold/mod.rs
+++ b/crates/jolt-verifier/src/stages/zk/blindfold/mod.rs
@@ -737,19 +737,7 @@ where
     PCS: CommitmentScheme,
     VC: VectorCommitment<Field = PCS::Field>,
 {
-    let log_t = input.checked.trace_length.ilog2() as usize;
-    let advice_layouts = crate::stages::advice_layouts(
-        input.proof.trace_polynomial_order,
-        log_t,
-        input.proof.one_hot_config.committed_chunk_bits(),
-        &input.checked.public_io.memory_layout,
-        input.checked.trusted_advice_commitment_present,
-        input.proof.untrusted_advice_commitment.is_some(),
-    );
-    match kind {
-        JoltAdviceKind::Trusted => advice_layouts.trusted,
-        JoltAdviceKind::Untrusted => advice_layouts.untrusted,
-    }
+    input.checked.precommitted.advice(kind).cloned()
 }
 
 #[expect(

--- a/crates/jolt-verifier/src/stages/zk/blindfold/mod.rs
+++ b/crates/jolt-verifier/src/stages/zk/blindfold/mod.rs
@@ -737,35 +737,19 @@ where
     PCS: CommitmentScheme,
     VC: VectorCommitment<Field = PCS::Field>,
 {
-    let present = match kind {
-        JoltAdviceKind::Trusted => input.checked.trusted_advice_commitment_present,
-        JoltAdviceKind::Untrusted => input.proof.untrusted_advice_commitment.is_some(),
-    };
-    present.then(|| {
-        let log_t = input.checked.trace_length.ilog2() as usize;
-        let max_size = match kind {
-            JoltAdviceKind::Trusted => {
-                input
-                    .checked
-                    .public_io
-                    .memory_layout
-                    .max_trusted_advice_size as usize
-            }
-            JoltAdviceKind::Untrusted => {
-                input
-                    .checked
-                    .public_io
-                    .memory_layout
-                    .max_untrusted_advice_size as usize
-            }
-        };
-        AdviceClaimReductionLayout::balanced(
-            input.proof.trace_polynomial_order,
-            log_t,
-            input.proof.one_hot_config.committed_chunk_bits(),
-            max_size,
-        )
-    })
+    let log_t = input.checked.trace_length.ilog2() as usize;
+    let advice_layouts = crate::stages::advice_layouts(
+        input.proof.trace_polynomial_order,
+        log_t,
+        input.proof.one_hot_config.committed_chunk_bits(),
+        &input.checked.public_io.memory_layout,
+        input.checked.trusted_advice_commitment_present,
+        input.proof.untrusted_advice_commitment.is_some(),
+    );
+    match kind {
+        JoltAdviceKind::Trusted => advice_layouts.trusted,
+        JoltAdviceKind::Untrusted => advice_layouts.untrusted,
+    }
 }
 
 #[expect(

--- a/crates/jolt-verifier/src/stages/zk/blindfold/mod.rs
+++ b/crates/jolt-verifier/src/stages/zk/blindfold/mod.rs
@@ -1111,6 +1111,12 @@ where
     PCS: CommitmentScheme,
     VC: VectorCommitment<Field = PCS::Field>,
 {
+    // The cycle-phase relation references `FinalScale` only when the reduction
+    // finalizes at the cycle-phase handoff; otherwise the stage 7 address
+    // phase supplies it.
+    if layout.dimensions().has_address_phase() {
+        return Ok(());
+    }
     let source_point = advice_source_point(input, kind)?;
     let scale = layout
         .cycle_phase_final_output_scale(&source_point, &public.sumcheck_point)

--- a/crates/jolt-verifier/src/verifier.rs
+++ b/crates/jolt-verifier/src/verifier.rs
@@ -15,6 +15,7 @@ use crate::{
     stages::{
         stage1, stage2, stage3, stage4, stage5, stage6, stage7, stage8,
         zk::{blindfold, committed, inputs::BlindFoldInputs, outputs::zk_stage_outputs},
+        PrecommittedSchedule,
     },
     VerifierError,
 };
@@ -152,6 +153,7 @@ pub struct CheckedInputs {
     pub preprocessing_digest: [u8; 32],
     pub trusted_advice_commitment_present: bool,
     pub vc_capacity: Option<usize>,
+    pub precommitted: PrecommittedSchedule,
 }
 
 pub fn validate_inputs<PCS, VC, ZkProof>(
@@ -231,6 +233,15 @@ where
             .map_or(0, |position| position + 1),
     );
 
+    let precommitted = PrecommittedSchedule::new(
+        proof.trace_polynomial_order,
+        proof.trace_length.ilog2() as usize,
+        proof.one_hot_config.committed_chunk_bits(),
+        &preprocessing.program.memory_layout,
+        trusted_advice_commitment_present,
+        proof.untrusted_advice_commitment.is_some(),
+    );
+
     Ok(CheckedInputs {
         public_io: normalized_public_io,
         zk,
@@ -240,6 +251,7 @@ where
         preprocessing_digest: preprocessing.preprocessing_digest,
         trusted_advice_commitment_present,
         vc_capacity,
+        precommitted,
     })
 }
 

--- a/crates/jolt-verifier/src/verifier.rs
+++ b/crates/jolt-verifier/src/verifier.rs
@@ -237,10 +237,18 @@ where
         proof.trace_polynomial_order,
         proof.trace_length.ilog2() as usize,
         proof.one_hot_config.committed_chunk_bits(),
-        &preprocessing.program.memory_layout,
-        trusted_advice_commitment_present,
-        proof.untrusted_advice_commitment.is_some(),
-    );
+        trusted_advice_commitment_present
+            .then_some(preprocessing.program.memory_layout.max_trusted_advice_size as usize),
+        proof.untrusted_advice_commitment.is_some().then_some(
+            preprocessing
+                .program
+                .memory_layout
+                .max_untrusted_advice_size as usize,
+        ),
+    )
+    .map_err(|error| VerifierError::InvalidPrecommittedSchedule {
+        reason: error.to_string(),
+    })?;
 
     Ok(CheckedInputs {
         public_io: normalized_public_io,

--- a/crates/jolt-verifier/tests/soundness/tampering/sumcheck.rs
+++ b/crates/jolt-verifier/tests/soundness/tampering/sumcheck.rs
@@ -1416,10 +1416,15 @@ fn case_advice_layouts(base: &CoreVerifierCase) -> PrecommittedSchedule {
         base.proof.trace_polynomial_order,
         base.proof.trace_length.ilog2() as usize,
         base.proof.one_hot_config.committed_chunk_bits(),
-        &base.public_io.memory_layout,
-        base.trusted_advice_commitment.is_some(),
-        base.proof.untrusted_advice_commitment.is_some(),
+        base.trusted_advice_commitment
+            .is_some()
+            .then_some(base.public_io.memory_layout.max_trusted_advice_size as usize),
+        base.proof
+            .untrusted_advice_commitment
+            .is_some()
+            .then_some(base.public_io.memory_layout.max_untrusted_advice_size as usize),
     )
+    .unwrap_or_else(|error| panic!("precommitted schedule should build: {error}"))
 }
 
 #[cfg(all(feature = "core-fixtures", not(feature = "zk")))]

--- a/crates/jolt-verifier/tests/soundness/tampering/sumcheck.rs
+++ b/crates/jolt-verifier/tests/soundness/tampering/sumcheck.rs
@@ -30,7 +30,7 @@ use jolt_claims::protocols::jolt::{
         },
     },
     AdviceClaimReductionLayout, JoltAdviceKind, JoltCommittedPolynomial, JoltOpeningId,
-    JoltPolynomialId, JoltRelationId, JoltVirtualPolynomial,
+    JoltPolynomialId, JoltRelationId, JoltVirtualPolynomial, PrecommittedClaimReduction,
 };
 #[cfg(all(feature = "core-fixtures", not(feature = "zk")))]
 use jolt_field::{Fr, FromPrimitiveInt};
@@ -1409,30 +1409,55 @@ fn stage6_formula_output_openings(base: &CoreVerifierCase) -> Vec<(&'static str,
 }
 
 #[cfg(all(feature = "core-fixtures", not(feature = "zk")))]
-fn stage6_advice_output_openings(base: &CoreVerifierCase) -> Vec<(&'static str, JoltOpeningId)> {
+fn case_advice_layouts(
+    base: &CoreVerifierCase,
+) -> (
+    Option<AdviceClaimReductionLayout>,
+    Option<AdviceClaimReductionLayout>,
+) {
     let log_t = base.proof.trace_length.ilog2() as usize;
+    let log_k_chunk = base.proof.one_hot_config.committed_chunk_bits();
+    let trusted_max_bytes = base
+        .trusted_advice_commitment
+        .is_some()
+        .then_some(base.public_io.memory_layout.max_trusted_advice_size as usize);
+    let untrusted_max_bytes = base
+        .proof
+        .untrusted_advice_commitment
+        .is_some()
+        .then_some(base.public_io.memory_layout.max_untrusted_advice_size as usize);
+    let candidates = advice::precommitted_candidates(trusted_max_bytes, untrusted_max_bytes);
+    let scheduling_reference = PrecommittedClaimReduction::scheduling_reference(
+        log_t + log_k_chunk,
+        &candidates,
+        log_k_chunk,
+    );
+    let layout = |max_bytes: Option<usize>| {
+        max_bytes.map(|max_bytes| {
+            AdviceClaimReductionLayout::balanced(
+                base.proof.trace_polynomial_order,
+                log_t,
+                scheduling_reference,
+                max_bytes,
+            )
+        })
+    };
+    (layout(trusted_max_bytes), layout(untrusted_max_bytes))
+}
+
+#[cfg(all(feature = "core-fixtures", not(feature = "zk")))]
+fn stage6_advice_output_openings(base: &CoreVerifierCase) -> Vec<(&'static str, JoltOpeningId)> {
+    let (trusted_layout, untrusted_layout) = case_advice_layouts(base);
     let mut openings = Vec::new();
 
-    if base.trusted_advice_commitment.is_some() {
-        let layout = AdviceClaimReductionLayout::balanced(
-            base.proof.trace_polynomial_order,
-            log_t,
-            base.proof.one_hot_config.committed_chunk_bits(),
-            base.public_io.memory_layout.max_trusted_advice_size as usize,
-        );
+    if let Some(layout) = trusted_layout {
         openings.extend(
             advice::cycle_phase_output_openings(JoltAdviceKind::Trusted, layout.dimensions())
                 .into_iter()
                 .map(|id| ("stage6.claims.advice_cycle_phase.trusted.opening_claim", id)),
         );
     }
-    if base.proof.untrusted_advice_commitment.is_some() {
-        let layout = AdviceClaimReductionLayout::balanced(
-            base.proof.trace_polynomial_order,
-            log_t,
-            base.proof.one_hot_config.committed_chunk_bits(),
-            base.public_io.memory_layout.max_untrusted_advice_size as usize,
-        );
+    if let Some(layout) = untrusted_layout {
         openings.extend(
             advice::cycle_phase_output_openings(JoltAdviceKind::Untrusted, layout.dimensions())
                 .into_iter()
@@ -1481,36 +1506,20 @@ fn stage7_formula_output_openings(base: &CoreVerifierCase) -> Vec<(&'static str,
 
 #[cfg(all(feature = "core-fixtures", not(feature = "zk")))]
 fn stage7_advice_output_openings(base: &CoreVerifierCase) -> Vec<(&'static str, JoltOpeningId)> {
-    let log_t = base.proof.trace_length.ilog2() as usize;
+    let (trusted_layout, untrusted_layout) = case_advice_layouts(base);
     let mut openings = Vec::new();
 
-    if base.trusted_advice_commitment.is_some() {
-        let layout = AdviceClaimReductionLayout::balanced(
-            base.proof.trace_polynomial_order,
-            log_t,
-            base.proof.one_hot_config.committed_chunk_bits(),
-            base.public_io.memory_layout.max_trusted_advice_size as usize,
-        );
-        if layout.dimensions().has_address_phase() {
-            openings.push((
-                "stage7.claims.advice_address_phase.trusted.opening_claim",
-                advice::final_advice_opening(JoltAdviceKind::Trusted),
-            ));
-        }
+    if trusted_layout.is_some_and(|layout| layout.dimensions().has_address_phase()) {
+        openings.push((
+            "stage7.claims.advice_address_phase.trusted.opening_claim",
+            advice::final_advice_opening(JoltAdviceKind::Trusted),
+        ));
     }
-    if base.proof.untrusted_advice_commitment.is_some() {
-        let layout = AdviceClaimReductionLayout::balanced(
-            base.proof.trace_polynomial_order,
-            log_t,
-            base.proof.one_hot_config.committed_chunk_bits(),
-            base.public_io.memory_layout.max_untrusted_advice_size as usize,
-        );
-        if layout.dimensions().has_address_phase() {
-            openings.push((
-                "stage7.claims.advice_address_phase.untrusted.opening_claim",
-                advice::final_advice_opening(JoltAdviceKind::Untrusted),
-            ));
-        }
+    if untrusted_layout.is_some_and(|layout| layout.dimensions().has_address_phase()) {
+        openings.push((
+            "stage7.claims.advice_address_phase.untrusted.opening_claim",
+            advice::final_advice_opening(JoltAdviceKind::Untrusted),
+        ));
     }
 
     openings

--- a/crates/jolt-verifier/tests/soundness/tampering/sumcheck.rs
+++ b/crates/jolt-verifier/tests/soundness/tampering/sumcheck.rs
@@ -29,8 +29,8 @@ use jolt_claims::protocols::jolt::{
             SpartanOuterDimensions,
         },
     },
-    AdviceClaimReductionLayout, JoltAdviceKind, JoltCommittedPolynomial, JoltOpeningId,
-    JoltPolynomialId, JoltRelationId, JoltVirtualPolynomial, PrecommittedClaimReduction,
+    JoltAdviceKind, JoltCommittedPolynomial, JoltOpeningId, JoltPolynomialId, JoltRelationId,
+    JoltVirtualPolynomial,
 };
 #[cfg(all(feature = "core-fixtures", not(feature = "zk")))]
 use jolt_field::{Fr, FromPrimitiveInt};
@@ -42,6 +42,8 @@ use jolt_poly::{CompressedPoly, UnivariatePoly};
 use jolt_sumcheck::{ClearProof, SumcheckProof};
 #[cfg(all(feature = "core-fixtures", not(feature = "zk")))]
 use jolt_verifier::compat::claims::{offset_opening_claim, opening_claim, upsert_opening_claim};
+#[cfg(all(feature = "core-fixtures", not(feature = "zk")))]
+use jolt_verifier::stages::PrecommittedSchedule;
 
 #[cfg(all(feature = "core-fixtures", not(feature = "zk")))]
 #[test]
@@ -1409,45 +1411,21 @@ fn stage6_formula_output_openings(base: &CoreVerifierCase) -> Vec<(&'static str,
 }
 
 #[cfg(all(feature = "core-fixtures", not(feature = "zk")))]
-fn case_advice_layouts(
-    base: &CoreVerifierCase,
-) -> (
-    Option<AdviceClaimReductionLayout>,
-    Option<AdviceClaimReductionLayout>,
-) {
-    let log_t = base.proof.trace_length.ilog2() as usize;
-    let log_k_chunk = base.proof.one_hot_config.committed_chunk_bits();
-    let trusted_max_bytes = base
-        .trusted_advice_commitment
-        .is_some()
-        .then_some(base.public_io.memory_layout.max_trusted_advice_size as usize);
-    let untrusted_max_bytes = base
-        .proof
-        .untrusted_advice_commitment
-        .is_some()
-        .then_some(base.public_io.memory_layout.max_untrusted_advice_size as usize);
-    let candidates = advice::precommitted_candidates(trusted_max_bytes, untrusted_max_bytes);
-    let scheduling_reference = PrecommittedClaimReduction::scheduling_reference(
-        log_t + log_k_chunk,
-        &candidates,
-        log_k_chunk,
-    );
-    let layout = |max_bytes: Option<usize>| {
-        max_bytes.map(|max_bytes| {
-            AdviceClaimReductionLayout::balanced(
-                base.proof.trace_polynomial_order,
-                log_t,
-                scheduling_reference,
-                max_bytes,
-            )
-        })
-    };
-    (layout(trusted_max_bytes), layout(untrusted_max_bytes))
+fn case_advice_layouts(base: &CoreVerifierCase) -> PrecommittedSchedule {
+    PrecommittedSchedule::new(
+        base.proof.trace_polynomial_order,
+        base.proof.trace_length.ilog2() as usize,
+        base.proof.one_hot_config.committed_chunk_bits(),
+        &base.public_io.memory_layout,
+        base.trusted_advice_commitment.is_some(),
+        base.proof.untrusted_advice_commitment.is_some(),
+    )
 }
 
 #[cfg(all(feature = "core-fixtures", not(feature = "zk")))]
 fn stage6_advice_output_openings(base: &CoreVerifierCase) -> Vec<(&'static str, JoltOpeningId)> {
-    let (trusted_layout, untrusted_layout) = case_advice_layouts(base);
+    let schedule = case_advice_layouts(base);
+    let (trusted_layout, untrusted_layout) = (schedule.trusted_advice, schedule.untrusted_advice);
     let mut openings = Vec::new();
 
     if let Some(layout) = trusted_layout {
@@ -1506,7 +1484,8 @@ fn stage7_formula_output_openings(base: &CoreVerifierCase) -> Vec<(&'static str,
 
 #[cfg(all(feature = "core-fixtures", not(feature = "zk")))]
 fn stage7_advice_output_openings(base: &CoreVerifierCase) -> Vec<(&'static str, JoltOpeningId)> {
-    let (trusted_layout, untrusted_layout) = case_advice_layouts(base);
+    let schedule = case_advice_layouts(base);
+    let (trusted_layout, untrusted_layout) = (schedule.trusted_advice, schedule.untrusted_advice);
     let mut openings = Vec::new();
 
     if trusted_layout.is_some_and(|layout| layout.dimensions().has_address_phase()) {


### PR DESCRIPTION
## Summary
- Ports jolt-core #1572 (precommitted polynomial reductions) into the modular verifier stack — step 02 of porting the bytecode-commitment series (#1571–#1584) into `crates/`.
- Advice claim reductions now run on a shared `PrecommittedClaimReduction` schedule: a reference domain spanning the main trace and all precommitted candidates, a Dory opening-round permutation projected per polynomial, full-phase round counts, and distinct cycle-only vs full `(1/2)^gap` skip scales.
- Stage 8 mirrors core's `compute_final_opening_point`: the unified opening point is assembled from the stage-6 inc-reduction cycle challenges and stage-7 hamming address challenges (trace-order dependent), with dominant-precommitted anchoring and a uniform per-claim Lagrange embedding scale replacing the previous special-cased scales.

## Changes
- `jolt-claims`: new `formulas/claim_reductions/precommitted.rs` (scheduling reference + per-poly round schedule; core's Dory globals are parameter-passed — `joint_col_vars` reduces to `ceil(rtv/2)` after the stage-6 re-embedding); `advice.rs` rewritten on top of it; `committed_openings.rs` adds `final_opening_point` and generalizes `advice_commitment_embedding_scale` → `commitment_embedding_scale`; new structured error variants.
- `jolt-verifier`: shared `stages::advice_layouts` helper (both advice kinds must share one scheduling reference), stage-6b/7 wiring, stage-8 clear+ZK rewrite (single point used for both PCS verify and transcript binding), blindfold layout plumbing, tampering-test helpers.
- Tests: jolt-claims layout tests re-pinned to the new schedule; new unit tests for skip scales, dominance permutation, and final-point assembly (passthrough, AddressMajor ordering, dominant-anchor agreement/mismatch).

Committed bytecode chunks and the program image (#1583/#1584) plug into this same scheduling as additional candidates in the follow-up port steps; this PR keeps the candidate list advice-only.

## Testing
Validated against jolt-core pinned at #1572 (`7f97cbad1`), where the regression is isolated (current main additionally diverges at stage 1 from #1583/#1584 — out of scope here, next port step):
- `standard_advice_consumer_core_proof_is_accepted`: failing (`StageClaimOutputMismatch { HammingWeightClaimReduction }`) → **passing**; muldiv stays green.
- Full `-p jolt-verifier --features core-fixtures` suite: **110/110** (incl. stage-4/6/7 advice tampering rejections).
- `--features core-fixtures,zk` suite: **71/71**.
- At HEAD: 170 jolt-claims/jolt-verifier unit tests pass; `cargo clippy -D warnings` clean for `host`, `host,zk`, `core-fixtures`, `core-fixtures,zk`.

Spec: `specs/1344-committed-bytecode-program-image.md`. Core counterpart: #1572.