### PR TITLE
Reorganize opcode 0x5B to allow for more custom instructions

### DIFF
--- a/crates/jolt-program/src/image/decode.rs
+++ b/crates/jolt-program/src/image/decode.rs
@@ -180,20 +180,22 @@ fn decode_system(word: u32) -> Result<SourceInstructionKind, ProgramError> {
 }
 
 fn decode_custom(word: u32) -> Result<SourceInstructionKind, ProgramError> {
-    match funct3(word) {
-        0b000 => Ok(SourceInstructionKind::VirtualRev8W(
+    let funct3 = funct3(word);
+    let funct7 = funct7(word);
+    match (funct3, funct7) {
+        (0b000, 0x00) => Ok(SourceInstructionKind::AdviceLB),
+        (0b000, 0x01) => Ok(SourceInstructionKind::AdviceLH),
+        (0b000, 0x02) => Ok(SourceInstructionKind::AdviceLW),
+        (0b000, 0x03) => Ok(SourceInstructionKind::AdviceLD),
+        (0b000, 0x04) => Ok(SourceInstructionKind::VirtualAdviceLen(
+            jolt_riscv::instructions::VirtualAdviceLen(()),
+        )),
+        (0b000, 0x05) => Ok(SourceInstructionKind::VirtualRev8W(
             jolt_riscv::instructions::VirtualRev8W(()),
         )),
-        0b001 => Ok(SourceInstructionKind::VirtualAssertEQ),
-        0b010 => Ok(SourceInstructionKind::VirtualHostIO(
+        (0b001, _) => Ok(SourceInstructionKind::VirtualAssertEQ),
+        (0b010, _) => Ok(SourceInstructionKind::VirtualHostIO(
             jolt_riscv::instructions::VirtualHostIO(()),
-        )),
-        0b011 => Ok(SourceInstructionKind::AdviceLB),
-        0b100 => Ok(SourceInstructionKind::AdviceLH),
-        0b101 => Ok(SourceInstructionKind::AdviceLW),
-        0b110 => Ok(SourceInstructionKind::AdviceLD),
-        0b111 => Ok(SourceInstructionKind::VirtualAdviceLen(
-            jolt_riscv::instructions::VirtualAdviceLen(()),
         )),
         _ => invalid("invalid custom instruction"),
     }

--- a/crates/jolt-program/src/image/decode.rs
+++ b/crates/jolt-program/src/image/decode.rs
@@ -283,6 +283,9 @@ fn operands(instruction_kind: SourceInstructionKind, word: u32) -> NormalizedOpe
         | SourceInstructionKind::AdviceLH
         | SourceInstructionKind::AdviceLW
         | SourceInstructionKind::AdviceLD => format_advice_load_operands(word),
+        SourceInstructionKind::VirtualRev8W(jolt_riscv::instructions::VirtualRev8W(())) => {
+            format_t_operands(word)
+        }
         #[cfg(feature = "field-inline")]
         SourceInstructionKind::FIELD_ADD
         | SourceInstructionKind::FIELD_SUB
@@ -380,8 +383,7 @@ fn uses_r_format(instruction_kind: SourceInstructionKind) -> bool {
             | SourceInstructionKind::MULW
             | SourceInstructionKind::DIVUW
             | SourceInstructionKind::REMW
-            | SourceInstructionKind::REMUW
-            | SourceInstructionKind::VirtualRev8W(jolt_riscv::instructions::VirtualRev8W(()))
+            | SourceInstructionKind::REMUW //| SourceInstructionKind::VirtualRev8W(jolt_riscv::instructions::VirtualRev8W(()))
     )
 }
 
@@ -418,6 +420,15 @@ fn format_advice_load_operands(word: u32) -> NormalizedOperands {
         rs1: None,
         rs2: None,
         imm: (word as i32 as i64 as u64) as i128,
+    }
+}
+
+fn format_t_operands(word: u32) -> NormalizedOperands {
+    NormalizedOperands {
+        rd: Some(rd(word)),
+        rs1: Some(rs1(word)),
+        rs2: None,
+        imm: 0,
     }
 }
 

--- a/crates/jolt-program/src/image/decode.rs
+++ b/crates/jolt-program/src/image/decode.rs
@@ -419,7 +419,7 @@ fn format_advice_load_operands(word: u32) -> NormalizedOperands {
         rd: Some(rd(word)),
         rs1: None,
         rs2: None,
-        imm: (word as i32 as i64 as u64) as i128,
+        imm: 0,
     }
 }
 

--- a/crates/jolt-program/src/image/decode.rs
+++ b/crates/jolt-program/src/image/decode.rs
@@ -383,7 +383,7 @@ fn uses_r_format(instruction_kind: SourceInstructionKind) -> bool {
             | SourceInstructionKind::MULW
             | SourceInstructionKind::DIVUW
             | SourceInstructionKind::REMW
-            | SourceInstructionKind::REMUW //| SourceInstructionKind::VirtualRev8W(jolt_riscv::instructions::VirtualRev8W(()))
+            | SourceInstructionKind::REMUW
     )
 }
 

--- a/crates/jolt-program/src/image/decode.rs
+++ b/crates/jolt-program/src/image/decode.rs
@@ -381,6 +381,7 @@ fn uses_r_format(instruction_kind: SourceInstructionKind) -> bool {
             | SourceInstructionKind::DIVUW
             | SourceInstructionKind::REMW
             | SourceInstructionKind::REMUW
+            | SourceInstructionKind::VirtualRev8W(jolt_riscv::instructions::VirtualRev8W(()))
     )
 }
 

--- a/jolt-inlines/sha2/src/lib.rs
+++ b/jolt-inlines/sha2/src/lib.rs
@@ -3,9 +3,10 @@
 #![cfg_attr(not(feature = "host"), no_std)]
 
 pub const INLINE_OPCODE: u32 = 0x0B;
-pub const VIRTUAL_INSTRUCTION_TYPE_I_OPCODE: u32 = 0x5B;
+pub const CUSTOM_OPCODE: u32 = 0x5B;
 
-pub const REV8W_FUNCT3: u32 = 0x00;
+pub const FUNCT3_VIRTUAL_R: u8 = 0b000;
+pub const FUNCT7_VIRTUAL_REV8W: u32 = 0x05;
 
 pub const SHA256_FUNCT3: u32 = 0x00;
 pub const SHA256_FUNCT7: u32 = 0x00;

--- a/jolt-inlines/sha2/src/sdk.rs
+++ b/jolt-inlines/sha2/src/sdk.rs
@@ -440,9 +440,10 @@ pub(crate) unsafe fn sha256_compression_initial(_input: *const u32, _state: *mut
 fn swap_bytes(mut v: u32) -> u32 {
     unsafe {
         core::arch::asm!(
-            ".insn i {opcode}, {funct3}, {r_inout}, {r_inout}, 0",
-            opcode = const crate::VIRTUAL_INSTRUCTION_TYPE_I_OPCODE,
-            funct3 = const crate::REV8W_FUNCT3,
+            ".insn r {opcode}, {funct3}, {funct7}, {r_inout}, {r_inout}, x0",
+            opcode = const crate::CUSTOM_OPCODE,
+            funct3 = const crate::FUNCT3_VIRTUAL_R,
+            funct7 = const crate::FUNCT7_VIRTUAL_REV8W,
             r_inout = inout(reg) v,
             options(nostack)
         );

--- a/jolt-sdk/src/lib.rs
+++ b/jolt-sdk/src/lib.rs
@@ -8,17 +8,19 @@ extern crate jolt_sdk_macros;
 #[doc(hidden)]
 pub const CUSTOM_OPCODE: u32 = 0x5B; // Custom instructions opcode
 #[doc(hidden)]
+pub const FUNCT3_VIRTUAL_R: u32 = 0b000; // Virtual R-type instructions funct3
+#[doc(hidden)]
 pub const FUNCT3_VIRTUAL_ASSERT_EQ: u32 = 0b001; // VirtualAssertEQ funct3
 #[doc(hidden)]
-pub const FUNCT3_ADVICE_LB: u32 = 0b011; // Load byte from advice tape
+pub const FUNCT7_ADVICE_LB: u32 = 0x00; // Load byte from advice tape
 #[doc(hidden)]
-pub const FUNCT3_ADVICE_LH: u32 = 0b100; // Load halfword from advice tape
+pub const FUNCT7_ADVICE_LH: u32 = 0x01; // Load halfword from advice tape
 #[doc(hidden)]
-pub const FUNCT3_ADVICE_LW: u32 = 0b101; // Load word from advice tape
+pub const FUNCT7_ADVICE_LW: u32 = 0x02; // Load word from advice tape
 #[doc(hidden)]
-pub const FUNCT3_ADVICE_LD: u32 = 0b110; // Load doubleword from advice tape
+pub const FUNCT7_ADVICE_LD: u32 = 0x03; // Load doubleword from advice tape
 #[doc(hidden)]
-pub const FUNCT3_ADVICE_LEN: u32 = 0b111; // Get number of remaining bytes in advice tape
+pub const FUNCT7_ADVICE_LEN: u32 = 0x04; // Get number of remaining bytes in advice tape
 
 #[doc(hidden)]
 pub const FIELD_INLINE_OPCODE: u32 = 0x7b;
@@ -368,9 +370,10 @@ impl AdviceReader {
         let x;
         unsafe {
             core::arch::asm!(
-                ".insn i {opcode}, {funct3}, {rd}, x0, 0",
+                ".insn r {opcode}, {funct3}, {funct7}, {rd}, x0, x0",
                 opcode = const CUSTOM_OPCODE,
-                funct3 = const FUNCT3_ADVICE_LB,
+                funct3 = const FUNCT3_VIRTUAL_R,
+                funct7 = const FUNCT7_ADVICE_LB,
                 rd = out(reg) x,
                 options(nostack)
             );
@@ -387,9 +390,10 @@ impl AdviceReader {
         let x;
         unsafe {
             core::arch::asm!(
-                ".insn i {opcode}, {funct3}, {rd}, x0, 0",
+                ".insn r {opcode}, {funct3}, {funct7}, {rd}, x0, x0",
                 opcode = const CUSTOM_OPCODE,
-                funct3 = const FUNCT3_ADVICE_LH,
+                funct3 = const FUNCT3_VIRTUAL_R,
+                funct7 = const FUNCT7_ADVICE_LH,
                 rd = out(reg) x,
                 options(nostack)
             );
@@ -406,9 +410,10 @@ impl AdviceReader {
         let x;
         unsafe {
             core::arch::asm!(
-                ".insn i {opcode}, {funct3}, {rd}, x0, 0",
+                ".insn r {opcode}, {funct3}, {funct7}, {rd}, x0, x0",
                 opcode = const CUSTOM_OPCODE,
-                funct3 = const FUNCT3_ADVICE_LW,
+                funct3 = const FUNCT3_VIRTUAL_R,
+                funct7 = const FUNCT7_ADVICE_LW,
                 rd = out(reg) x,
                 options(nostack)
             );
@@ -434,9 +439,10 @@ impl AdviceReader {
         let x;
         unsafe {
             core::arch::asm!(
-                ".insn i {opcode}, {funct3}, {rd}, x0, 0",
+                ".insn r {opcode}, {funct3}, {funct7}, {rd}, x0, x0",
                 opcode = const CUSTOM_OPCODE,
-                funct3 = const FUNCT3_ADVICE_LD,
+                funct3 = const FUNCT3_VIRTUAL_R,
+                funct7 = const FUNCT7_ADVICE_LD,
                 rd = out(reg) x,
                 options(nostack)
             );
@@ -455,9 +461,10 @@ impl AdviceReader {
         // Encode as I-format: opcode | rd | funct3 | rs1=x0 | imm=0
         unsafe {
             core::arch::asm!(
-                ".insn i {opcode}, {funct3}, {rd}, x0, 0",
+                ".insn r {opcode}, {funct3}, {funct7}, {rd}, x0, x0",
                 opcode = const CUSTOM_OPCODE,
-                funct3 = const FUNCT3_ADVICE_LEN,
+                funct3 = const FUNCT3_VIRTUAL_R,
+                funct7 = const FUNCT7_ADVICE_LEN,
                 rd = out(reg) remaining,
                 options(nostack)
             );

--- a/tracer/src/instruction/format/format_advice_load_i.rs
+++ b/tracer/src/instruction/format/format_advice_load_i.rs
@@ -12,7 +12,6 @@ use super::{
 #[derive(Default, Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
 pub struct FormatAdviceLoadI {
     pub rd: u8,
-    pub imm: u64,
 }
 
 #[derive(Default, Debug, Copy, Clone, Serialize, Deserialize, PartialEq)]
@@ -39,8 +38,7 @@ impl InstructionFormat for FormatAdviceLoadI {
 
     fn parse(word: u32) -> Self {
         FormatAdviceLoadI {
-            rd: ((word >> 7) & 0x1f) as u8,   // [11:7]
-            imm: (word as i32 as i64) as u64, // sign-extended immediate from [31:20]
+            rd: ((word >> 7) & 0x1f) as u8, // [11:7]
         }
     }
 
@@ -54,21 +52,10 @@ impl InstructionFormat for FormatAdviceLoadI {
 
     #[cfg(any(feature = "test-utils", test))]
     fn random(rng: &mut rand::rngs::StdRng) -> Self {
-        use common::constants::{RISCV_REGISTER_COUNT, XLEN};
+        use common::constants::RISCV_REGISTER_COUNT;
         use rand::RngCore;
 
-        let mut imm = rng.next_u64();
-
-        let (shift, len) = match XLEN {
-            32 => (imm & 0x1f, 32),
-            64 => (imm & 0x3f, 64),
-            _ => panic!(),
-        };
-        let ones = (1u128 << (len - shift)) - 1;
-        imm = (ones << shift) as u64;
-
         Self {
-            imm,
             rd: (rng.next_u64() as u8 % RISCV_REGISTER_COUNT),
         }
     }
@@ -82,7 +69,6 @@ impl From<NormalizedOperands> for FormatAdviceLoadI {
     fn from(operands: NormalizedOperands) -> Self {
         Self {
             rd: operands.rd.unwrap(),
-            imm: operands.imm as u64,
         }
     }
 }
@@ -93,7 +79,7 @@ impl From<FormatAdviceLoadI> for NormalizedOperands {
             rd: Some(format.rd),
             rs1: None,
             rs2: None,
-            imm: format.imm as i128,
+            imm: 0,
         }
     }
 }

--- a/tracer/src/instruction/format/format_t.rs
+++ b/tracer/src/instruction/format/format_t.rs
@@ -1,0 +1,114 @@
+//! Custom format for Jolt inline operations (not a RISC-V instruction format).
+//!
+//! FormatT reads from rs1 and writes to rd. This differs
+//! from FormatR instructions which read in both rs1 and rs2 and
+//! from FormatI instructions which read in rs1 and an immediate value.
+//! FormatT is used instead of FormatI in places where imm isn't needed
+//! and where it is useful to have opcode, funct3, and funct7
+//!
+//! Note: SDKs use FormatR in assembly code to be compatible with the `core::arch::asm` macro,
+//! but are parsed as FormatT instructions by the tracer.
+use crate::emulator::cpu::Cpu;
+use serde::{Deserialize, Serialize};
+use std::fmt::Debug;
+
+use super::{
+    normalize_register_value, InstructionFormat, InstructionRegisterState, NormalizedOperands,
+};
+
+#[derive(Default, Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+pub struct FormatT {
+    pub rd: u8,
+    pub rs1: u8,
+}
+
+#[derive(Default, Debug, Copy, Clone, Serialize, Deserialize, PartialEq)]
+pub struct RegisterStateFormatT {
+    pub rd: (u64, u64), // (old_value, new_value)
+    pub rs1: u64,
+}
+
+impl InstructionRegisterState for RegisterStateFormatT {
+    #[cfg(any(feature = "test-utils", test))]
+    fn random(rng: &mut rand::rngs::StdRng, operands: &NormalizedOperands) -> Self {
+        use rand::RngCore;
+        let rs1_value = if operands.rs1.unwrap() == 0 {
+            0
+        } else {
+            rng.next_u64()
+        };
+
+        Self {
+            rd: (
+                match operands.rd {
+                    _ if operands.rd == operands.rs1 => rs1_value,
+                    _ => rng.next_u64(),
+                },
+                rng.next_u64(),
+            ),
+            rs1: rs1_value,
+        }
+    }
+
+    fn rs1_value(&self) -> Option<u64> {
+        Some(self.rs1)
+    }
+
+    fn rd_values(&self) -> Option<(u64, u64)> {
+        Some(self.rd)
+    }
+}
+
+impl InstructionFormat for FormatT {
+    type RegisterState = RegisterStateFormatT;
+
+    fn parse(word: u32) -> Self {
+        FormatT {
+            rd: ((word >> 7) & 0x1f) as u8,   // [11:7]
+            rs1: ((word >> 15) & 0x1f) as u8, // [19:15]
+        }
+    }
+
+    fn capture_pre_execution_state(&self, state: &mut Self::RegisterState, cpu: &mut Cpu) {
+        state.rs1 = normalize_register_value(cpu, self.rs1 as usize);
+        state.rd.0 = normalize_register_value(cpu, self.rd as usize);
+    }
+
+    fn capture_post_execution_state(&self, state: &mut Self::RegisterState, cpu: &mut Cpu) {
+        state.rd.1 = normalize_register_value(cpu, self.rd as usize);
+    }
+
+    #[cfg(any(feature = "test-utils", test))]
+    fn random(rng: &mut rand::rngs::StdRng) -> Self {
+        use common::constants::RISCV_REGISTER_COUNT;
+        use rand::RngCore;
+        Self {
+            rd: (rng.next_u64() as u8 % RISCV_REGISTER_COUNT),
+            rs1: (rng.next_u64() as u8 % RISCV_REGISTER_COUNT),
+        }
+    }
+
+    fn set_rd(&mut self, rd: u8) {
+        self.rd = rd;
+    }
+}
+
+impl From<NormalizedOperands> for FormatT {
+    fn from(operands: NormalizedOperands) -> Self {
+        Self {
+            rd: operands.rd.unwrap(),
+            rs1: operands.rs1.unwrap(),
+        }
+    }
+}
+
+impl From<FormatT> for NormalizedOperands {
+    fn from(format: FormatT) -> Self {
+        Self {
+            rd: Some(format.rd),
+            rs1: Some(format.rs1),
+            rs2: None,
+            imm: 0,
+        }
+    }
+}

--- a/tracer/src/instruction/format/mod.rs
+++ b/tracer/src/instruction/format/mod.rs
@@ -16,6 +16,7 @@ pub mod format_j;
 pub mod format_load;
 pub mod format_r;
 pub mod format_s;
+pub mod format_t;
 pub mod format_u;
 pub mod format_virtual_right_shift_i;
 pub mod format_virtual_right_shift_r;

--- a/tracer/src/instruction/mod.rs
+++ b/tracer/src/instruction/mod.rs
@@ -5,14 +5,17 @@ pub const CUSTOM_OPCODE: u8 = 0x5B; // Custom instructions (virtual sequences, a
 pub const INLINE_OPCODE: u8 = 0x2B; // Inline instructions
 
 // funct3 values for CUSTOM_OPCODE (0x5B)
-pub const FUNCT3_VIRTUAL_REV8W: u8 = 0b000;
+pub const FUNCT3_VIRTUAL_R: u8 = 0b000; // funct3 for format R virtual instructions
 pub const FUNCT3_VIRTUAL_ASSERT_EQ: u8 = 0b001;
 pub const FUNCT3_VIRTUAL_HOST_IO: u8 = 0b010;
-pub const FUNCT3_ADVICE_LB: u8 = 0b011; // Load byte from advice tape
-pub const FUNCT3_ADVICE_LH: u8 = 0b100; // Load halfword from advice tape
-pub const FUNCT3_ADVICE_LW: u8 = 0b101; // Load word from advice tape
-pub const FUNCT3_ADVICE_LD: u8 = 0b110; // Load doubleword from advice tape
-pub const FUNCT3_ADVICE_LEN: u8 = 0b111; // Get remaining bytes in advice tape
+
+// funct7 values for format R virtual instructions (funct3 = 0b000)
+pub const FUNCT7_ADVICE_LB: u32 = 0x00; // Load byte from advice tape
+pub const FUNCT7_ADVICE_LH: u32 = 0x01; // Load halfword from advice tape
+pub const FUNCT7_ADVICE_LW: u32 = 0x02; // Load word from advice tape
+pub const FUNCT7_ADVICE_LD: u32 = 0x03; // Load doubleword from advice tape
+pub const FUNCT7_ADVICE_LEN: u32 = 0x04; // Get remaining bytes in advice tape
+pub const FUNCT7_VIRTUAL_REV8W: u32 = 0x05; // Reverse bytes in a word
 
 use add::ADD;
 use addi::ADDI;
@@ -1269,25 +1272,36 @@ impl Instruction {
             0b0101011 => Ok(INLINE::new(instr, address, false, compressed).into()),
             // 0x5B is reserved for custom/virtual instructions.
             0b1011011 => {
-                let funct3 = (instr >> 12) & 0x7;
-                match funct3 as u8 {
-                    FUNCT3_VIRTUAL_REV8W => {
-                        Ok(VirtualRev8W::new(instr, address, true, compressed).into())
+                let funct3 = ((instr >> 12) & 0x7) as u8;
+                if funct3 == FUNCT3_VIRTUAL_R {
+                    let funct7 = (instr >> 25) & 0x7f;
+                    match funct7 {
+                        FUNCT7_ADVICE_LB => {
+                            Ok(AdviceLB::new(instr, address, true, compressed).into())
+                        }
+                        FUNCT7_ADVICE_LH => {
+                            Ok(AdviceLH::new(instr, address, true, compressed).into())
+                        }
+                        FUNCT7_ADVICE_LW => {
+                            Ok(AdviceLW::new(instr, address, true, compressed).into())
+                        }
+                        FUNCT7_ADVICE_LD => {
+                            Ok(AdviceLD::new(instr, address, true, compressed).into())
+                        }
+                        FUNCT7_ADVICE_LEN => {
+                            Ok(VirtualAdviceLen::new(instr, address, true, compressed).into())
+                        }
+                        FUNCT7_VIRTUAL_REV8W => {
+                            Ok(VirtualRev8W::new(instr, address, true, compressed).into())
+                        }
+                        _ => Err("Invalid funct7 for virtual R-type instruction"),
                     }
-                    FUNCT3_VIRTUAL_ASSERT_EQ => {
-                        Ok(VirtualAssertEQ::new(instr, address, true, compressed).into())
-                    }
-                    FUNCT3_VIRTUAL_HOST_IO => {
-                        Ok(VirtualHostIO::new(instr, address, true, compressed).into())
-                    }
-                    FUNCT3_ADVICE_LB => Ok(AdviceLB::new(instr, address, true, compressed).into()),
-                    FUNCT3_ADVICE_LH => Ok(AdviceLH::new(instr, address, true, compressed).into()),
-                    FUNCT3_ADVICE_LW => Ok(AdviceLW::new(instr, address, true, compressed).into()),
-                    FUNCT3_ADVICE_LD => Ok(AdviceLD::new(instr, address, true, compressed).into()),
-                    FUNCT3_ADVICE_LEN => {
-                        Ok(VirtualAdviceLen::new(instr, address, true, compressed).into())
-                    }
-                    _ => Err("Invalid custom/virtual instruction"),
+                } else if funct3 == FUNCT3_VIRTUAL_ASSERT_EQ {
+                    Ok(VirtualAssertEQ::new(instr, address, true, compressed).into())
+                } else if funct3 == FUNCT3_VIRTUAL_HOST_IO {
+                    Ok(VirtualHostIO::new(instr, address, true, compressed).into())
+                } else {
+                    Err("Invalid custom/virtual instruction")
                 }
             }
             #[cfg(feature = "field-inline")]

--- a/tracer/src/instruction/test.rs
+++ b/tracer/src/instruction/test.rs
@@ -80,7 +80,7 @@ fn jolt_program_rv64_decode_matches_tracer_normalization() {
         (0x0010_0073, false),
         (0x3020_0073, false),
         (0x3001_10f3, false),
-        (0x0000_50db, false),
+        (0x0000_10db, false),
         (0x0020_802b, false),
         (uncompress_instruction(0x107a), true),
     ];

--- a/tracer/src/instruction/virtual_rev8w.rs
+++ b/tracer/src/instruction/virtual_rev8w.rs
@@ -2,13 +2,13 @@ use serde::{Deserialize, Serialize};
 
 use crate::{declare_riscv_instr, emulator::cpu::Cpu};
 
-use super::{format::format_r::FormatR, RISCVInstruction, RISCVTrace};
+use super::{format::format_t::FormatT, RISCVInstruction, RISCVTrace};
 
 declare_riscv_instr!(
     name = VirtualRev8W,
     mask = 0,
     match = 0,
-    format = FormatR,
+    format = FormatT,
     ram = ()
 );
 

--- a/tracer/src/instruction/virtual_rev8w.rs
+++ b/tracer/src/instruction/virtual_rev8w.rs
@@ -2,13 +2,13 @@ use serde::{Deserialize, Serialize};
 
 use crate::{declare_riscv_instr, emulator::cpu::Cpu};
 
-use super::{format::format_i::FormatI, RISCVInstruction, RISCVTrace};
+use super::{format::format_r::FormatR, RISCVInstruction, RISCVTrace};
 
 declare_riscv_instr!(
     name = VirtualRev8W,
     mask = 0,
     match = 0,
-    format = FormatI,
+    format = FormatR,
     ram = ()
 );
 

--- a/z3-verifier/src/cpu_constraints.rs
+++ b/z3-verifier/src/cpu_constraints.rs
@@ -512,7 +512,7 @@ test_instruction_constraints!(VirtualPow2, FormatI);
 test_instruction_constraints!(VirtualPow2I, FormatJ);
 test_instruction_constraints!(VirtualPow2IW, FormatJ);
 test_instruction_constraints!(VirtualPow2W, FormatI);
-test_instruction_constraints!(VirtualRev8W, FormatI);
+test_instruction_constraints!(VirtualRev8W, FormatR);
 test_instruction_constraints!(VirtualROTRIW, FormatVirtualRightShiftI);
 test_instruction_constraints!(VirtualShiftRightBitmask, FormatI);
 test_instruction_constraints!(VirtualShiftRightBitmaskI, FormatJ);

--- a/z3-verifier/src/cpu_constraints.rs
+++ b/z3-verifier/src/cpu_constraints.rs
@@ -30,7 +30,7 @@ use tracer::instruction::{
     format::{
         format_assert_align::FormatAssert, format_b::FormatB, format_fence::FormatFence,
         format_i::FormatI, format_j::FormatJ, format_load::FormatLoad, format_r::FormatR,
-        format_s::FormatS, format_u::FormatU,
+        format_s::FormatS, format_t::FormatT, format_u::FormatU,
         format_virtual_right_shift_i::FormatVirtualRightShiftI,
         format_virtual_right_shift_r::FormatVirtualRightShiftR,
     },
@@ -512,7 +512,7 @@ test_instruction_constraints!(VirtualPow2, FormatI);
 test_instruction_constraints!(VirtualPow2I, FormatJ);
 test_instruction_constraints!(VirtualPow2IW, FormatJ);
 test_instruction_constraints!(VirtualPow2W, FormatI);
-test_instruction_constraints!(VirtualRev8W, FormatR);
+test_instruction_constraints!(VirtualRev8W, FormatT);
 test_instruction_constraints!(VirtualROTRIW, FormatVirtualRightShiftI);
 test_instruction_constraints!(VirtualShiftRightBitmask, FormatI);
 test_instruction_constraints!(VirtualShiftRightBitmaskI, FormatJ);

--- a/z3-verifier/src/lib.rs
+++ b/z3-verifier/src/lib.rs
@@ -47,6 +47,9 @@ macro_rules! template_format {
     (FormatAssert) => {
         FormatAssert { rs1: 2, imm: 1234 }
     };
+    (FormatT) => {
+        FormatT { rd: 1, rs1: 2 }
+    };
     (FormatVirtualRightShiftI) => {
         FormatVirtualRightShiftI {
             rd: 1,


### PR DESCRIPTION
## Changes

- Modified `0x5B` opcode so that `funct3=0b000` is further split into up to 128 instructions based on `funct7`
- Moved advice instructions and `rev8w` to use `funct3=0b000`
- Modified `FormatAdviceLoadI` to remove unused `imm`
- Added `FormatT` instruction type for use in custom instructions that don't use `imm` or `rs2`
- Migrated `rev8w` to be `FormatT`
