### PR TITLE
docs: add safety documentation to jolt-platform random functions

### DIFF
--- a/jolt-platform/src/random.rs
+++ b/jolt-platform/src/random.rs
@@ -7,7 +7,17 @@ static mut RNG: Option<StdRng> = None;
 
 // Warning: This is a deterministic PRNG implementation. We could allow the prover/verifier to agree on a seed in the future.
 // No atomics support so we're using a static mutable variable
-#[allow(clippy::missing_safety_doc)]
+
+/// Fills `dest` with `len` pseudo-random bytes from a deterministic PRNG.
+///
+/// # Safety
+///
+/// - `dest` must point to a valid, writable buffer of at least `len` bytes.
+/// - `dest` must be properly aligned for `u8`.
+/// - The memory region `[dest, dest + len)` must not overlap with the internal
+///   `RNG` static.
+/// - This function is **not** thread-safe; it mutates a global static without
+///   synchronization. Callers must ensure exclusive access.
 #[no_mangle]
 pub unsafe fn sys_rand(dest: *mut u8, len: usize) {
     crate::println!("Warning: sys_rand is a deterministic PRNG, not a cryptographically secure RNG. Use with caution.");
@@ -29,9 +39,11 @@ pub unsafe fn sys_rand(dest: *mut u8, len: usize) {
     }
 }
 
-#[allow(clippy::missing_safety_doc)]
 #[no_mangle]
 pub fn _getrandom_v02(s: &mut [u8]) -> Result<(), getrandom_v02::Error> {
+    // SAFETY: s is a valid mutable slice, so its pointer and length satisfy sys_rand's requirements.
+    // Not thread-safe (sys_rand uses a global static), but this is acceptable in the single-threaded
+    // guest environment where getrandom is called.
     unsafe {
         sys_rand(s.as_mut_ptr(), s.len());
     }
@@ -39,12 +51,20 @@ pub fn _getrandom_v02(s: &mut [u8]) -> Result<(), getrandom_v02::Error> {
     Ok(())
 }
 
-#[allow(clippy::missing_safety_doc)]
+/// Custom `getrandom` v0.3 backend for the Jolt guest environment.
+///
+/// # Safety
+///
+/// - `dest` must point to a valid, writable buffer of at least `len` bytes.
+/// - `dest` must be properly aligned for `u8`.
+/// - This function is **not** thread-safe; it delegates to [`sys_rand`] which
+///   mutates a global static without synchronization.
 #[unsafe(no_mangle)]
 unsafe extern "Rust" fn __getrandom_v03_custom(
     dest: *mut u8,
     len: usize,
 ) -> Result<(), getrandom_v03::Error> {
+    // SAFETY: Caller guarantees dest and len satisfy sys_rand's safety requirements.
     sys_rand(dest, len);
 
     Ok(())


### PR DESCRIPTION
## Summary

<!-- What does this PR do and why? Link to relevant issues. -->

Remove three #[allow(clippy::missing_safety_doc)] suppressions in jolt-platform/src/random.rs by adding proper # Safety documentation to the unsafe fn items. Also add // SAFETY: comments to unsafe blocks that were previously undocumented, aligning with the workspace-level undocumented_unsafe_blocks = "deny" lint.


## Changes

<!-- Bulleted list of key changes. -->

- Add # Safety doc comment to sys_rand documenting raw-pointer requirements and thread-safety constraints
- Remove unnecessary #[allow] from _getrandom_v02 (safe function; lint does not apply) and add // SAFETY: comment to its internal unsafe block
- Add # Safety doc comment to __getrandom_v03_custom and // SAFETY: comment to its delegate call

## Testing

<!-- How was this tested? Which tests cover this change? -->

- [ ] Ran tests for modified crates
- [x] `cargo clippy` and `cargo fmt` pass

## Security Considerations

<!-- Every change to a zkVM has security implications. Describe them.
     Does this affect proof soundness? Verifier correctness? Private inputs? -->

## Breaking Changes

<!-- List any breaking changes to public APIs, proof formats, or serialization. Write "None" if not applicable. -->

None
