### PR TITLE
fix: repair jolt CLI install resolution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1407,7 +1407,7 @@ checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 name = "common"
 version = "0.2.0"
 dependencies = [
- "allocative 0.3.4 (git+https://github.com/facebookexperimental/allocative?rev=85b773d85d526d068ce94724ff7a7b81203fc95e)",
+ "allocative 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "ark-serialize 0.5.0 (git+https://github.com/a16z/arkworks-algebra?branch=dev%2Ftwist-shout)",
  "serde",
  "syn 2.0.117",
@@ -2843,7 +2843,7 @@ dependencies = [
 name = "jolt-core"
 version = "0.1.0"
 dependencies = [
- "allocative 0.3.4 (git+https://github.com/facebookexperimental/allocative?rev=85b773d85d526d068ce94724ff7a7b81203fc95e)",
+ "allocative 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "ark-bn254 0.5.0 (git+https://github.com/a16z/arkworks-algebra?branch=dev%2Ftwist-shout)",
  "ark-ec 0.5.0 (git+https://github.com/a16z/arkworks-algebra?branch=dev%2Ftwist-shout)",
  "ark-ff 0.5.0 (git+https://github.com/a16z/arkworks-algebra?branch=dev%2Ftwist-shout)",
@@ -2983,7 +2983,7 @@ dependencies = [
 name = "jolt-field"
 version = "0.1.0"
 dependencies = [
- "allocative 0.3.4 (git+https://github.com/facebookexperimental/allocative?rev=85b773d85d526d068ce94724ff7a7b81203fc95e)",
+ "allocative 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "ark-bn254 0.5.0 (git+https://github.com/a16z/arkworks-algebra?branch=dev%2Ftwist-shout)",
  "ark-ff 0.5.0 (git+https://github.com/a16z/arkworks-algebra?branch=dev%2Ftwist-shout)",
  "ark-serialize 0.5.0 (git+https://github.com/a16z/arkworks-algebra?branch=dev%2Ftwist-shout)",
@@ -3221,7 +3221,7 @@ dependencies = [
 name = "jolt-profiling"
 version = "0.1.0"
 dependencies = [
- "allocative 0.3.4 (git+https://github.com/facebookexperimental/allocative?rev=85b773d85d526d068ce94724ff7a7b81203fc95e)",
+ "allocative 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "inferno 0.12.6",
  "memory-stats",
  "pprof",
@@ -7287,7 +7287,7 @@ dependencies = [
 name = "zklean-extractor"
 version = "0.1.0"
 dependencies = [
- "allocative 0.3.4 (git+https://github.com/facebookexperimental/allocative?rev=85b773d85d526d068ce94724ff7a7b81203fc95e)",
+ "allocative 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "ark-bn254 0.5.0 (git+https://github.com/a16z/arkworks-algebra?branch=dev%2Ftwist-shout)",
  "ark-ff 0.5.0 (git+https://github.com/a16z/arkworks-algebra?branch=dev%2Ftwist-shout)",
  "ark-serialize 0.5.0 (git+https://github.com/a16z/arkworks-algebra?branch=dev%2Ftwist-shout)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -127,15 +127,9 @@ dependencies = [
 
 [[package]]
 name = "allocative"
-version = "0.3.4"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fac2ce611db8b8cee9b2aa886ca03c924e9da5e5295d0dbd0526e5d0b0710f7"
-replace = "allocative 0.3.4 (git+https://github.com/facebookexperimental/allocative?rev=85b773d85d526d068ce94724ff7a7b81203fc95e)"
-
-[[package]]
-name = "allocative"
-version = "0.3.4"
-source = "git+https://github.com/facebookexperimental/allocative?rev=85b773d85d526d068ce94724ff7a7b81203fc95e#85b773d85d526d068ce94724ff7a7b81203fc95e"
+checksum = "d8cf9afc79c83d514444b55df3935d317da54b1ce3b17a133c646889cc260de8"
 dependencies = [
  "allocative_derive",
  "ctor",
@@ -143,8 +137,9 @@ dependencies = [
 
 [[package]]
 name = "allocative_derive"
-version = "0.3.3"
-source = "git+https://github.com/facebookexperimental/allocative?rev=85b773d85d526d068ce94724ff7a7b81203fc95e#85b773d85d526d068ce94724ff7a7b81203fc95e"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "614043c56c1173b800acb007b81fd0cbc0a0d7d717b71ba705fc2230d0760a23"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -682,7 +677,7 @@ name = "ark-ff"
 version = "0.5.0"
 source = "git+https://github.com/a16z/arkworks-algebra?branch=dev%2Ftwist-shout#76bb3a4518928f1ff7f15875f940d614bb9845e6"
 dependencies = [
- "allocative 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "allocative",
  "ark-ff-asm 0.5.0",
  "ark-ff-macros 0.5.0",
  "ark-serialize 0.5.0 (git+https://github.com/a16z/arkworks-algebra?branch=dev%2Ftwist-shout)",
@@ -1407,7 +1402,7 @@ checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 name = "common"
 version = "0.2.0"
 dependencies = [
- "allocative 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "allocative",
  "ark-serialize 0.5.0 (git+https://github.com/a16z/arkworks-algebra?branch=dev%2Ftwist-shout)",
  "serde",
  "syn 2.0.117",
@@ -1665,12 +1660,12 @@ dependencies = [
 
 [[package]]
 name = "ctor"
-version = "0.1.26"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d2301688392eb071b0bf1a37be05c469d3cc4dbbd95df672fe28ab021e6a096"
+checksum = "01334b89b69ff726750c5ce5073fc8bd860e99aa9a8fc5ca11b04730e3aee97a"
 dependencies = [
- "quote",
- "syn 1.0.109",
+ "link-section",
+ "linktime-proc-macro",
 ]
 
 [[package]]
@@ -2843,7 +2838,7 @@ dependencies = [
 name = "jolt-core"
 version = "0.1.0"
 dependencies = [
- "allocative 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "allocative",
  "ark-bn254 0.5.0 (git+https://github.com/a16z/arkworks-algebra?branch=dev%2Ftwist-shout)",
  "ark-ec 0.5.0 (git+https://github.com/a16z/arkworks-algebra?branch=dev%2Ftwist-shout)",
  "ark-ff 0.5.0 (git+https://github.com/a16z/arkworks-algebra?branch=dev%2Ftwist-shout)",
@@ -2983,7 +2978,7 @@ dependencies = [
 name = "jolt-field"
 version = "0.1.0"
 dependencies = [
- "allocative 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "allocative",
  "ark-bn254 0.5.0 (git+https://github.com/a16z/arkworks-algebra?branch=dev%2Ftwist-shout)",
  "ark-ff 0.5.0 (git+https://github.com/a16z/arkworks-algebra?branch=dev%2Ftwist-shout)",
  "ark-serialize 0.5.0 (git+https://github.com/a16z/arkworks-algebra?branch=dev%2Ftwist-shout)",
@@ -3221,7 +3216,7 @@ dependencies = [
 name = "jolt-profiling"
 version = "0.1.0"
 dependencies = [
- "allocative 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "allocative",
  "inferno 0.12.6",
  "memory-stats",
  "pprof",
@@ -3457,6 +3452,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "link-section"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2b1dd6fe32e55c0fc0ea9493aa57459ca3cf4ff3c857c7d0302290150da6e4f"
+
+[[package]]
 name = "linked_list_allocator"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3464,6 +3465,12 @@ checksum = "9afa463f5405ee81cdb9cc2baf37e08ec7e4c8209442b5d72c04cfb2cd6e6286"
 dependencies = [
  "spinning_top",
 ]
+
+[[package]]
+name = "linktime-proc-macro"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c7b0a3383c2a1002d11349c92c85a666a5fb679e96c79d782cf0dbe557fd6ee"
 
 [[package]]
 name = "linux-raw-sys"
@@ -7287,7 +7294,7 @@ dependencies = [
 name = "zklean-extractor"
 version = "0.1.0"
 dependencies = [
- "allocative 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "allocative",
  "ark-bn254 0.5.0 (git+https://github.com/a16z/arkworks-algebra?branch=dev%2Ftwist-shout)",
  "ark-ff 0.5.0 (git+https://github.com/a16z/arkworks-algebra?branch=dev%2Ftwist-shout)",
  "ark-serialize 0.5.0 (git+https://github.com/a16z/arkworks-algebra?branch=dev%2Ftwist-shout)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -172,7 +172,6 @@ codegen-units = 1
 "ark-ff:0.5.0" = { git = "https://github.com/a16z/arkworks-algebra", branch = "dev/twist-shout" }
 "ark-ec:0.5.0" = { git = "https://github.com/a16z/arkworks-algebra", branch = "dev/twist-shout" }
 "ark-serialize:0.5.0" = { git = "https://github.com/a16z/arkworks-algebra", branch = "dev/twist-shout" }
-"allocative:0.3.4" = { git = "https://github.com/facebookexperimental/allocative", rev = "85b773d85d526d068ce94724ff7a7b81203fc95e" }
 
 [workspace.metadata.cargo-machete]
 ignored = ["jolt-sdk"]
@@ -324,7 +323,7 @@ tracing = { version = "0.1.37", default-features = false, features = [
 tracing-chrome = "0.7.1"
 tracing-subscriber = { version = "0.3.23", features = ["fmt", "env-filter"] }
 inferno = { version = "0.12.3" }
-allocative = { version = "=0.3.4" }
+allocative = { version = "=0.3.6" }
 pprof = { version = "0.15", features = [
   "prost-codec",
   "flamegraph",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -324,7 +324,7 @@ tracing = { version = "0.1.37", default-features = false, features = [
 tracing-chrome = "0.7.1"
 tracing-subscriber = { version = "0.3.23", features = ["fmt", "env-filter"] }
 inferno = { version = "0.12.3" }
-allocative = { git = "https://github.com/facebookexperimental/allocative", rev = "85b773d85d526d068ce94724ff7a7b81203fc95e" }
+allocative = { version = "=0.3.4" }
 pprof = { version = "0.15", features = [
   "prost-codec",
   "flamegraph",

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ For developers looking to contribute to Jolt, follow the instructions below.
 
 ## Installation
 
-You will need Rust [nightly](./rust-toolchain.toml).
+You will need the Rust toolchain pinned in [rust-toolchain.toml](./rust-toolchain.toml).
 
 If you have `rustup` installed, you do not need to do anything as it will
 automatically install the correct toolchain and any additional targets on the

--- a/book/src/usage/quickstart.md
+++ b/book/src/usage/quickstart.md
@@ -16,7 +16,7 @@ curl -sfL jolt.rs/skill | bash
 ## Installing
 Start by installing the `jolt` command line tool.
 ```
-cargo +nightly install --git https://github.com/a16z/jolt --force --bins jolt
+cargo install --git https://github.com/a16z/jolt --force --bins jolt
 ```
 
 ## Creating a Project


### PR DESCRIPTION
## Summary
- use released crates.io `allocative = =0.3.6`, which includes the `i128`/`u128` `Allocative` impl fix previously pinned via git
- drop the stale `[replace]` git pin to `facebookexperimental/allocative`
- update install docs to use stable cargo commands and remove the `+nightly` install instruction

## Root cause
`cargo install` ignores the repository `Cargo.lock` unless `--locked`, so the install graph was freshly resolved. Before this PR, Jolt directly used a git-pinned `allocative` 0.3.4 while transitive arkworks dependencies accepted crates.io `allocative` `^0.3.4` and resolved to a different published version. That created two distinct `Allocative` traits in the graph; arkworks field types implemented one, while `jolt-core` required the other, producing the `Fp<MontBackend<FrConfig, 4>, 4>: Allocative` failure.

The original git pin targeted `facebookexperimental/allocative` rev `85b773d85d526d068ce94724ff7a7b81203fc95e` (`Implement Allocative for i128 and u128 (#16)`). That fix is now published in crates.io `allocative` 0.3.6, so this PR removes the git pin and uses the released crate directly.

`facebookexperimental/allocative` is now archived; its README says maintenance has moved to `https://github.com/facebook/buck2`. Since the fix is released, no replacement git URL is needed.

## Verification
- `cargo install --path . --force` on stable toolchain 1.95: succeeds
- `cargo install --git https://github.com/a16z/jolt --branch fix-install-flow --force --bins jolt` on stable: succeeds
- `jolt --version`: `jolt 0.1.0 (9dadb855f 2026-06-17)`
- `cargo fmt -q --message-format=short`
- `cargo clippy --all --features host -q --all-targets --message-format=short -- -D warnings`
- `cargo clippy --all --features host,zk -q --all-targets --message-format=short -- -D warnings`
