### PR TITLE
feat: add jolt-prover

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -52,10 +52,7 @@ jobs:
       - name: cargo clippy --features allocative,host,zk
         run: cargo clippy --all --all-targets --features allocative,host,zk
       - name: cargo clippy --no-default-features
-        # jolt-backends is not standalone no-default-features-clean: cpu-gated code
-        # is the only consumer of a few pub(crate) helpers. jolt-prover (next PR in
-        # the stack) depends on it with default features and restores full coverage.
-        run: cargo clippy --all --all-targets --no-default-features --exclude jolt-backends
+        run: cargo clippy --all --all-targets --no-default-features
       # jolt-verifier's prover-fixtures feature gates live prover artifact
       # generation for verifier tests. It is not enabled by the workspace-wide
       # invocations above, so build it explicitly in both modes.
@@ -265,6 +262,23 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          components: rust-src
+          cache-directories: ~/.cache/dory
+      - name: Cache ZeroOS musl toolchain
+        id: cache-zeroos-musl
+        uses: actions/cache@v5
+        with:
+          path: ~/.zeroos/musl
+          key: zeroos-musl-toolchain-musl-1.2.3-gcc-9.4.0-Linux-x86_64
+      - name: Install ZeroOS musl toolchain
+        if: steps.cache-zeroos-musl.outputs.cache-hit != 'true'
+        run: |
+          curl -fsSL https://github.com/LayerZero-Labs/ZeroOS/releases/download/musl-toolchain-musl-1.2.3-gcc-9.4.0/zeroos-musl-toolchain-musl-1.2.3-gcc-9.4.0-Linux-x86_64.tar.gz -o /tmp/zeroos-musl.tar.gz
+          mkdir -p ~/.zeroos
+          tar -xzf /tmp/zeroos-musl.tar.gz -C ~/.zeroos
+      - name: Build and install jolt CLI
+        run: cargo install --path . --locked --force
       - name: Install nextest
         uses: taiki-e/install-action@nextest
       - name: Discover modular crates

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3224,6 +3224,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "jolt-prover"
+version = "0.1.0"
+dependencies = [
+ "bincode 2.0.1",
+ "blake2 0.11.0-rc.6",
+ "common",
+ "jolt-backends",
+ "jolt-blindfold",
+ "jolt-claims",
+ "jolt-crypto",
+ "jolt-dory",
+ "jolt-field",
+ "jolt-openings",
+ "jolt-poly",
+ "jolt-program",
+ "jolt-r1cs",
+ "jolt-riscv",
+ "jolt-sdk",
+ "jolt-sumcheck",
+ "jolt-transcript",
+ "jolt-verifier",
+ "jolt-witness",
+ "muldiv-guest",
+ "rand_core 0.6.4",
+ "rayon",
+ "serde",
+ "sha2-chain-guest",
+ "thiserror 2.0.18",
+ "tracer",
+]
+
+[[package]]
 name = "jolt-prover-legacy"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ members = [
   "crates/jolt-verifier",
   "crates/jolt-verifier-derive",
   "crates/jolt-witness",
+  "crates/jolt-prover",
   "crates/jolt-backends",
   "crates/jolt-dory",
   "crates/jolt-hyperkzg",
@@ -397,6 +398,7 @@ jolt-openings = { path = "./crates/jolt-openings" }
 jolt-verifier = { path = "./crates/jolt-verifier" }
 jolt-verifier-derive = { path = "./crates/jolt-verifier-derive" }
 jolt-witness = { path = "./crates/jolt-witness" }
+jolt-prover = { path = "./crates/jolt-prover" }
 jolt-backends = { path = "./crates/jolt-backends" }
 jolt-poly = { path = "./crates/jolt-poly" }
 jolt-r1cs = { path = "./crates/jolt-r1cs" }

--- a/crates/jolt-prover/CLEANUP_SPEC.md
+++ b/crates/jolt-prover/CLEANUP_SPEC.md
@@ -1,0 +1,549 @@
+# jolt-prover Readability Cleanup Spec
+
+## Goal
+
+`jolt-prover` should read like a direct proof recipe. It should coordinate
+checked inputs, preprocessing, witness providers, backend kernels, transcript
+ordering, verifier stage contracts, PCS openings, and BlindFold. It should not
+look like an independent protocol implementation.
+
+The new priority is readability first, then LOC reduction. A smaller file that
+is still hard to follow is not done.
+
+## Current Problem
+
+The largest files, especially `prover.rs` and several stage `prove.rs` files,
+are too verbose and mix too many jobs in one body:
+
+- dependency validation,
+- witness row extraction,
+- backend request construction,
+- sumcheck round loops,
+- clear/ZK transcript recording,
+- field-inline branching,
+- output-opening evaluation,
+- expected-output checks,
+- verifier output construction,
+- final proof packaging.
+
+That makes local cleanup easy to verify but hard to read. Future work should
+make the proof flow obvious from the top of each file.
+
+## Design Rule
+
+Each stage should be organized around the reader's question:
+
+1. What does this stage need?
+2. What does it ask the backend or witness for?
+3. What proof component does it produce?
+4. What verifier-owned output does it hand to later stages?
+
+If a helper does not make one of those answers clearer, it should not exist in
+`jolt-prover`.
+
+## Standard Stage Layout
+
+Each stage directory should use more than one file when the stage has enough
+surface area to make a single `prove.rs` hard to audit. Large monolithic
+stage files are explicitly not the target.
+
+```text
+stageN/
+  mod.rs
+  io.rs                 # stage input/output/prepared/batch data structures
+  prove.rs              # entrypoints and high-level stage recipe, about 800 LOC
+  prepare.rs            # dependency checks, witness access, backend requests
+  batch.rs              # temporary local sumcheck runner, until moved out
+  verifier_output.rs    # temporary verifier-output adapter, until verifier-owned
+```
+
+Rules:
+
+- `prove.rs` should be readable top to bottom and should generally stay near
+  800 LOC or less. Exceeding 800 LOC is a review smell unless the extra code is
+  visibly linear orchestration.
+- `io.rs` owns the stage-local data model: inputs, prepared state, proof
+  components, commitment components, retained prover state, and batch outputs.
+- `io.rs` should mostly be structs and small constructors. It should not contain
+  protocol formulas, backend request construction, or sumcheck loops.
+- `prepare.rs` should not contain sumcheck round logic.
+- `batch.rs` should not construct final verifier outputs.
+- `verifier_output.rs` is temporary. Prefer moving this construction to
+  `jolt-verifier`.
+- Do not recreate `assembly.rs`, `builder.rs`, `proof.rs`, `commitments.rs`,
+  `transcript.rs`, `timing.rs`, or `bounds.rs`.
+- Do not add a replacement module that only collects generic trait bounds; keep
+  caller-facing API constraints next to the public entrypoints.
+- Do not add files that only wrap one or two type aliases.
+
+## Preferred Stage Flow
+
+Every stage should converge toward this visible structure in `prove.rs`:
+
+```rust
+pub(crate) fn prove(...) -> Result<StageNProofComponent<...>, ProverError> {
+    validate_mode_and_inputs(...)?;
+    let prepared = prepare_stageN(...)?;
+    let batch = prove_stageN_batch(prepared.batch_input(), recorder)?;
+    let verifier_output = stageN_verifier_output(...)?;
+    Ok(stageN_proof_component(...))
+}
+```
+
+For ZK mode:
+
+```rust
+pub(crate) fn prove_commitment_component(...) -> Result<StageNCommitmentComponent<...>, ProverError> {
+    validate_mode_and_inputs(...)?;
+    let prepared = prepare_stageN(...)?;
+    let batch = prove_stageN_batch(prepared.batch_input(), committed_recorder)?;
+    let verifier_output = stageN_verifier_output(...)?;
+    Ok(stageN_commitment_component(...))
+}
+```
+
+The top-level flow should not hide protocol ordering behind a generic object.
+It should be explicit and short.
+
+Mode-specific entrypoints should be small wrappers over the same preparation and
+batch machinery. A stage should not have one 250-line clear function and one
+250-line committed function with the same loop.
+
+## Naming
+
+Use names that describe the role of the data.
+
+Preferred:
+
+- `StageNInput`
+- `StageNPrepared`
+- `StageNBatch`
+- `StageNProofComponent`
+- `StageNCommitmentComponent`
+- `StageNClaims`
+- `StageNVerifierOutputInput`
+- `StageNBatchRequest`
+- `StageNBatchOutput`
+- `StageNProofRecorder`
+
+Avoid:
+
+- `ProofArtifact`
+- `CommittedStageOutput`
+- `Boundary`
+- `Assembly`
+- `Builder`
+- `Sink`
+- `prove_with_output`
+- `shape`
+
+If the name needs "temporary" or "helper" to explain it, it probably belongs in
+another crate or should be folded into the call site.
+
+## Public Surface
+
+`jolt-prover` should export only the user-facing proving surface:
+
+- prover configuration,
+- preprocessing bundle,
+- primary prove entrypoints,
+- proof result,
+- backend trait alias or adapter needed by callers,
+- error type.
+
+Stage modules should remain private implementation details unless another crate
+has a concrete reason to depend on them.
+
+## Main Driver Target
+
+`prover.rs` should become a linear recipe:
+
+```rust
+let checked = validate_inputs(...)?;
+let stage0 = stage0::prove(...)?;
+let mut transcript = initialize_transcript(...)?;
+
+let stage1 = stage1::prove(...)?;
+let stage2 = stage2::prove(...)?;
+let stage3 = stage3::prove(...)?;
+let stage4 = stage4::prove(...)?;
+let stage5 = stage5::prove(...)?;
+let stage6 = stage6::prove(...)?;
+let stage7 = stage7::prove(...)?;
+let stage8 = stage8::prove(...)?;
+
+assemble_result(...)
+```
+
+Target size: 500-900 LOC.
+
+Allowed in `prover.rs`:
+
+- config-derived parameter calculation,
+- mode routing,
+- stage sequencing,
+- final proof/result packaging.
+
+Not allowed in `prover.rs`:
+
+- stage algebra,
+- backend request construction,
+- transcript preamble internals,
+- verifier output reconstruction details,
+- large ZK witness assignment.
+
+## Per-Stage File Template
+
+Use this template unless a stage has a specific reason to deviate.
+
+```text
+stageN/
+  mod.rs
+  io.rs
+  prove.rs
+  prepare.rs
+  batch.rs
+  verifier_output.rs
+```
+
+`mod.rs`:
+
+- declare modules,
+- expose only `prove`, `prove_commitment_component`, and the stage component
+  types needed by `prover.rs`,
+- no protocol logic.
+
+`io.rs`:
+
+- `StageNInput`,
+- `StageNPrepared`,
+- `StageNBatchInput`,
+- `StageNBatchOutput`,
+- `StageNProofComponent`,
+- `StageNCommitmentComponent`,
+- retained prover-only state.
+
+`prove.rs`:
+
+- validate mode and checked inputs,
+- call `prepare`,
+- call `batch`,
+- call verifier-output assembly,
+- return proof or commitment component.
+
+`prepare.rs`:
+
+- dependency validation calls into `jolt-verifier`,
+- witness row access,
+- backend request construction through `jolt-backends`,
+- no sumcheck loop.
+
+`batch.rs`:
+
+- local sumcheck runner while the runner has not moved to an owner crate,
+- proof recorder abstraction for clear/ZK,
+- no final verifier-output construction.
+
+`verifier_output.rs`:
+
+- temporary adapter from batch output to verifier-owned output,
+- should shrink as `jolt-verifier` gains direct constructors.
+
+## Stage Size Targets
+
+These are review signals, not hard quotas. The target for each `prove.rs` is
+about 800 LOC or less. A stage can exceed its target only when the ownership
+reason is explicit and the file remains easy to scan.
+
+| Stage | `prove.rs` target | Main remaining pressure |
+|---|---:|---|
+| Stage 0 | 300-500 | Commitment request/result normalization |
+| Stage 1 | 500-800 | Spartan row algebra and clear/ZK duplication |
+| Stage 2 | 500-800 | Product/remainder plumbing and field-inline extension setup |
+| Stage 3 | 500-800 | Batch runner and opening conversion |
+| Stage 4 | 500-800 | RAM init/advice plumbing and remaining batch mechanics |
+| Stage 5 | 500-800 | Specialized batch runner and field-register value plumbing |
+| Stage 6 | 700-1000 | Bytecode, booleanity, RA, increment, advice cycle-phase flow |
+| Stage 7 | 400-700 | Hamming/advice batch internals |
+| Stage 8 | 300-500 | Final opening orchestration only |
+
+For the whole stage directory, additional LOC in `io.rs`, `prepare.rs`,
+`batch.rs`, or `verifier_output.rs` is acceptable when it makes ownership and
+navigation clearer. The point is not to hide code; it is to make each file have
+one obvious job.
+
+## Ownership Rules
+
+Move computation to the crate that owns the concept.
+
+- `jolt-verifier` owns verifier transcript order, verifier outputs, expected
+  output formulas, and stage dependency contracts.
+- `jolt-claims` owns shared claim semantics, dimensions, address/chunk
+  derivation, and formula-level helpers.
+- `jolt-backends` owns backend relation ids, request construction, row
+  projection, state materialization contracts, and backend result validation.
+- `jolt-witness` owns witness row access and witness-specific row projections.
+- `jolt-prover` owns orchestration, mode selection, transcript sequencing calls,
+  PCS opening calls, and final result packaging.
+
+Use owner crates aggressively:
+
+- Prefer verifier-owned dependency and output objects over duplicate prover
+  structs.
+- Prefer `jolt-claims` dimensions and formula helpers over local arithmetic.
+- Prefer backend-owned request constructors and row projections over local
+  request assembly.
+- Prefer witness-owned row accessors over reinterpreting witness data locally.
+
+When code stays in `jolt-prover`, document whether it is:
+
+- orchestration that belongs here,
+- temporary adapter waiting for an owner crate,
+- prover-only retained data such as hidden evaluations or blindings.
+
+## Clear and ZK Paths
+
+Clear and ZK paths should share stage preparation and sumcheck mechanics.
+Separate only the proof recording behavior:
+
+- clear mode records input claims and transparent round polynomials,
+- ZK mode records committed rounds and hidden output-claim values,
+- both modes should produce the same verifier-facing stage output.
+
+Local recorder traits such as `StageNProofRecorder` are acceptable while they
+remove duplicate stage loops. They should stay small and private.
+
+This should mirror the `jolt-verifier` style: common stage semantics first,
+mode-specific proof material second. If clear and committed paths differ only in
+how rounds are recorded, the loop must be shared.
+
+## Field-Inline Paths
+
+Field-inline should be represented as a narrow extension bundle, not a second
+copy of the stage. Follow the `jolt-verifier` approach: a common base request or
+prepared value, plus field-inline extension data where needed.
+
+Preferred pattern:
+
+```rust
+let prepared = prepare_stageN(base_input, extension)?;
+let batch = prove_stageN_batch(prepared, recorder)?;
+```
+
+Avoid parallel function bodies where only one extra field-register instance is
+added. If the field-inline path needs extra state, put that state in a small
+typed extension value.
+
+The target is one readable flow:
+
+```rust
+let extension = StageNExtension::from_field_inline(...)?;
+let prepared = prepare_stageN(input, extension)?;
+let batch = prove_stageN_batch(prepared.batch_input(), recorder)?;
+```
+
+Not four independent bodies for:
+
+- clear,
+- ZK,
+- field-inline,
+- ZK field-inline.
+
+## Testing Gate
+
+No smoke-test-only confidence. The canonical prover gate is real e2e data:
+
+- `muldiv`
+- `sha2-chain`
+
+### Microbenchmarks
+
+Keep a lightweight bench suite under `crates/jolt-prover/benches/` for quick
+proof-system feedback during cleanup. These are not correctness replacements
+for nextest; every bench iteration must still produce a real proof and run the
+verifier on real guest data.
+
+Initial suite:
+
+- `sha2-chain` with modular prover target padded trace length `2^16`
+- `sha2-chain` with modular prover target padded trace length `2^20`, gated
+- default sample count 3, override with `JOLT_PROVER_MICROBENCH_SAMPLES=N`
+- derive cycles per input from tracer calibration and scale `sha2-chain`
+  iterations toward 90% of the requested padded trace length
+- choose the largest calibrated input count that stays under the target
+  unpadded cycle count and lands in the requested padded trace-length tier
+- print the selected iteration count, target unpadded cycles, calibration
+  cycles per input, selected unpadded cycles, and padded trace length
+- setup, guest tracing, preprocessing, and witness construction outside the
+  measured loop
+- measured loop is proof plus verifier acceptance
+
+The `2^20` case must not become the default feedback cost until `2^16` looks
+healthy. Run it automatically only when the default transparent run has
+`jolt-prover` within 15% of legacy `jolt-core` on the `2^16` case. For manual
+large-case investigation, force it with `JOLT_PROVER_MICROBENCH_RUN_2_20=1`.
+
+Comparison model:
+
+- default features: `jolt-prover` transparent vs legacy `jolt-core` transparent
+- `zk`: `jolt-prover` ZK proof plus verify
+- `field-inline`: `jolt-prover` field-inline overhead vs default modular prover
+- `zk,field-inline`: combined ZK plus field-inline overhead
+- no field-inline comparison against `jolt-core`, because legacy core does not
+  provide that path
+
+Useful commands:
+
+```bash
+cargo bench -p jolt-prover --bench e2e_micro
+cargo bench -p jolt-prover --bench e2e_micro --features zk
+cargo bench -p jolt-prover --bench e2e_micro --features field-inline
+cargo bench -p jolt-prover --bench e2e_micro --features zk,field-inline
+JOLT_PROVER_MICROBENCH_RUN_2_20=1 cargo bench -p jolt-prover --bench e2e_micro
+```
+
+Baseline from June 9, 2026, local bench profile, `samples=3`:
+
+Input calibration for `sha2-chain-2^16`:
+
+- selected iterations: 18
+- target unpadded cycles: 58982
+- calibration base cycles: 1084.0
+- calibration cycles per input: 3064.0
+- unpadded cycles: 56236
+- padded trace length: 65536
+
+| Mode | Command | Min | Median | Mean |
+| --- | --- | ---: | ---: | ---: |
+| `jolt-prover` transparent | `cargo bench -p jolt-prover --bench e2e_micro` | 2.749s | 2.752s | 2.753s |
+| legacy `jolt-core` transparent | `cargo bench -p jolt-prover --bench e2e_micro` | 2.085s | 2.127s | 2.129s |
+| `jolt-prover` ZK | `cargo bench -p jolt-prover --bench e2e_micro --features zk` | 3.325s | 3.430s | 3.397s |
+| `jolt-prover` field-inline | `cargo bench -p jolt-prover --bench e2e_micro --features field-inline` | 2.782s | 2.800s | 2.862s |
+| `jolt-prover` ZK field-inline | `cargo bench -p jolt-prover --bench e2e_micro --features zk,field-inline` | 3.766s | 3.776s | 3.777s |
+
+The transparent modular/core mean ratio was `1.293`, so `sha2-chain-2^20`
+was skipped by the 15% gate. Treat forced `2^20` runs as investigation until
+the `2^16` ratio is at or below `1.15`.
+
+For any stage-flow rewrite, run:
+
+```bash
+cargo fmt -q
+cargo clippy --no-deps -p jolt-prover --all-targets -q -- -D warnings
+cargo clippy --no-deps -p jolt-prover --all-targets --features zk -q -- -D warnings
+cargo clippy --no-deps -p jolt-prover --all-targets --features field-inline -q -- -D warnings
+cargo clippy --no-deps -p jolt-prover --all-targets --features zk,field-inline -q -- -D warnings
+cargo nextest run -p jolt-prover --cargo-quiet
+cargo nextest run -p jolt-prover --cargo-quiet --features zk
+cargo nextest run -p jolt-prover --cargo-quiet --features field-inline
+cargo nextest run -p jolt-prover --cargo-quiet --features zk,field-inline
+git diff --check
+```
+
+If a slice touches `jolt-verifier`, `jolt-backends`, `jolt-claims`, or
+`jolt-witness`, include the touched crates in clippy and nextest.
+
+## Current Progress
+
+- Phase 0 is in place: the readability contract exists, true e2e tests exist,
+  and the microbench harness records the `sha2-chain-2^16` feature matrix.
+- Phase 1 driver cleanup is in target range. `prover.rs` now delegates BlindFold row-committer
+  proof generation to `zk.rs`, and Stage 4 RAM value-check initial-evaluation
+  preparation lives in `stages/stage4/prepare.rs`.
+- Checked-input construction is now verifier-owned through
+  `jolt_verifier::validate_inputs_from_parts`; `prover.rs` only passes the
+  proof parameters and mode.
+- Stage 6, Stage 7, and Stage 8 prover-config assembly now lives in each
+  stage's `prepare.rs` module.
+- Stage 0 prover-config assembly now lives in `stages/stage0/prepare.rs`.
+- Public prove API wrappers and caller-facing proving requirements now live in
+  `api.rs`, outside the driver recipe.
+- Prover config validation now lives with `ProverConfig` in `config.rs`.
+- Clear and ZK proof-material packaging now uses small stage-payload helpers,
+  so the recipes are less interrupted by struct assembly.
+- Current `prover.rs` size after these slices is 869 LOC. The duplicated
+  clear/ZK stage call sequence remains explicit while stage-local flow is split.
+- Phase 2 has started with Stage 6: config/input/component/batch data types now
+  live in `stages/stage6/io.rs`, and clear/ZK proof recording now lives in
+  `stages/stage6/batch.rs`. Stage 6 prefix derivation, bytecode request inputs,
+  and backend state materialization now live in `stages/stage6/prepare.rs`.
+  Backend-output claim packaging lives in `stages/stage6/verifier_output.rs`.
+  The local batch context and verifier-aligned evaluation helpers also moved to
+  `stages/stage6/batch.rs`, bringing `stage6/prove.rs` to 567 LOC. The next
+  Stage 6 pressure point is reducing the temporary size of `batch.rs`.
+
+## Implementation Phases
+
+### Phase 0: Freeze Readability Contract
+
+Add this spec and use it to evaluate future cleanup. Stop optimizing for small
+internal refactors that leave the same giant file structure in place.
+
+### Phase 1: Driver Recipe
+
+Rewrite `prover.rs` until the stage sequence is obvious without scrolling
+through stage-local details.
+
+Deliverables:
+
+- one clear proof recipe,
+- one clear ZK routing strategy,
+- final packaging helper under 100 LOC,
+- no protocol algebra in the driver.
+
+### Phase 2: Stage Table of Contents
+
+For every stage, split or reorder code into:
+
+- `io.rs` for data structures,
+- `prove.rs` for entrypoints and high-level flow,
+- `prepare.rs` for dependency/witness/backend setup,
+- `batch.rs` for temporary local sumcheck runners,
+- `verifier_output.rs` for temporary verifier-output adapters.
+
+The first screen of each `prove.rs` should tell the reader what the stage does,
+and `prove.rs` should be around 800 LOC or less.
+
+### Phase 3: Split Only Large Responsibilities
+
+After the table-of-contents pass, split only files that remain hard to read.
+
+Allowed splits:
+
+- `io.rs`
+- `prepare.rs`
+- `batch.rs`
+- `verifier_output.rs`
+
+Each split must remove a real navigation problem.
+
+### Phase 4: Move Owners Out
+
+For each temporary local adapter, move it to the owning crate:
+
+- verifier output and expected-output helpers to `jolt-verifier`,
+- claim semantics to `jolt-claims`,
+- backend request construction to `jolt-backends`,
+- witness row projection to `jolt-witness`.
+
+### Phase 5: Final Condensed Path
+
+Accept the cleanup only when:
+
+- `prover.rs` is a readable recipe,
+- every large stage file has a clear responsibility split,
+- stage outputs use verifier-owned objects directly where possible,
+- no forbidden modules or terms have been reintroduced,
+- the full e2e feature matrix passes.
+
+## Review Checklist
+
+Before merging any cleanup slice:
+
+- Does the top-level flow read more clearly?
+- Did the change reduce a mixed-responsibility block?
+- Are names role-based and protocol-specific?
+- Did any computation stay in `jolt-prover` only for convenience?
+- Are clear, ZK, and field-inline paths sharing the right mechanics?
+- Are tests real e2e tests, not smoke tests?
+- Is the spec updated with the new state and next pressure point?

--- a/crates/jolt-prover/Cargo.toml
+++ b/crates/jolt-prover/Cargo.toml
@@ -1,0 +1,54 @@
+[package]
+name = "jolt-prover"
+version = "0.1.0"
+edition = "2021"
+license = "MIT OR Apache-2.0"
+description = "Protocol orchestration for modular Jolt proving"
+repository = "https://github.com/a16z/jolt"
+keywords = ["SNARK", "zkvm", "prover"]
+categories = ["cryptography"]
+
+[lints]
+workspace = true
+
+[features]
+default = []
+prover-harness = ["jolt-backends/prover-harness"]
+zk = ["jolt-backends/zk", "jolt-verifier/zk"]
+
+[dependencies]
+common.workspace = true
+jolt-backends.workspace = true
+jolt-blindfold.workspace = true
+jolt-claims.workspace = true
+jolt-crypto.workspace = true
+jolt-field.workspace = true
+jolt-openings.workspace = true
+jolt-poly.workspace = true
+jolt-program.workspace = true
+jolt-r1cs.workspace = true
+jolt-riscv.workspace = true
+jolt-sumcheck.workspace = true
+jolt-transcript.workspace = true
+jolt-verifier.workspace = true
+jolt-witness.workspace = true
+rand_core = { workspace = true, features = ["getrandom"] }
+rayon.workspace = true
+thiserror.workspace = true
+
+[dev-dependencies]
+bincode.workspace = true
+blake2.workspace = true
+jolt-dory = { path = "../jolt-dory" }
+jolt-field.workspace = true
+jolt-openings = { workspace = true, features = ["test-utils"] }
+jolt-program = { workspace = true, features = ["image"] }
+jolt-sdk = { workspace = true, features = ["host"] }
+muldiv-guest = { path = "../../examples/muldiv/guest" }
+serde = { workspace = true, features = ["std"] }
+sha2-chain-guest = { path = "../../examples/sha2-chain/guest" }
+tracer = { workspace = true, features = ["std"] }
+
+[[bench]]
+name = "e2e_micro"
+harness = false

--- a/crates/jolt-prover/benches/e2e_micro.rs
+++ b/crates/jolt-prover/benches/e2e_micro.rs
@@ -1,0 +1,724 @@
+#![expect(
+    clippy::expect_used,
+    reason = "bench setup and e2e verification should fail loudly"
+)]
+
+use std::{
+    io::Write,
+    sync::Once,
+    time::{Duration, Instant},
+};
+
+use blake2::{
+    digest::{consts::U32, Digest},
+    Blake2b,
+};
+use common::{
+    constants::ONEHOT_CHUNK_THRESHOLD_LOG_T,
+    jolt_device::{JoltDevice, MemoryLayout},
+};
+use jolt_backends::cpu::CpuBackend;
+use jolt_claims::protocols::jolt::{JoltOneHotConfig, JoltReadWriteConfig, TracePolynomialOrder};
+use jolt_crypto::{Bn254G1, Pedersen};
+use jolt_dory::DoryScheme;
+use jolt_field::Fr;
+use jolt_openings::CommitmentScheme;
+use jolt_program::{
+    execution::{JoltProgram, OwnedTrace, RamAccess, TraceOutput, TraceRow},
+    preprocess::JoltProgramPreprocessing,
+};
+use jolt_prover::{JoltProverPreprocessing, ProverConfig};
+use jolt_sdk::host::Program;
+use jolt_transcript::Blake2bTranscript;
+use jolt_verifier::{
+    compat, zk_vector_commitment_capacity_requirement, JoltVerifierPreprocessing,
+    ProgramPreprocessing,
+};
+use jolt_witness::protocols::jolt_vm::{
+    JoltVmWitnessConfig, JoltVmWitnessInputs, TraceBackedJoltVmWitness,
+};
+use serde::de::DeserializeOwned;
+use tracer::TracerBackend;
+
+type Pcs = DoryScheme;
+type Vc = Pedersen<Bn254G1>;
+
+static RAYON_INIT: Once = Once::new();
+
+const TARGET_DIR: &str = "/tmp/jolt-prover-microbench-guests";
+const SMALL_CASE: BenchCase = BenchCase {
+    name: "sha2-chain-2^16",
+    target_trace_length: 1 << 16,
+};
+const LARGE_CASE: BenchCase = BenchCase {
+    name: "sha2-chain-2^20",
+    target_trace_length: 1 << 20,
+};
+const TRACE_TARGET_UTILIZATION: f64 = 0.90;
+const LARGE_CASE_RATIO_GATE: f64 = 1.15;
+const FORCE_LARGE_CASE_ENV: &str = "JOLT_PROVER_MICROBENCH_RUN_2_20";
+const BENCH_STACK_SIZE: usize = 128 * 1024 * 1024;
+const DEFAULT_SAMPLES: usize = 3;
+
+fn main() {
+    initialize_rayon();
+
+    let samples = sample_count();
+    let mut stdout = std::io::stdout().lock();
+    writeln!(stdout, "jolt-prover e2e microbench").expect("bench output should write");
+    writeln!(stdout, "program: sha2-chain").expect("bench output should write");
+    writeln!(stdout, "samples: {samples}").expect("bench output should write");
+
+    let small = run_sha2_case(&mut stdout, SMALL_CASE, samples);
+
+    if should_run_large_case(small.core_ratio) {
+        let _ = run_sha2_case(&mut stdout, LARGE_CASE, samples);
+    } else {
+        writeln!(
+            stdout,
+            "{}: skipped; requires default transparent {} ratio <= {:.2} or {FORCE_LARGE_CASE_ENV}=1",
+            LARGE_CASE.name, SMALL_CASE.name, LARGE_CASE_RATIO_GATE
+        )
+        .expect("bench output should write");
+    }
+}
+
+fn sample_count() -> usize {
+    std::env::var("JOLT_PROVER_MICROBENCH_SAMPLES")
+        .ok()
+        .and_then(|value| value.parse::<usize>().ok())
+        .filter(|samples| *samples > 0)
+        .unwrap_or(DEFAULT_SAMPLES)
+}
+
+fn should_run_large_case(core_ratio: Option<f64>) -> bool {
+    force_large_case() || core_ratio.is_some_and(|ratio| ratio <= LARGE_CASE_RATIO_GATE)
+}
+
+fn force_large_case() -> bool {
+    std::env::var(FORCE_LARGE_CASE_ENV)
+        .ok()
+        .is_some_and(|value| value == "1" || value.eq_ignore_ascii_case("true"))
+}
+
+fn run_sha2_case(writer: &mut impl Write, case: BenchCase, samples: usize) -> BenchCaseOutcome {
+    writeln!(writer, "case: {}", case.name).expect("bench output should write");
+    writeln!(writer, "target_trace_length: {}", case.target_trace_length)
+        .expect("bench output should write");
+
+    let (modular_stats, run_input) =
+        bench_modular_sha2_chain(writer, case, modular_mode_label(), samples);
+    write_stats(writer, &modular_stats);
+
+    #[cfg(not(feature = "zk"))]
+    {
+        let core_stats = bench_core_sha2_chain(&run_input, samples);
+        write_stats(writer, &core_stats);
+        let ratio = modular_stats.mean_seconds() / core_stats.mean_seconds();
+        writeln!(writer, "{}: modular/core mean ratio={ratio:.3}", case.name)
+            .expect("bench output should write");
+        BenchCaseOutcome {
+            core_ratio: Some(ratio),
+        }
+    }
+
+    #[cfg(feature = "zk")]
+    {
+        let _ = run_input;
+        BenchCaseOutcome { core_ratio: None }
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+struct BenchCase {
+    name: &'static str,
+    target_trace_length: usize,
+}
+
+#[derive(Clone, Debug)]
+struct Sha2RunInput {
+    input: [u8; 32],
+    iters: u32,
+    expected_output: [u8; 32],
+}
+
+#[derive(Clone, Debug)]
+struct Sha2TraceStats {
+    iters: u32,
+    target_unpadded_cycles: usize,
+    calibration_base_cycles: f64,
+    calibration_cycles_per_input: f64,
+    unpadded_cycles: usize,
+    padded_trace_length: usize,
+}
+
+#[derive(Clone, Copy, Debug)]
+struct BenchCaseOutcome {
+    core_ratio: Option<f64>,
+}
+
+struct SelectedSha2Input {
+    run_input: Sha2RunInput,
+    trace_stats: Sha2TraceStats,
+    trace: TraceOutput<OwnedTrace>,
+}
+
+struct Sha2CycleCalibration {
+    base_cycles: f64,
+    cycles_per_input: f64,
+}
+
+struct TracedSha2Input {
+    run_input: Sha2RunInput,
+    trace: TraceOutput<OwnedTrace>,
+    unpadded_cycles: usize,
+    padded_trace_length: usize,
+}
+
+fn select_sha2_chain_input(program: &mut Program, target_trace_length: usize) -> SelectedSha2Input {
+    let input = [5u8; 32];
+    let calibration = calibrate_sha2_chain_cycles(program, input);
+    let target_unpadded_cycles = target_unpadded_cycles(target_trace_length);
+    let estimated_iters = ((target_unpadded_cycles as f64 - calibration.base_cycles)
+        / calibration.cycles_per_input)
+        .floor()
+        .clamp(1.0, f64::from(u32::MAX)) as u32;
+
+    let selected = trace_scaled_sha2_input(
+        program,
+        input,
+        estimated_iters,
+        target_trace_length,
+        target_unpadded_cycles,
+    );
+
+    SelectedSha2Input {
+        trace_stats: Sha2TraceStats {
+            iters: selected.run_input.iters,
+            target_unpadded_cycles,
+            calibration_base_cycles: calibration.base_cycles,
+            calibration_cycles_per_input: calibration.cycles_per_input,
+            unpadded_cycles: selected.unpadded_cycles,
+            padded_trace_length: selected.padded_trace_length,
+        },
+        run_input: selected.run_input,
+        trace: selected.trace,
+    }
+}
+
+fn calibrate_sha2_chain_cycles(program: &mut Program, input: [u8; 32]) -> Sha2CycleCalibration {
+    let low_iters = 1;
+    let high_iters = 8;
+    let low_cycles = trace_sha2_chain_cycles(program, input, low_iters);
+    let high_cycles = trace_sha2_chain_cycles(program, input, high_iters);
+    let cycles_per_input = (high_cycles.saturating_sub(low_cycles) as f64
+        / f64::from(high_iters - low_iters))
+    .max(1.0);
+    let base_cycles = low_cycles as f64 - cycles_per_input * f64::from(low_iters);
+
+    Sha2CycleCalibration {
+        base_cycles,
+        cycles_per_input,
+    }
+}
+
+fn target_unpadded_cycles(target_trace_length: usize) -> usize {
+    let target = (target_trace_length as f64 * TRACE_TARGET_UTILIZATION).floor() as usize;
+    target
+        .max(target_trace_length / 2)
+        .min(target_trace_length.saturating_sub(1))
+}
+
+fn trace_scaled_sha2_input(
+    program: &mut Program,
+    input: [u8; 32],
+    estimated_iters: u32,
+    target_trace_length: usize,
+    target_unpadded_cycles: usize,
+) -> TracedSha2Input {
+    let mut best = trace_sha2_chain_candidate(program, input, 1);
+    assert!(
+        best.padded_trace_length <= target_trace_length,
+        "sha2-chain trace exceeds target length at one iteration"
+    );
+
+    let mut upper_iters = estimated_iters.max(2);
+    loop {
+        let candidate = trace_sha2_chain_candidate(program, input, upper_iters);
+        if !candidate_fits(&candidate, target_trace_length, target_unpadded_cycles) {
+            break;
+        }
+
+        best = candidate;
+        if upper_iters == u32::MAX {
+            break;
+        }
+
+        let scale = target_unpadded_cycles as f64 / best.unpadded_cycles.max(1) as f64;
+        let next_iters = ((f64::from(upper_iters) * scale * 1.02).ceil()).clamp(
+            f64::from(upper_iters.saturating_add(1)),
+            f64::from(u32::MAX),
+        ) as u32;
+        if next_iters == upper_iters {
+            break;
+        }
+        upper_iters = next_iters;
+    }
+
+    let mut low_iters = best.run_input.iters;
+    while low_iters.saturating_add(1) < upper_iters {
+        let mid_iters = low_iters + (upper_iters - low_iters) / 2;
+        let candidate = trace_sha2_chain_candidate(program, input, mid_iters);
+        if candidate_fits(&candidate, target_trace_length, target_unpadded_cycles) {
+            low_iters = mid_iters;
+            best = candidate;
+        } else {
+            upper_iters = mid_iters;
+        }
+    }
+
+    assert!(
+        best.padded_trace_length == target_trace_length,
+        "scaled sha2-chain padded trace length {} did not hit target {target_trace_length}",
+        best.padded_trace_length
+    );
+    best
+}
+
+fn candidate_fits(
+    candidate: &TracedSha2Input,
+    target_trace_length: usize,
+    target_unpadded_cycles: usize,
+) -> bool {
+    candidate.padded_trace_length <= target_trace_length
+        && candidate.unpadded_cycles <= target_unpadded_cycles
+}
+
+fn trace_sha2_chain_candidate(
+    program: &mut Program,
+    input: [u8; 32],
+    iters: u32,
+) -> TracedSha2Input {
+    let run_input = sha2_run_input(input, iters);
+    let trace = trace_sha2_chain(program, &run_input);
+    let unpadded_cycles = trace.trace.rows().len();
+    let padded_trace_length = padded_trace_length_from_unpadded(unpadded_cycles);
+
+    TracedSha2Input {
+        run_input,
+        trace,
+        unpadded_cycles,
+        padded_trace_length,
+    }
+}
+
+fn sha2_run_input(input: [u8; 32], iters: u32) -> Sha2RunInput {
+    Sha2RunInput {
+        input,
+        iters,
+        expected_output: sha2_chain_guest::sha2_chain(input, iters),
+    }
+}
+
+fn trace_sha2_chain_cycles(program: &mut Program, input: [u8; 32], iters: u32) -> usize {
+    let run_input = sha2_run_input(input, iters);
+    trace_sha2_chain(program, &run_input).trace.rows().len()
+}
+
+fn trace_sha2_chain(program: &mut Program, run_input: &Sha2RunInput) -> TraceOutput<OwnedTrace> {
+    let mut tracer = TracerBackend::new();
+    program
+        .trace_with_backend(&mut tracer, &sha2_input_bytes(run_input), &[], &[])
+        .expect("guest should execute through the tracer backend")
+}
+
+fn sha2_input_bytes(run_input: &Sha2RunInput) -> Vec<u8> {
+    let mut input_bytes = Vec::new();
+    append_input(&mut input_bytes, &run_input.input);
+    append_input(&mut input_bytes, &run_input.iters);
+    input_bytes
+}
+
+fn bench_modular_sha2_chain(
+    writer: &mut impl Write,
+    case: BenchCase,
+    bench_id: &'static str,
+    samples: usize,
+) -> (BenchStats, Sha2RunInput) {
+    let mut host_program = sha2_chain_guest::compile_sha2_chain(TARGET_DIR);
+    let program = host_program
+        .jolt_program()
+        .expect("guest should compile into a modular Jolt program");
+    let selected = select_sha2_chain_input(&mut host_program, case.target_trace_length);
+    write_trace_stats(writer, &selected.trace_stats);
+    let run_input = selected.run_input.clone();
+    let trace = selected.trace;
+    let public_io = trace.device.clone();
+    let program_preprocessing =
+        program_preprocessing(&program, &public_io, case.target_trace_length);
+    let proof_parameters = proof_parameters(&program_preprocessing, &trace);
+    let preprocessing = prover_preprocessing(program_preprocessing, case.target_trace_length);
+    let witness = trace_witness(
+        &program,
+        preprocessing
+            .verifier
+            .program
+            .as_full()
+            .expect("prover preprocessing should retain the full program preprocessing"),
+        trace,
+        proof_parameters,
+    );
+    let config = proof_parameters;
+
+    let stats = measure(bench_id, samples, || {
+        let mut backend = CpuBackend::default();
+        let expected_output = run_input.expected_output;
+        let preprocessing_ref = &preprocessing;
+        let public_io_ref = &public_io;
+        let witness_ref = &witness;
+        let config_ref = &config;
+
+        run_on_bench_stack(move || {
+            let prover_output = jolt_prover::prove_with_components(
+                preprocessing_ref,
+                public_io_ref,
+                witness_ref,
+                *config_ref,
+                &mut backend,
+            )
+            .expect("modular prover should produce a proof");
+
+            jolt_verifier::verify::<Fr, Pcs, Vc, Blake2bTranscript>(
+                &preprocessing_ref.verifier,
+                public_io_ref,
+                &prover_output.proof,
+                prover_output.trusted_advice_commitment.as_ref(),
+                cfg!(feature = "zk"),
+            )
+            .expect("modular verifier should accept the modular proof");
+
+            let actual_output: [u8; 32] = decode_output(public_io_ref);
+            assert_eq!(actual_output, expected_output, "sha2-chain output mismatch");
+            let _ = std::hint::black_box(prover_output);
+        });
+    });
+
+    (stats, run_input)
+}
+
+#[cfg(not(feature = "zk"))]
+fn bench_core_sha2_chain(run_input: &Sha2RunInput, samples: usize) -> BenchStats {
+    let mut program = sha2_chain_guest::compile_sha2_chain(TARGET_DIR);
+    let shared_preprocessing = sha2_chain_guest::preprocess_shared_sha2_chain(&mut program)
+        .expect("jolt-core shared preprocessing should build");
+    let prover_preprocessing =
+        sha2_chain_guest::preprocess_prover_sha2_chain(shared_preprocessing.clone());
+    let verifier_preprocessing = sha2_chain_guest::preprocess_verifier_sha2_chain(
+        shared_preprocessing,
+        prover_preprocessing.generators.to_verifier_setup(),
+        None,
+    );
+    let prove_sha2_chain = sha2_chain_guest::build_prover_sha2_chain(program, prover_preprocessing);
+    let verify_sha2_chain = sha2_chain_guest::build_verifier_sha2_chain(verifier_preprocessing);
+
+    measure("jolt-core-transparent", samples, || {
+        run_on_bench_stack(|| {
+            let (output, proof, program_io) = prove_sha2_chain(run_input.input, run_input.iters);
+            assert_eq!(
+                output, run_input.expected_output,
+                "jolt-core sha2-chain output mismatch"
+            );
+            let accepted = verify_sha2_chain(
+                run_input.input,
+                run_input.iters,
+                output,
+                program_io.panic,
+                proof,
+            );
+            assert!(accepted, "jolt-core verifier should accept the proof");
+            let _ = std::hint::black_box(accepted);
+        });
+    })
+}
+
+fn modular_mode_label() -> &'static str {
+    if cfg!(feature = "zk") {
+        "jolt-prover-zk"
+    } else {
+        "jolt-prover-transparent"
+    }
+}
+
+fn run_on_bench_stack<R>(f: impl FnOnce() -> R + Send) -> R
+where
+    R: Send,
+{
+    std::thread::scope(|scope| {
+        std::thread::Builder::new()
+            .name("jolt-prover-microbench".to_string())
+            .stack_size(BENCH_STACK_SIZE)
+            .spawn_scoped(scope, f)
+            .expect("bench thread should spawn")
+            .join()
+            .expect("bench thread should not panic")
+    })
+}
+
+fn initialize_rayon() {
+    RAYON_INIT.call_once(|| {
+        rayon::ThreadPoolBuilder::new()
+            .stack_size(BENCH_STACK_SIZE)
+            .build_global()
+            .expect("global rayon pool should initialize for e2e benches");
+    });
+}
+
+#[derive(Debug)]
+struct BenchStats {
+    label: &'static str,
+    samples: usize,
+    min: Duration,
+    median: Duration,
+    mean: Duration,
+}
+
+fn measure(label: &'static str, samples: usize, mut run: impl FnMut()) -> BenchStats {
+    let mut durations = Vec::with_capacity(samples);
+    for _ in 0..samples {
+        let started = Instant::now();
+        run();
+        durations.push(started.elapsed());
+    }
+    BenchStats::from_durations(label, durations)
+}
+
+impl BenchStats {
+    fn from_durations(label: &'static str, mut durations: Vec<Duration>) -> Self {
+        durations.sort_unstable();
+        let samples = durations.len();
+        let min = durations[0];
+        let median = durations[samples / 2];
+        let total_nanos = durations.iter().map(Duration::as_nanos).sum::<u128>();
+        let mean_nanos = (total_nanos / samples as u128).min(u128::from(u64::MAX));
+        let mean = Duration::from_nanos(
+            u64::try_from(mean_nanos).expect("mean duration should fit after saturation"),
+        );
+
+        Self {
+            label,
+            samples,
+            min,
+            median,
+            mean,
+        }
+    }
+
+    #[cfg(not(feature = "zk"))]
+    fn mean_seconds(&self) -> f64 {
+        self.mean.as_secs_f64()
+    }
+}
+
+fn write_trace_stats(writer: &mut impl Write, stats: &Sha2TraceStats) {
+    writeln!(
+        writer,
+        "input: sha2_chain_iterations={} target_unpadded_cycles={} calibration_base_cycles={:.1} calibration_cycles_per_input={:.1} unpadded_cycles={} padded_trace_length={}",
+        stats.iters,
+        stats.target_unpadded_cycles,
+        stats.calibration_base_cycles,
+        stats.calibration_cycles_per_input,
+        stats.unpadded_cycles,
+        stats.padded_trace_length
+    )
+    .expect("bench output should write");
+}
+
+fn write_stats(writer: &mut impl Write, stats: &BenchStats) {
+    writeln!(
+        writer,
+        "{}: samples={} min={} median={} mean={}",
+        stats.label,
+        stats.samples,
+        format_duration(stats.min),
+        format_duration(stats.median),
+        format_duration(stats.mean)
+    )
+    .expect("bench output should write");
+}
+
+fn format_duration(duration: Duration) -> String {
+    format!("{:.3}s", duration.as_secs_f64())
+}
+
+fn append_input<T>(bytes: &mut Vec<u8>, value: &T)
+where
+    T: serde::Serialize + ?Sized,
+{
+    bytes.append(
+        &mut jolt_sdk::postcard::to_stdvec(value)
+            .expect("guest input should serialize with postcard"),
+    );
+}
+
+fn decode_output<Output>(public_io: &JoltDevice) -> Output
+where
+    Output: DeserializeOwned,
+{
+    let mut outputs = public_io.outputs.clone();
+    outputs.resize(public_io.memory_layout.max_output_size as usize, 0);
+    jolt_sdk::postcard::from_bytes(&outputs).expect("guest output should deserialize with postcard")
+}
+
+fn program_preprocessing(
+    program: &JoltProgram,
+    public_io: &JoltDevice,
+    max_trace_length: usize,
+) -> JoltProgramPreprocessing {
+    JoltProgramPreprocessing::new(
+        program.expanded_bytecode.clone(),
+        program.memory_init.clone(),
+        public_io.memory_layout.clone(),
+        program.entry_address,
+        max_trace_length,
+        program.profile,
+    )
+    .expect("program preprocessing should be valid")
+}
+
+fn prover_preprocessing(
+    program: JoltProgramPreprocessing,
+    max_trace_length: usize,
+) -> JoltProverPreprocessing<Pcs, Vc> {
+    let max_log_t = max_trace_length.next_power_of_two().trailing_zeros() as usize;
+    let max_log_k_chunk = if max_log_t < ONEHOT_CHUNK_THRESHOLD_LOG_T {
+        4
+    } else {
+        8
+    };
+    let (pcs_setup, _) = Pcs::setup(max_log_k_chunk + max_log_t);
+    let preprocessing_digest = preprocessing_digest(&program);
+    let verifier = JoltVerifierPreprocessing::<Pcs, Vc>::from_pcs_prover_setup(
+        ProgramPreprocessing::Full(program),
+        preprocessing_digest,
+        &pcs_setup,
+        zk_vector_commitment_capacity_requirement(),
+    );
+
+    JoltProverPreprocessing::new(verifier, pcs_setup)
+}
+
+fn preprocessing_digest(program: &JoltProgramPreprocessing) -> [u8; 32] {
+    let bytes = bincode::serde::encode_to_vec(program, bincode::config::standard())
+        .expect("program preprocessing should serialize into memory");
+    Blake2b::<U32>::digest(bytes).into()
+}
+
+fn trace_witness<'a>(
+    program: &'a JoltProgram,
+    preprocessing: &'a JoltProgramPreprocessing,
+    trace: TraceOutput<OwnedTrace>,
+    proof_parameters: ProverConfig,
+) -> TraceBackedJoltVmWitness<'a, OwnedTrace> {
+    let config = JoltVmWitnessConfig::new(
+        proof_parameters.trace_length.trailing_zeros() as usize,
+        proof_parameters.ram_k,
+        proof_parameters.one_hot_config,
+    )
+    .retain_trace_rows(true)
+    .include_trusted_advice(!trace.device.trusted_advice.is_empty())
+    .include_untrusted_advice(!trace.device.untrusted_advice.is_empty());
+
+    TraceBackedJoltVmWitness::new(
+        config,
+        JoltVmWitnessInputs::new(program, preprocessing, trace),
+    )
+}
+
+fn proof_parameters(
+    preprocessing: &JoltProgramPreprocessing,
+    trace: &TraceOutput<OwnedTrace>,
+) -> ProverConfig {
+    let trace_length = padded_trace_length(trace.trace.rows().len(), preprocessing);
+    let log_t = trace_length.trailing_zeros() as usize;
+    let ram_k = ram_k(
+        preprocessing,
+        trace.trace.rows(),
+        &trace.device.memory_layout,
+    );
+    let ram_log_k = ram_k.trailing_zeros() as usize;
+
+    let rw_config = compat::config::ReadWriteConfig::try_from((log_t, ram_log_k))
+        .expect("read-write config should be valid");
+    let one_hot_config = compat::config::OneHotConfig::from(log_t);
+
+    ProverConfig::new(
+        trace_length,
+        ram_k,
+        JoltReadWriteConfig {
+            ram_rw_phase1_num_rounds: rw_config.ram_rw_phase1_num_rounds,
+            ram_rw_phase2_num_rounds: rw_config.ram_rw_phase2_num_rounds,
+            registers_rw_phase1_num_rounds: rw_config.registers_rw_phase1_num_rounds,
+            registers_rw_phase2_num_rounds: rw_config.registers_rw_phase2_num_rounds,
+        },
+        JoltOneHotConfig {
+            log_k_chunk: one_hot_config.log_k_chunk,
+            lookups_ra_virtual_log_k_chunk: one_hot_config.lookups_ra_virtual_log_k_chunk,
+        },
+        TracePolynomialOrder::CycleMajor,
+    )
+}
+
+fn padded_trace_length(
+    unpadded_trace_length: usize,
+    preprocessing: &JoltProgramPreprocessing,
+) -> usize {
+    let trace_length = padded_trace_length_from_unpadded(unpadded_trace_length);
+    assert!(
+        trace_length <= preprocessing.max_padded_trace_length,
+        "trace length {trace_length} exceeds max {}",
+        preprocessing.max_padded_trace_length
+    );
+    trace_length
+}
+
+fn padded_trace_length_from_unpadded(unpadded_trace_length: usize) -> usize {
+    if unpadded_trace_length < 256 {
+        256
+    } else {
+        (unpadded_trace_length + 1).next_power_of_two()
+    }
+}
+
+fn ram_k(
+    preprocessing: &JoltProgramPreprocessing,
+    rows: &[TraceRow],
+    layout: &MemoryLayout,
+) -> usize {
+    let trace_max = rows
+        .iter()
+        .filter_map(|row| {
+            ram_access_address(row).and_then(|address| remap_address(address, layout))
+        })
+        .max()
+        .unwrap_or(0);
+    let bytecode_end = remap_address(preprocessing.ram.min_bytecode_address, layout).unwrap_or(0)
+        + preprocessing.ram.bytecode_words.len() as u64
+        + 1;
+    trace_max.max(bytecode_end).next_power_of_two() as usize
+}
+
+fn ram_access_address(row: &TraceRow) -> Option<u64> {
+    match row.ram_access {
+        RamAccess::Read(read) => Some(read.address),
+        RamAccess::Write(write) => Some(write.address),
+        RamAccess::NoOp => None,
+    }
+}
+
+fn remap_address(address: u64, layout: &MemoryLayout) -> Option<u64> {
+    if address == 0 || address < layout.get_lowest_address() {
+        None
+    } else {
+        Some((address - layout.get_lowest_address()) / 8)
+    }
+}

--- a/crates/jolt-prover/src/api.rs
+++ b/crates/jolt-prover/src/api.rs
@@ -1,0 +1,226 @@
+use common::jolt_device::JoltDevice;
+#[cfg(feature = "zk")]
+use jolt_backends::BlindFoldBackend;
+use jolt_backends::{
+    RamReadWriteSumcheckBackend, Stage3SpartanSumcheckBackend, Stage4ReadWriteSumcheckBackend,
+    Stage5ValueEvaluationSumcheckBackend, Stage6RegularBatchSumcheckBackend, SumcheckBackend,
+};
+use jolt_crypto::{HomomorphicCommitment, VectorCommitment};
+use jolt_field::Field;
+#[cfg(feature = "zk")]
+use jolt_openings::ZkOpeningScheme;
+use jolt_openings::{AdditivelyHomomorphic, CommitmentScheme};
+use jolt_transcript::AppendToTranscript;
+use jolt_verifier::JoltProof;
+use jolt_witness::{
+    protocols::jolt_vm::{
+        JoltVmNamespace, JoltVmRegisterReadWriteRows, JoltVmSpartanOuterRows, JoltVmStage2Rows,
+        JoltVmStage3InstructionRegisterRows, JoltVmStage3ShiftRows,
+        JoltVmStage5InstructionReadRafRows, JoltVmStage6Rows,
+    },
+    CommittedWitnessProvider, WitnessProvider,
+};
+
+use crate::stages::stage0;
+use crate::{JoltProverPreprocessing, ProverConfig, ProverError};
+
+#[doc(hidden)]
+pub trait JoltVmProverWitness<F>:
+    CommittedWitnessProvider<F, JoltVmNamespace>
+    + WitnessProvider<F, JoltVmNamespace>
+    + jolt_witness::RaFamilyCycleIndexSource<F, JoltVmNamespace>
+    + JoltVmSpartanOuterRows
+    + JoltVmStage2Rows
+    + JoltVmStage3ShiftRows
+    + JoltVmStage3InstructionRegisterRows
+    + JoltVmRegisterReadWriteRows
+    + JoltVmStage5InstructionReadRafRows
+    + JoltVmStage6Rows
+    + Sync
+where
+    F: Field,
+{
+}
+
+impl<F, T> JoltVmProverWitness<F> for T
+where
+    F: Field,
+    T: CommittedWitnessProvider<F, JoltVmNamespace>
+        + WitnessProvider<F, JoltVmNamespace>
+        + jolt_witness::RaFamilyCycleIndexSource<F, JoltVmNamespace>
+        + JoltVmSpartanOuterRows
+        + JoltVmStage2Rows
+        + JoltVmStage3ShiftRows
+        + JoltVmStage3InstructionRegisterRows
+        + JoltVmRegisterReadWriteRows
+        + JoltVmStage5InstructionReadRafRows
+        + JoltVmStage6Rows
+        + Sync,
+{
+}
+
+#[doc(hidden)]
+pub trait ClearProverBackend<F>:
+    SumcheckBackend<F, JoltVmNamespace>
+    + RamReadWriteSumcheckBackend<F>
+    + Stage3SpartanSumcheckBackend<F>
+    + Stage4ReadWriteSumcheckBackend<F>
+    + Stage5ValueEvaluationSumcheckBackend<F>
+    + Stage6RegularBatchSumcheckBackend<F>
+where
+    F: Field,
+{
+}
+
+impl<F, T> ClearProverBackend<F> for T
+where
+    F: Field,
+    T: SumcheckBackend<F, JoltVmNamespace>
+        + RamReadWriteSumcheckBackend<F>
+        + Stage3SpartanSumcheckBackend<F>
+        + Stage4ReadWriteSumcheckBackend<F>
+        + Stage5ValueEvaluationSumcheckBackend<F>
+        + Stage6RegularBatchSumcheckBackend<F>,
+{
+}
+
+#[doc(hidden)]
+#[cfg(feature = "zk")]
+pub trait BlindFoldProverBackend<F>: BlindFoldBackend<F>
+where
+    F: Field,
+{
+}
+
+#[cfg(feature = "zk")]
+impl<F, T> BlindFoldProverBackend<F> for T
+where
+    F: Field,
+    T: BlindFoldBackend<F>,
+{
+}
+
+#[doc(hidden)]
+#[cfg(not(feature = "zk"))]
+pub trait BlindFoldProverBackend<F> {}
+
+#[cfg(not(feature = "zk"))]
+impl<F, T> BlindFoldProverBackend<F> for T {}
+
+#[cfg(feature = "zk")]
+pub trait ProverPcs<VC>:
+    CommitmentScheme
+    + AdditivelyHomomorphic
+    + ZkOpeningScheme<
+        HidingCommitment = <VC as jolt_crypto::Commitment>::Output,
+        Blind = <Self as CommitmentScheme>::Field,
+    >
+where
+    VC: VectorCommitment<Field = <Self as CommitmentScheme>::Field>,
+    <Self as jolt_crypto::Commitment>::Output:
+        HomomorphicCommitment<<Self as CommitmentScheme>::Field>,
+    <VC as jolt_crypto::Commitment>::Output:
+        HomomorphicCommitment<<Self as CommitmentScheme>::Field>,
+{
+}
+
+#[cfg(feature = "zk")]
+impl<PCS, VC> ProverPcs<VC> for PCS
+where
+    PCS: CommitmentScheme
+        + AdditivelyHomomorphic
+        + ZkOpeningScheme<
+            HidingCommitment = <VC as jolt_crypto::Commitment>::Output,
+            Blind = <PCS as CommitmentScheme>::Field,
+        >,
+    VC: VectorCommitment<Field = <PCS as CommitmentScheme>::Field>,
+    <PCS as jolt_crypto::Commitment>::Output:
+        HomomorphicCommitment<<PCS as CommitmentScheme>::Field>,
+    <VC as jolt_crypto::Commitment>::Output:
+        HomomorphicCommitment<<PCS as CommitmentScheme>::Field>,
+{
+}
+
+#[cfg(not(feature = "zk"))]
+pub trait ProverPcs<VC>: CommitmentScheme + AdditivelyHomomorphic
+where
+    VC: VectorCommitment<Field = <Self as CommitmentScheme>::Field>,
+    <Self as jolt_crypto::Commitment>::Output:
+        HomomorphicCommitment<<Self as CommitmentScheme>::Field>,
+{
+}
+
+#[cfg(not(feature = "zk"))]
+impl<PCS, VC> ProverPcs<VC> for PCS
+where
+    PCS: CommitmentScheme + AdditivelyHomomorphic,
+    VC: VectorCommitment<Field = <PCS as CommitmentScheme>::Field>,
+    <PCS as jolt_crypto::Commitment>::Output:
+        HomomorphicCommitment<<PCS as CommitmentScheme>::Field>,
+{
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ProofResult<PCS, VC>
+where
+    PCS: CommitmentScheme,
+    VC: VectorCommitment<Field = PCS::Field>,
+{
+    pub proof: JoltProof<PCS, VC>,
+    pub trusted_advice_commitment: Option<PCS::Output>,
+}
+
+impl<PCS, VC> ProofResult<PCS, VC>
+where
+    PCS: CommitmentScheme,
+    VC: VectorCommitment<Field = PCS::Field>,
+{
+    pub fn into_proof(self) -> JoltProof<PCS, VC> {
+        self.proof
+    }
+}
+
+pub fn prove<PCS, VC, B, W>(
+    preprocessing: &JoltProverPreprocessing<PCS, VC>,
+    public_io: &JoltDevice,
+    witness: &W,
+    config: ProverConfig,
+    backend: &mut B,
+) -> Result<JoltProof<PCS, VC>, ProverError>
+where
+    PCS: ProverPcs<VC>,
+    PCS::Output: AppendToTranscript + HomomorphicCommitment<PCS::Field>,
+    <PCS::Field as jolt_field::WithAccumulator>::Accumulator:
+        jolt_field::RingAccumulator<Element = PCS::Field>,
+    VC: VectorCommitment<Field = PCS::Field>,
+    VC::Output: HomomorphicCommitment<PCS::Field>,
+    B: stage0::CommitmentStageBackend<PCS::Field, PCS>
+        + ClearProverBackend<PCS::Field>
+        + BlindFoldProverBackend<PCS::Field>,
+    W: JoltVmProverWitness<PCS::Field>,
+{
+    prove_with_components(preprocessing, public_io, witness, config, backend)
+        .map(ProofResult::into_proof)
+}
+
+pub fn prove_with_components<PCS, VC, B, W>(
+    preprocessing: &JoltProverPreprocessing<PCS, VC>,
+    public_io: &JoltDevice,
+    witness: &W,
+    config: ProverConfig,
+    backend: &mut B,
+) -> Result<ProofResult<PCS, VC>, ProverError>
+where
+    PCS: ProverPcs<VC>,
+    PCS::Output: AppendToTranscript + HomomorphicCommitment<PCS::Field>,
+    <PCS::Field as jolt_field::WithAccumulator>::Accumulator:
+        jolt_field::RingAccumulator<Element = PCS::Field>,
+    VC: VectorCommitment<Field = PCS::Field>,
+    VC::Output: HomomorphicCommitment<PCS::Field>,
+    B: stage0::CommitmentStageBackend<PCS::Field, PCS>
+        + ClearProverBackend<PCS::Field>
+        + BlindFoldProverBackend<PCS::Field>,
+    W: JoltVmProverWitness<PCS::Field>,
+{
+    crate::prover::prove_with_components_inner(preprocessing, public_io, witness, config, backend)
+}

--- a/crates/jolt-prover/src/committed.rs
+++ b/crates/jolt-prover/src/committed.rs
@@ -1,0 +1,137 @@
+use jolt_crypto::VectorCommitment;
+use jolt_field::Field;
+use jolt_poly::UnivariatePoly;
+use jolt_sumcheck::{
+    CommittedOutputClaims, CommittedRound, CommittedRoundWitness, CommittedSumcheckProof,
+    RoundMessage, SumcheckProof,
+};
+use jolt_transcript::{AppendToTranscript, Transcript};
+use rand_core::OsRng;
+
+use crate::ProverError;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct CommittedSumcheckWitness<F: Field> {
+    pub(crate) round_coefficients: Vec<Vec<F>>,
+    pub(crate) round_blindings: Vec<F>,
+    pub(crate) output_claim_rows: Vec<Vec<F>>,
+    pub(crate) output_claim_blindings: Vec<F>,
+}
+
+impl<F: Field> CommittedSumcheckWitness<F> {
+    fn new(round_capacity: usize) -> Self {
+        Self {
+            round_coefficients: Vec::with_capacity(round_capacity),
+            round_blindings: Vec::with_capacity(round_capacity),
+            output_claim_rows: Vec::new(),
+            output_claim_blindings: Vec::new(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct BuiltCommittedSumcheck<F: Field, C> {
+    pub(crate) proof: SumcheckProof<F, C>,
+    pub(crate) witness: CommittedSumcheckWitness<F>,
+}
+
+pub(crate) struct CommittedSumcheckBuilder<'a, F, VC>
+where
+    F: Field,
+    VC: VectorCommitment<Field = F>,
+{
+    setup: &'a VC::Setup,
+    rng: OsRng,
+    rounds: Vec<CommittedRound<VC::Output>>,
+    witness: CommittedSumcheckWitness<F>,
+}
+
+impl<'a, F, VC> CommittedSumcheckBuilder<'a, F, VC>
+where
+    F: Field,
+    VC: VectorCommitment<Field = F>,
+{
+    pub(crate) fn new(setup: &'a VC::Setup, round_capacity: usize) -> Result<Self, ProverError> {
+        let capacity = VC::capacity(setup);
+        if capacity == 0 {
+            return Err(invalid_committed_sumcheck_output(
+                "vector-commitment setup has zero capacity",
+            ));
+        }
+        Ok(Self {
+            setup,
+            rng: OsRng,
+            rounds: Vec::with_capacity(round_capacity),
+            witness: CommittedSumcheckWitness::new(round_capacity),
+        })
+    }
+
+    pub(crate) fn commit_round<T>(
+        &mut self,
+        round_poly: &UnivariatePoly<F>,
+        transcript: &mut T,
+    ) -> Result<F, ProverError>
+    where
+        T: Transcript<Challenge = F>,
+    {
+        let coefficients = round_poly.coefficients().to_vec();
+        if coefficients.len() > VC::capacity(self.setup) {
+            return Err(invalid_committed_sumcheck_output(format!(
+                "round polynomial has {} coefficients, but vector-commitment capacity is {}",
+                coefficients.len(),
+                VC::capacity(self.setup)
+            )));
+        }
+
+        let blinding = F::random(&mut self.rng);
+        let witness = CommittedRoundWitness {
+            coefficients: coefficients.clone(),
+            blinding,
+        };
+        let round = witness
+            .commit::<VC>(self.setup)
+            .map_err(|error| invalid_committed_sumcheck_output(error.to_string()))?;
+        round.append_to_transcript(transcript);
+        let challenge = transcript.challenge();
+
+        self.rounds.push(round);
+        self.witness.round_coefficients.push(coefficients);
+        self.witness.round_blindings.push(blinding);
+        Ok(challenge)
+    }
+
+    pub(crate) fn finish<T>(
+        mut self,
+        output_claim_values: &[F],
+        transcript: &mut T,
+    ) -> Result<BuiltCommittedSumcheck<F, VC::Output>, ProverError>
+    where
+        T: Transcript<Challenge = F>,
+    {
+        let capacity = VC::capacity(self.setup);
+        let mut commitments = Vec::with_capacity(output_claim_values.len().div_ceil(capacity));
+        for row in output_claim_values.chunks(capacity) {
+            let blinding = F::random(&mut self.rng);
+            let commitment = VC::commit(self.setup, row, &blinding);
+            commitments.push(commitment);
+            self.witness.output_claim_rows.push(row.to_vec());
+            self.witness.output_claim_blindings.push(blinding);
+        }
+
+        let output_claims = CommittedOutputClaims { commitments };
+        output_claims.append_to_transcript(transcript);
+        Ok(BuiltCommittedSumcheck {
+            proof: SumcheckProof::Committed(CommittedSumcheckProof {
+                rounds: self.rounds,
+                output_claims,
+            }),
+            witness: self.witness,
+        })
+    }
+}
+
+fn invalid_committed_sumcheck_output(reason: impl Into<String>) -> ProverError {
+    ProverError::InvalidSumcheckOutput {
+        reason: reason.into(),
+    }
+}

--- a/crates/jolt-prover/src/config.rs
+++ b/crates/jolt-prover/src/config.rs
@@ -1,0 +1,91 @@
+use jolt_claims::protocols::jolt::{JoltOneHotConfig, JoltReadWriteConfig, TracePolynomialOrder};
+use jolt_verifier::{JoltProtocolConfig, ZkConfig, JOLT_VERIFIER_CONFIG};
+
+use crate::error::ProverError;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ProverFeatureSet {
+    pub zk: bool,
+}
+
+impl ProverFeatureSet {
+    pub const COMPILED: Self = Self {
+        zk: cfg!(feature = "zk"),
+    };
+
+    pub fn from_protocol(protocol: &JoltProtocolConfig) -> Self {
+        Self {
+            zk: matches!(protocol.zk, ZkConfig::BlindFold),
+        }
+    }
+}
+
+/// The per-run prover inputs: the workload shape for a single proof.
+///
+/// The protocol is *not* a field — a prover binary always proves against its
+/// compiled [`JOLT_VERIFIER_CONFIG`], so it is referenced as that constant
+/// wherever needed rather than carried (and varied) per config.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ProverConfig {
+    pub trace_length: usize,
+    pub ram_k: usize,
+    pub rw_config: JoltReadWriteConfig,
+    pub one_hot_config: JoltOneHotConfig,
+    pub trace_polynomial_order: TracePolynomialOrder,
+}
+
+impl ProverConfig {
+    pub const fn new(
+        trace_length: usize,
+        ram_k: usize,
+        rw_config: JoltReadWriteConfig,
+        one_hot_config: JoltOneHotConfig,
+        trace_polynomial_order: TracePolynomialOrder,
+    ) -> Self {
+        Self {
+            trace_length,
+            ram_k,
+            rw_config,
+            one_hot_config,
+            trace_polynomial_order,
+        }
+    }
+
+    /// The compile-relevant feature subset (`zk`) this binary proves with,
+    /// derived from the pinned [`JOLT_VERIFIER_CONFIG`].
+    pub fn features() -> ProverFeatureSet {
+        ProverFeatureSet::from_protocol(&JOLT_VERIFIER_CONFIG)
+    }
+
+    pub(crate) fn validate_for_proving(&self) -> Result<(), ProverError> {
+        let features = Self::features();
+        if features != ProverFeatureSet::COMPILED {
+            return Err(ProverError::InvalidProverConfig {
+                reason: format!(
+                    "the verifier protocol implies prover features {features:?}, but this binary was compiled with {:?}",
+                    ProverFeatureSet::COMPILED
+                ),
+            });
+        }
+
+        if self.trace_length == 0 || !self.trace_length.is_power_of_two() {
+            return Err(ProverError::InvalidProverConfig {
+                reason: format!(
+                    "proof trace_length must be a nonzero power of two, got {}",
+                    self.trace_length
+                ),
+            });
+        }
+
+        if self.ram_k == 0 || !self.ram_k.is_power_of_two() {
+            return Err(ProverError::InvalidProverConfig {
+                reason: format!(
+                    "proof ram_k must be a nonzero power of two, got {}",
+                    self.ram_k
+                ),
+            });
+        }
+
+        Ok(())
+    }
+}

--- a/crates/jolt-prover/src/error.rs
+++ b/crates/jolt-prover/src/error.rs
@@ -1,0 +1,21 @@
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum ProverError {
+    #[error("prover path is not implemented yet: {path}")]
+    ProverPathNotImplemented { path: &'static str },
+    #[error("invalid prover configuration: {reason}")]
+    InvalidProverConfig { reason: String },
+    #[error("invalid commitment output result: {reason}")]
+    InvalidCommitmentOutput { reason: String },
+    #[error("invalid stage request: {reason}")]
+    InvalidStageRequest { reason: String },
+    #[error("invalid sumcheck output result: {reason}")]
+    InvalidSumcheckOutput { reason: String },
+    #[error(transparent)]
+    Backend(#[from] jolt_backends::BackendError),
+    #[error(transparent)]
+    Verifier(#[from] jolt_verifier::VerifierError),
+    #[error(transparent)]
+    Witness(#[from] jolt_witness::WitnessError),
+}

--- a/crates/jolt-prover/src/lib.rs
+++ b/crates/jolt-prover/src/lib.rs
@@ -1,0 +1,21 @@
+//! Protocol orchestration for modular Jolt proving.
+//!
+//! This crate owns proof order, transcript scheduling, and typed verifier-proof
+//! construction. Concrete compute implementations live in `jolt-backends`.
+
+mod api;
+#[cfg(feature = "zk")]
+mod committed;
+mod config;
+mod error;
+mod preprocessing;
+mod prover;
+mod stages;
+#[cfg(feature = "zk")]
+mod zk;
+
+pub use api::BlindFoldProverBackend;
+pub use api::{prove, prove_with_components, ProofResult};
+pub use config::{ProverConfig, ProverFeatureSet};
+pub use error::ProverError;
+pub use preprocessing::JoltProverPreprocessing;

--- a/crates/jolt-prover/src/preprocessing.rs
+++ b/crates/jolt-prover/src/preprocessing.rs
@@ -1,0 +1,26 @@
+use jolt_crypto::VectorCommitment;
+use jolt_openings::CommitmentScheme;
+use jolt_verifier::JoltVerifierPreprocessing;
+
+#[derive(Clone)]
+pub struct JoltProverPreprocessing<PCS, VC>
+where
+    PCS: CommitmentScheme,
+    VC: VectorCommitment<Field = PCS::Field>,
+{
+    pub verifier: JoltVerifierPreprocessing<PCS, VC>,
+    pub pcs_setup: PCS::ProverSetup,
+}
+
+impl<PCS, VC> JoltProverPreprocessing<PCS, VC>
+where
+    PCS: CommitmentScheme,
+    VC: VectorCommitment<Field = PCS::Field>,
+{
+    pub fn new(verifier: JoltVerifierPreprocessing<PCS, VC>, pcs_setup: PCS::ProverSetup) -> Self {
+        Self {
+            verifier,
+            pcs_setup,
+        }
+    }
+}

--- a/crates/jolt-prover/src/prover.rs
+++ b/crates/jolt-prover/src/prover.rs
@@ -1,0 +1,763 @@
+use common::jolt_device::JoltDevice;
+#[cfg(feature = "zk")]
+use jolt_backends::BlindFoldBackend;
+use jolt_claims::protocols::jolt::JoltFormulaDimensions;
+use jolt_crypto::{HomomorphicCommitment, VectorCommitment};
+use jolt_openings::{AdditivelyHomomorphic, CommitmentScheme};
+use jolt_sumcheck::SumcheckProof;
+use jolt_transcript::AppendToTranscript;
+use jolt_transcript::{Blake2bTranscript, Transcript};
+use jolt_verifier::proof::{ClearProofClaims, JoltProofClaims, JoltStageProofs};
+use jolt_verifier::{
+    absorb_transcript_commitments, absorb_transcript_preamble, JoltProof, ProofTranscriptConfig,
+    JOLT_VERIFIER_CONFIG,
+};
+use jolt_witness::{
+    protocols::jolt_vm::{JoltVmNamespace, RV64_LOOKUP_ADDRESS_BITS},
+    CommittedWitnessProvider,
+};
+
+use crate::api::{
+    BlindFoldProverBackend, ClearProverBackend, JoltVmProverWitness, ProofResult, ProverPcs,
+};
+#[cfg(feature = "zk")]
+use crate::committed::CommittedSumcheckWitness;
+use crate::stages::stage0::{self, prepare as stage0_prepare};
+use crate::stages::stage0::{CommitmentComponent, CommitmentStageInput};
+#[cfg(feature = "zk")]
+use crate::stages::stage1::prove::Stage1CommittedProofComponent;
+use crate::stages::stage1::prove::{Stage1ProofComponent, Stage1ProverConfig, Stage1ProverInput};
+#[cfg(feature = "zk")]
+use crate::stages::stage2::prove::Stage2CommittedProofComponent;
+use crate::stages::stage2::prove::{
+    Stage2BatchProverConfig, Stage2ProofComponent, Stage2ProverInput,
+};
+#[cfg(feature = "zk")]
+use crate::stages::stage3::prove::Stage3CommittedProofComponent;
+use crate::stages::stage3::prove::{Stage3ProofComponent, Stage3ProverConfig, Stage3ProverInput};
+use crate::stages::stage4::prepare as stage4_prepare;
+#[cfg(feature = "zk")]
+use crate::stages::stage4::prove::Stage4CommittedProofComponent;
+use crate::stages::stage4::prove::{Stage4ProofComponent, Stage4ProverConfig, Stage4ProverInput};
+#[cfg(feature = "zk")]
+use crate::stages::stage5::prove::Stage5CommittedProofComponent;
+use crate::stages::stage5::prove::{Stage5ProofComponent, Stage5ProverConfig, Stage5ProverInput};
+use crate::stages::stage6::prepare as stage6_prepare;
+#[cfg(feature = "zk")]
+use crate::stages::stage6::Stage6CommittedProofComponent;
+use crate::stages::stage6::{Stage6ProofComponent, Stage6ProverInput};
+use crate::stages::stage7::prepare as stage7_prepare;
+#[cfg(feature = "zk")]
+use crate::stages::stage7::prove::Stage7CommittedProofComponent;
+use crate::stages::stage7::prove::{Stage7ProofComponent, Stage7ProverInput};
+use crate::stages::stage8::prepare as stage8_prepare;
+#[cfg(feature = "zk")]
+use crate::zk;
+use crate::{JoltProverPreprocessing, ProverConfig, ProverError};
+use jolt_verifier::stages::stage1::stage1_claims_from_r1cs_inputs;
+
+type ClearProofPayload<PCS, VC> = (
+    JoltStageProofs<<PCS as CommitmentScheme>::Field, VC>,
+    ClearProofClaims<<PCS as CommitmentScheme>::Field>,
+    <PCS as CommitmentScheme>::Proof,
+);
+
+type ClearStagePayload<PCS, VC> = (
+    JoltStageProofs<<PCS as CommitmentScheme>::Field, VC>,
+    ClearProofClaims<<PCS as CommitmentScheme>::Field>,
+);
+
+type ProofBuildOutput<PCS, VC> = (
+    JoltProof<PCS, VC>,
+    Option<<PCS as jolt_crypto::Commitment>::Output>,
+);
+
+type StageSumcheckProof<F, VC> = SumcheckProof<F, <VC as jolt_crypto::Commitment>::Output>;
+
+#[cfg(feature = "zk")]
+type ZkProofPayload<PCS, VC> = (
+    JoltStageProofs<<PCS as CommitmentScheme>::Field, VC>,
+    <PCS as CommitmentScheme>::Proof,
+    jolt_blindfold::BlindFoldProof<
+        <PCS as CommitmentScheme>::Field,
+        <VC as jolt_crypto::Commitment>::Output,
+    >,
+);
+
+#[cfg(feature = "zk")]
+type ZkStagePayload<PCS, VC> = (
+    JoltStageProofs<<PCS as CommitmentScheme>::Field, VC>,
+    Vec<CommittedSumcheckWitness<<PCS as CommitmentScheme>::Field>>,
+);
+
+pub(crate) fn prove_with_components_inner<PCS, VC, B, W>(
+    preprocessing: &JoltProverPreprocessing<PCS, VC>,
+    public_io: &JoltDevice,
+    witness: &W,
+    config: ProverConfig,
+    backend: &mut B,
+) -> Result<ProofResult<PCS, VC>, ProverError>
+where
+    PCS: ProverPcs<VC>,
+    PCS::Output: AppendToTranscript + HomomorphicCommitment<PCS::Field>,
+    <PCS::Field as jolt_field::WithAccumulator>::Accumulator:
+        jolt_field::RingAccumulator<Element = PCS::Field>,
+    VC: VectorCommitment<Field = PCS::Field>,
+    VC::Output: HomomorphicCommitment<PCS::Field>,
+    B: stage0::CommitmentStageBackend<PCS::Field, PCS>
+        + ClearProverBackend<PCS::Field>
+        + BlindFoldProverBackend<PCS::Field>,
+    W: JoltVmProverWitness<PCS::Field>,
+{
+    config.validate_for_proving()?;
+    let stage0 = prove_stage0(preprocessing, public_io, witness, &config, backend)?;
+
+    #[cfg(feature = "zk")]
+    if ProverConfig::features().zk {
+        let (stage_proofs, joint_opening_proof, blindfold_proof) =
+            prove_zk_stages(preprocessing, public_io, witness, &config, backend, &stage0)?;
+        let (proof, trusted_advice_commitment) = build_zk_proof(
+            &config,
+            stage0,
+            stage_proofs,
+            joint_opening_proof,
+            blindfold_proof,
+        )?;
+        return Ok(ProofResult {
+            proof,
+            trusted_advice_commitment,
+        });
+    }
+
+    let (stage_proofs, clear_claims, joint_opening_proof) =
+        prove_clear_stages(preprocessing, public_io, witness, &config, backend, &stage0)?;
+
+    if !ProverConfig::features().zk {
+        let (proof, trusted_advice_commitment) = build_clear_proof(
+            &config,
+            stage0,
+            stage_proofs,
+            clear_claims,
+            joint_opening_proof,
+        )?;
+        return Ok(ProofResult {
+            proof,
+            trusted_advice_commitment,
+        });
+    }
+
+    Err(ProverError::ProverPathNotImplemented {
+        path: "full Jolt proof",
+    })
+}
+
+fn absorb_stage0_transcript<PCS, T>(
+    checked: &jolt_verifier::CheckedInputs,
+    proof_parameters: ProverConfig,
+    stage0: &CommitmentComponent<PCS>,
+    transcript: &mut T,
+) where
+    PCS: CommitmentScheme,
+    PCS::Output: AppendToTranscript,
+    T: Transcript,
+{
+    let config = ProofTranscriptConfig::new(
+        proof_parameters.rw_config,
+        proof_parameters.one_hot_config,
+        proof_parameters.trace_polynomial_order,
+    );
+    absorb_transcript_preamble(checked, config, transcript);
+    absorb_transcript_commitments(
+        &stage0.commitments,
+        stage0.untrusted_advice_commitment.as_ref(),
+        stage0.trusted_advice_commitment.as_ref(),
+        transcript,
+    );
+}
+
+fn build_clear_proof<PCS, VC>(
+    config: &ProverConfig,
+    stage0: CommitmentComponent<PCS>,
+    stages: JoltStageProofs<PCS::Field, VC>,
+    claims: ClearProofClaims<PCS::Field>,
+    joint_opening_proof: PCS::Proof,
+) -> Result<ProofBuildOutput<PCS, VC>, ProverError>
+where
+    PCS: CommitmentScheme,
+    VC: VectorCommitment<Field = PCS::Field>,
+{
+    if ProverConfig::features().zk {
+        return Err(ProverError::InvalidStageRequest {
+            reason: "clear proof construction cannot finish a ZK proof".to_owned(),
+        });
+    }
+    let proof_parameters = *config;
+    let proof = JoltProof::new(
+        stage0.commitments,
+        stages,
+        joint_opening_proof,
+        stage0.untrusted_advice_commitment,
+        JoltProofClaims::Clear(claims),
+        proof_parameters.trace_length,
+        proof_parameters.ram_k,
+        proof_parameters.rw_config,
+        proof_parameters.one_hot_config,
+        proof_parameters.trace_polynomial_order,
+    );
+    Ok((proof, stage0.trusted_advice_commitment))
+}
+
+#[cfg(feature = "zk")]
+fn build_zk_proof<PCS, VC>(
+    config: &ProverConfig,
+    stage0: CommitmentComponent<PCS>,
+    stages: JoltStageProofs<PCS::Field, VC>,
+    joint_opening_proof: PCS::Proof,
+    blindfold_proof: jolt_blindfold::BlindFoldProof<PCS::Field, VC::Output>,
+) -> Result<ProofBuildOutput<PCS, VC>, ProverError>
+where
+    PCS: CommitmentScheme,
+    VC: VectorCommitment<Field = PCS::Field>,
+{
+    if !ProverConfig::features().zk {
+        return Err(ProverError::InvalidStageRequest {
+            reason: "ZK proof construction cannot finish a clear proof".to_owned(),
+        });
+    }
+    let proof_parameters = *config;
+    let proof = JoltProof::new(
+        stage0.commitments,
+        stages,
+        joint_opening_proof,
+        stage0.untrusted_advice_commitment,
+        JoltProofClaims::Zk { blindfold_proof },
+        proof_parameters.trace_length,
+        proof_parameters.ram_k,
+        proof_parameters.rw_config,
+        proof_parameters.one_hot_config,
+        proof_parameters.trace_polynomial_order,
+    );
+    Ok((proof, stage0.trusted_advice_commitment))
+}
+
+fn clear_stage_payload<PCS, VC>(
+    stage1: Stage1ProofComponent<PCS::Field, StageSumcheckProof<PCS::Field, VC>>,
+    stage2: Stage2ProofComponent<PCS::Field, StageSumcheckProof<PCS::Field, VC>>,
+    stage3: Stage3ProofComponent<PCS::Field, StageSumcheckProof<PCS::Field, VC>>,
+    stage4: Stage4ProofComponent<PCS::Field, StageSumcheckProof<PCS::Field, VC>>,
+    stage5: Stage5ProofComponent<PCS::Field, StageSumcheckProof<PCS::Field, VC>>,
+    stage6: Stage6ProofComponent<PCS::Field, StageSumcheckProof<PCS::Field, VC>>,
+    stage7: Stage7ProofComponent<PCS::Field, StageSumcheckProof<PCS::Field, VC>>,
+) -> Result<ClearStagePayload<PCS, VC>, ProverError>
+where
+    PCS: CommitmentScheme,
+    VC: VectorCommitment<Field = PCS::Field>,
+{
+    let stage1_claims = stage1_claims_from_r1cs_inputs(
+        stage1.uniskip_output_claim,
+        stage1
+            .r1cs_input_claims
+            .iter()
+            .map(crate::stages::stage1::prove::Stage1R1csInputClaim::verifier_input),
+    )?;
+    let stage_proofs = JoltStageProofs {
+        stage1_uni_skip_first_round_proof: stage1.uniskip_proof,
+        stage1_sumcheck_proof: stage1.remainder_proof,
+        stage2_uni_skip_first_round_proof: stage2.product_uniskip_proof,
+        stage2_sumcheck_proof: stage2.regular_batch_proof,
+        stage3_sumcheck_proof: stage3.stage3_sumcheck_proof,
+        stage4_sumcheck_proof: stage4.stage4_sumcheck_proof,
+        stage5_sumcheck_proof: stage5.stage5_sumcheck_proof,
+        stage6a_sumcheck_proof: stage6.stage6a_sumcheck_proof,
+        stage6b_sumcheck_proof: stage6.stage6b_sumcheck_proof,
+        stage7_sumcheck_proof: stage7.stage7_sumcheck_proof,
+    };
+    let clear_claims = ClearProofClaims {
+        stage1: stage1_claims,
+        stage2: stage2.claims,
+        stage3: stage3.claims,
+        stage4: stage4.claims,
+        stage5: stage5.claims,
+        stage6: stage6.claims,
+        stage7: stage7.claims,
+    };
+
+    Ok((stage_proofs, clear_claims))
+}
+
+#[cfg(feature = "zk")]
+fn zk_stage_payload<PCS, VC>(
+    stage1: Stage1CommittedProofComponent<PCS::Field, VC>,
+    stage2: Stage2CommittedProofComponent<PCS::Field, VC>,
+    stage3: Stage3CommittedProofComponent<PCS::Field, VC>,
+    stage4: Stage4CommittedProofComponent<PCS::Field, VC>,
+    stage5: Stage5CommittedProofComponent<PCS::Field, VC>,
+    stage6: Stage6CommittedProofComponent<PCS::Field, VC>,
+    stage7: Stage7CommittedProofComponent<PCS::Field, VC>,
+) -> ZkStagePayload<PCS, VC>
+where
+    PCS: CommitmentScheme,
+    VC: VectorCommitment<Field = PCS::Field>,
+{
+    let stage_proofs = JoltStageProofs {
+        stage1_uni_skip_first_round_proof: stage1.uniskip_proof,
+        stage1_sumcheck_proof: stage1.remainder_proof,
+        stage2_uni_skip_first_round_proof: stage2.product_uniskip_proof,
+        stage2_sumcheck_proof: stage2.regular_batch_proof,
+        stage3_sumcheck_proof: stage3.stage3_sumcheck_proof,
+        stage4_sumcheck_proof: stage4.stage4_sumcheck_proof,
+        stage5_sumcheck_proof: stage5.stage5_sumcheck_proof,
+        stage6a_sumcheck_proof: stage6.stage6a_sumcheck_proof,
+        stage6b_sumcheck_proof: stage6.stage6b_sumcheck_proof,
+        stage7_sumcheck_proof: stage7.stage7_sumcheck_proof,
+    };
+    let committed_sumchecks = vec![
+        stage1.uniskip_committed_witness,
+        stage1.remainder_committed_witness,
+        stage2.product_uniskip_committed_witness,
+        stage2.batch_committed_witness,
+        stage3.committed_witness,
+        stage4.committed_witness,
+        stage5.committed_witness,
+        stage6.stage6a_committed_witness,
+        stage6.committed_witness,
+        stage7.committed_witness,
+    ];
+
+    (stage_proofs, committed_sumchecks)
+}
+
+#[cfg(feature = "zk")]
+fn prove_zk_stages<PCS, VC, B, W>(
+    preprocessing: &JoltProverPreprocessing<PCS, VC>,
+    public_io: &JoltDevice,
+    witness: &W,
+    config: &ProverConfig,
+    backend: &mut B,
+    stage0: &CommitmentComponent<PCS>,
+) -> Result<ZkProofPayload<PCS, VC>, ProverError>
+where
+    PCS: ProverPcs<VC>,
+    PCS::Output: AppendToTranscript + HomomorphicCommitment<PCS::Field>,
+    <PCS::Field as jolt_field::WithAccumulator>::Accumulator:
+        jolt_field::RingAccumulator<Element = PCS::Field>,
+    VC: VectorCommitment<Field = PCS::Field>,
+    VC::Output: HomomorphicCommitment<PCS::Field>,
+    B: ClearProverBackend<PCS::Field> + BlindFoldBackend<PCS::Field>,
+    W: JoltVmProverWitness<PCS::Field>,
+{
+    let proof_parameters = *config;
+    let checked = checked_inputs(preprocessing, public_io, config, true)?;
+    let vc_setup = preprocessing.verifier.vc_setup.as_ref().ok_or_else(|| {
+        ProverError::InvalidProverConfig {
+            reason: "ZK proving requires verifier preprocessing with vector-commitment setup"
+                .to_owned(),
+        }
+    })?;
+    let mut transcript = Blake2bTranscript::<PCS::Field>::new(b"Jolt");
+    absorb_stage0_transcript(&checked, proof_parameters, stage0, &mut transcript);
+    let log_t = proof_parameters_log_t(proof_parameters);
+
+    let stage1: Stage1CommittedProofComponent<PCS::Field, VC> =
+        crate::stages::stage1::prove::prove_committed_proof_component(
+            Stage1ProverInput::new(Stage1ProverConfig::new(log_t), witness),
+            backend,
+            &mut transcript,
+            vc_setup,
+        )?;
+    let stage1_verifier_output = stage1.verifier_output.clone();
+
+    let log_k = proof_parameters_log_k(proof_parameters);
+    let stage2: Stage2CommittedProofComponent<PCS::Field, VC> =
+        crate::stages::stage2::prove::prove_committed_proof_component(
+            Stage2ProverInput::new(
+                Stage2BatchProverConfig::new(log_t, log_k, proof_parameters.rw_config),
+                &checked,
+                &stage1_verifier_output,
+                witness,
+            ),
+            backend,
+            vc_setup,
+            &mut transcript,
+        )?;
+    let stage2_verifier_output = stage2.verifier_output.clone();
+
+    let stage3: Stage3CommittedProofComponent<PCS::Field, VC> =
+        crate::stages::stage3::prove::prove_committed_proof_component(
+            Stage3ProverInput::new(
+                Stage3ProverConfig::new(log_t),
+                &checked,
+                &stage1_verifier_output,
+                &stage2_verifier_output,
+                witness,
+            ),
+            backend,
+            &mut transcript,
+            vc_setup,
+        )?;
+    let stage3_verifier_output = stage3.verifier_output.clone();
+
+    let ram_val_check_init = stage4_prepare::ram_val_check_initial_evaluation(
+        preprocessing,
+        &checked,
+        &stage2_verifier_output,
+        log_k,
+    )?;
+    let stage4: Stage4CommittedProofComponent<PCS::Field, VC> =
+        crate::stages::stage4::prove::prove_committed_proof_component(
+            Stage4ProverInput::new(
+                Stage4ProverConfig::new(log_t, log_k, proof_parameters.rw_config),
+                &checked,
+                &stage2_verifier_output,
+                &stage3_verifier_output,
+                ram_val_check_init,
+                witness,
+            ),
+            backend,
+            &mut transcript,
+            vc_setup,
+        )?;
+    let stage4_verifier_output = stage4.verifier_output.clone();
+
+    let formula_dimensions = proof_parameters_formula_dimensions(preprocessing, proof_parameters)?;
+    let stage5: Stage5CommittedProofComponent<PCS::Field, VC> =
+        crate::stages::stage5::prove::prove_committed_proof_component(
+            Stage5ProverInput::new(
+                Stage5ProverConfig::new(log_t, log_k, formula_dimensions.instruction_read_raf),
+                &checked,
+                &stage2_verifier_output,
+                &stage4_verifier_output,
+                witness,
+            ),
+            backend,
+            &mut transcript,
+            vc_setup,
+        )?;
+    let stage5_verifier_output = stage5.verifier_output.clone();
+
+    let stage6_config = stage6_prepare::prover_config(
+        preprocessing,
+        public_io,
+        proof_parameters,
+        formula_dimensions,
+    )?;
+    let stage6: Stage6CommittedProofComponent<PCS::Field, VC> =
+        crate::stages::stage6::prove::prove_committed_proof_component(
+            Stage6ProverInput::new(
+                &stage6_config,
+                &checked,
+                &stage1_verifier_output,
+                &stage2_verifier_output,
+                &stage3_verifier_output,
+                &stage4_verifier_output,
+                &stage5_verifier_output,
+                witness,
+            ),
+            backend,
+            &mut transcript,
+            vc_setup,
+        )?;
+    let stage6_verifier_output = stage6.verifier_output.clone();
+
+    let stage7_config =
+        stage7_prepare::prover_config(public_io, proof_parameters, formula_dimensions)?;
+    let stage7: Stage7CommittedProofComponent<PCS::Field, VC> =
+        crate::stages::stage7::prove::prove_committed_proof_component(
+            Stage7ProverInput::new(
+                &stage7_config,
+                &checked,
+                &stage4_verifier_output,
+                &stage6_verifier_output,
+                witness,
+            ),
+            backend,
+            &mut transcript,
+            vc_setup,
+        )?;
+    let stage7_verifier_output = stage7.verifier_output.clone();
+    let (stage_proofs, committed_sumchecks) =
+        zk_stage_payload::<PCS, VC>(stage1, stage2, stage3, stage4, stage5, stage6, stage7);
+
+    let stage8_config =
+        stage8_prepare::prover_config(public_io, proof_parameters, formula_dimensions)?;
+    let (commitments, hints) = stage0.stage8_opening_inputs(stage8_config.layout)?;
+    let stage8 = crate::stages::stage8::prove::prove_stage8_zk::<
+        PCS::Field,
+        PCS,
+        W,
+        Blake2bTranscript<PCS::Field>,
+    >(
+        &stage8_config,
+        &stage6_verifier_output,
+        &stage7_verifier_output,
+        witness,
+        commitments.as_slice(),
+        hints,
+        &preprocessing.pcs_setup,
+        &mut transcript,
+    )?;
+    let blindfold = zk::build_blindfold_protocol(
+        config,
+        &preprocessing.verifier,
+        public_io,
+        stage0,
+        &stage_proofs,
+        &stage8.joint_opening_proof,
+    )?;
+    let mut rng = rand_core::OsRng;
+    let blindfold_witness = zk::assemble_blindfold_witness::<PCS, VC, _>(
+        &blindfold,
+        &committed_sumchecks,
+        &stage8,
+        &mut rng,
+    )?;
+
+    let blindfold_proof = zk::prove_blindfold::<PCS::Field, VC, _, _, _>(
+        vc_setup,
+        &blindfold,
+        &blindfold_witness,
+        &mut transcript,
+        &mut rng,
+        backend,
+    )?;
+    Ok((stage_proofs, stage8.joint_opening_proof, blindfold_proof))
+}
+
+fn prove_clear_stages<PCS, VC, B, W>(
+    preprocessing: &JoltProverPreprocessing<PCS, VC>,
+    public_io: &JoltDevice,
+    witness: &W,
+    config: &ProverConfig,
+    backend: &mut B,
+    stage0: &CommitmentComponent<PCS>,
+) -> Result<ClearProofPayload<PCS, VC>, ProverError>
+where
+    PCS: CommitmentScheme + AdditivelyHomomorphic,
+    PCS::Output: AppendToTranscript + HomomorphicCommitment<PCS::Field>,
+    <PCS::Field as jolt_field::WithAccumulator>::Accumulator:
+        jolt_field::RingAccumulator<Element = PCS::Field>,
+    VC: VectorCommitment<Field = PCS::Field>,
+    B: ClearProverBackend<PCS::Field>,
+    W: JoltVmProverWitness<PCS::Field>,
+{
+    let proof_parameters = *config;
+    let checked = checked_inputs(preprocessing, public_io, config, false)?;
+    let mut transcript = Blake2bTranscript::<PCS::Field>::new(b"Jolt");
+    absorb_stage0_transcript(&checked, proof_parameters, stage0, &mut transcript);
+
+    let log_t = proof_parameters_log_t(proof_parameters);
+    let stage1 = crate::stages::stage1::prove::prove(
+        Stage1ProverInput::new(Stage1ProverConfig::new(log_t), witness),
+        backend,
+        &mut transcript,
+    )?;
+    let stage1_verifier_output =
+        stage1
+            .verifier_output
+            .clone()
+            .ok_or_else(|| ProverError::InvalidStageRequest {
+                reason: "Stage 1 clear prover did not return verifier output".to_owned(),
+            })?;
+
+    let log_k = proof_parameters_log_k(proof_parameters);
+    let stage2 = crate::stages::stage2::prove::prove(
+        Stage2ProverInput::new(
+            Stage2BatchProverConfig::new(log_t, log_k, proof_parameters.rw_config),
+            &checked,
+            &stage1_verifier_output,
+            witness,
+        ),
+        backend,
+        &mut transcript,
+    )?;
+    let stage2_verifier_output = stage2.verifier_output.clone();
+
+    let stage3 = crate::stages::stage3::prove::prove(
+        Stage3ProverInput::new(
+            Stage3ProverConfig::new(log_t),
+            &checked,
+            &stage1_verifier_output,
+            &stage2_verifier_output,
+            witness,
+        ),
+        backend,
+        &mut transcript,
+    )?;
+    let stage3_verifier_output = stage3.verifier_output.clone();
+
+    let ram_val_check_init = stage4_prepare::ram_val_check_initial_evaluation(
+        preprocessing,
+        &checked,
+        &stage2_verifier_output,
+        log_k,
+    )?;
+    let stage4 = crate::stages::stage4::prove::prove(
+        Stage4ProverInput::new(
+            Stage4ProverConfig::new(log_t, log_k, proof_parameters.rw_config),
+            &checked,
+            &stage2_verifier_output,
+            &stage3_verifier_output,
+            ram_val_check_init,
+            witness,
+        ),
+        backend,
+        &mut transcript,
+    )?;
+    let stage4_verifier_output = stage4.verifier_output.clone();
+
+    let formula_dimensions = proof_parameters_formula_dimensions(preprocessing, proof_parameters)?;
+    let stage5 = crate::stages::stage5::prove::prove(
+        Stage5ProverInput::new(
+            Stage5ProverConfig::new(log_t, log_k, formula_dimensions.instruction_read_raf),
+            &checked,
+            &stage2_verifier_output,
+            &stage4_verifier_output,
+            witness,
+        ),
+        backend,
+        &mut transcript,
+    )?;
+    let stage5_verifier_output = stage5.verifier_output.clone();
+
+    let stage6_config = stage6_prepare::prover_config(
+        preprocessing,
+        public_io,
+        proof_parameters,
+        formula_dimensions,
+    )?;
+    let stage6 = crate::stages::stage6::prove::prove(
+        Stage6ProverInput::new(
+            &stage6_config,
+            &checked,
+            &stage1_verifier_output,
+            &stage2_verifier_output,
+            &stage3_verifier_output,
+            &stage4_verifier_output,
+            &stage5_verifier_output,
+            witness,
+        ),
+        backend,
+        &mut transcript,
+    )?;
+    let stage6_verifier_output = stage6.verifier_output.clone();
+
+    let stage7_config =
+        stage7_prepare::prover_config(public_io, proof_parameters, formula_dimensions)?;
+    let stage7 = crate::stages::stage7::prove::prove(
+        Stage7ProverInput::new(
+            &stage7_config,
+            &checked,
+            &stage4_verifier_output,
+            &stage6_verifier_output,
+            witness,
+        ),
+        backend,
+        &mut transcript,
+    )?;
+    let stage7_verifier_output = stage7.verifier_output.clone();
+
+    let (stage_proofs, clear_claims) =
+        clear_stage_payload::<PCS, VC>(stage1, stage2, stage3, stage4, stage5, stage6, stage7)?;
+
+    let stage8_config =
+        stage8_prepare::prover_config(public_io, proof_parameters, formula_dimensions)?;
+    let (commitments, hints) = stage0.stage8_opening_inputs(stage8_config.layout)?;
+    let stage8 = crate::stages::stage8::prove::prove_stage8::<
+        PCS::Field,
+        PCS,
+        W,
+        Blake2bTranscript<PCS::Field>,
+    >(
+        &stage8_config,
+        &stage6_verifier_output,
+        &stage7_verifier_output,
+        witness,
+        commitments.as_slice(),
+        hints,
+        &preprocessing.pcs_setup,
+        &mut transcript,
+    )?;
+    let joint_opening_proof = stage8.joint_opening_proof;
+
+    Ok((stage_proofs, clear_claims, joint_opening_proof))
+}
+
+fn checked_inputs<PCS, VC>(
+    preprocessing: &JoltProverPreprocessing<PCS, VC>,
+    public_io: &JoltDevice,
+    config: &ProverConfig,
+    zk: bool,
+) -> Result<jolt_verifier::CheckedInputs, ProverError>
+where
+    PCS: CommitmentScheme,
+    VC: VectorCommitment<Field = PCS::Field>,
+{
+    let proof_parameters = *config;
+    Ok(jolt_verifier::validate_inputs_from_parts(
+        &preprocessing.verifier,
+        public_io,
+        proof_parameters.trace_length,
+        proof_parameters.ram_k,
+        proof_parameters.trace_polynomial_order,
+        proof_parameters.one_hot_config,
+        !public_io.trusted_advice.is_empty(),
+        !public_io.untrusted_advice.is_empty(),
+        zk,
+    )?)
+}
+
+fn prove_stage0<PCS, VC, B, W>(
+    preprocessing: &JoltProverPreprocessing<PCS, VC>,
+    public_io: &JoltDevice,
+    witness: &W,
+    config: &ProverConfig,
+    backend: &mut B,
+) -> Result<CommitmentComponent<PCS>, ProverError>
+where
+    PCS: CommitmentScheme,
+    VC: VectorCommitment<Field = PCS::Field>,
+    B: stage0::CommitmentStageBackend<PCS::Field, PCS>,
+    W: CommittedWitnessProvider<PCS::Field, JoltVmNamespace> + Sync,
+{
+    let proof_parameters = *config;
+    let formula_dimensions = proof_parameters_formula_dimensions(preprocessing, proof_parameters)?;
+    let stage0_config =
+        stage0_prepare::commitment_config(public_io, proof_parameters, formula_dimensions);
+    stage0::prove::<PCS::Field, _, _, PCS>(
+        CommitmentStageInput::new(
+            witness,
+            &preprocessing.pcs_setup,
+            stage0_config,
+            JOLT_VERIFIER_CONFIG,
+        ),
+        backend,
+    )
+}
+
+fn proof_parameters_log_t(proof_parameters: ProverConfig) -> usize {
+    proof_parameters.trace_length.trailing_zeros() as usize
+}
+
+fn proof_parameters_log_k(proof_parameters: ProverConfig) -> usize {
+    proof_parameters.ram_k.trailing_zeros() as usize
+}
+
+fn proof_parameters_formula_dimensions<PCS, VC>(
+    preprocessing: &JoltProverPreprocessing<PCS, VC>,
+    proof_parameters: ProverConfig,
+) -> Result<JoltFormulaDimensions, ProverError>
+where
+    PCS: CommitmentScheme,
+    VC: VectorCommitment<Field = PCS::Field>,
+{
+    let log_t = proof_parameters_log_t(proof_parameters);
+    JoltFormulaDimensions::try_from(proof_parameters.one_hot_config.dimensions(
+        log_t,
+        RV64_LOOKUP_ADDRESS_BITS,
+        preprocessing.verifier.program.bytecode_len(),
+        proof_parameters.ram_k,
+    ))
+    .map_err(|error| ProverError::InvalidProverConfig {
+        reason: format!("invalid proof formula dimensions: {error}"),
+    })
+}

--- a/crates/jolt-prover/src/stages/advice.rs
+++ b/crates/jolt-prover/src/stages/advice.rs
@@ -1,0 +1,53 @@
+use common::jolt_device::JoltDevice;
+use jolt_claims::protocols::jolt::formulas::claim_reductions::advice::candidate_total_vars;
+use jolt_claims::protocols::jolt::{AdviceClaimReductionLayout, PrecommittedClaimReduction};
+
+use crate::{ProverConfig, ProverError};
+
+/// Builds the trusted/untrusted advice claim-reduction layouts exactly as the
+/// verifier's `PrecommittedSchedule::new` does.
+pub(crate) fn advice_layouts(
+    public_io: &JoltDevice,
+    proof_parameters: ProverConfig,
+    log_t: usize,
+    committed_chunk_bits: usize,
+) -> Result<
+    (
+        Option<AdviceClaimReductionLayout>,
+        Option<AdviceClaimReductionLayout>,
+    ),
+    ProverError,
+> {
+    let trusted_max_bytes = (!public_io.trusted_advice.is_empty())
+        .then_some(public_io.memory_layout.max_trusted_advice_size as usize);
+    let untrusted_max_bytes = (!public_io.untrusted_advice.is_empty())
+        .then_some(public_io.memory_layout.max_untrusted_advice_size as usize);
+
+    let candidates = candidate_total_vars(trusted_max_bytes, untrusted_max_bytes);
+    let scheduling_reference = PrecommittedClaimReduction::scheduling_reference(
+        log_t + committed_chunk_bits,
+        &candidates,
+        committed_chunk_bits,
+    );
+
+    let layout =
+        |max_bytes: Option<usize>| -> Result<Option<AdviceClaimReductionLayout>, ProverError> {
+            max_bytes
+                .map(|max_bytes| {
+                    AdviceClaimReductionLayout::balanced(
+                        proof_parameters.trace_polynomial_order,
+                        log_t,
+                        scheduling_reference,
+                        max_bytes,
+                    )
+                    .map_err(|error| ProverError::InvalidProverConfig {
+                        reason: format!(
+                            "advice claim-reduction layout could not be built: {error}"
+                        ),
+                    })
+                })
+                .transpose()
+        };
+
+    Ok((layout(trusted_max_bytes)?, layout(untrusted_max_bytes)?))
+}

--- a/crates/jolt-prover/src/stages/mod.rs
+++ b/crates/jolt-prover/src/stages/mod.rs
@@ -1,0 +1,53 @@
+pub mod stage0;
+
+pub mod stage1;
+pub mod stage2;
+pub mod stage3;
+pub mod stage4;
+pub mod stage5;
+pub mod stage6;
+pub mod stage7;
+pub mod stage8;
+
+pub(crate) mod advice;
+mod recorder;
+
+#[cfg(test)]
+use jolt_witness::{OracleRef, ViewRequirement, WitnessNamespace, WitnessProvider};
+
+use crate::ProverError;
+
+#[cfg(feature = "zk")]
+pub mod zk {}
+
+#[cfg(test)]
+pub(crate) fn primary_view_requirement<F, W, N>(
+    witness: &W,
+    oracle: OracleRef<N>,
+) -> Result<ViewRequirement<N>, ProverError>
+where
+    N: WitnessNamespace,
+    W: WitnessProvider<F, N>,
+{
+    let Some(requirement) = witness.view_requirements(oracle)?.into_iter().next() else {
+        return Err(ProverError::InvalidStageRequest {
+            reason: format!("witness returned no view requirement for {:?}", oracle),
+        });
+    };
+    if requirement.oracle != oracle {
+        return Err(ProverError::InvalidStageRequest {
+            reason: format!(
+                "witness returned requirement for {:?}, expected {oracle:?}",
+                requirement.oracle,
+                oracle = oracle
+            ),
+        });
+    }
+    Ok(requirement)
+}
+
+pub(crate) fn invalid_sumcheck_output(error: impl std::fmt::Display) -> ProverError {
+    ProverError::InvalidSumcheckOutput {
+        reason: error.to_string(),
+    }
+}

--- a/crates/jolt-prover/src/stages/recorder.rs
+++ b/crates/jolt-prover/src/stages/recorder.rs
@@ -1,0 +1,193 @@
+//! Shared sumcheck proof recorder.
+//!
+//! A batched sumcheck's round loop is identical in clear and ZK mode; only the
+//! per-round recording differs (cleartext round polynomials vs. Pedersen
+//! commitments) and whether input/output claims are appended to the transcript
+//! in the clear. [`SumcheckRecorder`] captures exactly that difference so a stage
+//! can write its round loop once, generic over the recorder.
+//!
+//! Stages flatten their structured input/output claims to `&[F]` at the call
+//! site (the per-stage `stageN_output_claim_values` helpers), keeping the
+//! recorder itself stage-agnostic.
+
+use std::marker::PhantomData;
+
+use jolt_field::Field;
+use jolt_poly::{CompressedPoly, UnivariatePoly};
+use jolt_sumcheck::{
+    append_sumcheck_claim, ClearProof, CompressedLabeledRoundPoly, CompressedSumcheckProof,
+    RoundMessage, SumcheckProof,
+};
+use jolt_transcript::Transcript;
+
+use crate::ProverError;
+
+#[cfg(feature = "zk")]
+use crate::committed::{CommittedSumcheckBuilder, CommittedSumcheckWitness};
+#[cfg(feature = "zk")]
+use jolt_crypto::VectorCommitment;
+
+/// Records the rounds of a single batched sumcheck, abstracting over clear vs.
+/// committed (ZK) recording. A stage drives this from its round loop:
+/// `absorb_input_claims` once, `absorb_round` per round (returning the
+/// Fiat-Shamir challenge), then `finish` with the flattened output claims.
+pub(crate) trait SumcheckRecorder<F: Field> {
+    type Commitment;
+
+    fn absorb_input_claims<T>(&mut self, input_claims: &[F], transcript: &mut T)
+    where
+        T: Transcript<Challenge = F>;
+
+    fn absorb_round<T>(
+        &mut self,
+        round_poly: &UnivariatePoly<F>,
+        transcript: &mut T,
+    ) -> Result<F, ProverError>
+    where
+        T: Transcript<Challenge = F>;
+
+    fn finish<T>(
+        self,
+        output_claim_values: &[F],
+        transcript: &mut T,
+    ) -> Result<RecordedSumcheck<F, Self::Commitment>, ProverError>
+    where
+        T: Transcript<Challenge = F>;
+}
+
+/// Output of a recorded sumcheck. `committed_witness`/`output_claim_values` carry
+/// the BlindFold material in ZK mode and are `None` in clear mode.
+pub(crate) struct RecordedSumcheck<F: Field, C> {
+    pub(crate) proof: SumcheckProof<F, C>,
+    #[cfg(feature = "zk")]
+    pub(crate) committed_witness: Option<CommittedSumcheckWitness<F>>,
+    #[cfg(feature = "zk")]
+    pub(crate) output_claim_values: Option<Vec<F>>,
+}
+
+pub(crate) struct ClearSumcheckRecorder<F: Field, C> {
+    round_polynomials: Vec<CompressedPoly<F>>,
+    _marker: PhantomData<C>,
+}
+
+impl<F: Field, C> ClearSumcheckRecorder<F, C> {
+    pub(crate) fn new(round_capacity: usize) -> Self {
+        Self {
+            round_polynomials: Vec::with_capacity(round_capacity),
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<F: Field, C> SumcheckRecorder<F> for ClearSumcheckRecorder<F, C> {
+    type Commitment = C;
+
+    fn absorb_input_claims<T>(&mut self, input_claims: &[F], transcript: &mut T)
+    where
+        T: Transcript<Challenge = F>,
+    {
+        for input_claim in input_claims {
+            append_sumcheck_claim(transcript, input_claim);
+        }
+    }
+
+    fn absorb_round<T>(
+        &mut self,
+        round_poly: &UnivariatePoly<F>,
+        transcript: &mut T,
+    ) -> Result<F, ProverError>
+    where
+        T: Transcript<Challenge = F>,
+    {
+        CompressedLabeledRoundPoly::sumcheck(round_poly).append_to_transcript(transcript);
+        let challenge = transcript.challenge();
+        self.round_polynomials.push(round_poly.compress());
+        Ok(challenge)
+    }
+
+    fn finish<T>(
+        self,
+        output_claim_values: &[F],
+        transcript: &mut T,
+    ) -> Result<RecordedSumcheck<F, Self::Commitment>, ProverError>
+    where
+        T: Transcript<Challenge = F>,
+    {
+        for opening_claim in output_claim_values {
+            transcript.append_labeled(b"opening_claim", opening_claim);
+        }
+        Ok(RecordedSumcheck {
+            proof: SumcheckProof::Clear(ClearProof::Compressed(CompressedSumcheckProof {
+                round_polynomials: self.round_polynomials,
+            })),
+            #[cfg(feature = "zk")]
+            committed_witness: None,
+            #[cfg(feature = "zk")]
+            output_claim_values: None,
+        })
+    }
+}
+
+#[cfg(feature = "zk")]
+pub(crate) struct CommittedSumcheckRecorder<'a, F, VC>
+where
+    F: Field,
+    VC: VectorCommitment<Field = F>,
+{
+    builder: CommittedSumcheckBuilder<'a, F, VC>,
+}
+
+#[cfg(feature = "zk")]
+impl<'a, F, VC> CommittedSumcheckRecorder<'a, F, VC>
+where
+    F: Field,
+    VC: VectorCommitment<Field = F>,
+{
+    pub(crate) fn new(setup: &'a VC::Setup) -> Result<Self, ProverError> {
+        Ok(Self {
+            builder: CommittedSumcheckBuilder::new(setup, 0)?,
+        })
+    }
+}
+
+#[cfg(feature = "zk")]
+impl<F, VC> SumcheckRecorder<F> for CommittedSumcheckRecorder<'_, F, VC>
+where
+    F: Field,
+    VC: VectorCommitment<Field = F>,
+{
+    type Commitment = VC::Output;
+
+    fn absorb_input_claims<T>(&mut self, _input_claims: &[F], _transcript: &mut T)
+    where
+        T: Transcript<Challenge = F>,
+    {
+    }
+
+    fn absorb_round<T>(
+        &mut self,
+        round_poly: &UnivariatePoly<F>,
+        transcript: &mut T,
+    ) -> Result<F, ProverError>
+    where
+        T: Transcript<Challenge = F>,
+    {
+        self.builder.commit_round(round_poly, transcript)
+    }
+
+    fn finish<T>(
+        self,
+        output_claim_values: &[F],
+        transcript: &mut T,
+    ) -> Result<RecordedSumcheck<F, Self::Commitment>, ProverError>
+    where
+        T: Transcript<Challenge = F>,
+    {
+        let built = self.builder.finish(output_claim_values, transcript)?;
+        Ok(RecordedSumcheck {
+            proof: built.proof,
+            committed_witness: Some(built.witness),
+            output_claim_values: Some(output_claim_values.to_vec()),
+        })
+    }
+}

--- a/crates/jolt-prover/src/stages/stage0/mod.rs
+++ b/crates/jolt-prover/src/stages/stage0/mod.rs
@@ -1,0 +1,6 @@
+pub(crate) mod prepare;
+mod prove;
+#[cfg(test)]
+mod tests;
+
+pub use prove::{prove, CommitmentComponent, CommitmentStageBackend, CommitmentStageInput};

--- a/crates/jolt-prover/src/stages/stage0/prepare.rs
+++ b/crates/jolt-prover/src/stages/stage0/prepare.rs
@@ -1,0 +1,24 @@
+use common::jolt_device::JoltDevice;
+use jolt_claims::protocols::jolt::JoltFormulaDimensions;
+
+use super::prove::CommitmentStageConfig;
+use crate::ProverConfig;
+
+pub(crate) fn commitment_config(
+    public_io: &JoltDevice,
+    proof_parameters: ProverConfig,
+    formula_dimensions: JoltFormulaDimensions,
+) -> CommitmentStageConfig {
+    let log_t = proof_parameters.trace_length.trailing_zeros() as usize;
+
+    CommitmentStageConfig::new(
+        formula_dimensions.ra_layout,
+        !public_io.trusted_advice.is_empty(),
+        !public_io.untrusted_advice.is_empty(),
+    )
+    .with_final_opening_trace_embedding(
+        log_t,
+        proof_parameters.one_hot_config.committed_chunk_bits(),
+        proof_parameters.trace_polynomial_order,
+    )
+}

--- a/crates/jolt-prover/src/stages/stage0/prove.rs
+++ b/crates/jolt-prover/src/stages/stage0/prove.rs
@@ -1,0 +1,503 @@
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    fmt::Debug,
+};
+
+use jolt_backends::{
+    CommitmentBackend, CommitmentMode, CommitmentRequest, CommitmentRequestItem, CommitmentResult,
+    CommitmentSlot, TracePolynomialEmbedding,
+};
+use jolt_claims::protocols::jolt::{
+    formulas::{dimensions::TracePolynomialOrder, ra::JoltRaPolynomialLayout},
+    JoltCommittedPolynomial,
+};
+use jolt_openings::CommitmentScheme;
+use jolt_verifier::config::{JoltProtocolConfig, ZkConfig};
+use jolt_verifier::proof::{JoltCommitments, JoltRaCommitments};
+use jolt_verifier::stages::stage8::{stage8_final_opening_order, Stage8FinalOpening};
+use jolt_witness::{
+    protocols::jolt_vm::JoltVmNamespace, CommittedWitnessProvider, MaterializationPolicy,
+    OracleRef, RetentionHint, ViewRequirement, WitnessNamespace,
+};
+
+use crate::ProverError;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct CommitmentStageConfig {
+    pub ra_layout: JoltRaPolynomialLayout,
+    pub include_trusted_advice: bool,
+    pub include_untrusted_advice: bool,
+    pub trace_polynomial_order: TracePolynomialOrder,
+    pub final_opening_trace_rows: Option<usize>,
+    pub final_opening_address_columns: Option<usize>,
+}
+
+impl CommitmentStageConfig {
+    pub const fn new(
+        ra_layout: JoltRaPolynomialLayout,
+        include_trusted_advice: bool,
+        include_untrusted_advice: bool,
+    ) -> Self {
+        Self {
+            ra_layout,
+            include_trusted_advice,
+            include_untrusted_advice,
+            trace_polynomial_order: TracePolynomialOrder::CycleMajor,
+            final_opening_trace_rows: None,
+            final_opening_address_columns: None,
+        }
+    }
+
+    pub fn with_final_opening_trace_embedding(
+        mut self,
+        log_t: usize,
+        committed_chunk_bits: usize,
+        trace_polynomial_order: TracePolynomialOrder,
+    ) -> Self {
+        self.trace_polynomial_order = trace_polynomial_order;
+        self.final_opening_trace_rows = Some(1usize << log_t);
+        self.final_opening_address_columns = Some(1usize << committed_chunk_bits);
+        self
+    }
+}
+
+#[derive(Clone)]
+pub struct CommitmentStageInput<'a, W, PCS: CommitmentScheme> {
+    pub witness: &'a W,
+    pub setup: &'a PCS::ProverSetup,
+    pub config: CommitmentStageConfig,
+    pub protocol: JoltProtocolConfig,
+}
+
+impl<'a, W, PCS: CommitmentScheme> CommitmentStageInput<'a, W, PCS> {
+    pub fn new(
+        witness: &'a W,
+        setup: &'a PCS::ProverSetup,
+        config: CommitmentStageConfig,
+        protocol: JoltProtocolConfig,
+    ) -> Self {
+        Self {
+            witness,
+            setup,
+            config,
+            protocol,
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct CommitmentComponent<PCS: CommitmentScheme> {
+    pub commitments: JoltCommitments<PCS::Output>,
+    pub trusted_advice_commitment: Option<PCS::Output>,
+    pub untrusted_advice_commitment: Option<PCS::Output>,
+    pub(crate) prover_state: CommitmentProverState<PCS::OpeningHint>,
+}
+
+#[derive(Clone)]
+pub(crate) struct CommitmentProverState<OpeningHint> {
+    pub opening_hints: BTreeMap<JoltCommittedPolynomial, OpeningHint>,
+}
+
+pub type Stage8OpeningInputs<PCS> = (
+    Vec<<PCS as jolt_crypto::Commitment>::Output>,
+    Vec<<PCS as CommitmentScheme>::OpeningHint>,
+);
+
+impl<PCS: CommitmentScheme> CommitmentComponent<PCS> {
+    pub fn from_backend_result(
+        result: CommitmentResult<JoltVmNamespace, PCS>,
+        config: CommitmentStageConfig,
+    ) -> Result<Self, ProverError> {
+        let mut jolt_outputs =
+            CommitmentOutputMap::<JoltCommittedPolynomial, PCS>::from_backend_result(
+                "Jolt", result,
+            )?;
+        let jolt = take_jolt_commitments(&mut jolt_outputs, config)?;
+        let opening_hints = jolt_outputs.finish()?;
+
+        let commitments = JoltCommitments::new(jolt.rd_inc, jolt.ram_inc, jolt.ra);
+
+        Ok(Self {
+            commitments,
+            trusted_advice_commitment: jolt.trusted_advice_commitment,
+            untrusted_advice_commitment: jolt.untrusted_advice_commitment,
+            prover_state: CommitmentProverState { opening_hints },
+        })
+    }
+
+    pub fn stage8_opening_inputs(
+        &self,
+        layout: JoltRaPolynomialLayout,
+    ) -> Result<Stage8OpeningInputs<PCS>, ProverError>
+    where
+        PCS::Output: Clone,
+        PCS::OpeningHint: Clone,
+    {
+        let final_openings = stage8_final_opening_order(
+            layout,
+            self.trusted_advice_commitment.is_some(),
+            self.untrusted_advice_commitment.is_some(),
+        );
+        let mut ordered_commitments = Vec::with_capacity(final_openings.len());
+        let mut opening_hints = Vec::with_capacity(ordered_commitments.capacity());
+
+        for opening in final_openings {
+            match opening {
+                Stage8FinalOpening::Jolt(polynomial) => {
+                    let commitment = self.jolt_stage8_commitment(polynomial)?;
+                    push_jolt_stage8_opening(
+                        &mut ordered_commitments,
+                        &mut opening_hints,
+                        commitment,
+                        &self.prover_state,
+                        polynomial,
+                    )?;
+                }
+            }
+        }
+
+        Ok((ordered_commitments, opening_hints))
+    }
+
+    fn jolt_stage8_commitment(
+        &self,
+        polynomial: JoltCommittedPolynomial,
+    ) -> Result<&PCS::Output, ProverError> {
+        match polynomial {
+            JoltCommittedPolynomial::RdInc => Ok(&self.commitments.rd_inc),
+            JoltCommittedPolynomial::RamInc => Ok(&self.commitments.ram_inc),
+            JoltCommittedPolynomial::InstructionRa(index) => self
+                .commitments
+                .ra
+                .instruction
+                .get(index)
+                .ok_or_else(|| missing_stage8_commitment(polynomial)),
+            JoltCommittedPolynomial::BytecodeRa(index) => self
+                .commitments
+                .ra
+                .bytecode
+                .get(index)
+                .ok_or_else(|| missing_stage8_commitment(polynomial)),
+            JoltCommittedPolynomial::RamRa(index) => self
+                .commitments
+                .ra
+                .ram
+                .get(index)
+                .ok_or_else(|| missing_stage8_commitment(polynomial)),
+            JoltCommittedPolynomial::TrustedAdvice => self
+                .trusted_advice_commitment
+                .as_ref()
+                .ok_or_else(|| missing_stage8_commitment(polynomial)),
+            JoltCommittedPolynomial::UntrustedAdvice => self
+                .untrusted_advice_commitment
+                .as_ref()
+                .ok_or_else(|| missing_stage8_commitment(polynomial)),
+            JoltCommittedPolynomial::BytecodeChunk(_) | JoltCommittedPolynomial::ProgramImageInit => {
+                Err(ProverError::InvalidStageRequest {
+                    reason: format!(
+                        "committed-program polynomial {polynomial:?} is not part of the stage 8 prover order"
+                    ),
+                })
+            }
+        }
+    }
+}
+
+fn missing_stage8_commitment(polynomial: JoltCommittedPolynomial) -> ProverError {
+    ProverError::InvalidStageRequest {
+        reason: format!("Stage 8 opening commitment is missing for {polynomial:?}"),
+    }
+}
+
+fn push_jolt_stage8_opening<C, H>(
+    commitments: &mut Vec<C>,
+    hints: &mut Vec<H>,
+    commitment: &C,
+    prover_state: &CommitmentProverState<H>,
+    polynomial: JoltCommittedPolynomial,
+) -> Result<(), ProverError>
+where
+    C: Clone,
+    H: Clone,
+{
+    commitments.push(commitment.clone());
+    let hint = prover_state
+        .opening_hints
+        .get(&polynomial)
+        .cloned()
+        .ok_or_else(|| ProverError::InvalidStageRequest {
+            reason: format!("Stage 8 opening hint is missing for {polynomial:?}"),
+        })?;
+    hints.push(hint);
+    Ok(())
+}
+
+pub fn prove<F, W, B, PCS>(
+    input: CommitmentStageInput<'_, W, PCS>,
+    backend: &mut B,
+) -> Result<CommitmentComponent<PCS>, ProverError>
+where
+    F: jolt_field::Field,
+    PCS: CommitmentScheme<Field = F>,
+    W: CommittedWitnessProvider<F, JoltVmNamespace> + Sync,
+    B: CommitmentStageBackend<F, PCS>,
+{
+    let mode = match input.protocol.zk {
+        ZkConfig::Transparent => CommitmentMode::Transparent,
+        ZkConfig::BlindFold => CommitmentMode::Zk,
+    };
+    let trace_embedding = final_opening_trace_embedding(&input.config)?;
+    let result = commit::<F, JoltVmNamespace, W, B, PCS>(
+        input.witness,
+        backend,
+        input.setup,
+        mode,
+        input.config.trace_polynomial_order,
+        trace_embedding,
+    )?;
+
+    CommitmentComponent::from_backend_result(result, input.config)
+}
+
+pub trait CommitmentStageBackend<F, PCS>: CommitmentBackend<F, JoltVmNamespace, PCS>
+where
+    PCS: CommitmentScheme<Field = F>,
+{
+}
+
+impl<F, PCS, B> CommitmentStageBackend<F, PCS> for B
+where
+    PCS: CommitmentScheme<Field = F>,
+    B: CommitmentBackend<F, JoltVmNamespace, PCS>,
+{
+}
+
+pub(super) fn build_commitment_request<F, N, W>(
+    witness: &W,
+    mode: CommitmentMode,
+    trace_polynomial_order: TracePolynomialOrder,
+    trace_embedding: Option<TracePolynomialEmbedding>,
+) -> Result<CommitmentRequest<N>, ProverError>
+where
+    N: WitnessNamespace,
+    W: CommittedWitnessProvider<F, N> + ?Sized,
+{
+    let mut items = Vec::new();
+    for (index, committed) in witness.committed_oracle_order()?.into_iter().enumerate() {
+        let oracle = OracleRef::committed(committed);
+        let descriptor = witness.describe_oracle(oracle)?;
+        let retention = witness
+            .view_requirements(oracle)?
+            .first()
+            .map_or(RetentionHint::ThroughStage8, |requirement| {
+                requirement.retention
+            });
+
+        items.push(
+            CommitmentRequestItem::with_mode(
+                CommitmentSlot(index as u32),
+                ViewRequirement::new(
+                    oracle,
+                    descriptor.encoding,
+                    MaterializationPolicy::Streaming,
+                    retention,
+                ),
+                mode,
+            )
+            .with_trace_polynomial_order(trace_polynomial_order)
+            .with_trace_embedding(trace_embedding),
+        );
+    }
+
+    Ok(CommitmentRequest::new(items))
+}
+
+pub(super) fn commit<F, N, W, B, PCS>(
+    witness: &W,
+    backend: &mut B,
+    setup: &PCS::ProverSetup,
+    mode: CommitmentMode,
+    trace_polynomial_order: TracePolynomialOrder,
+    trace_embedding: Option<TracePolynomialEmbedding>,
+) -> Result<CommitmentResult<N, PCS>, ProverError>
+where
+    N: WitnessNamespace,
+    PCS: CommitmentScheme<Field = F>,
+    W: CommittedWitnessProvider<F, N> + Sync + ?Sized,
+    B: CommitmentBackend<F, N, PCS>,
+{
+    let request = build_commitment_request::<F, N, W>(
+        witness,
+        mode,
+        trace_polynomial_order,
+        trace_embedding,
+    )?;
+    Ok(backend.commit(&request, witness, setup)?)
+}
+
+struct CommitmentOutputMap<Id, PCS>
+where
+    Id: Copy + Ord + Debug,
+    PCS: CommitmentScheme,
+{
+    label: &'static str,
+    pending: BTreeMap<Id, (PCS::Output, PCS::OpeningHint)>,
+    opening_hints: BTreeMap<Id, PCS::OpeningHint>,
+}
+
+impl<Id, PCS> CommitmentOutputMap<Id, PCS>
+where
+    Id: Copy + Ord + Debug,
+    PCS: CommitmentScheme,
+{
+    fn from_backend_result<N>(
+        label: &'static str,
+        result: CommitmentResult<N, PCS>,
+    ) -> Result<Self, ProverError>
+    where
+        N: WitnessNamespace<CommittedId = Id>,
+    {
+        let mut pending = BTreeMap::new();
+        let mut slots = BTreeSet::new();
+
+        for output in result.commitments {
+            if !slots.insert(output.slot.0) {
+                return Err(ProverError::InvalidCommitmentOutput {
+                    reason: format!("duplicate {label} commitment output slot {:?}", output.slot),
+                });
+            }
+            let OracleRef::Committed(polynomial) = output.oracle else {
+                return Err(ProverError::InvalidCommitmentOutput {
+                    reason: format!("{label} commitment backend emitted a virtual oracle output"),
+                });
+            };
+            if output.rows == 0 {
+                return Err(ProverError::InvalidCommitmentOutput {
+                    reason: format!("{label} commitment output for {polynomial:?} has zero rows"),
+                });
+            }
+            if pending
+                .insert(polynomial, (output.commitment, output.opening_hint))
+                .is_some()
+            {
+                return Err(ProverError::InvalidCommitmentOutput {
+                    reason: format!("duplicate {label} commitment output for {polynomial:?}"),
+                });
+            }
+        }
+
+        Ok(Self {
+            label,
+            pending,
+            opening_hints: BTreeMap::new(),
+        })
+    }
+
+    fn take(&mut self, polynomial: Id) -> Result<PCS::Output, ProverError> {
+        let (commitment, opening_hint) = self.pending.remove(&polynomial).ok_or_else(|| {
+            ProverError::InvalidCommitmentOutput {
+                reason: format!(
+                    "missing {} commitment output for {polynomial:?}",
+                    self.label
+                ),
+            }
+        })?;
+        let _ = self.opening_hints.insert(polynomial, opening_hint);
+        Ok(commitment)
+    }
+
+    fn take_vec(
+        &mut self,
+        polynomial_at: impl Fn(usize) -> Id,
+        count: usize,
+    ) -> Result<Vec<PCS::Output>, ProverError> {
+        let mut commitments = Vec::with_capacity(count);
+        for index in 0..count {
+            commitments.push(self.take(polynomial_at(index))?);
+        }
+        Ok(commitments)
+    }
+
+    fn take_optional(
+        &mut self,
+        polynomial: Id,
+        expected: bool,
+    ) -> Result<Option<PCS::Output>, ProverError> {
+        expected.then(|| self.take(polynomial)).transpose()
+    }
+
+    fn finish(self) -> Result<BTreeMap<Id, PCS::OpeningHint>, ProverError> {
+        if let Some(unexpected) = self.pending.keys().next().copied() {
+            return Err(ProverError::InvalidCommitmentOutput {
+                reason: format!(
+                    "unexpected {} commitment output for {unexpected:?}",
+                    self.label
+                ),
+            });
+        }
+        Ok(self.opening_hints)
+    }
+}
+
+struct JoltCommitmentParts<C> {
+    rd_inc: C,
+    ram_inc: C,
+    ra: JoltRaCommitments<C>,
+    trusted_advice_commitment: Option<C>,
+    untrusted_advice_commitment: Option<C>,
+}
+
+fn take_jolt_commitments<PCS>(
+    outputs: &mut CommitmentOutputMap<JoltCommittedPolynomial, PCS>,
+    config: CommitmentStageConfig,
+) -> Result<JoltCommitmentParts<PCS::Output>, ProverError>
+where
+    PCS: CommitmentScheme,
+{
+    let rd_inc = outputs.take(JoltCommittedPolynomial::RdInc)?;
+    let ram_inc = outputs.take(JoltCommittedPolynomial::RamInc)?;
+    let instruction = outputs.take_vec(
+        JoltCommittedPolynomial::InstructionRa,
+        config.ra_layout.instruction(),
+    )?;
+    let ram = outputs.take_vec(JoltCommittedPolynomial::RamRa, config.ra_layout.ram())?;
+    let bytecode = outputs.take_vec(
+        JoltCommittedPolynomial::BytecodeRa,
+        config.ra_layout.bytecode(),
+    )?;
+
+    Ok(JoltCommitmentParts {
+        rd_inc,
+        ram_inc,
+        ra: JoltRaCommitments::new(instruction, ram, bytecode),
+        trusted_advice_commitment: outputs.take_optional(
+            JoltCommittedPolynomial::TrustedAdvice,
+            config.include_trusted_advice,
+        )?,
+        untrusted_advice_commitment: outputs.take_optional(
+            JoltCommittedPolynomial::UntrustedAdvice,
+            config.include_untrusted_advice,
+        )?,
+    })
+}
+
+fn final_opening_trace_embedding(
+    config: &CommitmentStageConfig,
+) -> Result<Option<TracePolynomialEmbedding>, ProverError> {
+    match (
+        config.final_opening_trace_rows,
+        config.final_opening_address_columns,
+    ) {
+        (Some(trace_rows), Some(address_columns)) => Ok(Some(TracePolynomialEmbedding::new(
+            trace_rows,
+            address_columns,
+            config.trace_polynomial_order,
+        ))),
+        (None, None) => Ok(None),
+        _ => Err(ProverError::InvalidStageRequest {
+            reason:
+                "Stage 0 final-opening trace embedding requires both trace rows and address columns"
+                    .to_owned(),
+        }),
+    }
+}

--- a/crates/jolt-prover/src/stages/stage0/tests.rs
+++ b/crates/jolt-prover/src/stages/stage0/tests.rs
@@ -1,0 +1,485 @@
+#![expect(
+    clippy::expect_used,
+    reason = "commitment stage tests should fail loudly on impossible fixtures"
+)]
+
+use jolt_backends::{
+    Backend, BackendError, CommitmentBackend, CommitmentMode, CommitmentRequest, CommitmentResult,
+    CommitmentSlot, CommittedPolynomialOutput, StreamedWitnessOutput,
+};
+use jolt_claims::protocols::jolt::{
+    formulas::{dimensions::TracePolynomialOrder, ra::JoltRaPolynomialLayout},
+    JoltCommittedPolynomial,
+};
+use jolt_field::{Fr, FromPrimitiveInt};
+use jolt_openings::{mock::MockCommitmentScheme, CommitmentScheme};
+use jolt_poly::Polynomial;
+use jolt_verifier::config::{JoltProtocolConfig, ZkConfig};
+use jolt_witness::{
+    protocols::jolt_vm::JoltVmNamespace, CommittedWitnessProvider, MaterializationPolicy,
+    NamespaceId, OracleDescriptor, OracleRef, PolynomialEncoding, PolynomialView, RetentionHint,
+    ViewRequirement, WitnessDimensions, WitnessError, WitnessNamespace, WitnessProvider,
+};
+
+use super::prove::{build_commitment_request, CommitmentStageConfig};
+use super::*;
+use crate::ProverError;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+enum TestNamespace {}
+
+impl WitnessNamespace for TestNamespace {
+    type ChallengeId = u8;
+    type CommittedId = u8;
+    type OpeningId = u8;
+    type PublicId = u8;
+    type VirtualId = u8;
+
+    const ID: NamespaceId = NamespaceId::new("commitment_stage_test");
+}
+
+#[derive(Clone, Debug)]
+struct TestWitness {
+    committed: Vec<u8>,
+}
+
+impl<F> WitnessProvider<F, TestNamespace> for TestWitness {
+    fn describe_oracle(
+        &self,
+        oracle: OracleRef<TestNamespace>,
+    ) -> Result<OracleDescriptor<TestNamespace>, WitnessError> {
+        Ok(OracleDescriptor::new(
+            oracle,
+            WitnessDimensions::new(3),
+            match oracle {
+                OracleRef::Committed(1) => PolynomialEncoding::OneHot,
+                _ => PolynomialEncoding::Compact,
+            },
+        ))
+    }
+
+    fn view_requirements(
+        &self,
+        oracle: OracleRef<TestNamespace>,
+    ) -> Result<Vec<ViewRequirement<TestNamespace>>, WitnessError> {
+        let retention = match oracle {
+            OracleRef::Committed(2) => RetentionHint::ThroughBlindFold,
+            _ => RetentionHint::ThroughStage8,
+        };
+        Ok(vec![ViewRequirement::new(
+            oracle,
+            PolynomialEncoding::Dense,
+            MaterializationPolicy::BackendChoice,
+            retention,
+        )])
+    }
+
+    fn oracle_view(
+        &self,
+        _requirement: ViewRequirement<TestNamespace>,
+    ) -> Result<PolynomialView<'_, F, TestNamespace>, WitnessError> {
+        Err(WitnessError::UnsupportedView {
+            view: "test oracle views",
+        })
+    }
+}
+
+impl<F> CommittedWitnessProvider<F, TestNamespace> for TestWitness {
+    fn committed_oracle_order(&self) -> Result<Vec<u8>, WitnessError> {
+        Ok(self.committed.clone())
+    }
+}
+
+type MockPcs = MockCommitmentScheme<Fr>;
+
+fn mock_commitment(seed: u64) -> <MockPcs as jolt_crypto::Commitment>::Output {
+    let poly = Polynomial::new(vec![Fr::from_u64(seed), Fr::from_u64(seed + 1)]);
+    <MockPcs as CommitmentScheme>::commit(&poly, &()).0
+}
+
+fn jolt_output(
+    slot: u32,
+    polynomial: JoltCommittedPolynomial,
+    seed: u64,
+) -> CommittedPolynomialOutput<JoltVmNamespace, MockPcs> {
+    CommittedPolynomialOutput::new(
+        CommitmentSlot(slot),
+        OracleRef::committed(polynomial),
+        2,
+        mock_commitment(seed),
+        (),
+    )
+}
+
+fn stage_config(
+    include_trusted_advice: bool,
+    include_untrusted_advice: bool,
+) -> CommitmentStageConfig {
+    let ra_layout = JoltRaPolynomialLayout::new(2, 1, 2)
+        .expect("test Jolt RA polynomial layout should be valid");
+    CommitmentStageConfig::new(ra_layout, include_trusted_advice, include_untrusted_advice)
+}
+
+fn jolt_commitment_result(
+    commitments: Vec<CommittedPolynomialOutput<JoltVmNamespace, MockPcs>>,
+) -> CommitmentResult<JoltVmNamespace, MockPcs> {
+    CommitmentResult::new(Vec::new(), Vec::new(), commitments)
+}
+
+fn assemble_test_jolt_commitment_stage(
+    result: CommitmentResult<JoltVmNamespace, MockPcs>,
+    config: CommitmentStageConfig,
+) -> Result<CommitmentComponent<MockPcs>, ProverError> {
+    CommitmentComponent::from_backend_result(result, config)
+}
+
+#[derive(Debug, Default)]
+struct RecordingBackend {
+    last_request: Option<CommitmentRequest<TestNamespace>>,
+}
+
+impl Backend for RecordingBackend {
+    fn name(&self) -> &'static str {
+        "recording"
+    }
+}
+
+impl CommitmentBackend<Fr, TestNamespace, MockPcs> for RecordingBackend {
+    fn commit<W>(
+        &mut self,
+        request: &CommitmentRequest<TestNamespace>,
+        _witness: &W,
+        _setup: &(),
+    ) -> Result<CommitmentResult<TestNamespace, MockPcs>, BackendError>
+    where
+        W: WitnessProvider<Fr, TestNamespace> + Sync + ?Sized,
+    {
+        self.last_request = Some(request.clone());
+        Ok(CommitmentResult::new(
+            Vec::new(),
+            vec![StreamedWitnessOutput::new(CommitmentSlot(0), Vec::new())],
+            Vec::new(),
+        ))
+    }
+}
+
+#[derive(Clone, Debug)]
+struct JoltVmTestWitness {
+    committed: Vec<JoltCommittedPolynomial>,
+}
+
+impl<F> WitnessProvider<F, JoltVmNamespace> for JoltVmTestWitness {
+    fn describe_oracle(
+        &self,
+        oracle: OracleRef<JoltVmNamespace>,
+    ) -> Result<OracleDescriptor<JoltVmNamespace>, WitnessError> {
+        Ok(OracleDescriptor::new(
+            oracle,
+            WitnessDimensions::new(3),
+            PolynomialEncoding::Compact,
+        ))
+    }
+
+    fn view_requirements(
+        &self,
+        oracle: OracleRef<JoltVmNamespace>,
+    ) -> Result<Vec<ViewRequirement<JoltVmNamespace>>, WitnessError> {
+        Ok(vec![ViewRequirement::new(
+            oracle,
+            PolynomialEncoding::Compact,
+            MaterializationPolicy::Streaming,
+            RetentionHint::ThroughStage8,
+        )])
+    }
+
+    fn oracle_view(
+        &self,
+        _requirement: ViewRequirement<JoltVmNamespace>,
+    ) -> Result<PolynomialView<'_, F, JoltVmNamespace>, WitnessError> {
+        Err(WitnessError::UnsupportedView {
+            view: "test Jolt VM oracle views",
+        })
+    }
+}
+
+impl<F> CommittedWitnessProvider<F, JoltVmNamespace> for JoltVmTestWitness {
+    fn committed_oracle_order(&self) -> Result<Vec<JoltCommittedPolynomial>, WitnessError> {
+        Ok(self.committed.clone())
+    }
+}
+
+#[derive(Debug, Default)]
+struct JoltVmRecordingBackend {
+    last_request: Option<CommitmentRequest<JoltVmNamespace>>,
+}
+
+impl Backend for JoltVmRecordingBackend {
+    fn name(&self) -> &'static str {
+        "jolt-vm-recording"
+    }
+}
+
+impl CommitmentBackend<Fr, JoltVmNamespace, MockPcs> for JoltVmRecordingBackend {
+    fn commit<W>(
+        &mut self,
+        request: &CommitmentRequest<JoltVmNamespace>,
+        _witness: &W,
+        _setup: &(),
+    ) -> Result<CommitmentResult<JoltVmNamespace, MockPcs>, BackendError>
+    where
+        W: WitnessProvider<Fr, JoltVmNamespace> + Sync + ?Sized,
+    {
+        self.last_request = Some(request.clone());
+        let commitments = request
+            .items
+            .iter()
+            .map(|item| {
+                let OracleRef::Committed(polynomial) = item.requirement.oracle else {
+                    unreachable!("commitment request should contain committed oracles only")
+                };
+                jolt_output(item.slot.0, polynomial, u64::from(item.slot.0) + 1)
+            })
+            .collect();
+        Ok(CommitmentResult::new(Vec::new(), Vec::new(), commitments))
+    }
+}
+
+#[test]
+fn canonical_stage0_contract_requests_and_assembles_verifier_fields() -> Result<(), String> {
+    let witness = JoltVmTestWitness {
+        committed: vec![
+            JoltCommittedPolynomial::RdInc,
+            JoltCommittedPolynomial::RamInc,
+            JoltCommittedPolynomial::InstructionRa(0),
+            JoltCommittedPolynomial::InstructionRa(1),
+            JoltCommittedPolynomial::RamRa(0),
+            JoltCommittedPolynomial::RamRa(1),
+            JoltCommittedPolynomial::BytecodeRa(0),
+            JoltCommittedPolynomial::TrustedAdvice,
+            JoltCommittedPolynomial::UntrustedAdvice,
+        ],
+    };
+    let config = stage_config(true, true);
+    let input = CommitmentStageInput::new(&witness, &(), config, JoltProtocolConfig::for_zk(true));
+    assert_eq!(input.protocol.zk, ZkConfig::BlindFold);
+    let mut backend = JoltVmRecordingBackend::default();
+
+    let output = prove::<Fr, _, _, MockPcs>(input, &mut backend).map_err(|e| e.to_string())?;
+
+    let request = backend
+        .last_request
+        .expect("recording backend should capture canonical Stage 0 request");
+    assert!(request
+        .items
+        .iter()
+        .all(|item| item.mode == CommitmentMode::Zk));
+    let requested = request
+        .items
+        .iter()
+        .map(|item| item.requirement.oracle)
+        .collect::<Vec<_>>();
+    assert_eq!(
+        requested,
+        vec![
+            OracleRef::Committed(JoltCommittedPolynomial::RdInc),
+            OracleRef::Committed(JoltCommittedPolynomial::RamInc),
+            OracleRef::Committed(JoltCommittedPolynomial::InstructionRa(0)),
+            OracleRef::Committed(JoltCommittedPolynomial::InstructionRa(1)),
+            OracleRef::Committed(JoltCommittedPolynomial::RamRa(0)),
+            OracleRef::Committed(JoltCommittedPolynomial::RamRa(1)),
+            OracleRef::Committed(JoltCommittedPolynomial::BytecodeRa(0)),
+            OracleRef::Committed(JoltCommittedPolynomial::TrustedAdvice),
+            OracleRef::Committed(JoltCommittedPolynomial::UntrustedAdvice),
+        ]
+    );
+
+    assert_eq!(output.commitments.rd_inc, mock_commitment(1));
+    assert_eq!(output.commitments.ram_inc, mock_commitment(2));
+    assert_eq!(
+        output.commitments.ra.instruction,
+        vec![mock_commitment(3), mock_commitment(4)]
+    );
+    assert_eq!(
+        output.commitments.ra.ram,
+        vec![mock_commitment(5), mock_commitment(6)]
+    );
+    assert_eq!(output.commitments.ra.bytecode, vec![mock_commitment(7)]);
+    assert_eq!(
+        output.trusted_advice_commitment.as_ref(),
+        Some(&mock_commitment(8))
+    );
+    assert_eq!(
+        output.untrusted_advice_commitment.as_ref(),
+        Some(&mock_commitment(9))
+    );
+    Ok(())
+}
+
+#[test]
+fn commitment_request_uses_committed_order_and_streaming_requirements() -> Result<(), String> {
+    let witness = TestWitness {
+        committed: vec![1, 2],
+    };
+
+    let request = build_commitment_request::<Fr, TestNamespace, _>(
+        &witness,
+        CommitmentMode::Transparent,
+        TracePolynomialOrder::CycleMajor,
+        None,
+    )
+    .map_err(|e| e.to_string())?;
+
+    assert_eq!(request.items.len(), 2);
+    assert_eq!(request.items[0].slot, CommitmentSlot(0));
+    assert_eq!(request.items[0].mode, CommitmentMode::Transparent);
+    assert_eq!(request.items[0].requirement.oracle, OracleRef::committed(1));
+    assert_eq!(
+        request.items[0].requirement.encoding,
+        PolynomialEncoding::OneHot
+    );
+    assert_eq!(
+        request.items[0].requirement.materialization,
+        MaterializationPolicy::Streaming
+    );
+    assert_eq!(request.items[1].slot, CommitmentSlot(1));
+    assert_eq!(request.items[1].mode, CommitmentMode::Transparent);
+    assert_eq!(request.items[1].requirement.oracle, OracleRef::committed(2));
+    assert_eq!(
+        request.items[1].requirement.retention,
+        RetentionHint::ThroughBlindFold
+    );
+    Ok(())
+}
+
+#[test]
+fn commit_schedules_the_backend_owned_request() -> Result<(), String> {
+    let witness = TestWitness { committed: vec![3] };
+    let mut backend = RecordingBackend::default();
+
+    let result = super::prove::commit::<Fr, TestNamespace, _, _, MockPcs>(
+        &witness,
+        &mut backend,
+        &(),
+        CommitmentMode::Zk,
+        TracePolynomialOrder::CycleMajor,
+        None,
+    )
+    .map_err(|e| e.to_string())?;
+
+    let request = backend
+        .last_request
+        .expect("recording backend should capture commitment request");
+    assert_eq!(request.items.len(), 1);
+    assert_eq!(request.items[0].requirement.oracle, OracleRef::committed(3));
+    assert_eq!(request.items[0].mode, CommitmentMode::Zk);
+    assert_eq!(result.streamed_witness.len(), 1);
+    Ok(())
+}
+
+#[test]
+fn jolt_commitment_output_maps_by_polynomial_not_backend_order() -> Result<(), String> {
+    let result = jolt_commitment_result(vec![
+        jolt_output(8, JoltCommittedPolynomial::RamRa(1), 7),
+        jolt_output(1, JoltCommittedPolynomial::RdInc, 1),
+        jolt_output(3, JoltCommittedPolynomial::InstructionRa(1), 4),
+        jolt_output(7, JoltCommittedPolynomial::TrustedAdvice, 9),
+        jolt_output(4, JoltCommittedPolynomial::BytecodeRa(0), 5),
+        jolt_output(0, JoltCommittedPolynomial::RamInc, 2),
+        jolt_output(2, JoltCommittedPolynomial::InstructionRa(0), 3),
+        jolt_output(9, JoltCommittedPolynomial::UntrustedAdvice, 10),
+        jolt_output(6, JoltCommittedPolynomial::RamRa(0), 6),
+    ]);
+
+    let output = assemble_test_jolt_commitment_stage(result, stage_config(true, true))
+        .map_err(|e| e.to_string())?;
+
+    assert_eq!(output.commitments.rd_inc, mock_commitment(1));
+    assert_eq!(output.commitments.ram_inc, mock_commitment(2));
+    assert_eq!(
+        output.commitments.ra.instruction,
+        vec![mock_commitment(3), mock_commitment(4)]
+    );
+    assert_eq!(
+        output.commitments.ra.ram,
+        vec![mock_commitment(6), mock_commitment(7),]
+    );
+    assert_eq!(output.commitments.ra.bytecode, vec![mock_commitment(5)]);
+    assert_eq!(
+        output.trusted_advice_commitment.as_ref(),
+        Some(&mock_commitment(9))
+    );
+    assert_eq!(
+        output.untrusted_advice_commitment.as_ref(),
+        Some(&mock_commitment(10))
+    );
+    assert_eq!(output.prover_state.opening_hints.len(), 9);
+    assert!(output
+        .prover_state
+        .opening_hints
+        .contains_key(&JoltCommittedPolynomial::RamInc));
+    Ok(())
+}
+
+#[test]
+fn jolt_commitment_output_requires_all_layout_polynomials() {
+    let result = jolt_commitment_result(vec![
+        jolt_output(0, JoltCommittedPolynomial::RamInc, 2),
+        jolt_output(1, JoltCommittedPolynomial::RdInc, 1),
+        jolt_output(2, JoltCommittedPolynomial::InstructionRa(0), 3),
+        jolt_output(4, JoltCommittedPolynomial::BytecodeRa(0), 5),
+        jolt_output(6, JoltCommittedPolynomial::RamRa(0), 6),
+        jolt_output(8, JoltCommittedPolynomial::RamRa(1), 7),
+    ]);
+
+    let error = assemble_test_jolt_commitment_stage(result, stage_config(false, false))
+        .err()
+        .expect("missing InstructionRa(1) should fail output construction");
+
+    assert!(matches!(
+        error,
+        ProverError::InvalidCommitmentOutput { reason }
+            if reason.contains("missing Jolt commitment output for InstructionRa(1)")
+    ));
+}
+
+#[test]
+fn jolt_commitment_output_rejects_unplanned_advice_commitments() {
+    let result = jolt_commitment_result(vec![
+        jolt_output(0, JoltCommittedPolynomial::RamInc, 2),
+        jolt_output(1, JoltCommittedPolynomial::RdInc, 1),
+        jolt_output(2, JoltCommittedPolynomial::InstructionRa(0), 3),
+        jolt_output(3, JoltCommittedPolynomial::InstructionRa(1), 4),
+        jolt_output(4, JoltCommittedPolynomial::BytecodeRa(0), 5),
+        jolt_output(6, JoltCommittedPolynomial::RamRa(0), 6),
+        jolt_output(8, JoltCommittedPolynomial::RamRa(1), 7),
+        jolt_output(9, JoltCommittedPolynomial::TrustedAdvice, 9),
+    ]);
+
+    let error = assemble_test_jolt_commitment_stage(result, stage_config(false, false))
+        .err()
+        .expect("disabled trusted advice commitment should fail output construction");
+
+    assert!(matches!(
+        error,
+        ProverError::InvalidCommitmentOutput { reason }
+            if reason.contains("unexpected Jolt commitment output for TrustedAdvice")
+    ));
+}
+
+#[test]
+fn jolt_commitment_output_rejects_duplicate_slots() {
+    let result = jolt_commitment_result(vec![
+        jolt_output(0, JoltCommittedPolynomial::RamInc, 2),
+        jolt_output(0, JoltCommittedPolynomial::RdInc, 1),
+    ]);
+
+    let error = assemble_test_jolt_commitment_stage(result, stage_config(false, false))
+        .err()
+        .expect("duplicate backend slots should fail output construction");
+
+    assert!(matches!(
+        error,
+        ProverError::InvalidCommitmentOutput { reason }
+            if reason.contains("duplicate Jolt commitment output slot CommitmentSlot(0)")
+    ));
+}

--- a/crates/jolt-prover/src/stages/stage1/mod.rs
+++ b/crates/jolt-prover/src/stages/stage1/mod.rs
@@ -1,0 +1,4 @@
+pub mod prove;
+
+#[cfg(test)]
+mod tests;

--- a/crates/jolt-prover/src/stages/stage1/prove.rs
+++ b/crates/jolt-prover/src/stages/stage1/prove.rs
@@ -1,0 +1,1917 @@
+#[cfg(test)]
+use jolt_backends::SumcheckMaterializationOutput;
+use jolt_backends::{
+    spartan_outer_row, stage1_r1cs_input_slot, BackendValueSlot, SumcheckBackend,
+    SumcheckLinearProductOutput, SumcheckPrefixProductSumQuery, SumcheckPrefixProductSumRequest,
+    SumcheckSpartanOuterRemainderQuery, SumcheckSpartanOuterRemainderRequest,
+    SumcheckSpartanOuterRemainderRound, SumcheckSpartanOuterRemainderRowStateRequest,
+    SumcheckSpartanOuterRemainderState, SumcheckSpartanOuterRemainderStateRequest,
+    SumcheckSpartanOuterRow, SumcheckSpartanOuterUniskipQuery, SumcheckSpartanOuterUniskipRequest,
+    SPARTAN_OUTER_REMAINDER_RELATION, SPARTAN_OUTER_UNISKIP_RELATION,
+    STAGE1_SPARTAN_OUTER_OPTIMIZATION_IDS,
+};
+#[cfg(test)]
+use jolt_backends::{SumcheckMaterializationRequest, SumcheckViewMaterializationRequest};
+use jolt_claims::protocols::jolt::{
+    formulas::spartan::{SpartanOuterDimensions, SPARTAN_OUTER_R1CS_INPUTS},
+    JoltVirtualPolynomial,
+};
+#[cfg(feature = "zk")]
+use jolt_crypto::VectorCommitment;
+use jolt_field::Field;
+use jolt_poly::{
+    lagrange::{
+        centered_domain_start, centered_lagrange_evals, centered_lagrange_kernel,
+        interpolate_to_coeffs, poly_mul,
+    },
+    TensorEqTable, UnivariatePoly,
+};
+use jolt_r1cs::{
+    constraints::{
+        jolt::{
+            spartan_outer_constraints, spartan_outer_opening_columns, spartan_outer_row_weights,
+            JoltSpartanOuterRemainder, JoltSpartanOuterRemainderChallenges,
+            SPARTAN_OUTER_REMAINDER_DEGREE, SPARTAN_OUTER_UNISKIP_DOMAIN_SIZE,
+        },
+        rv64,
+    },
+    ConstraintMatrices,
+};
+use jolt_riscv::CircuitFlags;
+use jolt_sumcheck::{
+    append_sumcheck_claim, ClearProof, ClearSumcheckProof, CompressedLabeledRoundPoly,
+    CompressedSumcheckProof, LabeledRoundPoly, RoundMessage, SumcheckProof,
+};
+use jolt_transcript::Transcript;
+#[cfg(feature = "zk")]
+use jolt_verifier::stages::stage1::Stage1PublicOutput;
+use jolt_verifier::stages::stage1::{stage1_clear_output, Stage1ClearOutput};
+use jolt_witness::protocols::jolt_vm::JoltVmSpartanOuterRows;
+use jolt_witness::protocols::jolt_vm::{JoltVmNamespace, JoltVmSpartanOuterRow};
+use jolt_witness::WitnessProvider;
+#[cfg(test)]
+use jolt_witness::{OracleRef, ViewRequirement};
+
+#[cfg(feature = "zk")]
+use crate::committed::{CommittedSumcheckBuilder, CommittedSumcheckWitness};
+use crate::stages::invalid_sumcheck_output;
+#[cfg(test)]
+use crate::stages::primary_view_requirement;
+use crate::ProverError;
+
+const STAGE1_RV64_R1CS_INPUT_COUNT: usize = SPARTAN_OUTER_R1CS_INPUTS.len();
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Stage1ProverConfig {
+    pub log_t: usize,
+    #[cfg(feature = "zk")]
+    pub committed_rounds: bool,
+}
+
+impl Stage1ProverConfig {
+    pub const fn new(log_t: usize) -> Self {
+        Self {
+            log_t,
+            #[cfg(feature = "zk")]
+            committed_rounds: false,
+        }
+    }
+
+    pub fn dimensions(self) -> SpartanOuterDimensions {
+        SpartanOuterDimensions::rv64(self.log_t)
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct Stage1ProverInput<'a, W> {
+    pub config: Stage1ProverConfig,
+    pub witness: &'a W,
+}
+
+impl<'a, W> Stage1ProverInput<'a, W> {
+    pub const fn new(config: Stage1ProverConfig, witness: &'a W) -> Self {
+        Self { config, witness }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Stage1ProofComponent<F: Field, Proof> {
+    pub uniskip_proof: Proof,
+    pub remainder_proof: Proof,
+    pub uniskip_output_claim: F,
+    pub remainder_output_claim: F,
+    pub r1cs_input_claims: Vec<Stage1R1csInputClaim<F>>,
+    /// Verifier-mirroring Stage 1 output that downstream stages consume as a
+    /// dependency, produced by the clear prover (`prove`). The pure-backend test
+    /// path (`from_backend_result`) leaves it `None`; the full-proof
+    /// orchestrator requires it.
+    pub verifier_output: Option<Stage1ClearOutput<F>>,
+}
+
+#[cfg(feature = "zk")]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Stage1CommittedProofComponent<F, VC>
+where
+    F: Field,
+    VC: VectorCommitment<Field = F>,
+{
+    pub uniskip_proof: SumcheckProof<F, VC::Output>,
+    pub remainder_proof: SumcheckProof<F, VC::Output>,
+    pub public: Stage1PublicOutput<F>,
+    pub verifier_output: Stage1ClearOutput<F>,
+    pub uniskip_output_claim_values: Vec<F>,
+    pub remainder_output_claim_values: Vec<F>,
+    pub(crate) uniskip_committed_witness: CommittedSumcheckWitness<F>,
+    pub(crate) remainder_committed_witness: CommittedSumcheckWitness<F>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Stage1R1csInputClaim<F: Field> {
+    pub variable: JoltVirtualPolynomial,
+    pub slot: BackendValueSlot,
+    pub value: F,
+}
+
+impl<F: Field> Stage1R1csInputClaim<F> {
+    pub(crate) fn verifier_input(&self) -> (JoltVirtualPolynomial, F) {
+        (self.variable, self.value)
+    }
+}
+
+#[cfg(test)]
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct Stage1R1csMaterializationRequest {
+    materializations: SumcheckMaterializationRequest<JoltVmNamespace>,
+    r1cs_inputs: Vec<Stage1R1csInputRequest>,
+}
+
+#[cfg(test)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct Stage1R1csInputRequest {
+    variable: JoltVirtualPolynomial,
+    slot: BackendValueSlot,
+    view: ViewRequirement<JoltVmNamespace>,
+}
+
+#[cfg(test)]
+fn build_stage1_r1cs_materialization_request<F, W>(
+    config: Stage1ProverConfig,
+    witness: &W,
+) -> Result<Stage1R1csMaterializationRequest, ProverError>
+where
+    F: Field,
+    W: WitnessProvider<F, JoltVmNamespace>,
+{
+    let r1cs_inputs = config
+        .dimensions()
+        .variables()
+        .iter()
+        .copied()
+        .enumerate()
+        .map(|(index, variable)| {
+            let oracle = OracleRef::virtual_polynomial(variable);
+            let view = primary_view_requirement::<F, W, JoltVmNamespace>(witness, oracle)?;
+            Ok(Stage1R1csInputRequest {
+                variable,
+                slot: stage1_r1cs_input_slot(index),
+                view,
+            })
+        })
+        .collect::<Result<Vec<_>, ProverError>>()?;
+    let views = r1cs_inputs
+        .iter()
+        .map(|input| SumcheckViewMaterializationRequest::new(input.slot, input.view))
+        .collect();
+
+    Ok(Stage1R1csMaterializationRequest {
+        materializations: SumcheckMaterializationRequest::new(
+            "stage1.spartan_outer.r1cs_inputs.materialize",
+            views,
+        ),
+        r1cs_inputs,
+    })
+}
+
+/// Proves Stage 1 with the trace-row Spartan-outer CPU kernel, in verifier
+/// order: prelude challenges, uni-skip, remainder, opening claims.
+pub fn prove<F, W, B, T, C>(
+    input: Stage1ProverInput<'_, W>,
+    backend: &mut B,
+    transcript: &mut T,
+) -> Result<Stage1ProofComponent<F, SumcheckProof<F, C>>, ProverError>
+where
+    F: Field,
+    W: JoltVmSpartanOuterRows + WitnessProvider<F, JoltVmNamespace>,
+    B: SumcheckBackend<F, JoltVmNamespace>,
+    T: Transcript<Challenge = F>,
+{
+    let config = input.config;
+    let witness = input.witness;
+    let spartan_rows = materialize_stage1_spartan_outer_rows(config, witness)?;
+    let backend_rows = spartan_rows
+        .iter()
+        .copied()
+        .map(spartan_outer_row)
+        .collect::<Vec<_>>();
+    let context = SpartanOuterContext::new(config, Vec::new());
+
+    prove_stage1_transparent_sumchecks_with_context(
+        config,
+        backend,
+        transcript,
+        context,
+        Some(&backend_rows),
+        |_, backend, tau| {
+            prove_uniskip_round_poly_from_spartan_outer_backend_rows(
+                config,
+                &backend_rows,
+                backend,
+                tau,
+            )
+        },
+        |context, _backend, opening_point| {
+            let r1cs_input_claims = evaluate_stage1_r1cs_inputs_from_spartan_outer_rows_at_point(
+                context.config,
+                &spartan_rows,
+                &opening_point,
+            )?;
+            Ok(Stage1OpeningClaims { r1cs_input_claims })
+        },
+    )
+}
+
+#[cfg(feature = "zk")]
+pub fn prove_committed_proof_component<F, W, B, T, VC>(
+    input: Stage1ProverInput<'_, W>,
+    backend: &mut B,
+    transcript: &mut T,
+    vc_setup: &VC::Setup,
+) -> Result<Stage1CommittedProofComponent<F, VC>, ProverError>
+where
+    F: Field,
+    W: JoltVmSpartanOuterRows + WitnessProvider<F, JoltVmNamespace>,
+    B: SumcheckBackend<F, JoltVmNamespace>,
+    T: Transcript<Challenge = F>,
+    VC: VectorCommitment<Field = F>,
+    VC::Output: jolt_transcript::AppendToTranscript,
+{
+    let config = input.config;
+    let witness = input.witness;
+    let spartan_rows = materialize_stage1_spartan_outer_rows(config, witness)?;
+    let backend_rows = spartan_rows
+        .iter()
+        .copied()
+        .map(spartan_outer_row)
+        .collect::<Vec<_>>();
+    let context = SpartanOuterContext::new(config, Vec::new());
+
+    prove_stage1_committed_sumchecks_with_context::<F, B, T, VC, _, _>(
+        config,
+        backend,
+        transcript,
+        vc_setup,
+        context,
+        Some(&backend_rows),
+        |_, backend, tau| {
+            prove_uniskip_round_poly_from_spartan_outer_backend_rows(
+                config,
+                &backend_rows,
+                backend,
+                tau,
+            )
+        },
+        |context, _backend, opening_point| {
+            let r1cs_input_claims = evaluate_stage1_r1cs_inputs_from_spartan_outer_rows_at_point(
+                context.config,
+                &spartan_rows,
+                &opening_point,
+            )?;
+            Ok(Stage1OpeningClaims { r1cs_input_claims })
+        },
+    )
+}
+
+#[cfg(test)]
+pub(super) fn prove_stage1_transparent_sumchecks<F, W, B, T, C>(
+    config: Stage1ProverConfig,
+    witness: &W,
+    backend: &mut B,
+    transcript: &mut T,
+) -> Result<Stage1ProofComponent<F, SumcheckProof<F, C>>, ProverError>
+where
+    F: Field,
+    W: WitnessProvider<F, JoltVmNamespace>,
+    B: SumcheckBackend<F, JoltVmNamespace>,
+    T: Transcript<Challenge = F>,
+{
+    let request = build_stage1_r1cs_materialization_request::<F, W>(config, witness)?;
+    let materializations =
+        backend.materialize_sumcheck_views(&request.materializations, witness)?;
+    let r1cs_inputs = materialized_stage1_r1cs_inputs(config, &request, materializations)?;
+    let context = SpartanOuterContext::new(config, r1cs_inputs);
+
+    prove_stage1_transparent_sumchecks_with_context(
+        config,
+        backend,
+        transcript,
+        context,
+        None,
+        prove_uniskip_round_poly,
+        |context, backend, opening_point| {
+            let r1cs_input_claims =
+                evaluate_stage1_r1cs_inputs_from_context(context, &opening_point)?;
+            let _ = backend;
+            Ok(Stage1OpeningClaims { r1cs_input_claims })
+        },
+    )
+}
+
+fn prove_stage1_transparent_sumchecks_with_context<F, B, T, C, U, E>(
+    config: Stage1ProverConfig,
+    backend: &mut B,
+    transcript: &mut T,
+    context: SpartanOuterContext<F>,
+    backend_rows: Option<&[SumcheckSpartanOuterRow]>,
+    prove_uniskip: U,
+    evaluate_openings: E,
+) -> Result<Stage1ProofComponent<F, SumcheckProof<F, C>>, ProverError>
+where
+    F: Field,
+    B: SumcheckBackend<F, JoltVmNamespace>,
+    T: Transcript<Challenge = F>,
+    U: FnOnce(&SpartanOuterContext<F>, &mut B, &[F]) -> Result<UnivariatePoly<F>, ProverError>,
+    E: FnOnce(
+        &SpartanOuterContext<F>,
+        &mut B,
+        Vec<F>,
+    ) -> Result<Stage1OpeningClaims<F>, ProverError>,
+{
+    let tau = transcript.challenge_vector(config.log_t + 2);
+    let uniskip_poly = prove_uniskip(&context, backend, &tau)?;
+    LabeledRoundPoly::uniskip(&uniskip_poly).append_to_transcript(transcript);
+    let uniskip_challenge = transcript.challenge();
+    let uniskip_output_claim = uniskip_poly.evaluate(uniskip_challenge);
+    let uniskip_proof = SumcheckProof::Clear(ClearProof::Full(ClearSumcheckProof {
+        round_polynomials: vec![uniskip_poly],
+    }));
+
+    transcript.append_labeled(b"opening_claim", &uniskip_output_claim);
+    append_sumcheck_claim(transcript, &uniskip_output_claim);
+    let batching_coefficient = transcript.challenge_scalar();
+
+    let remainder = if let Some(rows) = backend_rows {
+        prove_remainder_sumcheck_from_spartan_outer_backend_rows(
+            config,
+            rows,
+            backend,
+            &tau,
+            uniskip_challenge,
+            batching_coefficient,
+            uniskip_output_claim,
+            transcript,
+        )
+    } else {
+        prove_remainder_sumcheck(
+            &context,
+            backend,
+            &tau,
+            uniskip_challenge,
+            batching_coefficient,
+            uniskip_output_claim,
+            transcript,
+        )
+    }?;
+
+    let opening_point = normalized_remainder_opening_point(&remainder.challenges);
+    let opening_claims = evaluate_openings(&context, backend, opening_point)?;
+    let opening_values = opening_claims.opening_values();
+    let expected_remainder_output =
+        JoltSpartanOuterRemainder::new(JoltSpartanOuterRemainderChallenges {
+            tau: &tau,
+            uniskip: uniskip_challenge,
+            remainder: &remainder.challenges,
+        })
+        .map_err(invalid_sumcheck_output)?
+        .expected_output_claim(&opening_values)
+        .map_err(invalid_sumcheck_output)?
+            * batching_coefficient;
+    if remainder.output_claim != expected_remainder_output {
+        return Err(invalid_sumcheck_output(
+            "Stage 1 transparent remainder proof final claim did not match R1CS openings",
+        ));
+    }
+    for opening_claim in &opening_values {
+        transcript.append_labeled(b"opening_claim", opening_claim);
+    }
+
+    let verifier_output = Some(stage1_clear_output(
+        tau,
+        uniskip_challenge,
+        uniskip_output_claim,
+        batching_coefficient,
+        remainder.challenges.clone(),
+        remainder.output_claim,
+        expected_remainder_output,
+        opening_claims
+            .r1cs_input_claims
+            .iter()
+            .map(Stage1R1csInputClaim::verifier_input),
+    )?);
+
+    Ok(Stage1ProofComponent {
+        uniskip_proof,
+        remainder_proof: SumcheckProof::Clear(ClearProof::Compressed(CompressedSumcheckProof {
+            round_polynomials: remainder.round_polynomials,
+        })),
+        uniskip_output_claim,
+        remainder_output_claim: remainder.output_claim,
+        r1cs_input_claims: opening_claims.r1cs_input_claims,
+        verifier_output,
+    })
+}
+
+#[cfg(feature = "zk")]
+#[expect(
+    clippy::too_many_arguments,
+    reason = "Temporary shared clear/ZK Stage 1 helper; Phase 6 will collapse this into a mode-aware stage input."
+)]
+fn prove_stage1_committed_sumchecks_with_context<F, B, T, VC, U, E>(
+    config: Stage1ProverConfig,
+    backend: &mut B,
+    transcript: &mut T,
+    vc_setup: &VC::Setup,
+    context: SpartanOuterContext<F>,
+    backend_rows: Option<&[SumcheckSpartanOuterRow]>,
+    prove_uniskip: U,
+    evaluate_openings: E,
+) -> Result<Stage1CommittedProofComponent<F, VC>, ProverError>
+where
+    F: Field,
+    B: SumcheckBackend<F, JoltVmNamespace>,
+    T: Transcript<Challenge = F>,
+    VC: VectorCommitment<Field = F>,
+    VC::Output: jolt_transcript::AppendToTranscript,
+    U: FnOnce(&SpartanOuterContext<F>, &mut B, &[F]) -> Result<UnivariatePoly<F>, ProverError>,
+    E: FnOnce(
+        &SpartanOuterContext<F>,
+        &mut B,
+        Vec<F>,
+    ) -> Result<Stage1OpeningClaims<F>, ProverError>,
+{
+    let tau = transcript.challenge_vector(config.log_t + 2);
+    let uniskip_poly = prove_uniskip(&context, backend, &tau)?;
+    let mut uniskip_builder = CommittedSumcheckBuilder::<F, VC>::new(vc_setup, 1)?;
+    let uniskip_challenge = uniskip_builder.commit_round(&uniskip_poly, transcript)?;
+    let uniskip_output_claim = uniskip_poly.evaluate(uniskip_challenge);
+    let uniskip_output_claim_values = vec![uniskip_output_claim];
+    let uniskip_built = uniskip_builder.finish(&uniskip_output_claim_values, transcript)?;
+
+    let batching_coefficient = transcript.challenge_scalar();
+    let remainder = if let Some(rows) = backend_rows {
+        prove_remainder_committed_sumcheck_from_spartan_outer_backend_rows::<F, B, T, VC>(
+            config,
+            rows,
+            backend,
+            &tau,
+            uniskip_challenge,
+            batching_coefficient,
+            uniskip_output_claim,
+            transcript,
+            vc_setup,
+        )
+    } else {
+        prove_remainder_committed_sumcheck::<F, B, T, VC>(
+            &context,
+            backend,
+            &tau,
+            uniskip_challenge,
+            batching_coefficient,
+            uniskip_output_claim,
+            transcript,
+            vc_setup,
+        )
+    }?;
+
+    let opening_point = normalized_remainder_opening_point(&remainder.challenges);
+    let opening_claims = evaluate_openings(&context, backend, opening_point)?;
+    let remainder_output_claim_values = opening_claims.opening_values();
+    let expected_remainder_output =
+        JoltSpartanOuterRemainder::new(JoltSpartanOuterRemainderChallenges {
+            tau: &tau,
+            uniskip: uniskip_challenge,
+            remainder: &remainder.challenges,
+        })
+        .map_err(invalid_sumcheck_output)?
+        .expected_output_claim(&remainder_output_claim_values)
+        .map_err(invalid_sumcheck_output)?
+            * batching_coefficient;
+    if remainder.output_claim != expected_remainder_output {
+        return Err(invalid_sumcheck_output(
+            "Stage 1 committed remainder proof final claim did not match R1CS openings",
+        ));
+    }
+
+    let remainder_built = remainder
+        .builder
+        .finish(&remainder_output_claim_values, transcript)?;
+    let verifier_output = stage1_clear_output(
+        tau,
+        uniskip_challenge,
+        uniskip_output_claim,
+        batching_coefficient,
+        remainder.challenges,
+        remainder.output_claim,
+        expected_remainder_output,
+        opening_claims
+            .r1cs_input_claims
+            .iter()
+            .map(Stage1R1csInputClaim::verifier_input),
+    )?;
+
+    Ok(Stage1CommittedProofComponent {
+        uniskip_proof: uniskip_built.proof,
+        remainder_proof: remainder_built.proof,
+        public: verifier_output.public.clone(),
+        verifier_output,
+        uniskip_output_claim_values,
+        remainder_output_claim_values,
+        uniskip_committed_witness: uniskip_built.witness,
+        remainder_committed_witness: remainder_built.witness,
+    })
+}
+
+fn materialize_stage1_spartan_outer_rows<W>(
+    config: Stage1ProverConfig,
+    witness: &W,
+) -> Result<Vec<JoltVmSpartanOuterRow>, ProverError>
+where
+    W: JoltVmSpartanOuterRows,
+{
+    let rows = witness.spartan_outer_rows()?;
+    let expected_rows = checked_trace_rows(config.log_t, "Stage 1")?;
+    if rows.len() != expected_rows {
+        return Err(ProverError::InvalidStageRequest {
+            reason: format!(
+                "Stage 1 Spartan outer witness returned {} rows, expected {expected_rows}",
+                rows.len()
+            ),
+        });
+    }
+    Ok(rows)
+}
+
+#[cfg(test)]
+fn evaluate_stage1_r1cs_inputs_from_context<F>(
+    context: &SpartanOuterContext<F>,
+    point: &[F],
+) -> Result<Vec<Stage1R1csInputClaim<F>>, ProverError>
+where
+    F: Field,
+{
+    let dimensions = context.config.dimensions();
+    let variables = dimensions.variables();
+    let values = evaluate_context_r1cs_columns(context, 0, variables.len(), point)?;
+    variables
+        .iter()
+        .copied()
+        .enumerate()
+        .zip(values)
+        .map(|((index, variable), value)| {
+            Ok(Stage1R1csInputClaim {
+                variable,
+                slot: stage1_r1cs_input_slot(index),
+                value,
+            })
+        })
+        .collect()
+}
+
+fn evaluate_stage1_r1cs_inputs_from_spartan_outer_rows_at_point<F>(
+    config: Stage1ProverConfig,
+    rows: &[JoltVmSpartanOuterRow],
+    point: &[F],
+) -> Result<Vec<Stage1R1csInputClaim<F>>, ProverError>
+where
+    F: Field,
+{
+    if point.len() != config.log_t {
+        return Err(ProverError::InvalidStageRequest {
+            reason: format!(
+                "Stage 1 raw-row R1CS evaluation point has {} variables, expected {}",
+                point.len(),
+                config.log_t
+            ),
+        });
+    }
+    let expected_rows = checked_trace_rows(config.log_t, "Stage 1")?;
+    if rows.len() != expected_rows {
+        return Err(ProverError::InvalidStageRequest {
+            reason: format!(
+                "Stage 1 raw-row R1CS evaluation received {} rows, expected {expected_rows}",
+                rows.len()
+            ),
+        });
+    }
+
+    let dimensions = config.dimensions();
+    let variables = dimensions.variables();
+    if variables == SPARTAN_OUTER_R1CS_INPUTS.as_slice() {
+        return Ok(evaluate_stage1_rv64_r1cs_inputs_from_spartan_outer_rows_at_point(rows, point));
+    }
+    for &variable in variables {
+        if !spartan_outer_row_variable_supported(variable) {
+            return Err(invalid_sumcheck_output(format!(
+                "unsupported Stage 1 Spartan outer R1CS input {variable:?}"
+            )));
+        }
+    }
+
+    let eq = TensorEqTable::new(point);
+    let values = eq.par_fold_out_in(
+        || vec![F::zero(); variables.len()],
+        |inner, row_index, _x_in, e_in| {
+            if e_in.is_zero() {
+                return;
+            }
+            let row = &rows[row_index];
+            for (accumulator, &variable) in inner.iter_mut().zip(variables) {
+                let value = spartan_outer_row_value_known(row, variable).unwrap_or(F::zero());
+                *accumulator += e_in * value;
+            }
+        },
+        |_x_out, e_out, mut inner| {
+            if e_out.is_zero() {
+                inner.fill(F::zero());
+            } else {
+                for value in &mut inner {
+                    *value *= e_out;
+                }
+            }
+            inner
+        },
+        |mut left, right| {
+            for (left, right) in left.iter_mut().zip(right) {
+                *left += right;
+            }
+            left
+        },
+    );
+
+    variables
+        .iter()
+        .copied()
+        .enumerate()
+        .zip(values)
+        .map(|((index, variable), value)| {
+            Ok(Stage1R1csInputClaim {
+                variable,
+                slot: stage1_r1cs_input_slot(index),
+                value,
+            })
+        })
+        .collect()
+}
+
+fn evaluate_stage1_rv64_r1cs_inputs_from_spartan_outer_rows_at_point<F>(
+    rows: &[JoltVmSpartanOuterRow],
+    point: &[F],
+) -> Vec<Stage1R1csInputClaim<F>>
+where
+    F: Field,
+{
+    let eq = TensorEqTable::new(point);
+    let values = eq.par_fold_out_in(
+        || [F::zero(); STAGE1_RV64_R1CS_INPUT_COUNT],
+        |inner, row_index, _x_in, e_in| {
+            if e_in.is_zero() {
+                return;
+            }
+            let row = &rows[row_index];
+            inner[0] += e_in * F::from_u64(row.left_instruction_input);
+            inner[1] += e_in * F::from_i128(row.right_instruction_input);
+            let product = e_in * F::from_u128(row.product_magnitude);
+            if row.product_is_positive {
+                inner[2] += product;
+            } else {
+                inner[2] -= product;
+            }
+            accumulate_bool(&mut inner[3], e_in, row.should_branch);
+            inner[4] += e_in * F::from_u64(row.pc);
+            inner[5] += e_in * F::from_u64(row.unexpanded_pc);
+            inner[6] += e_in * F::from_i128(row.imm);
+            inner[7] += e_in * F::from_u64(row.ram_address);
+            inner[8] += e_in * F::from_u64(row.rs1_value);
+            inner[9] += e_in * F::from_u64(row.rs2_value);
+            inner[10] += e_in * F::from_u64(row.rd_write_value);
+            inner[11] += e_in * F::from_u64(row.ram_read_value);
+            inner[12] += e_in * F::from_u64(row.ram_write_value);
+            inner[13] += e_in * F::from_u64(row.left_lookup_operand);
+            inner[14] += e_in * F::from_u128(row.right_lookup_operand);
+            inner[15] += e_in * F::from_u64(row.next_unexpanded_pc);
+            inner[16] += e_in * F::from_u64(row.next_pc);
+            accumulate_bool(&mut inner[17], e_in, row.next_is_virtual);
+            accumulate_bool(&mut inner[18], e_in, row.next_is_first_in_sequence);
+            inner[19] += e_in * F::from_u64(row.lookup_output);
+            accumulate_bool(&mut inner[20], e_in, row.should_jump);
+            accumulate_bool(&mut inner[21], e_in, row.flag_add_operands);
+            accumulate_bool(&mut inner[22], e_in, row.flag_subtract_operands);
+            accumulate_bool(&mut inner[23], e_in, row.flag_multiply_operands);
+            accumulate_bool(&mut inner[24], e_in, row.flag_load);
+            accumulate_bool(&mut inner[25], e_in, row.flag_store);
+            accumulate_bool(&mut inner[26], e_in, row.flag_jump);
+            accumulate_bool(&mut inner[27], e_in, row.flag_write_lookup_output_to_rd);
+            accumulate_bool(&mut inner[28], e_in, row.flag_virtual_instruction);
+            accumulate_bool(&mut inner[29], e_in, row.flag_assert);
+            accumulate_bool(&mut inner[30], e_in, row.flag_do_not_update_unexpanded_pc);
+            accumulate_bool(&mut inner[31], e_in, row.flag_advice);
+            accumulate_bool(&mut inner[32], e_in, row.flag_is_compressed);
+            accumulate_bool(&mut inner[33], e_in, row.flag_is_first_in_sequence);
+            accumulate_bool(&mut inner[34], e_in, row.flag_is_last_in_sequence);
+        },
+        |_x_out, e_out, mut inner| {
+            if e_out.is_zero() {
+                inner.fill(F::zero());
+            } else {
+                for value in &mut inner {
+                    *value *= e_out;
+                }
+            }
+            inner
+        },
+        |mut left, right| {
+            for (left, right) in left.iter_mut().zip(right) {
+                *left += right;
+            }
+            left
+        },
+    );
+
+    SPARTAN_OUTER_R1CS_INPUTS
+        .iter()
+        .copied()
+        .enumerate()
+        .zip(values)
+        .map(|((index, variable), value)| Stage1R1csInputClaim {
+            variable,
+            slot: stage1_r1cs_input_slot(index),
+            value,
+        })
+        .collect()
+}
+
+#[inline]
+fn accumulate_bool<F: Field>(accumulator: &mut F, scale: F, flag: bool) {
+    if flag {
+        *accumulator += scale;
+    }
+}
+
+#[cfg(test)]
+fn evaluate_context_r1cs_columns<F>(
+    context: &SpartanOuterContext<F>,
+    start: usize,
+    count: usize,
+    point: &[F],
+) -> Result<Vec<F>, ProverError>
+where
+    F: Field,
+{
+    if point.len() != context.config.log_t {
+        return Err(ProverError::InvalidStageRequest {
+            reason: format!(
+                "Stage 1 R1CS context evaluation point has {} variables, expected {}",
+                point.len(),
+                context.config.log_t
+            ),
+        });
+    }
+    let end = start
+        .checked_add(count)
+        .ok_or_else(|| invalid_sumcheck_output("Stage 1 R1CS context column range overflowed"))?;
+    if end > context.r1cs_inputs.len() {
+        return Err(invalid_sumcheck_output(format!(
+            "Stage 1 R1CS context has {} columns, requested range {start}..{end}",
+            context.r1cs_inputs.len()
+        )));
+    }
+    let expected_rows = checked_trace_rows(context.config.log_t, "Stage 1")?;
+    for (index, column) in context.r1cs_inputs[start..end].iter().enumerate() {
+        if column.len() != expected_rows {
+            return Err(invalid_sumcheck_output(format!(
+                "Stage 1 R1CS context column {} has {} rows, expected {expected_rows}",
+                start + index,
+                column.len()
+            )));
+        }
+    }
+    let eq = TensorEqTable::new(point);
+    Ok(eq.evaluate_slices(
+        &context.r1cs_inputs[start..end]
+            .iter()
+            .map(Vec::as_slice)
+            .collect::<Vec<_>>(),
+    ))
+}
+
+fn spartan_outer_row_variable_supported(variable: JoltVirtualPolynomial) -> bool {
+    matches!(
+        variable,
+        JoltVirtualPolynomial::LeftInstructionInput
+            | JoltVirtualPolynomial::RightInstructionInput
+            | JoltVirtualPolynomial::Product
+            | JoltVirtualPolynomial::ShouldBranch
+            | JoltVirtualPolynomial::PC
+            | JoltVirtualPolynomial::UnexpandedPC
+            | JoltVirtualPolynomial::Imm
+            | JoltVirtualPolynomial::RamAddress
+            | JoltVirtualPolynomial::Rs1Value
+            | JoltVirtualPolynomial::Rs2Value
+            | JoltVirtualPolynomial::RdWriteValue
+            | JoltVirtualPolynomial::RamReadValue
+            | JoltVirtualPolynomial::RamWriteValue
+            | JoltVirtualPolynomial::LeftLookupOperand
+            | JoltVirtualPolynomial::RightLookupOperand
+            | JoltVirtualPolynomial::NextUnexpandedPC
+            | JoltVirtualPolynomial::NextPC
+            | JoltVirtualPolynomial::NextIsVirtual
+            | JoltVirtualPolynomial::NextIsFirstInSequence
+            | JoltVirtualPolynomial::LookupOutput
+            | JoltVirtualPolynomial::ShouldJump
+            | JoltVirtualPolynomial::OpFlags(_)
+    )
+}
+
+fn spartan_outer_row_value_known<F>(
+    row: &JoltVmSpartanOuterRow,
+    variable: JoltVirtualPolynomial,
+) -> Option<F>
+where
+    F: Field,
+{
+    let value = match variable {
+        JoltVirtualPolynomial::LeftInstructionInput => F::from_u64(row.left_instruction_input),
+        JoltVirtualPolynomial::RightInstructionInput => F::from_i128(row.right_instruction_input),
+        JoltVirtualPolynomial::Product => signed_product_from_spartan_outer_row(row),
+        JoltVirtualPolynomial::ShouldBranch => F::from_bool(row.should_branch),
+        JoltVirtualPolynomial::PC => F::from_u64(row.pc),
+        JoltVirtualPolynomial::UnexpandedPC => F::from_u64(row.unexpanded_pc),
+        JoltVirtualPolynomial::Imm => F::from_i128(row.imm),
+        JoltVirtualPolynomial::RamAddress => F::from_u64(row.ram_address),
+        JoltVirtualPolynomial::Rs1Value => F::from_u64(row.rs1_value),
+        JoltVirtualPolynomial::Rs2Value => F::from_u64(row.rs2_value),
+        JoltVirtualPolynomial::RdWriteValue => F::from_u64(row.rd_write_value),
+        JoltVirtualPolynomial::RamReadValue => F::from_u64(row.ram_read_value),
+        JoltVirtualPolynomial::RamWriteValue => F::from_u64(row.ram_write_value),
+        JoltVirtualPolynomial::LeftLookupOperand => F::from_u64(row.left_lookup_operand),
+        JoltVirtualPolynomial::RightLookupOperand => F::from_u128(row.right_lookup_operand),
+        JoltVirtualPolynomial::NextUnexpandedPC => F::from_u64(row.next_unexpanded_pc),
+        JoltVirtualPolynomial::NextPC => F::from_u64(row.next_pc),
+        JoltVirtualPolynomial::NextIsVirtual => F::from_bool(row.next_is_virtual),
+        JoltVirtualPolynomial::NextIsFirstInSequence => F::from_bool(row.next_is_first_in_sequence),
+        JoltVirtualPolynomial::LookupOutput => F::from_u64(row.lookup_output),
+        JoltVirtualPolynomial::ShouldJump => F::from_bool(row.should_jump),
+        JoltVirtualPolynomial::OpFlags(flag) => F::from_bool(spartan_outer_flag(row, flag)),
+        _ => return None,
+    };
+    Some(value)
+}
+
+fn signed_product_from_spartan_outer_row<F: Field>(row: &JoltVmSpartanOuterRow) -> F {
+    let magnitude = F::from_u128(row.product_magnitude);
+    if row.product_is_positive {
+        magnitude
+    } else {
+        -magnitude
+    }
+}
+
+fn spartan_outer_flag(row: &JoltVmSpartanOuterRow, flag: CircuitFlags) -> bool {
+    match flag {
+        CircuitFlags::AddOperands => row.flag_add_operands,
+        CircuitFlags::SubtractOperands => row.flag_subtract_operands,
+        CircuitFlags::MultiplyOperands => row.flag_multiply_operands,
+        CircuitFlags::Load => row.flag_load,
+        CircuitFlags::Store => row.flag_store,
+        CircuitFlags::Jump => row.flag_jump,
+        CircuitFlags::WriteLookupOutputToRD => row.flag_write_lookup_output_to_rd,
+        CircuitFlags::VirtualInstruction => row.flag_virtual_instruction,
+        CircuitFlags::Assert => row.flag_assert,
+        CircuitFlags::DoNotUpdateUnexpandedPC => row.flag_do_not_update_unexpanded_pc,
+        CircuitFlags::Advice => row.flag_advice,
+        CircuitFlags::IsCompressed => row.flag_is_compressed,
+        CircuitFlags::IsFirstInSequence => row.flag_is_first_in_sequence,
+        CircuitFlags::IsLastInSequence => row.flag_is_last_in_sequence,
+    }
+}
+
+struct SpartanOuterContext<F: Field> {
+    config: Stage1ProverConfig,
+    r1cs_inputs: Vec<Vec<F>>,
+    opening_columns: Vec<usize>,
+    matrices: ConstraintMatrices<F>,
+}
+
+impl<F: Field> SpartanOuterContext<F> {
+    fn new(config: Stage1ProverConfig, r1cs_inputs: Vec<Vec<F>>) -> Self {
+        Self {
+            config,
+            r1cs_inputs,
+            opening_columns: spartan_outer_opening_columns(),
+            matrices: spartan_outer_constraints(),
+        }
+    }
+
+    fn prefix_product_sum_request(
+        &self,
+        label: &'static str,
+        queries: Vec<SumcheckPrefixProductSumQuery<F>>,
+    ) -> SumcheckPrefixProductSumRequest<'_, F> {
+        SumcheckPrefixProductSumRequest::new(
+            label,
+            &self.r1cs_inputs,
+            &self.opening_columns,
+            rv64::const_column(),
+            &self.matrices.a,
+            &self.matrices.b,
+            queries,
+        )
+    }
+
+    fn remainder_state_request(
+        &self,
+        params: &RemainderEvalParams<'_, F>,
+        stream_challenge: F,
+    ) -> Result<SumcheckSpartanOuterRemainderStateRequest<'_, F>, ProverError> {
+        let tau_kernel_scale =
+            spartan_outer_tau_kernel_scale(params.tau, params.uniskip_challenge)?
+                * params.batching_coefficient;
+        let tau_low = &params.tau[..params.tau.len() - 1];
+        let (row_weights_at_zero, row_weights_at_one) =
+            spartan_outer_stream_row_weights(params.uniskip_challenge)?;
+        Ok(SumcheckSpartanOuterRemainderStateRequest::new(
+            "stage1.spartan_outer.remainder_state",
+            &self.r1cs_inputs,
+            &self.opening_columns,
+            rv64::const_column(),
+            &self.matrices.a,
+            &self.matrices.b,
+            tau_low.to_vec(),
+            row_weights_at_zero,
+            row_weights_at_one,
+            stream_challenge,
+            tau_kernel_scale,
+        )
+        .with_relation(SPARTAN_OUTER_REMAINDER_RELATION)
+        .with_optimization_ids(STAGE1_SPARTAN_OUTER_OPTIMIZATION_IDS))
+    }
+}
+
+struct RemainderProof<F: Field> {
+    round_polynomials: Vec<jolt_poly::CompressedPoly<F>>,
+    challenges: Vec<F>,
+    output_claim: F,
+}
+
+#[cfg(feature = "zk")]
+struct PendingCommittedRemainder<'a, F, VC>
+where
+    F: Field,
+    VC: VectorCommitment<Field = F>,
+{
+    builder: CommittedSumcheckBuilder<'a, F, VC>,
+    challenges: Vec<F>,
+    output_claim: F,
+}
+
+struct Stage1OpeningClaims<F: Field> {
+    r1cs_input_claims: Vec<Stage1R1csInputClaim<F>>,
+}
+
+impl<F: Field> Stage1OpeningClaims<F> {
+    fn opening_values(&self) -> Vec<F> {
+        let values = self
+            .r1cs_input_claims
+            .iter()
+            .map(|claim| claim.value)
+            .collect::<Vec<_>>();
+        {
+            values
+        }
+    }
+}
+
+struct RemainderEvalParams<'a, F: Field> {
+    tau: &'a [F],
+    uniskip_challenge: F,
+    batching_coefficient: F,
+}
+
+#[cfg(test)]
+fn materialized_stage1_r1cs_inputs<F>(
+    config: Stage1ProverConfig,
+    request: &Stage1R1csMaterializationRequest,
+    materializations: Vec<SumcheckMaterializationOutput<F>>,
+) -> Result<Vec<Vec<F>>, ProverError>
+where
+    F: Field,
+{
+    let mut by_slot = std::collections::BTreeMap::new();
+    for output in materializations {
+        if by_slot.insert(output.slot, output.values).is_some() {
+            return Err(invalid_sumcheck_output(format!(
+                "duplicate Stage 1 R1CS materialization slot {:?}",
+                output.slot
+            )));
+        }
+    }
+    let expected_len = 1usize << config.log_t;
+    let inputs = request
+        .r1cs_inputs
+        .iter()
+        .map(|input| {
+            let values = by_slot.remove(&input.slot).ok_or_else(|| {
+                invalid_sumcheck_output(format!(
+                    "missing Stage 1 R1CS materialization for {:?}",
+                    input.variable
+                ))
+            })?;
+            if values.len() != expected_len {
+                return Err(invalid_sumcheck_output(format!(
+                    "Stage 1 R1CS input {:?} materialized {} rows, expected {expected_len}",
+                    input.variable,
+                    values.len()
+                )));
+            }
+            Ok(values)
+        })
+        .collect::<Result<Vec<_>, ProverError>>()?;
+    if let Some(slot) = by_slot.keys().next() {
+        return Err(invalid_sumcheck_output(format!(
+            "unexpected Stage 1 R1CS materialization slot {slot:?}"
+        )));
+    }
+    Ok(inputs)
+}
+
+#[cfg(test)]
+fn prove_uniskip_round_poly<F, B>(
+    context: &SpartanOuterContext<F>,
+    backend: &mut B,
+    tau: &[F],
+) -> Result<UnivariatePoly<F>, ProverError>
+where
+    F: Field,
+    B: SumcheckBackend<F, JoltVmNamespace>,
+{
+    if tau.len() != context.config.log_t + 2 {
+        return Err(invalid_sumcheck_output(format!(
+            "Stage 1 tau has {} variables, expected {}",
+            tau.len(),
+            context.config.log_t + 2
+        )));
+    }
+    let degree = SPARTAN_OUTER_UNISKIP_DOMAIN_SIZE - 1;
+    let targets = uniskip_targets(SPARTAN_OUTER_UNISKIP_DOMAIN_SIZE, degree)?;
+    let tau_low = &tau[..tau.len() - 1];
+    let queries = targets
+        .into_iter()
+        .enumerate()
+        .map(|(index, target)| {
+            let (row_weights_at_zero, row_weights_at_one) =
+                spartan_outer_stream_row_weights(F::from_i64(target))?;
+            Ok(SumcheckPrefixProductSumQuery::new(
+                value_slot(index)?,
+                tau_low.to_vec(),
+                Vec::new(),
+                context.config.log_t + 1,
+                row_weights_at_zero,
+                row_weights_at_one,
+                F::one(),
+            ))
+        })
+        .collect::<Result<Vec<_>, ProverError>>()?;
+    let product_request = context
+        .prefix_product_sum_request("stage1.spartan_outer.uniskip_t1", queries)
+        .with_relation(SPARTAN_OUTER_UNISKIP_RELATION)
+        .with_optimization_ids(STAGE1_SPARTAN_OUTER_OPTIMIZATION_IDS);
+    let outputs = backend.evaluate_sumcheck_prefix_product_sums(&product_request)?;
+    let extended_evals = ordered_linear_product_outputs(outputs, degree)?;
+    build_uniskip_first_round_poly(
+        SPARTAN_OUTER_UNISKIP_DOMAIN_SIZE,
+        &extended_evals,
+        tau[tau.len() - 1],
+    )
+}
+
+fn prove_uniskip_round_poly_from_spartan_outer_backend_rows<F, B>(
+    config: Stage1ProverConfig,
+    rows: &[SumcheckSpartanOuterRow],
+    backend: &mut B,
+    tau: &[F],
+) -> Result<UnivariatePoly<F>, ProverError>
+where
+    F: Field,
+    B: SumcheckBackend<F, JoltVmNamespace>,
+{
+    if tau.len() != config.log_t + 2 {
+        return Err(invalid_sumcheck_output(format!(
+            "Stage 1 tau has {} variables, expected {}",
+            tau.len(),
+            config.log_t + 2
+        )));
+    }
+    let expected_rows = checked_trace_rows(config.log_t, "Stage 1")?;
+    if rows.len() != expected_rows {
+        return Err(ProverError::InvalidStageRequest {
+            reason: format!(
+                "Stage 1 Spartan outer witness returned {} rows, expected {expected_rows}",
+                rows.len()
+            ),
+        });
+    }
+
+    let degree = SPARTAN_OUTER_UNISKIP_DOMAIN_SIZE - 1;
+    let tau_low = &tau[..tau.len() - 1];
+    let queries = uniskip_targets(SPARTAN_OUTER_UNISKIP_DOMAIN_SIZE, degree)?
+        .into_iter()
+        .enumerate()
+        .map(|(index, target)| {
+            Ok(SumcheckSpartanOuterUniskipQuery::new(
+                value_slot(index)?,
+                tau_low.to_vec(),
+                centered_lagrange_integer_coeffs(SPARTAN_OUTER_UNISKIP_DOMAIN_SIZE, target)?,
+                F::one(),
+            ))
+        })
+        .collect::<Result<Vec<_>, ProverError>>()?;
+    let request = SumcheckSpartanOuterUniskipRequest::new(
+        "stage1.spartan_outer.uniskip_raw_rows",
+        rows,
+        queries,
+    )
+    .with_relation(SPARTAN_OUTER_UNISKIP_RELATION)
+    .with_optimization_ids(STAGE1_SPARTAN_OUTER_OPTIMIZATION_IDS);
+    let outputs = backend.evaluate_sumcheck_spartan_outer_uniskip_rows(&request)?;
+    let extended_evals = ordered_linear_product_outputs(outputs, degree)?;
+    build_uniskip_first_round_poly(
+        SPARTAN_OUTER_UNISKIP_DOMAIN_SIZE,
+        &extended_evals,
+        tau[tau.len() - 1],
+    )
+}
+
+fn prove_remainder_sumcheck<F, B, T>(
+    context: &SpartanOuterContext<F>,
+    backend: &mut B,
+    tau: &[F],
+    uniskip_challenge: F,
+    batching_coefficient: F,
+    uniskip_output_claim: F,
+    transcript: &mut T,
+) -> Result<RemainderProof<F>, ProverError>
+where
+    F: Field,
+    B: SumcheckBackend<F, JoltVmNamespace>,
+    T: Transcript<Challenge = F>,
+{
+    let num_vars = context.config.log_t + 1;
+    let mut prefix = Vec::with_capacity(num_vars);
+    let mut round_polynomials = Vec::with_capacity(num_vars);
+    let mut running_claim = uniskip_output_claim * batching_coefficient;
+    let params = RemainderEvalParams {
+        tau,
+        uniskip_challenge,
+        batching_coefficient,
+    };
+    let mut state = None;
+
+    for round in 0..num_vars {
+        let suffix_vars = num_vars - round - 1;
+        let evaluations = if round == 0 {
+            sum_remainder_suffix_evals(context, backend, &params, &prefix, suffix_vars)?
+        } else {
+            let state_ref = state.as_ref().ok_or_else(|| {
+                invalid_sumcheck_output("Stage 1 remainder state was not initialized")
+            })?;
+            let round_inputs =
+                backend.evaluate_sumcheck_spartan_outer_remainder_round(state_ref)?;
+            let round_poly =
+                remainder_round_poly_from_state(state_ref, round_inputs, running_claim)?;
+            finish_remainder_round(
+                round,
+                round_poly,
+                transcript,
+                &mut running_claim,
+                &mut prefix,
+                &mut round_polynomials,
+            )?;
+            if round + 1 < num_vars {
+                let state_mut = state.as_mut().ok_or_else(|| {
+                    invalid_sumcheck_output("Stage 1 remainder state was not initialized")
+                })?;
+                backend.bind_sumcheck_spartan_outer_remainder_state(state_mut, prefix[round])?;
+            }
+            continue;
+        };
+        let round_poly = UnivariatePoly::interpolate_over_integers(&evaluations);
+        finish_remainder_round(
+            round,
+            round_poly,
+            transcript,
+            &mut running_claim,
+            &mut prefix,
+            &mut round_polynomials,
+        )?;
+        if round == 0 {
+            state = Some(materialize_remainder_state(
+                context,
+                backend,
+                &params,
+                prefix[round],
+            )?);
+        }
+    }
+
+    Ok(RemainderProof {
+        round_polynomials,
+        challenges: prefix,
+        output_claim: running_claim,
+    })
+}
+
+#[expect(
+    clippy::too_many_arguments,
+    reason = "Temporary backend-row helper retaining the existing Stage 1 transparent flow until stage inputs are consolidated."
+)]
+fn prove_remainder_sumcheck_from_spartan_outer_backend_rows<F, B, T>(
+    config: Stage1ProverConfig,
+    rows: &[SumcheckSpartanOuterRow],
+    backend: &mut B,
+    tau: &[F],
+    uniskip_challenge: F,
+    batching_coefficient: F,
+    uniskip_output_claim: F,
+    transcript: &mut T,
+) -> Result<RemainderProof<F>, ProverError>
+where
+    F: Field,
+    B: SumcheckBackend<F, JoltVmNamespace>,
+    T: Transcript<Challenge = F>,
+{
+    let num_vars = config.log_t + 1;
+    let mut prefix = Vec::with_capacity(num_vars);
+    let mut round_polynomials = Vec::with_capacity(num_vars);
+    let mut running_claim = uniskip_output_claim * batching_coefficient;
+    let params = RemainderEvalParams {
+        tau,
+        uniskip_challenge,
+        batching_coefficient,
+    };
+    let mut state = None;
+
+    for round in 0..num_vars {
+        let suffix_vars = num_vars - round - 1;
+        if round == 0 {
+            let evaluations = sum_remainder_suffix_evals_from_spartan_outer_backend_rows(
+                config,
+                rows,
+                backend,
+                &params,
+                &prefix,
+                suffix_vars,
+            )?;
+            let round_poly = UnivariatePoly::interpolate_over_integers(&evaluations);
+            finish_remainder_round(
+                round,
+                round_poly,
+                transcript,
+                &mut running_claim,
+                &mut prefix,
+                &mut round_polynomials,
+            )?;
+            state = Some(materialize_remainder_row_state(
+                config,
+                rows,
+                backend,
+                &params,
+                prefix[round],
+            )?);
+            continue;
+        }
+
+        let state_ref = state.as_ref().ok_or_else(|| {
+            invalid_sumcheck_output("Stage 1 remainder state was not initialized")
+        })?;
+        let round_inputs = backend.evaluate_sumcheck_spartan_outer_remainder_round(state_ref)?;
+        let round_poly = remainder_round_poly_from_state(state_ref, round_inputs, running_claim)?;
+        finish_remainder_round(
+            round,
+            round_poly,
+            transcript,
+            &mut running_claim,
+            &mut prefix,
+            &mut round_polynomials,
+        )?;
+        if round + 1 < num_vars {
+            let state_mut = state.as_mut().ok_or_else(|| {
+                invalid_sumcheck_output("Stage 1 remainder state was not initialized")
+            })?;
+            backend.bind_sumcheck_spartan_outer_remainder_state(state_mut, prefix[round])?;
+        }
+    }
+
+    Ok(RemainderProof {
+        round_polynomials,
+        challenges: prefix,
+        output_claim: running_claim,
+    })
+}
+
+#[cfg(feature = "zk")]
+#[expect(
+    clippy::too_many_arguments,
+    reason = "Mirrors the transparent Stage 1 remainder loop while swapping only the proof recorder."
+)]
+fn prove_remainder_committed_sumcheck<'a, F, B, T, VC>(
+    context: &SpartanOuterContext<F>,
+    backend: &mut B,
+    tau: &[F],
+    uniskip_challenge: F,
+    batching_coefficient: F,
+    uniskip_output_claim: F,
+    transcript: &mut T,
+    vc_setup: &'a VC::Setup,
+) -> Result<PendingCommittedRemainder<'a, F, VC>, ProverError>
+where
+    F: Field,
+    B: SumcheckBackend<F, JoltVmNamespace>,
+    T: Transcript<Challenge = F>,
+    VC: VectorCommitment<Field = F>,
+    VC::Output: jolt_transcript::AppendToTranscript,
+{
+    let num_vars = context.config.log_t + 1;
+    let mut prefix = Vec::with_capacity(num_vars);
+    let mut running_claim = uniskip_output_claim * batching_coefficient;
+    let params = RemainderEvalParams {
+        tau,
+        uniskip_challenge,
+        batching_coefficient,
+    };
+    let mut state = None;
+    let mut builder = CommittedSumcheckBuilder::<F, VC>::new(vc_setup, num_vars)?;
+
+    for round in 0..num_vars {
+        let suffix_vars = num_vars - round - 1;
+        let round_poly = if round == 0 {
+            let evaluations =
+                sum_remainder_suffix_evals(context, backend, &params, &prefix, suffix_vars)?;
+            UnivariatePoly::interpolate_over_integers(&evaluations)
+        } else {
+            let state_ref = state.as_ref().ok_or_else(|| {
+                invalid_sumcheck_output("Stage 1 committed remainder state was not initialized")
+            })?;
+            let round_inputs =
+                backend.evaluate_sumcheck_spartan_outer_remainder_round(state_ref)?;
+            remainder_round_poly_from_state(state_ref, round_inputs, running_claim)?
+        };
+
+        let challenge = commit_remainder_round(
+            round,
+            &round_poly,
+            transcript,
+            &mut running_claim,
+            &mut builder,
+        )?;
+        prefix.push(challenge);
+
+        if round == 0 {
+            state = Some(materialize_remainder_state(
+                context, backend, &params, challenge,
+            )?);
+        } else if round + 1 < num_vars {
+            let state_mut = state.as_mut().ok_or_else(|| {
+                invalid_sumcheck_output("Stage 1 committed remainder state was not initialized")
+            })?;
+            backend.bind_sumcheck_spartan_outer_remainder_state(state_mut, challenge)?;
+        }
+    }
+
+    Ok(PendingCommittedRemainder {
+        builder,
+        challenges: prefix,
+        output_claim: running_claim,
+    })
+}
+
+#[cfg(feature = "zk")]
+#[expect(
+    clippy::too_many_arguments,
+    reason = "Mirrors the transparent raw-row Stage 1 remainder loop while swapping only the proof recorder."
+)]
+fn prove_remainder_committed_sumcheck_from_spartan_outer_backend_rows<'a, F, B, T, VC>(
+    config: Stage1ProverConfig,
+    rows: &[SumcheckSpartanOuterRow],
+    backend: &mut B,
+    tau: &[F],
+    uniskip_challenge: F,
+    batching_coefficient: F,
+    uniskip_output_claim: F,
+    transcript: &mut T,
+    vc_setup: &'a VC::Setup,
+) -> Result<PendingCommittedRemainder<'a, F, VC>, ProverError>
+where
+    F: Field,
+    B: SumcheckBackend<F, JoltVmNamespace>,
+    T: Transcript<Challenge = F>,
+    VC: VectorCommitment<Field = F>,
+    VC::Output: jolt_transcript::AppendToTranscript,
+{
+    let num_vars = config.log_t + 1;
+    let mut prefix = Vec::with_capacity(num_vars);
+    let mut running_claim = uniskip_output_claim * batching_coefficient;
+    let params = RemainderEvalParams {
+        tau,
+        uniskip_challenge,
+        batching_coefficient,
+    };
+    let mut state = None;
+    let mut builder = CommittedSumcheckBuilder::<F, VC>::new(vc_setup, num_vars)?;
+
+    for round in 0..num_vars {
+        let suffix_vars = num_vars - round - 1;
+        let round_poly = if round == 0 {
+            let evaluations = sum_remainder_suffix_evals_from_spartan_outer_backend_rows(
+                config,
+                rows,
+                backend,
+                &params,
+                &prefix,
+                suffix_vars,
+            )?;
+            UnivariatePoly::interpolate_over_integers(&evaluations)
+        } else {
+            let state_ref = state.as_ref().ok_or_else(|| {
+                invalid_sumcheck_output("Stage 1 committed remainder state was not initialized")
+            })?;
+            let round_inputs =
+                backend.evaluate_sumcheck_spartan_outer_remainder_round(state_ref)?;
+            remainder_round_poly_from_state(state_ref, round_inputs, running_claim)?
+        };
+
+        let challenge = commit_remainder_round(
+            round,
+            &round_poly,
+            transcript,
+            &mut running_claim,
+            &mut builder,
+        )?;
+        prefix.push(challenge);
+
+        if round == 0 {
+            state = Some(materialize_remainder_row_state(
+                config, rows, backend, &params, challenge,
+            )?);
+        } else if round + 1 < num_vars {
+            let state_mut = state.as_mut().ok_or_else(|| {
+                invalid_sumcheck_output("Stage 1 committed remainder state was not initialized")
+            })?;
+            backend.bind_sumcheck_spartan_outer_remainder_state(state_mut, challenge)?;
+        }
+    }
+
+    Ok(PendingCommittedRemainder {
+        builder,
+        challenges: prefix,
+        output_claim: running_claim,
+    })
+}
+
+fn finish_remainder_round<F, T>(
+    round: usize,
+    round_poly: UnivariatePoly<F>,
+    transcript: &mut T,
+    running_claim: &mut F,
+    prefix: &mut Vec<F>,
+    round_polynomials: &mut Vec<jolt_poly::CompressedPoly<F>>,
+) -> Result<(), ProverError>
+where
+    F: Field,
+    T: Transcript<Challenge = F>,
+{
+    let round_sum = round_poly.evaluate(F::zero()) + round_poly.evaluate(F::one());
+    if round_sum != *running_claim {
+        return Err(invalid_sumcheck_output(format!(
+            "Stage 1 remainder round {round} sumcheck invariant failed"
+        )));
+    }
+
+    CompressedLabeledRoundPoly::sumcheck(&round_poly).append_to_transcript(transcript);
+    let challenge = transcript.challenge();
+    *running_claim = round_poly.evaluate(challenge);
+    prefix.push(challenge);
+    round_polynomials.push(round_poly.compress());
+    Ok(())
+}
+
+#[cfg(feature = "zk")]
+fn commit_remainder_round<F, T, VC>(
+    round: usize,
+    round_poly: &UnivariatePoly<F>,
+    transcript: &mut T,
+    running_claim: &mut F,
+    builder: &mut CommittedSumcheckBuilder<'_, F, VC>,
+) -> Result<F, ProverError>
+where
+    F: Field,
+    T: Transcript<Challenge = F>,
+    VC: VectorCommitment<Field = F>,
+    VC::Output: jolt_transcript::AppendToTranscript,
+{
+    let round_sum = round_poly.evaluate(F::zero()) + round_poly.evaluate(F::one());
+    if round_sum != *running_claim {
+        return Err(invalid_sumcheck_output(format!(
+            "Stage 1 committed remainder round {round} sumcheck invariant failed"
+        )));
+    }
+
+    let challenge = builder.commit_round(round_poly, transcript)?;
+    *running_claim = round_poly.evaluate(challenge);
+    Ok(challenge)
+}
+
+fn remainder_round_poly_from_state<F: Field>(
+    state: &SumcheckSpartanOuterRemainderState<F>,
+    round: SumcheckSpartanOuterRemainderRound<F>,
+    previous_claim: F,
+) -> Result<UnivariatePoly<F>, ProverError> {
+    if state.active_len == 0 || !state.active_len.is_power_of_two() {
+        return Err(invalid_sumcheck_output(format!(
+            "Stage 1 remainder state active length {} is invalid",
+            state.active_len
+        )));
+    }
+    let active_log = state.active_len.trailing_zeros() as usize;
+    if active_log == 0 {
+        return Err(invalid_sumcheck_output(
+            "Stage 1 remainder state has no unbound variables",
+        ));
+    }
+    let challenge_index = active_log - 1;
+    let Some(&tau_current) = state.eq_point.get(challenge_index) else {
+        return Err(invalid_sumcheck_output(format!(
+            "Stage 1 remainder state missing equality challenge {challenge_index}"
+        )));
+    };
+
+    let eq_eval_1 = state.scale * tau_current;
+    let eq_eval_0 = state.scale - eq_eval_1;
+    let eq_slope = eq_eval_1 - eq_eval_0;
+    let eq_eval_2 = eq_eval_1 + eq_slope;
+    let eq_eval_3 = eq_eval_2 + eq_slope;
+
+    let cubic_eval_0 = eq_eval_0 * round.q_at_zero;
+    let cubic_eval_1 = previous_claim - cubic_eval_0;
+    let Some(eq_eval_1_inv) = eq_eval_1.inverse() else {
+        return Err(invalid_sumcheck_output(
+            "Stage 1 remainder current equality evaluation was not invertible",
+        ));
+    };
+    let quadratic_eval_1 = cubic_eval_1 * eq_eval_1_inv;
+    let q_inf_times_2 = round.q_at_infinity + round.q_at_infinity;
+    let quadratic_eval_2 = quadratic_eval_1 + quadratic_eval_1 - round.q_at_zero + q_inf_times_2;
+    let quadratic_eval_3 =
+        quadratic_eval_2 + quadratic_eval_1 - round.q_at_zero + q_inf_times_2 + q_inf_times_2;
+
+    Ok(UnivariatePoly::from_evals(&[
+        cubic_eval_0,
+        cubic_eval_1,
+        eq_eval_2 * quadratic_eval_2,
+        eq_eval_3 * quadratic_eval_3,
+    ]))
+}
+
+fn sum_remainder_suffix_evals<F: Field>(
+    context: &SpartanOuterContext<F>,
+    backend: &mut impl SumcheckBackend<F, JoltVmNamespace>,
+    params: &RemainderEvalParams<'_, F>,
+    prefix: &[F],
+    suffix_vars: usize,
+) -> Result<Vec<F>, ProverError> {
+    let expected_vars = context.config.log_t + 1;
+    if prefix.len() + 1 + suffix_vars != expected_vars {
+        return Err(invalid_sumcheck_output(format!(
+            "Stage 1 remainder prefix fixes {} variables and leaves {suffix_vars} suffix variables, expected {expected_vars} total variables",
+            prefix.len() + 1,
+        )));
+    }
+    let tau_kernel_scale = spartan_outer_tau_kernel_scale(params.tau, params.uniskip_challenge)?
+        * params.batching_coefficient;
+    let tau_low = &params.tau[..params.tau.len() - 1];
+    let (row_weights_at_zero, row_weights_at_one) =
+        spartan_outer_stream_row_weights(params.uniskip_challenge)?;
+    let queries = (0..=SPARTAN_OUTER_REMAINDER_DEGREE)
+        .map(|point| {
+            let mut fixed_prefix = Vec::with_capacity(prefix.len() + 1);
+            fixed_prefix.extend_from_slice(prefix);
+            fixed_prefix.push(F::from_u64(point as u64));
+            Ok(SumcheckPrefixProductSumQuery::new(
+                value_slot(point)?,
+                tau_low.to_vec(),
+                fixed_prefix,
+                suffix_vars,
+                row_weights_at_zero.clone(),
+                row_weights_at_one.clone(),
+                tau_kernel_scale,
+            ))
+        })
+        .collect::<Result<Vec<_>, ProverError>>()?;
+    let product_request = context
+        .prefix_product_sum_request("stage1.spartan_outer.remainder_suffix", queries)
+        .with_relation(SPARTAN_OUTER_REMAINDER_RELATION)
+        .with_optimization_ids(STAGE1_SPARTAN_OUTER_OPTIMIZATION_IDS);
+    let outputs = backend.evaluate_sumcheck_prefix_product_sums(&product_request)?;
+    ordered_linear_product_outputs(outputs, SPARTAN_OUTER_REMAINDER_DEGREE + 1)
+}
+
+fn sum_remainder_suffix_evals_from_spartan_outer_backend_rows<F: Field>(
+    config: Stage1ProverConfig,
+    rows: &[SumcheckSpartanOuterRow],
+    backend: &mut impl SumcheckBackend<F, JoltVmNamespace>,
+    params: &RemainderEvalParams<'_, F>,
+    prefix: &[F],
+    suffix_vars: usize,
+) -> Result<Vec<F>, ProverError> {
+    let expected_vars = config.log_t + 1;
+    if prefix.len() + 1 + suffix_vars != expected_vars {
+        return Err(invalid_sumcheck_output(format!(
+            "Stage 1 raw-row remainder prefix fixes {} variables and leaves {suffix_vars} suffix variables, expected {expected_vars} total variables",
+            prefix.len() + 1,
+        )));
+    }
+    let expected_rows = checked_trace_rows(config.log_t, "Stage 1")?;
+    if rows.len() != expected_rows {
+        return Err(ProverError::InvalidStageRequest {
+            reason: format!(
+                "Stage 1 raw-row remainder received {} rows, expected {expected_rows}",
+                rows.len()
+            ),
+        });
+    }
+    let tau_kernel_scale = spartan_outer_tau_kernel_scale(params.tau, params.uniskip_challenge)?
+        * params.batching_coefficient;
+    let tau_low = &params.tau[..params.tau.len() - 1];
+    let queries = (0..=SPARTAN_OUTER_REMAINDER_DEGREE)
+        .map(|point| {
+            let mut fixed_prefix = Vec::with_capacity(prefix.len() + 1);
+            fixed_prefix.extend_from_slice(prefix);
+            fixed_prefix.push(F::from_u64(point as u64));
+            Ok(SumcheckSpartanOuterRemainderQuery::new(
+                value_slot(point)?,
+                tau_low.to_vec(),
+                fixed_prefix,
+                suffix_vars,
+                params.uniskip_challenge,
+                tau_kernel_scale,
+            )
+            .with_uniskip_domain_size(SPARTAN_OUTER_UNISKIP_DOMAIN_SIZE))
+        })
+        .collect::<Result<Vec<_>, ProverError>>()?;
+    let request = SumcheckSpartanOuterRemainderRequest::new(
+        "stage1.spartan_outer.remainder_raw_rows",
+        rows,
+        queries,
+    )
+    .with_relation(SPARTAN_OUTER_REMAINDER_RELATION)
+    .with_optimization_ids(STAGE1_SPARTAN_OUTER_OPTIMIZATION_IDS);
+    let outputs = backend.evaluate_sumcheck_spartan_outer_remainder_rows(&request)?;
+    ordered_linear_product_outputs(outputs, SPARTAN_OUTER_REMAINDER_DEGREE + 1)
+}
+
+fn materialize_remainder_state<F: Field>(
+    context: &SpartanOuterContext<F>,
+    backend: &mut impl SumcheckBackend<F, JoltVmNamespace>,
+    params: &RemainderEvalParams<'_, F>,
+    stream_challenge: F,
+) -> Result<SumcheckSpartanOuterRemainderState<F>, ProverError> {
+    let request = context.remainder_state_request(params, stream_challenge)?;
+    Ok(backend.materialize_sumcheck_spartan_outer_remainder_state(&request)?)
+}
+
+fn materialize_remainder_row_state<F: Field>(
+    config: Stage1ProverConfig,
+    rows: &[SumcheckSpartanOuterRow],
+    backend: &mut impl SumcheckBackend<F, JoltVmNamespace>,
+    params: &RemainderEvalParams<'_, F>,
+    stream_challenge: F,
+) -> Result<SumcheckSpartanOuterRemainderState<F>, ProverError> {
+    let expected_rows = checked_trace_rows(config.log_t, "Stage 1")?;
+    if rows.len() != expected_rows {
+        return Err(ProverError::InvalidStageRequest {
+            reason: format!(
+                "Stage 1 raw-row remainder state received {} rows, expected {expected_rows}",
+                rows.len()
+            ),
+        });
+    }
+    let tau_kernel_scale = spartan_outer_tau_kernel_scale(params.tau, params.uniskip_challenge)?
+        * params.batching_coefficient;
+    let tau_low = &params.tau[..params.tau.len() - 1];
+    let request = SumcheckSpartanOuterRemainderRowStateRequest::new(
+        "stage1.spartan_outer.remainder_raw_row_state",
+        rows,
+        tau_low.to_vec(),
+        params.uniskip_challenge,
+        stream_challenge,
+        tau_kernel_scale,
+    )
+    .with_uniskip_domain_size(SPARTAN_OUTER_UNISKIP_DOMAIN_SIZE)
+    .with_relation(SPARTAN_OUTER_REMAINDER_RELATION)
+    .with_optimization_ids(STAGE1_SPARTAN_OUTER_OPTIMIZATION_IDS);
+    Ok(backend.materialize_sumcheck_spartan_outer_remainder_row_state(&request)?)
+}
+
+fn build_uniskip_first_round_poly<F: Field>(
+    domain_size: usize,
+    extended_evals: &[F],
+    tau_high: F,
+) -> Result<UnivariatePoly<F>, ProverError> {
+    let degree = domain_size - 1;
+    if extended_evals.len() != degree {
+        return Err(invalid_sumcheck_output(format!(
+            "Stage 1 uniskip extended eval count mismatch: got {}, expected {degree}",
+            extended_evals.len()
+        )));
+    }
+
+    let extended_size = 2 * degree + 1;
+    let extended_start = -(degree as i64);
+    let mut t1_values = vec![F::zero(); extended_size];
+    let targets = uniskip_targets(domain_size, degree)?;
+    for (target, &value) in targets.iter().zip(extended_evals) {
+        let index = usize::try_from(target - extended_start).map_err(|_| {
+            invalid_sumcheck_output(format!("Stage 1 uniskip target {target} is out of range"))
+        })?;
+        t1_values[index] = value;
+    }
+
+    let t1_coeffs = interpolate_to_coeffs(extended_start, &t1_values);
+    let base_start = centered_domain_start(domain_size).map_err(invalid_sumcheck_output)?;
+    let lagrange_values =
+        centered_lagrange_evals(domain_size, tau_high).map_err(invalid_sumcheck_output)?;
+    let lagrange_coeffs = interpolate_to_coeffs(base_start, &lagrange_values);
+    Ok(UnivariatePoly::new(poly_mul(&lagrange_coeffs, &t1_coeffs)))
+}
+
+fn uniskip_targets(domain_size: usize, degree: usize) -> Result<Vec<i64>, ProverError> {
+    let base_left = centered_domain_start(domain_size).map_err(invalid_sumcheck_output)?;
+    let base_right = base_left
+        + i64::try_from(domain_size).map_err(|_| {
+            invalid_sumcheck_output(format!(
+                "Stage 1 uniskip domain size {domain_size} is too large"
+            ))
+        })?
+        - 1;
+    let ext_left = -(degree as i64);
+    let ext_right = degree as i64;
+    let mut targets = Vec::with_capacity(degree);
+    let mut left = base_left - 1;
+    let mut right = base_right + 1;
+
+    while targets.len() < degree && left >= ext_left && right <= ext_right {
+        targets.push(left);
+        if targets.len() < degree {
+            targets.push(right);
+        }
+        left -= 1;
+        right += 1;
+    }
+    while targets.len() < degree && left >= ext_left {
+        targets.push(left);
+        left -= 1;
+    }
+    while targets.len() < degree && right <= ext_right {
+        targets.push(right);
+        right += 1;
+    }
+
+    Ok(targets)
+}
+
+fn spartan_outer_tau_kernel_scale<F: Field>(tau: &[F], uniskip: F) -> Result<F, ProverError> {
+    if tau.len() < 2 {
+        return Err(invalid_sumcheck_output(format!(
+            "Stage 1 tau has {} variables, expected at least 2",
+            tau.len()
+        )));
+    }
+    let tau_high = tau[tau.len() - 1];
+    centered_lagrange_kernel(SPARTAN_OUTER_UNISKIP_DOMAIN_SIZE, tau_high, uniskip)
+        .map_err(invalid_sumcheck_output)
+}
+
+fn spartan_outer_stream_row_weights<F: Field>(uniskip: F) -> Result<(Vec<F>, Vec<F>), ProverError> {
+    let at_zero = spartan_outer_row_weights(uniskip, F::zero()).map_err(invalid_sumcheck_output)?;
+    let at_one = spartan_outer_row_weights(uniskip, F::one()).map_err(invalid_sumcheck_output)?;
+    Ok((at_zero, at_one))
+}
+
+fn normalized_remainder_opening_point<F: Field>(remainder_challenges: &[F]) -> Vec<F> {
+    let mut point = remainder_challenges[1..].to_vec();
+    point.reverse();
+    point
+}
+
+fn centered_lagrange_integer_coeffs(
+    domain_size: usize,
+    target: i64,
+) -> Result<Vec<i32>, ProverError> {
+    let start = centered_domain_start(domain_size).map_err(invalid_sumcheck_output)?;
+    (0..domain_size)
+        .map(|index| {
+            let x_i = start
+                + i64::try_from(index).map_err(|_| {
+                    invalid_sumcheck_output(format!(
+                        "Stage 1 Lagrange index {index} is out of range"
+                    ))
+                })?;
+            let mut numerator = 1i128;
+            let mut denominator = 1i128;
+            for other in 0..domain_size {
+                if other == index {
+                    continue;
+                }
+                let x_j = start
+                    + i64::try_from(other).map_err(|_| {
+                        invalid_sumcheck_output(format!(
+                            "Stage 1 Lagrange index {other} is out of range"
+                        ))
+                    })?;
+                numerator *= i128::from(target - x_j);
+                denominator *= i128::from(x_i - x_j);
+            }
+            if denominator == 0 || numerator % denominator != 0 {
+                return Err(invalid_sumcheck_output(format!(
+                    "Stage 1 centered Lagrange coefficient for target {target} is non-integral"
+                )));
+            }
+            i32::try_from(numerator / denominator).map_err(|_| {
+                invalid_sumcheck_output(format!(
+                    "Stage 1 centered Lagrange coefficient for target {target} exceeds i32"
+                ))
+            })
+        })
+        .collect()
+}
+
+fn checked_trace_rows(log_t: usize, label: &str) -> Result<usize, ProverError> {
+    1usize
+        .checked_shl(log_t as u32)
+        .ok_or_else(|| ProverError::InvalidStageRequest {
+            reason: format!("{label} trace length overflows for log_t={log_t}"),
+        })
+}
+
+fn value_slot(index: usize) -> Result<BackendValueSlot, ProverError> {
+    Ok(BackendValueSlot(u32::try_from(index).map_err(|_| {
+        invalid_sumcheck_output(format!(
+            "Stage 1 query index {index} exceeds value slot range"
+        ))
+    })?))
+}
+
+fn ordered_linear_product_outputs<F: Field>(
+    outputs: Vec<SumcheckLinearProductOutput<F>>,
+    expected_count: usize,
+) -> Result<Vec<F>, ProverError> {
+    if outputs.len() != expected_count {
+        return Err(invalid_sumcheck_output(format!(
+            "Stage 1 linear product backend returned {} outputs, expected {expected_count}",
+            outputs.len()
+        )));
+    }
+    let mut seen = vec![false; expected_count];
+    let mut ordered = vec![F::zero(); expected_count];
+    for output in outputs {
+        let index = usize::try_from(output.slot.0).map_err(|_| {
+            invalid_sumcheck_output(format!(
+                "Stage 1 linear product output slot {:?} is out of range",
+                output.slot
+            ))
+        })?;
+        if index >= expected_count {
+            return Err(invalid_sumcheck_output(format!(
+                "Stage 1 linear product output slot {:?} exceeds expected count {expected_count}",
+                output.slot
+            )));
+        }
+        if seen[index] {
+            return Err(invalid_sumcheck_output(format!(
+                "duplicate Stage 1 linear product output slot {:?}",
+                output.slot
+            )));
+        }
+        seen[index] = true;
+        ordered[index] = output.value;
+    }
+    Ok(ordered)
+}

--- a/crates/jolt-prover/src/stages/stage1/tests.rs
+++ b/crates/jolt-prover/src/stages/stage1/tests.rs
@@ -1,0 +1,1496 @@
+use std::collections::{btree_map::Entry, BTreeMap, BTreeSet};
+
+#[cfg(feature = "zk")]
+use jolt_backends::cpu::CpuBackend;
+use jolt_backends::{
+    stage1_r1cs_input_slot, Backend, BackendError, BackendRelationId, BackendValueSlot,
+    SumcheckBackend, SumcheckEvaluationOutput, SumcheckEvaluationRequest, SumcheckInstanceRequest,
+    SumcheckProofOutput, SumcheckRequest, SumcheckResult, SumcheckSlot,
+    SumcheckViewEvaluationRequest, SPARTAN_OUTER_REMAINDER_RELATION,
+    SPARTAN_OUTER_UNISKIP_RELATION, STAGE1_REMAINDER_OUTPUT_SLOT, STAGE1_REMAINDER_SLOT,
+    STAGE1_SPARTAN_OUTER_OPTIMIZATION_IDS, STAGE1_UNISKIP_INPUT_SLOT, STAGE1_UNISKIP_OUTPUT_SLOT,
+    STAGE1_UNISKIP_SLOT,
+};
+use jolt_backends::{
+    SumcheckLinearProductOutput, SumcheckLinearProductRequest, SumcheckMaterializationOutput,
+    SumcheckMaterializationRequest, SumcheckPrefixProductSumRequest,
+    SumcheckSpartanOuterRemainderRound, SumcheckSpartanOuterRemainderState,
+    SumcheckSpartanOuterRemainderStateRequest,
+};
+use jolt_claims::protocols::jolt::{
+    formulas::spartan::{SpartanOuterDimensions, SPARTAN_OUTER_R1CS_INPUTS},
+    JoltVirtualPolynomial,
+};
+#[cfg(feature = "zk")]
+use jolt_crypto::{Bn254, JoltGroup, PedersenSetup, VectorCommitment};
+#[cfg(feature = "zk")]
+use jolt_crypto::{Bn254G1, Commitment, Pedersen};
+use jolt_field::{Fr, FromPrimitiveInt};
+#[cfg(feature = "zk")]
+use jolt_openings::CommitmentScheme;
+use jolt_poly::{MultilinearPoly, TensorEqTable};
+use jolt_r1cs::constraints::jolt::{
+    JoltSpartanOuterRemainder, JoltSpartanOuterRemainderChallenges, SPARTAN_OUTER_REMAINDER_DEGREE,
+    SPARTAN_OUTER_UNISKIP_DOMAIN_SIZE, SPARTAN_OUTER_UNISKIP_FIRST_ROUND_DEGREE,
+};
+use jolt_sumcheck::{
+    BatchedSumcheckVerifier, CenteredIntegerDomain, SumcheckClaim, UNISKIP_ROUND_TRANSCRIPT_LABEL,
+};
+#[cfg(feature = "zk")]
+use jolt_sumcheck::{ClearProof, ClearSumcheckProof, SumcheckProof};
+use jolt_transcript::{Blake2bTranscript, Transcript};
+use jolt_verifier::stages::stage1::{
+    spartan_outer_claims_from_r1cs_inputs, stage1_claims_from_r1cs_inputs,
+};
+use jolt_witness::protocols::jolt_vm::{JoltVmSpartanOuterRow, JoltVmSpartanOuterRows};
+use jolt_witness::{
+    protocols::jolt_vm::JoltVmNamespace, MaterializationPolicy, OracleDescriptor, OracleRef,
+    PolynomialEncoding, PolynomialView, RetentionHint, ViewRequirement, WitnessDimensions,
+    WitnessError, WitnessNamespace, WitnessProvider,
+};
+
+use crate::stages::primary_view_requirement;
+use crate::ProverError;
+
+#[cfg(feature = "zk")]
+use super::prove::prove_committed_proof_component as prove_stage1_committed_proof_component;
+use super::prove::prove_stage1_transparent_sumchecks;
+#[cfg(feature = "zk")]
+use super::prove::Stage1ProverInput;
+use super::prove::{Stage1ProofComponent, Stage1ProverConfig, Stage1R1csInputClaim};
+
+fn verifier_r1cs_inputs<F: jolt_field::Field>(
+    claims: &[Stage1R1csInputClaim<F>],
+) -> impl Iterator<Item = (JoltVirtualPolynomial, F)> + '_ {
+    claims.iter().map(|claim| (claim.variable, claim.value))
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct Stage1Request {
+    sumchecks: SumcheckRequest<JoltVmNamespace>,
+    r1cs_inputs: Vec<Stage1R1csInputRequest>,
+}
+
+impl Stage1Request {
+    fn expected_value_slots(&self) -> Vec<BackendValueSlot> {
+        let mut slots = Vec::with_capacity(2 + self.r1cs_inputs.len());
+        slots.push(STAGE1_UNISKIP_OUTPUT_SLOT);
+        slots.push(STAGE1_REMAINDER_OUTPUT_SLOT);
+        slots.extend(self.r1cs_inputs.iter().map(|input| input.slot));
+        slots
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct Stage1R1csEvaluationRequest<F: jolt_field::Field> {
+    evaluations: SumcheckEvaluationRequest<F, JoltVmNamespace>,
+    r1cs_inputs: Vec<Stage1R1csInputRequest>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct Stage1R1csInputRequest {
+    variable: JoltVirtualPolynomial,
+    slot: BackendValueSlot,
+    view: ViewRequirement<JoltVmNamespace>,
+}
+
+fn build_stage1_request<F, W>(
+    config: Stage1ProverConfig,
+    witness: &W,
+) -> Result<Stage1Request, ProverError>
+where
+    W: WitnessProvider<F, JoltVmNamespace>,
+{
+    let dimensions = config.dimensions();
+    let r1cs_inputs = dimensions
+        .variables()
+        .iter()
+        .copied()
+        .enumerate()
+        .map(|(index, variable)| {
+            let oracle = OracleRef::virtual_polynomial(variable);
+            let view = primary_view_requirement::<F, W, JoltVmNamespace>(witness, oracle)?;
+            Ok(Stage1R1csInputRequest {
+                variable,
+                slot: stage1_r1cs_input_slot(index),
+                view,
+            })
+        })
+        .collect::<Result<Vec<_>, ProverError>>()?;
+
+    let witness_views = r1cs_inputs
+        .iter()
+        .map(|input| input.view)
+        .collect::<Vec<_>>();
+    let uniskip_spec = dimensions.uniskip_sumcheck();
+    let remainder_spec = dimensions.remainder_sumcheck();
+
+    let uniskip = with_zk_round_mode(
+        SumcheckInstanceRequest::new(
+            STAGE1_UNISKIP_SLOT,
+            SPARTAN_OUTER_UNISKIP_RELATION,
+            witness_views.clone(),
+            uniskip_spec.rounds,
+            uniskip_spec.degree,
+            STAGE1_UNISKIP_INPUT_SLOT,
+            STAGE1_UNISKIP_OUTPUT_SLOT,
+        )
+        .with_optimization_ids(STAGE1_SPARTAN_OUTER_OPTIMIZATION_IDS),
+        config,
+    );
+    let remainder = with_zk_round_mode(
+        SumcheckInstanceRequest::new(
+            STAGE1_REMAINDER_SLOT,
+            SPARTAN_OUTER_REMAINDER_RELATION,
+            witness_views,
+            remainder_spec.rounds,
+            remainder_spec.degree,
+            STAGE1_UNISKIP_OUTPUT_SLOT,
+            STAGE1_REMAINDER_OUTPUT_SLOT,
+        )
+        .with_optimization_ids(STAGE1_SPARTAN_OUTER_OPTIMIZATION_IDS),
+        config,
+    );
+
+    Ok(Stage1Request {
+        sumchecks: SumcheckRequest::new("stage1.spartan_outer", vec![uniskip, remainder]),
+        r1cs_inputs,
+    })
+}
+
+fn build_stage1_r1cs_evaluation_request<F, W>(
+    config: Stage1ProverConfig,
+    witness: &W,
+    point: Vec<F>,
+) -> Result<Stage1R1csEvaluationRequest<F>, ProverError>
+where
+    F: jolt_field::Field,
+    W: WitnessProvider<F, JoltVmNamespace>,
+{
+    if point.len() != config.log_t {
+        return Err(ProverError::InvalidStageRequest {
+            reason: format!(
+                "Stage 1 R1CS evaluation point has {} variables, expected {}",
+                point.len(),
+                config.log_t
+            ),
+        });
+    }
+    let r1cs_inputs = config
+        .dimensions()
+        .variables()
+        .iter()
+        .copied()
+        .enumerate()
+        .map(|(index, variable)| {
+            let oracle = OracleRef::virtual_polynomial(variable);
+            let view = primary_view_requirement::<F, W, JoltVmNamespace>(witness, oracle)?;
+            Ok(Stage1R1csInputRequest {
+                variable,
+                slot: stage1_r1cs_input_slot(index),
+                view,
+            })
+        })
+        .collect::<Result<Vec<_>, ProverError>>()?;
+    let views = r1cs_inputs
+        .iter()
+        .map(|input| SumcheckViewEvaluationRequest::new(input.slot, input.view, point.clone()))
+        .collect();
+
+    Ok(Stage1R1csEvaluationRequest {
+        evaluations: SumcheckEvaluationRequest::new("stage1.spartan_outer.r1cs_inputs", views),
+        r1cs_inputs,
+    })
+}
+
+fn prove_stage1_sumchecks<F, W, B>(
+    config: Stage1ProverConfig,
+    witness: &W,
+    backend: &mut B,
+) -> Result<Stage1ProofComponent<F, B::Proof>, ProverError>
+where
+    F: jolt_field::Field,
+    W: WitnessProvider<F, JoltVmNamespace>,
+    B: SumcheckBackend<F, JoltVmNamespace>,
+{
+    let request = build_stage1_request::<F, W>(config, witness)?;
+    let result = backend.prove_sumcheck(&request.sumchecks, witness)?;
+    stage1_component_from_backend_result(&request, result)
+}
+
+fn evaluate_stage1_r1cs_inputs<F, W, B>(
+    config: Stage1ProverConfig,
+    witness: &W,
+    backend: &mut B,
+    point: Vec<F>,
+) -> Result<Vec<Stage1R1csInputClaim<F>>, ProverError>
+where
+    F: jolt_field::Field,
+    W: WitnessProvider<F, JoltVmNamespace>,
+    B: SumcheckBackend<F, JoltVmNamespace>,
+{
+    let request = build_stage1_r1cs_evaluation_request(config, witness, point)?;
+    let evaluations = backend.evaluate_sumcheck_views(&request.evaluations, witness)?;
+    r1cs_input_claims_from_evaluations(&request, evaluations)
+}
+
+fn stage1_component_from_backend_result<F, Proof>(
+    request: &Stage1Request,
+    result: SumcheckResult<F, Proof>,
+) -> Result<Stage1ProofComponent<F, Proof>, ProverError>
+where
+    F: jolt_field::Field,
+{
+    let mut proofs = collect_proofs(result.proofs)?;
+    let mut values = collect_values(result.evaluations)?;
+
+    let uniskip_proof = take_proof(&mut proofs, STAGE1_UNISKIP_SLOT)?;
+    let remainder_proof = take_proof(&mut proofs, STAGE1_REMAINDER_SLOT)?;
+    reject_extra_proofs(&proofs)?;
+
+    let uniskip_output_claim = take_value(
+        &mut values,
+        STAGE1_UNISKIP_OUTPUT_SLOT,
+        "stage1 uniskip output",
+    )?;
+    let remainder_output_claim = take_value(
+        &mut values,
+        STAGE1_REMAINDER_OUTPUT_SLOT,
+        "stage1 remainder output",
+    )?;
+    let r1cs_input_claims = request
+        .r1cs_inputs
+        .iter()
+        .map(|input| {
+            Ok(Stage1R1csInputClaim {
+                variable: input.variable,
+                slot: input.slot,
+                value: take_value(&mut values, input.slot, "stage1 R1CS input")?,
+            })
+        })
+        .collect::<Result<Vec<_>, ProverError>>()?;
+    reject_extra_values(&values, request)?;
+
+    Ok(Stage1ProofComponent {
+        uniskip_proof,
+        remainder_proof,
+        uniskip_output_claim,
+        remainder_output_claim,
+        r1cs_input_claims,
+        verifier_output: None,
+    })
+}
+
+fn r1cs_input_claims_from_evaluations<F: jolt_field::Field>(
+    request: &Stage1R1csEvaluationRequest<F>,
+    evaluations: Vec<SumcheckEvaluationOutput<F>>,
+) -> Result<Vec<Stage1R1csInputClaim<F>>, ProverError> {
+    let mut values = collect_values(evaluations)?;
+    let claims = request
+        .r1cs_inputs
+        .iter()
+        .map(|input| {
+            Ok(Stage1R1csInputClaim {
+                variable: input.variable,
+                slot: input.slot,
+                value: take_value(&mut values, input.slot, "stage1 R1CS input")?,
+            })
+        })
+        .collect::<Result<Vec<_>, ProverError>>()?;
+    if let Some(slot) = values.keys().next() {
+        return Err(ProverError::InvalidSumcheckOutput {
+            reason: format!("unexpected sumcheck value slot {slot:?}"),
+        });
+    }
+    Ok(claims)
+}
+
+fn collect_proofs<Proof>(
+    proofs: Vec<SumcheckProofOutput<Proof>>,
+) -> Result<BTreeMap<SumcheckSlot, Proof>, ProverError> {
+    let mut by_slot = BTreeMap::new();
+    for proof in proofs {
+        match by_slot.entry(proof.slot) {
+            Entry::Vacant(entry) => {
+                let _ = entry.insert(proof.proof);
+            }
+            Entry::Occupied(_) => {
+                return Err(ProverError::InvalidSumcheckOutput {
+                    reason: format!("duplicate sumcheck proof slot {:?}", proof.slot),
+                });
+            }
+        }
+    }
+    Ok(by_slot)
+}
+
+fn collect_values<F: jolt_field::Field>(
+    values: Vec<SumcheckEvaluationOutput<F>>,
+) -> Result<BTreeMap<BackendValueSlot, F>, ProverError> {
+    let mut by_slot = BTreeMap::new();
+    for value in values {
+        if by_slot.insert(value.slot, value.value).is_some() {
+            return Err(ProverError::InvalidSumcheckOutput {
+                reason: format!("duplicate sumcheck value slot {:?}", value.slot),
+            });
+        }
+    }
+    Ok(by_slot)
+}
+
+fn take_proof<Proof>(
+    proofs: &mut BTreeMap<SumcheckSlot, Proof>,
+    slot: SumcheckSlot,
+) -> Result<Proof, ProverError> {
+    proofs
+        .remove(&slot)
+        .ok_or_else(|| ProverError::InvalidSumcheckOutput {
+            reason: format!("missing sumcheck proof slot {slot:?}"),
+        })
+}
+
+fn take_value<F: jolt_field::Field>(
+    values: &mut BTreeMap<BackendValueSlot, F>,
+    slot: BackendValueSlot,
+    label: &'static str,
+) -> Result<F, ProverError> {
+    values
+        .remove(&slot)
+        .ok_or_else(|| ProverError::InvalidSumcheckOutput {
+            reason: format!("missing {label} value slot {slot:?}"),
+        })
+}
+
+fn reject_extra_proofs<Proof>(proofs: &BTreeMap<SumcheckSlot, Proof>) -> Result<(), ProverError> {
+    if let Some(slot) = proofs.keys().next() {
+        return Err(ProverError::InvalidSumcheckOutput {
+            reason: format!("unexpected sumcheck proof slot {slot:?}"),
+        });
+    }
+    Ok(())
+}
+
+fn reject_extra_values<F: jolt_field::Field>(
+    values: &BTreeMap<BackendValueSlot, F>,
+    request: &Stage1Request,
+) -> Result<(), ProverError> {
+    if values.is_empty() {
+        return Ok(());
+    }
+    let expected = request
+        .expected_value_slots()
+        .into_iter()
+        .collect::<BTreeSet<_>>();
+    let unexpected = values
+        .keys()
+        .find(|slot| !expected.contains(slot))
+        .or_else(|| values.keys().next());
+    if let Some(slot) = unexpected {
+        return Err(ProverError::InvalidSumcheckOutput {
+            reason: format!("unexpected sumcheck value slot {slot:?}"),
+        });
+    }
+    Ok(())
+}
+
+fn with_zk_round_mode(
+    instance: SumcheckInstanceRequest<JoltVmNamespace>,
+    config: Stage1ProverConfig,
+) -> SumcheckInstanceRequest<JoltVmNamespace> {
+    #[cfg(feature = "zk")]
+    {
+        let mut instance = instance;
+        instance.committed_rounds = config.committed_rounds;
+        instance
+    }
+    #[cfg(not(feature = "zk"))]
+    {
+        let _ = config;
+        instance
+    }
+}
+
+#[test]
+fn stage1_request_matches_verifier_spartan_outer_shape() -> Result<(), Box<dyn std::error::Error>> {
+    let witness = Stage1Witness;
+    let config = Stage1ProverConfig::new(4);
+    let request = build_stage1_request::<Fr, _>(config, &witness)?;
+    let dimensions = SpartanOuterDimensions::rv64(config.log_t);
+
+    assert_eq!(request.sumchecks.label, "stage1.spartan_outer");
+    assert_eq!(request.sumchecks.instances.len(), 2);
+    assert_eq!(request.r1cs_inputs.len(), dimensions.variables().len());
+    assert_eq!(request.r1cs_inputs.len(), SPARTAN_OUTER_R1CS_INPUTS.len());
+
+    let uniskip = &request.sumchecks.instances[0];
+    let uniskip_spec = dimensions.uniskip_sumcheck();
+    assert_eq!(uniskip.slot, STAGE1_UNISKIP_SLOT);
+    assert_eq!(uniskip.relation, SPARTAN_OUTER_UNISKIP_RELATION);
+    assert_eq!(
+        uniskip.optimization_ids,
+        STAGE1_SPARTAN_OUTER_OPTIMIZATION_IDS
+    );
+    assert_eq!(uniskip.rounds, uniskip_spec.rounds);
+    assert_eq!(uniskip.degree, uniskip_spec.degree);
+    assert_eq!(uniskip.input_claim, STAGE1_UNISKIP_INPUT_SLOT);
+    assert_eq!(uniskip.output_claim, STAGE1_UNISKIP_OUTPUT_SLOT);
+
+    let remainder = &request.sumchecks.instances[1];
+    let remainder_spec = dimensions.remainder_sumcheck();
+    assert_eq!(remainder.slot, STAGE1_REMAINDER_SLOT);
+    assert_eq!(remainder.relation, SPARTAN_OUTER_REMAINDER_RELATION);
+    assert_eq!(
+        remainder.optimization_ids,
+        STAGE1_SPARTAN_OUTER_OPTIMIZATION_IDS
+    );
+    assert_eq!(remainder.rounds, remainder_spec.rounds);
+    assert_eq!(remainder.degree, remainder_spec.degree);
+    assert_eq!(remainder.input_claim, STAGE1_UNISKIP_OUTPUT_SLOT);
+    assert_eq!(remainder.output_claim, STAGE1_REMAINDER_OUTPUT_SLOT);
+
+    let expected_views = request
+        .r1cs_inputs
+        .iter()
+        .map(|input| input.view)
+        .collect::<Vec<_>>();
+    assert_eq!(uniskip.witness_views, expected_views);
+    assert_eq!(remainder.witness_views, expected_views);
+
+    for (index, input) in request.r1cs_inputs.iter().enumerate() {
+        assert_eq!(input.variable, SPARTAN_OUTER_R1CS_INPUTS[index]);
+        assert_eq!(input.slot, stage1_r1cs_input_slot(index));
+        assert_eq!(
+            input.view.oracle,
+            OracleRef::virtual_polynomial(input.variable)
+        );
+        assert_eq!(input.view.encoding, PolynomialEncoding::Dense);
+        assert_eq!(
+            input.view.materialization,
+            MaterializationPolicy::BackendChoice
+        );
+        assert_eq!(input.view.retention, RetentionHint::ThroughStage8);
+    }
+
+    Ok(())
+}
+
+#[test]
+#[cfg(feature = "zk")]
+fn stage1_request_marks_committed_rounds_in_zk_mode() -> Result<(), Box<dyn std::error::Error>> {
+    let witness = Stage1Witness;
+    let mut config = Stage1ProverConfig::new(4);
+    config.committed_rounds = true;
+    let request = build_stage1_request::<Fr, _>(config, &witness)?;
+
+    assert!(request
+        .sumchecks
+        .instances
+        .iter()
+        .all(|instance| instance.committed_rounds));
+    Ok(())
+}
+
+#[test]
+fn stage1_prove_maps_backend_outputs_by_slot() -> Result<(), Box<dyn std::error::Error>> {
+    let witness = Stage1Witness;
+    let config = Stage1ProverConfig::new(3);
+    let mut backend = RecordingSumcheckBackend::default();
+
+    let output = prove_stage1_sumchecks::<Fr, _, _>(config, &witness, &mut backend)?;
+
+    assert_eq!(backend.labels, vec!["stage1.spartan_outer"]);
+    assert_eq!(backend.relations[0], SPARTAN_OUTER_UNISKIP_RELATION);
+    assert_eq!(backend.relations[1], SPARTAN_OUTER_REMAINDER_RELATION);
+    assert_eq!(output.uniskip_proof, "uniskip");
+    assert_eq!(output.remainder_proof, "remainder");
+    assert_eq!(output.uniskip_output_claim, Fr::from_u64(11));
+    assert_eq!(output.remainder_output_claim, Fr::from_u64(17));
+    assert_eq!(
+        output.r1cs_input_claims.len(),
+        SPARTAN_OUTER_R1CS_INPUTS.len()
+    );
+    assert_eq!(
+        output.r1cs_input_claims[0].variable,
+        JoltVirtualPolynomial::LeftInstructionInput
+    );
+    assert_eq!(output.r1cs_input_claims[0].value, Fr::from_u64(100));
+
+    Ok(())
+}
+
+#[test]
+fn stage1_evaluation_helper_runs_backend_owned_view_evaluations(
+) -> Result<(), Box<dyn std::error::Error>> {
+    let witness = Stage1Witness;
+    let config = Stage1ProverConfig::new(3);
+    let mut backend = RecordingSumcheckBackend::default();
+
+    let claims = evaluate_stage1_r1cs_inputs(
+        config,
+        &witness,
+        &mut backend,
+        vec![Fr::from_u64(2), Fr::from_u64(3), Fr::from_u64(5)],
+    )?;
+
+    assert_eq!(
+        backend.evaluation_labels,
+        vec!["stage1.spartan_outer.r1cs_inputs"]
+    );
+    assert_eq!(
+        backend.evaluation_points[0],
+        vec![Fr::from_u64(2), Fr::from_u64(3), Fr::from_u64(5)]
+    );
+    assert_eq!(claims.len(), SPARTAN_OUTER_R1CS_INPUTS.len());
+    assert_eq!(
+        claims[0].variable,
+        JoltVirtualPolynomial::LeftInstructionInput
+    );
+    assert_eq!(claims[0].value, Fr::from_u64(200));
+    assert_eq!(
+        claims.last().map(|claim| claim.value),
+        Some(Fr::from_u64(
+            200 + SPARTAN_OUTER_R1CS_INPUTS.len() as u64 - 1
+        ))
+    );
+    Ok(())
+}
+
+#[test]
+fn stage1_transparent_helper_produces_verifier_compatible_sumchecks(
+) -> Result<(), Box<dyn std::error::Error>> {
+    let witness = SatisfyingStage1Witness;
+    let config = Stage1ProverConfig::new(4);
+    let mut backend = EvaluationBackend;
+    let mut prover_transcript = Blake2bTranscript::<Fr>::new(b"stage1-test");
+
+    let output = prove_stage1_transparent_sumchecks::<Fr, _, _, _, Fr>(
+        config,
+        &witness,
+        &mut backend,
+        &mut prover_transcript,
+    )?;
+
+    let mut verifier_transcript = Blake2bTranscript::<Fr>::new(b"stage1-test");
+    let tau = verifier_transcript.challenge_vector(config.log_t + 2);
+    let uniskip_reduction = output.uniskip_proof.verify(
+        &SumcheckClaim::new(1, SPARTAN_OUTER_UNISKIP_FIRST_ROUND_DEGREE, Fr::from_u64(0)),
+        CenteredIntegerDomain::new(SPARTAN_OUTER_UNISKIP_DOMAIN_SIZE),
+        UNISKIP_ROUND_TRANSCRIPT_LABEL,
+        &mut verifier_transcript,
+    )?;
+    assert_eq!(uniskip_reduction.value, output.uniskip_output_claim);
+
+    verifier_transcript.append_labeled(b"opening_claim", &output.uniskip_output_claim);
+    let remainder_batch = BatchedSumcheckVerifier::verify_compressed_boolean(
+        &[SumcheckClaim::new(
+            config.log_t + 1,
+            SPARTAN_OUTER_REMAINDER_DEGREE,
+            output.uniskip_output_claim,
+        )],
+        &output.remainder_proof,
+        &mut verifier_transcript,
+    )?;
+    let r1cs_input_claims = output
+        .r1cs_input_claims
+        .iter()
+        .map(|claim| claim.value)
+        .collect::<Vec<_>>();
+    let expected_remainder = JoltSpartanOuterRemainder::new(JoltSpartanOuterRemainderChallenges {
+        tau: &tau,
+        uniskip: uniskip_reduction.point[0],
+        remainder: &remainder_batch.reduction.point,
+    })?
+    .expected_output_claim(&r1cs_input_claims)?
+        * remainder_batch.batching_coefficients[0];
+    assert_eq!(remainder_batch.reduction.value, expected_remainder);
+    for opening_claim in &r1cs_input_claims {
+        verifier_transcript.append_labeled(b"opening_claim", opening_claim);
+    }
+    assert_eq!(prover_transcript.state(), verifier_transcript.state());
+
+    Ok(())
+}
+
+#[test]
+#[cfg(feature = "zk")]
+fn stage1_committed_proof_component_produces_native_verifier_output(
+) -> Result<(), Box<dyn std::error::Error>> {
+    let witness = SatisfyingStage1Witness;
+    let config = Stage1ProverConfig::new(4);
+    let mut backend = CpuBackend::default();
+    let vc_setup = pedersen_setup(64);
+    let mut prover_transcript = Blake2bTranscript::<Fr>::new(b"stage1-zk-test");
+
+    let output = prove_stage1_committed_proof_component::<Fr, _, _, _, Pedersen<Bn254G1>>(
+        Stage1ProverInput::new(config, &witness),
+        &mut backend,
+        &mut prover_transcript,
+        &vc_setup,
+    )?;
+
+    assert_eq!(output.uniskip_output_claim_values.len(), 1);
+    assert_eq!(
+        output.remainder_output_claim_values.len(),
+        SpartanOuterDimensions::rv64(config.log_t).variables().len()
+    );
+    assert_eq!(output.uniskip_committed_witness.round_coefficients.len(), 1);
+    assert_eq!(
+        output.remainder_committed_witness.round_coefficients.len(),
+        config.log_t + 1
+    );
+
+    let trace_length = 1 << config.log_t;
+    let proof = stage1_zk_proof(
+        output.uniskip_proof.clone(),
+        output.remainder_proof.clone(),
+        trace_length,
+    );
+    let checked = jolt_verifier::CheckedInputs {
+        public_io: common::jolt_device::JoltDevice::default(),
+        zk: true,
+        trace_length,
+        ram_K: 16,
+        entry_address: 0,
+        preprocessing_digest: [0; 32],
+        trusted_advice_commitment_present: false,
+        vc_capacity: Some(Pedersen::<Bn254G1>::capacity(&vc_setup)),
+        precommitted: empty_precommitted_schedule(trace_length),
+    };
+    let mut verifier_transcript = Blake2bTranscript::<Fr>::new(b"stage1-zk-test");
+    let native_output =
+        jolt_verifier::stages::stage1::verify(&checked, &proof, &mut verifier_transcript)?;
+    let jolt_verifier::stages::stage1::Stage1Output::Zk(native_output) = native_output else {
+        return Err("Stage 1 verifier did not return ZK output".into());
+    };
+
+    assert_eq!(native_output.public, output.public);
+    assert_eq!(
+        native_output.uniskip_output_claims.shape.output_claim_count,
+        output.uniskip_output_claim_values.len()
+    );
+    assert_eq!(
+        native_output
+            .remainder_output_claims
+            .shape
+            .output_claim_count,
+        output.remainder_output_claim_values.len()
+    );
+    assert_eq!(verifier_transcript.state(), prover_transcript.state());
+
+    Ok(())
+}
+
+/// A schedule with no committed program and no advice: every layout is `None`,
+/// so the log_t/log_k_chunk inputs do not affect the resulting value.
+#[cfg(feature = "zk")]
+#[expect(
+    clippy::expect_used,
+    reason = "Test helper; the empty schedule is infallible."
+)]
+fn empty_precommitted_schedule(trace_length: usize) -> jolt_verifier::stages::PrecommittedSchedule {
+    jolt_verifier::stages::PrecommittedSchedule::new(
+        jolt_claims::protocols::jolt::TracePolynomialOrder::default(),
+        trace_length.ilog2() as usize,
+        0,
+        None,
+        None,
+        None,
+    )
+    .expect("empty precommitted schedule has no candidates and cannot fail")
+}
+
+#[test]
+fn stage1_output_rejects_missing_backend_values() -> Result<(), Box<dyn std::error::Error>> {
+    let witness = Stage1Witness;
+    let request = build_stage1_request::<Fr, _>(Stage1ProverConfig::new(2), &witness)?;
+    let result = SumcheckResult::new(
+        vec![
+            SumcheckProofOutput::new(STAGE1_UNISKIP_SLOT, "uniskip"),
+            SumcheckProofOutput::new(STAGE1_REMAINDER_SLOT, "remainder"),
+        ],
+        vec![SumcheckEvaluationOutput::new(
+            STAGE1_UNISKIP_OUTPUT_SLOT,
+            Fr::from_u64(11),
+        )],
+    );
+
+    assert!(stage1_component_from_backend_result(&request, result).is_err());
+    Ok(())
+}
+
+#[test]
+fn stage1_r1cs_inputs_assemble_verifier_spartan_outer_claims(
+) -> Result<(), Box<dyn std::error::Error>> {
+    let claims = r1cs_claims();
+    let outer = spartan_outer_claims_from_r1cs_inputs(verifier_r1cs_inputs(&claims))?;
+
+    assert_eq!(
+        outer.left_instruction_input,
+        value_for(JoltVirtualPolynomial::LeftInstructionInput)
+    );
+    assert_eq!(outer.product, value_for(JoltVirtualPolynomial::Product));
+    assert_eq!(
+        outer.next_is_first_in_sequence,
+        value_for(JoltVirtualPolynomial::NextIsFirstInSequence)
+    );
+    assert_eq!(
+        outer.flags.add_operands,
+        value_for(JoltVirtualPolynomial::OpFlags(
+            jolt_riscv::CircuitFlags::AddOperands
+        ))
+    );
+    assert_eq!(
+        outer.flags.is_last_in_sequence,
+        value_for(JoltVirtualPolynomial::OpFlags(
+            jolt_riscv::CircuitFlags::IsLastInSequence
+        ))
+    );
+    Ok(())
+}
+
+#[test]
+fn stage1_r1cs_inputs_assemble_verifier_stage_claims() -> Result<(), Box<dyn std::error::Error>> {
+    let claims = r1cs_claims();
+    let stage_claims =
+        stage1_claims_from_r1cs_inputs(Fr::from_u64(77), verifier_r1cs_inputs(&claims))?;
+
+    assert_eq!(stage_claims.uniskip_output_claim, Fr::from_u64(77));
+    assert_eq!(
+        stage_claims.outer.lookup_output,
+        value_for(JoltVirtualPolynomial::LookupOutput)
+    );
+    Ok(())
+}
+
+#[test]
+fn stage1_r1cs_claim_assembly_rejects_duplicate_inputs() {
+    let duplicate = JoltVirtualPolynomial::LeftInstructionInput;
+    let claims = vec![
+        Stage1R1csInputClaim {
+            variable: duplicate,
+            slot: stage1_r1cs_input_slot(0),
+            value: Fr::from_u64(1),
+        },
+        Stage1R1csInputClaim {
+            variable: duplicate,
+            slot: stage1_r1cs_input_slot(1),
+            value: Fr::from_u64(2),
+        },
+    ];
+
+    assert!(spartan_outer_claims_from_r1cs_inputs(verifier_r1cs_inputs(&claims)).is_err());
+}
+
+fn value_for(variable: JoltVirtualPolynomial) -> Fr {
+    SPARTAN_OUTER_R1CS_INPUTS
+        .iter()
+        .position(|candidate| *candidate == variable)
+        .map_or(Fr::from_u64(0), |index| Fr::from_u64(100 + index as u64))
+}
+
+fn r1cs_claims() -> Vec<Stage1R1csInputClaim<Fr>> {
+    SPARTAN_OUTER_R1CS_INPUTS
+        .iter()
+        .copied()
+        .enumerate()
+        .map(|(index, variable)| Stage1R1csInputClaim {
+            variable,
+            slot: stage1_r1cs_input_slot(index),
+            value: Fr::from_u64(100 + index as u64),
+        })
+        .collect()
+}
+
+#[cfg(feature = "zk")]
+fn stage1_zk_proof(
+    uniskip_proof: SumcheckProof<Fr, Bn254G1>,
+    remainder_proof: SumcheckProof<Fr, Bn254G1>,
+    trace_length: usize,
+) -> jolt_verifier::proof::JoltProof<
+    jolt_openings::mock::MockCommitmentScheme<Fr>,
+    Pedersen<Bn254G1>,
+    (),
+> {
+    type MockPcs = jolt_openings::mock::MockCommitmentScheme<Fr>;
+    let commitment = <MockPcs as Commitment>::Output::default();
+    let commitments = jolt_verifier::proof::JoltCommitments::new(
+        commitment.clone(),
+        commitment,
+        jolt_verifier::proof::JoltRaCommitments::new(Vec::new(), Vec::new(), Vec::new()),
+    );
+    let empty = SumcheckProof::Clear(ClearProof::Full(ClearSumcheckProof::default()));
+    let stages = jolt_verifier::proof::JoltStageProofs {
+        stage1_uni_skip_first_round_proof: uniskip_proof,
+        stage1_sumcheck_proof: remainder_proof,
+        stage2_uni_skip_first_round_proof: empty.clone(),
+        stage2_sumcheck_proof: empty.clone(),
+        stage3_sumcheck_proof: empty.clone(),
+        stage4_sumcheck_proof: empty.clone(),
+        stage5_sumcheck_proof: empty.clone(),
+        stage6a_sumcheck_proof: empty.clone(),
+        stage6b_sumcheck_proof: empty.clone(),
+        stage7_sumcheck_proof: empty,
+    };
+    let poly = jolt_poly::Polynomial::new(vec![Fr::from_u64(0)]);
+    let mut transcript = Blake2bTranscript::<Fr>::new(b"stage1-zk-opening");
+    let opening_proof = MockPcs::open(&poly, &[], Fr::from_u64(0), &(), None, &mut transcript);
+    jolt_verifier::proof::JoltProof::<MockPcs, Pedersen<Bn254G1>, ()>::new(
+        commitments,
+        stages,
+        opening_proof,
+        None,
+        jolt_verifier::proof::JoltProofClaims::Zk {
+            blindfold_proof: (),
+        },
+        trace_length,
+        16,
+        jolt_claims::protocols::jolt::JoltReadWriteConfig {
+            ram_rw_phase1_num_rounds: 1,
+            ram_rw_phase2_num_rounds: 1,
+            registers_rw_phase1_num_rounds: 1,
+            registers_rw_phase2_num_rounds: 1,
+        },
+        jolt_claims::protocols::jolt::JoltOneHotConfig {
+            log_k_chunk: 4,
+            lookups_ra_virtual_log_k_chunk: 16,
+        },
+        jolt_verifier::proof::TracePolynomialOrder::AddressMajor,
+    )
+}
+
+#[cfg(feature = "zk")]
+fn pedersen_setup(capacity: usize) -> PedersenSetup<Bn254G1> {
+    let generator = Bn254::g1_generator();
+    let message_generators = (1..=capacity)
+        .map(|index| generator.scalar_mul(&Fr::from_u64(index as u64)))
+        .collect();
+    PedersenSetup::new(message_generators, generator.scalar_mul(&Fr::from_u64(99)))
+}
+
+#[derive(Clone, Copy, Debug)]
+struct Stage1Witness;
+
+impl WitnessProvider<Fr, JoltVmNamespace> for Stage1Witness {
+    fn describe_oracle(
+        &self,
+        oracle: OracleRef<JoltVmNamespace>,
+    ) -> Result<OracleDescriptor<JoltVmNamespace>, WitnessError> {
+        let OracleRef::Virtual(_) = oracle else {
+            return Err(WitnessError::UnknownOracle {
+                namespace: JoltVmNamespace::ID.name,
+            });
+        };
+        Ok(OracleDescriptor::new(
+            oracle,
+            WitnessDimensions::new(4),
+            PolynomialEncoding::Dense,
+        ))
+    }
+
+    fn view_requirements(
+        &self,
+        oracle: OracleRef<JoltVmNamespace>,
+    ) -> Result<Vec<ViewRequirement<JoltVmNamespace>>, WitnessError> {
+        let descriptor = self.describe_oracle(oracle)?;
+        Ok(vec![ViewRequirement::new(
+            descriptor.reference,
+            descriptor.encoding,
+            MaterializationPolicy::BackendChoice,
+            RetentionHint::ThroughStage8,
+        )])
+    }
+
+    fn oracle_view(
+        &self,
+        requirement: ViewRequirement<JoltVmNamespace>,
+    ) -> Result<PolynomialView<'_, Fr, JoltVmNamespace>, WitnessError> {
+        let descriptor = self.describe_oracle(requirement.oracle)?;
+        Ok(PolynomialView::owned(descriptor, vec![Fr::from_u64(0); 16]))
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+struct SatisfyingStage1Witness;
+
+impl WitnessProvider<Fr, JoltVmNamespace> for SatisfyingStage1Witness {
+    fn describe_oracle(
+        &self,
+        oracle: OracleRef<JoltVmNamespace>,
+    ) -> Result<OracleDescriptor<JoltVmNamespace>, WitnessError> {
+        let OracleRef::Virtual(_) = oracle else {
+            return Err(WitnessError::UnknownOracle {
+                namespace: JoltVmNamespace::ID.name,
+            });
+        };
+        Ok(OracleDescriptor::new(
+            oracle,
+            WitnessDimensions::new(4),
+            PolynomialEncoding::Dense,
+        ))
+    }
+
+    fn view_requirements(
+        &self,
+        oracle: OracleRef<JoltVmNamespace>,
+    ) -> Result<Vec<ViewRequirement<JoltVmNamespace>>, WitnessError> {
+        let descriptor = self.describe_oracle(oracle)?;
+        Ok(vec![ViewRequirement::new(
+            descriptor.reference,
+            descriptor.encoding,
+            MaterializationPolicy::BackendChoice,
+            RetentionHint::ThroughStage8,
+        )])
+    }
+
+    fn oracle_view(
+        &self,
+        requirement: ViewRequirement<JoltVmNamespace>,
+    ) -> Result<PolynomialView<'_, Fr, JoltVmNamespace>, WitnessError> {
+        let descriptor = self.describe_oracle(requirement.oracle)?;
+        let OracleRef::Virtual(variable) = requirement.oracle else {
+            return Err(WitnessError::UnknownOracle {
+                namespace: JoltVmNamespace::ID.name,
+            });
+        };
+        Ok(PolynomialView::owned(
+            descriptor,
+            vec![satisfying_stage1_value(variable); 16],
+        ))
+    }
+}
+
+impl JoltVmSpartanOuterRows for SatisfyingStage1Witness {
+    fn spartan_outer_rows(&self) -> Result<Vec<JoltVmSpartanOuterRow>, WitnessError> {
+        Ok(vec![
+            JoltVmSpartanOuterRow {
+                left_instruction_input: 0,
+                right_instruction_input: 0,
+                product_magnitude: 0,
+                product_is_positive: false,
+                should_branch: false,
+                pc: 0,
+                unexpanded_pc: 0,
+                imm: 0,
+                ram_address: 0,
+                rs1_value: 0,
+                rs2_value: 0,
+                rd_write_value: 0,
+                ram_read_value: 0,
+                ram_write_value: 0,
+                left_lookup_operand: 0,
+                right_lookup_operand: 0,
+                next_unexpanded_pc: 4,
+                next_pc: 0,
+                next_is_virtual: false,
+                next_is_first_in_sequence: false,
+                lookup_output: 0,
+                should_jump: false,
+                flag_add_operands: false,
+                flag_subtract_operands: false,
+                flag_multiply_operands: false,
+                flag_load: false,
+                flag_store: false,
+                flag_jump: false,
+                flag_write_lookup_output_to_rd: false,
+                flag_virtual_instruction: false,
+                flag_assert: false,
+                flag_do_not_update_unexpanded_pc: false,
+                flag_advice: false,
+                flag_is_compressed: false,
+                flag_is_first_in_sequence: false,
+                flag_is_last_in_sequence: false,
+            };
+            16
+        ])
+    }
+}
+
+fn satisfying_stage1_value(variable: JoltVirtualPolynomial) -> Fr {
+    match variable {
+        JoltVirtualPolynomial::NextUnexpandedPC => Fr::from_u64(4),
+        _ => Fr::from_u64(0),
+    }
+}
+
+#[derive(Default)]
+struct RecordingSumcheckBackend {
+    labels: Vec<&'static str>,
+    relations: Vec<BackendRelationId>,
+    evaluation_labels: Vec<&'static str>,
+    evaluation_points: Vec<Vec<Fr>>,
+}
+
+impl Backend for RecordingSumcheckBackend {
+    fn name(&self) -> &'static str {
+        "recording"
+    }
+}
+
+impl SumcheckBackend<Fr, JoltVmNamespace> for RecordingSumcheckBackend {
+    type Proof = &'static str;
+
+    fn prove_sumcheck<W>(
+        &mut self,
+        request: &SumcheckRequest<JoltVmNamespace>,
+        _witness: &W,
+    ) -> Result<SumcheckResult<Fr, Self::Proof>, BackendError>
+    where
+        W: WitnessProvider<Fr, JoltVmNamespace>,
+    {
+        self.labels.push(request.label);
+        self.relations
+            .extend(request.instances.iter().map(|instance| instance.relation));
+
+        let proofs = vec![
+            SumcheckProofOutput::new(STAGE1_UNISKIP_SLOT, "uniskip"),
+            SumcheckProofOutput::new(STAGE1_REMAINDER_SLOT, "remainder"),
+        ];
+        let mut evaluations = vec![
+            SumcheckEvaluationOutput::new(STAGE1_UNISKIP_OUTPUT_SLOT, Fr::from_u64(11)),
+            SumcheckEvaluationOutput::new(STAGE1_REMAINDER_OUTPUT_SLOT, Fr::from_u64(17)),
+        ];
+        evaluations.extend((0..SPARTAN_OUTER_R1CS_INPUTS.len()).map(|index| {
+            SumcheckEvaluationOutput::new(
+                stage1_r1cs_input_slot(index),
+                Fr::from_u64(100 + index as u64),
+            )
+        }));
+
+        Ok(SumcheckResult::new(proofs, evaluations))
+    }
+
+    fn evaluate_sumcheck_views<W>(
+        &mut self,
+        request: &SumcheckEvaluationRequest<Fr, JoltVmNamespace>,
+        _witness: &W,
+    ) -> Result<Vec<SumcheckEvaluationOutput<Fr>>, BackendError>
+    where
+        W: WitnessProvider<Fr, JoltVmNamespace>,
+    {
+        self.evaluation_labels.push(request.label);
+        self.evaluation_points
+            .extend(request.views.iter().map(|view| view.point.clone()));
+        Ok(request
+            .views
+            .iter()
+            .enumerate()
+            .map(|(index, view)| {
+                SumcheckEvaluationOutput::new(view.slot, Fr::from_u64(200 + index as u64))
+            })
+            .collect())
+    }
+}
+
+struct EvaluationBackend;
+
+impl Backend for EvaluationBackend {
+    fn name(&self) -> &'static str {
+        "evaluation"
+    }
+}
+
+impl SumcheckBackend<Fr, JoltVmNamespace> for EvaluationBackend {
+    type Proof = ();
+
+    fn materialize_sumcheck_views<W>(
+        &mut self,
+        request: &SumcheckMaterializationRequest<JoltVmNamespace>,
+        witness: &W,
+    ) -> Result<Vec<SumcheckMaterializationOutput<Fr>>, BackendError>
+    where
+        W: WitnessProvider<Fr, JoltVmNamespace>,
+    {
+        request
+            .views
+            .iter()
+            .map(|view| {
+                let materialized = witness.oracle_view(view.requirement)?;
+                let Some(values) = materialized.as_slice() else {
+                    return Err(BackendError::InvalidRequest {
+                        backend: self.name(),
+                        task: "test materialization",
+                        reason: "deferred test view".to_owned(),
+                    });
+                };
+                Ok(SumcheckMaterializationOutput::new(
+                    view.slot,
+                    values.to_vec(),
+                ))
+            })
+            .collect()
+    }
+
+    fn evaluate_sumcheck_views<W>(
+        &mut self,
+        request: &SumcheckEvaluationRequest<Fr, JoltVmNamespace>,
+        witness: &W,
+    ) -> Result<Vec<SumcheckEvaluationOutput<Fr>>, BackendError>
+    where
+        W: WitnessProvider<Fr, JoltVmNamespace>,
+    {
+        request
+            .views
+            .iter()
+            .map(|view| {
+                let materialized = witness.oracle_view(view.requirement)?;
+                let Some(values) = materialized.as_slice() else {
+                    return Err(BackendError::InvalidRequest {
+                        backend: self.name(),
+                        task: "test evaluation",
+                        reason: "deferred test view".to_owned(),
+                    });
+                };
+                Ok(SumcheckEvaluationOutput::new(
+                    view.slot,
+                    values.evaluate(&view.point),
+                ))
+            })
+            .collect()
+    }
+
+    fn evaluate_sumcheck_linear_products(
+        &mut self,
+        request: &SumcheckLinearProductRequest<Fr>,
+    ) -> Result<Vec<SumcheckLinearProductOutput<Fr>>, BackendError> {
+        request
+            .queries
+            .iter()
+            .map(|query| {
+                let witness_evaluations = request
+                    .witness_polynomials
+                    .iter()
+                    .map(|polynomial| polynomial.evaluate(&query.point))
+                    .collect::<Vec<_>>();
+                let left = test_weighted_linear_rows(
+                    request.left_rows,
+                    &query.row_weights,
+                    request.input_columns,
+                    request.constant_column,
+                    &witness_evaluations,
+                )?;
+                let right = test_weighted_linear_rows(
+                    request.right_rows,
+                    &query.row_weights,
+                    request.input_columns,
+                    request.constant_column,
+                    &witness_evaluations,
+                )?;
+                Ok(SumcheckLinearProductOutput::new(
+                    query.slot,
+                    query.scale * left * right,
+                ))
+            })
+            .collect()
+    }
+
+    fn evaluate_sumcheck_prefix_product_sums(
+        &mut self,
+        request: &SumcheckPrefixProductSumRequest<Fr>,
+    ) -> Result<Vec<SumcheckLinearProductOutput<Fr>>, BackendError> {
+        let Some(first) = request.witness_polynomials.first() else {
+            return Err(BackendError::InvalidRequest {
+                backend: self.name(),
+                task: "test prefix product sum",
+                reason: "missing witness polynomials".to_owned(),
+            });
+        };
+        let log_rows = first.len().trailing_zeros() as usize;
+        let total_vars = log_rows + 1;
+        request
+            .queries
+            .iter()
+            .map(|query| {
+                let suffix_count = 1usize << query.suffix_vars;
+                let mut total = Fr::from_u64(0);
+                for suffix_index in 0..suffix_count {
+                    let value = |position: usize| {
+                        if position < query.fixed_prefix.len() {
+                            query.fixed_prefix[position]
+                        } else {
+                            let suffix_position = position - query.fixed_prefix.len();
+                            let shift = query.suffix_vars - suffix_position - 1;
+                            Fr::from_bool(((suffix_index >> shift) & 1) == 1)
+                        }
+                    };
+                    let stream = value(0);
+                    let row_weights = test_blend_row_weights(
+                        stream,
+                        &query.row_weights_at_zero,
+                        &query.row_weights_at_one,
+                    );
+                    let cycle_point = (1..total_vars).rev().map(value).collect::<Vec<_>>();
+                    let witness_evaluations = request
+                        .witness_polynomials
+                        .iter()
+                        .map(|polynomial| polynomial.evaluate(&cycle_point))
+                        .collect::<Vec<_>>();
+                    let left = test_weighted_linear_rows(
+                        request.left_rows,
+                        &row_weights,
+                        request.input_columns,
+                        request.constant_column,
+                        &witness_evaluations,
+                    )?;
+                    let right = test_weighted_linear_rows(
+                        request.right_rows,
+                        &row_weights,
+                        request.input_columns,
+                        request.constant_column,
+                        &witness_evaluations,
+                    )?;
+                    let eq = (0..total_vars)
+                        .map(|position| {
+                            let challenge = query.eq_point[total_vars - position - 1];
+                            let point = value(position);
+                            challenge * point
+                                + (Fr::from_u64(1) - challenge) * (Fr::from_u64(1) - point)
+                        })
+                        .product::<Fr>();
+                    total += query.scale * eq * left * right;
+                }
+                Ok(SumcheckLinearProductOutput::new(query.slot, total))
+            })
+            .collect()
+    }
+
+    fn materialize_sumcheck_spartan_outer_remainder_state(
+        &mut self,
+        request: &SumcheckSpartanOuterRemainderStateRequest<Fr>,
+    ) -> Result<SumcheckSpartanOuterRemainderState<Fr>, BackendError> {
+        let Some(first) = request.witness_polynomials.first() else {
+            return Err(BackendError::InvalidRequest {
+                backend: self.name(),
+                task: "test remainder state",
+                reason: "missing witness polynomials".to_owned(),
+            });
+        };
+        let log_rows = first.len().trailing_zeros() as usize;
+        if request.eq_point.len() != log_rows + 1 {
+            return Err(BackendError::InvalidRequest {
+                backend: self.name(),
+                task: "test remainder state",
+                reason: format!(
+                    "equality point has {} variables, expected {}",
+                    request.eq_point.len(),
+                    log_rows + 1
+                ),
+            });
+        }
+        let stream_eq = test_eq_factor(request.eq_point[log_rows], request.stream_challenge);
+        let row_weights = test_blend_row_weights(
+            request.stream_challenge,
+            &request.row_weights_at_zero,
+            &request.row_weights_at_one,
+        );
+        let mut left = Vec::with_capacity(first.len());
+        let mut right = Vec::with_capacity(first.len());
+        for row_index in 0..first.len() {
+            left.push(test_weighted_linear_rows_at_row(
+                request.left_rows,
+                &row_weights,
+                request.input_columns,
+                request.constant_column,
+                request.witness_polynomials,
+                row_index,
+            )?);
+            right.push(test_weighted_linear_rows_at_row(
+                request.right_rows,
+                &row_weights,
+                request.input_columns,
+                request.constant_column,
+                request.witness_polynomials,
+                row_index,
+            )?);
+        }
+        Ok(SumcheckSpartanOuterRemainderState::new(
+            request.label,
+            request.eq_point[..log_rows].to_vec(),
+            left,
+            right,
+            first.len(),
+            request.scale * stream_eq,
+        ))
+    }
+
+    fn evaluate_sumcheck_spartan_outer_remainder_round(
+        &mut self,
+        state: &SumcheckSpartanOuterRemainderState<Fr>,
+    ) -> Result<SumcheckSpartanOuterRemainderRound<Fr>, BackendError> {
+        let active_log = state.active_len.trailing_zeros() as usize;
+        let remaining_vars = active_log - 1;
+        let eq_tensor = TensorEqTable::<Fr>::new(&state.eq_point[..remaining_vars]);
+        let (q_at_zero, q_at_infinity) = test_sum_bound_pair_endpoints(
+            &eq_tensor,
+            &state.left[..state.active_len],
+            &state.right[..state.active_len],
+        );
+        Ok(SumcheckSpartanOuterRemainderRound::new(
+            q_at_zero,
+            q_at_infinity,
+        ))
+    }
+
+    fn bind_sumcheck_spartan_outer_remainder_state(
+        &mut self,
+        state: &mut SumcheckSpartanOuterRemainderState<Fr>,
+        challenge: Fr,
+    ) -> Result<(), BackendError> {
+        let active_log = state.active_len.trailing_zeros() as usize;
+        state.scale *= test_eq_factor(state.eq_point[active_log - 1], challenge);
+        state.active_len = test_bind_low_variable(&mut state.left, state.active_len, challenge);
+        let right_len = test_bind_low_variable(&mut state.right, state.active_len * 2, challenge);
+        assert_eq!(state.active_len, right_len);
+        Ok(())
+    }
+}
+
+fn test_blend_row_weights(selector: Fr, zero: &[Fr], one: &[Fr]) -> Vec<Fr> {
+    if selector == Fr::from_u64(0) {
+        return zero.to_vec();
+    }
+    if selector == Fr::from_u64(1) {
+        return one.to_vec();
+    }
+    zero.iter()
+        .zip(one)
+        .map(|(&at_zero, &at_one)| at_zero + selector * (at_one - at_zero))
+        .collect()
+}
+
+fn test_weighted_linear_rows(
+    rows: &[Vec<(usize, Fr)>],
+    row_weights: &[Fr],
+    input_columns: &[usize],
+    constant_column: usize,
+    witness_evaluations: &[Fr],
+) -> Result<Fr, BackendError> {
+    rows.iter()
+        .zip(row_weights)
+        .map(|(row, &weight)| {
+            if weight == Fr::from_u64(0) {
+                Ok(Fr::from_u64(0))
+            } else {
+                test_linear_row(row, input_columns, constant_column, witness_evaluations)
+                    .map(|value| weight * value)
+            }
+        })
+        .sum()
+}
+
+fn test_weighted_linear_rows_at_row(
+    rows: &[Vec<(usize, Fr)>],
+    row_weights: &[Fr],
+    input_columns: &[usize],
+    constant_column: usize,
+    witness_polynomials: &[Vec<Fr>],
+    row_index: usize,
+) -> Result<Fr, BackendError> {
+    rows.iter()
+        .zip(row_weights)
+        .map(|(row, &weight)| {
+            if weight == Fr::from_u64(0) {
+                Ok(Fr::from_u64(0))
+            } else {
+                test_linear_row_at_row(
+                    row,
+                    input_columns,
+                    constant_column,
+                    witness_polynomials,
+                    row_index,
+                )
+                .map(|value| weight * value)
+            }
+        })
+        .sum()
+}
+
+fn test_linear_row(
+    row: &[(usize, Fr)],
+    input_columns: &[usize],
+    constant_column: usize,
+    witness_evaluations: &[Fr],
+) -> Result<Fr, BackendError> {
+    row.iter()
+        .map(|&(column, coefficient)| {
+            if column == constant_column {
+                return Ok(coefficient);
+            }
+            let Some(index) = input_columns
+                .iter()
+                .position(|candidate| *candidate == column)
+            else {
+                return Err(BackendError::InvalidRequest {
+                    backend: "evaluation",
+                    task: "test linear product",
+                    reason: format!("unsupported column {column}"),
+                });
+            };
+            Ok(coefficient * witness_evaluations[index])
+        })
+        .sum()
+}
+
+fn test_linear_row_at_row(
+    row: &[(usize, Fr)],
+    input_columns: &[usize],
+    constant_column: usize,
+    witness_polynomials: &[Vec<Fr>],
+    row_index: usize,
+) -> Result<Fr, BackendError> {
+    row.iter()
+        .map(|&(column, coefficient)| {
+            if column == constant_column {
+                return Ok(coefficient);
+            }
+            let Some(index) = input_columns
+                .iter()
+                .position(|candidate| *candidate == column)
+            else {
+                return Err(BackendError::InvalidRequest {
+                    backend: "evaluation",
+                    task: "test linear product row",
+                    reason: format!("unsupported column {column}"),
+                });
+            };
+            Ok(coefficient * witness_polynomials[index][row_index])
+        })
+        .sum()
+}
+
+fn test_eq_factor(challenge: Fr, value: Fr) -> Fr {
+    challenge * value + (Fr::from_u64(1) - challenge) * (Fr::from_u64(1) - value)
+}
+
+fn test_sum_bound_pair_endpoints(
+    eq_tensor: &TensorEqTable<Fr>,
+    left: &[Fr],
+    right: &[Fr],
+) -> (Fr, Fr) {
+    let [q_at_zero, q_at_infinity] = eq_tensor.par_fold_out_in(
+        || [Fr::from_u64(0); 2],
+        |inner, row_index, _x_in, e_in| {
+            let low_index = 2 * row_index;
+            let high_index = low_index + 1;
+            inner[0] += e_in * left[low_index] * right[low_index];
+            inner[1] += e_in
+                * (left[high_index] - left[low_index])
+                * (right[high_index] - right[low_index]);
+        },
+        |_x_out, e_out, inner| [e_out * inner[0], e_out * inner[1]],
+        |mut left, right| {
+            left[0] += right[0];
+            left[1] += right[1];
+            left
+        },
+    );
+    (q_at_zero, q_at_infinity)
+}
+
+fn test_bind_low_variable(values: &mut [Fr], active_len: usize, point: Fr) -> usize {
+    let next_len = active_len / 2;
+    let one_minus_point = Fr::from_u64(1) - point;
+    for index in 0..next_len {
+        values[index] = one_minus_point * values[2 * index] + point * values[2 * index + 1];
+    }
+    next_len
+}

--- a/crates/jolt-prover/src/stages/stage2/mod.rs
+++ b/crates/jolt-prover/src/stages/stage2/mod.rs
@@ -1,0 +1,4 @@
+pub mod prove;
+
+#[cfg(test)]
+mod tests;

--- a/crates/jolt-prover/src/stages/stage2/prove.rs
+++ b/crates/jolt-prover/src/stages/stage2/prove.rs
@@ -1,0 +1,1354 @@
+#[cfg(feature = "zk")]
+use crate::committed::{CommittedSumcheckBuilder, CommittedSumcheckWitness};
+use crate::stages::invalid_sumcheck_output;
+#[cfg(feature = "zk")]
+use crate::stages::recorder::CommittedSumcheckRecorder;
+use crate::stages::recorder::{ClearSumcheckRecorder, SumcheckRecorder};
+use crate::ProverError;
+use jolt_backends::{
+    ram_read_write_rows_from_trace, stage2_product_instruction_openings_from_rows,
+    stage2_product_uniskip_first_round, stage2_ram_state_requests, RamReadWriteSumcheckBackend,
+    Stage2ProductUniskipFirstRoundRequest, Stage2RamStateRequests, Stage2RamStateRequestsRequest,
+    Stage2RegularBatchInstanceRequest, SumcheckBackend, SumcheckRamOutputCheckStateRequest,
+    SumcheckRamRafStateRequest, SumcheckRamReadWriteRow, SumcheckRamReadWriteStateRequest,
+    SumcheckRegularBatchInstance, SumcheckRegularBatchState,
+};
+use jolt_backends::{
+    stage2_product_uniskip_extended_eval_outputs, stage2_product_uniskip_extended_eval_request,
+    stage2_product_uniskip_rows_from_stage2_trace, stage2_regular_batch_instances,
+};
+use jolt_claims::protocols::jolt::{
+    formulas::{
+        dimensions::{ReadWriteDimensions, TraceDimensions},
+        ram::RamRafEvaluationDimensions,
+        spartan::SpartanProductDimensions,
+    },
+    JoltReadWriteConfig,
+};
+#[cfg(feature = "zk")]
+use jolt_crypto::VectorCommitment;
+use jolt_field::Field;
+use jolt_poly::{Point, UnivariatePoly};
+use jolt_program::preprocess::PublicIoMemory;
+use jolt_r1cs::constraints::jolt::{
+    SPARTAN_PRODUCT_UNISKIP_DOMAIN_SIZE, SPARTAN_PRODUCT_UNISKIP_FIRST_ROUND_DEGREE,
+};
+use jolt_sumcheck::{
+    ClearProof, ClearSumcheckProof, LabeledRoundPoly, RoundMessage, SumcheckProof,
+};
+use jolt_transcript::Transcript;
+use jolt_verifier::stages::relations::{OpeningClaim, SumcheckInstance};
+use jolt_verifier::stages::stage1::Stage1ClearOutput;
+use jolt_verifier::stages::stage2::outputs::{
+    product_uniskip_input_claim, InstructionClaimReductionOutputClaims,
+    ProductRemainderOutputClaims, RamReadWriteOutputClaims, Stage2BatchOutputClaims,
+    Stage2OutputClaims, Stage2ProductUniSkipInputValues,
+};
+use jolt_verifier::stages::stage2::outputs::{Stage2ClearOutput, Stage2PublicOutput};
+use jolt_verifier::stages::stage2::{
+    stage2_batch_output_claims_with_points, stage2_expected_final_claim, InstructionClaimReduction,
+    InstructionClaimReductionInputClaims, ProductRemainder, ProductRemainderInputClaims,
+    RamOutputCheck, RamOutputCheckInputClaims, RamOutputCheckOutputClaims, RamRafEvaluation,
+    RamRafEvaluationInputClaims, RamRafEvaluationOutputClaims, RamReadWriteChecking,
+    RamReadWriteInputClaims, VerifiedProductUniSkip,
+};
+use jolt_verifier::{CheckedInputs, VerifierError};
+use jolt_witness::{
+    protocols::jolt_vm::{JoltVmNamespace, JoltVmStage2Rows, JoltVmStage2TraceRow},
+    WitnessProvider,
+};
+
+const PRODUCT_UNISKIP_EXTENDED_EVAL_COUNT: usize = SPARTAN_PRODUCT_UNISKIP_DOMAIN_SIZE - 1;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Stage2ProverConfig {
+    pub log_t: usize,
+}
+
+impl Stage2ProverConfig {
+    pub const fn new(log_t: usize) -> Self {
+        Self { log_t }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Stage2BatchProverConfig {
+    pub log_t: usize,
+    pub log_k: usize,
+    pub rw_config: JoltReadWriteConfig,
+}
+
+impl Stage2BatchProverConfig {
+    pub const fn new(log_t: usize, log_k: usize, rw_config: JoltReadWriteConfig) -> Self {
+        Self {
+            log_t,
+            log_k,
+            rw_config,
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Stage2ProductUniSkipInput<F: Field> {
+    pub tau_low: Vec<F>,
+    pub product: F,
+    pub should_branch: F,
+    pub should_jump: F,
+}
+
+impl<F: Field> Stage2ProductUniSkipInput<F> {
+    pub fn from_stage1(stage1: &Stage1ClearOutput<F>) -> Self {
+        let mut tau_low = stage1.public.remainder_challenges[1..].to_vec();
+        tau_low.reverse();
+        Self {
+            tau_low,
+            product: stage1.outer.product,
+            should_branch: stage1.outer.should_branch,
+            should_jump: stage1.outer.should_jump,
+        }
+    }
+
+    fn input_values(&self) -> Stage2ProductUniSkipInputValues<F> {
+        Stage2ProductUniSkipInputValues {
+            product: self.product,
+            should_branch: self.should_branch,
+            should_jump: self.should_jump,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct Stage2ProverInput<'a, F: Field, W> {
+    pub config: Stage2BatchProverConfig,
+    pub checked: &'a CheckedInputs,
+    pub stage1: &'a Stage1ClearOutput<F>,
+    pub witness: &'a W,
+}
+
+impl<'a, F: Field, W> Stage2ProverInput<'a, F, W> {
+    pub const fn new(
+        config: Stage2BatchProverConfig,
+        checked: &'a CheckedInputs,
+        stage1: &'a Stage1ClearOutput<F>,
+        witness: &'a W,
+    ) -> Self {
+        Self {
+            config,
+            checked,
+            stage1,
+            witness,
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Stage2ProductUniSkipOutput<F: Field, C> {
+    pub proof: SumcheckProof<F, C>,
+    pub input_claim: F,
+    pub output_claim: F,
+    pub challenge: F,
+    pub tau_high: F,
+    pub tau_low: Vec<F>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Stage2ProofComponent<F: Field, Proof> {
+    pub product_uniskip_proof: Proof,
+    pub regular_batch_proof: Proof,
+    pub claims: Stage2OutputClaims<F>,
+    pub verifier_output: Stage2ClearOutput<F>,
+}
+
+#[cfg(feature = "zk")]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Stage2CommittedProofComponent<F, VC>
+where
+    F: Field,
+    VC: VectorCommitment<Field = F>,
+{
+    pub product_uniskip_proof: SumcheckProof<F, VC::Output>,
+    pub regular_batch_proof: SumcheckProof<F, VC::Output>,
+    pub public: Stage2PublicOutput<F>,
+    pub verifier_output: Stage2ClearOutput<F>,
+    pub product_uniskip_output_claim_values: Vec<F>,
+    pub batch_output_claim_values: Vec<F>,
+    pub(crate) product_uniskip_committed_witness: CommittedSumcheckWitness<F>,
+    pub(crate) batch_committed_witness: CommittedSumcheckWitness<F>,
+}
+
+/// The five stage 2 batch sumcheck input claims (claimed sums), one per batched
+/// relation. Computed via the relation objects' `input_claim` so the prover and
+/// verifier derive them identically. Prover-local mirror of the deleted verifier
+/// struct (cf. stage 3's local `Stage3InputClaims`).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Stage2BatchInputClaims<F: Field> {
+    pub ram_read_write: F,
+    pub product_remainder: F,
+    pub instruction_claim_reduction: F,
+    pub ram_raf_evaluation: F,
+    pub ram_output_check: F,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Stage2RegularBatchPrefixOutput<F: Field> {
+    pub input_claims: Stage2BatchInputClaims<F>,
+    pub ram_read_write_gamma: F,
+    pub instruction_gamma: F,
+    pub output_address_challenges: Vec<F>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Stage2RamTerminalOutputOpeningClaims<F: Field> {
+    pub ram_raf_evaluation: F,
+    pub ram_output_check: F,
+}
+
+/// The five stage 2 batch relation objects bundled with their wired input claims.
+/// The prover builds them inline (mirroring the verifier's `verify_regular_batch`
+/// clear arm) and reuses them for both the input-claim derivation (before the
+/// batched sumcheck) and the opening-point/expected-output derivation (after).
+struct Stage2BatchRelations<F: Field> {
+    ram_read_write: RamReadWriteChecking<F>,
+    product_remainder: ProductRemainder<F>,
+    instruction_reduction: InstructionClaimReduction<F>,
+    ram_raf: RamRafEvaluation<F>,
+    ram_output: RamOutputCheck<F>,
+    ram_read_write_inputs: RamReadWriteInputClaims<OpeningClaim<F>>,
+    product_remainder_inputs: ProductRemainderInputClaims<OpeningClaim<F>>,
+    instruction_reduction_inputs: InstructionClaimReductionInputClaims<OpeningClaim<F>>,
+    ram_raf_inputs: RamRafEvaluationInputClaims<OpeningClaim<F>>,
+    ram_output_inputs: RamOutputCheckInputClaims<OpeningClaim<F>>,
+}
+
+/// The per-instance sumcheck points derived from the flat batch `challenges`,
+/// before each relation maps them to its produced opening points. Recreates the
+/// split the deleted `stage2_batch_opening_points` performed.
+struct Stage2BatchSumcheckPoints<F: Field> {
+    ram_read_write: Vec<F>,
+    product: Vec<F>,
+    instruction: Vec<F>,
+    terminal: Vec<F>,
+}
+
+fn to_prover_error(error: VerifierError) -> ProverError {
+    invalid_sumcheck_output(error.to_string())
+}
+
+impl<F: Field> Stage2BatchRelations<F> {
+    fn input_claims(&self) -> Result<Stage2BatchInputClaims<F>, ProverError> {
+        Ok(Stage2BatchInputClaims {
+            ram_read_write: self
+                .ram_read_write
+                .input_claim(&self.ram_read_write_inputs)
+                .map_err(to_prover_error)?,
+            product_remainder: self
+                .product_remainder
+                .input_claim(&self.product_remainder_inputs)
+                .map_err(to_prover_error)?,
+            instruction_claim_reduction: self
+                .instruction_reduction
+                .input_claim(&self.instruction_reduction_inputs)
+                .map_err(to_prover_error)?,
+            ram_raf_evaluation: self
+                .ram_raf
+                .input_claim(&self.ram_raf_inputs)
+                .map_err(to_prover_error)?,
+            ram_output_check: self
+                .ram_output
+                .input_claim(&self.ram_output_inputs)
+                .map_err(to_prover_error)?,
+        })
+    }
+
+    /// Map each instance's sumcheck point to its produced opening points, in the
+    /// same `Stage2BatchOutputClaims<Vec<F>>` aggregate the verifier feeds to
+    /// `stage2_batch_output_claims_with_points`.
+    fn derive_opening_points(
+        &self,
+        points: &Stage2BatchSumcheckPoints<F>,
+    ) -> Result<Stage2BatchOutputClaims<Vec<F>>, ProverError> {
+        Ok(Stage2BatchOutputClaims {
+            ram_read_write: self
+                .ram_read_write
+                .derive_opening_points(&points.ram_read_write, &self.ram_read_write_inputs)
+                .map_err(to_prover_error)?,
+            product_remainder: self
+                .product_remainder
+                .derive_opening_points(&points.product, &self.product_remainder_inputs)
+                .map_err(to_prover_error)?,
+            instruction_claim_reduction: self
+                .instruction_reduction
+                .derive_opening_points(&points.instruction, &self.instruction_reduction_inputs)
+                .map_err(to_prover_error)?,
+            ram_raf_evaluation: self
+                .ram_raf
+                .derive_opening_points(&points.terminal, &self.ram_raf_inputs)
+                .map_err(to_prover_error)?,
+            ram_output_check: self
+                .ram_output
+                .derive_opening_points(&points.terminal, &self.ram_output_inputs)
+                .map_err(to_prover_error)?,
+        })
+    }
+}
+
+fn read_write_dimensions(config: Stage2BatchProverConfig) -> ReadWriteDimensions {
+    config.rw_config.ram_dimensions(config.log_t, config.log_k)
+}
+
+/// Recreate the deleted `stage2_batch_opening_points` per-instance sumcheck-point
+/// split from the flat batch `challenges`: RAM read-write reads every challenge,
+/// the product and instruction instances share the last `log_t` challenges, and
+/// the RAM RAF / output-check instances share the terminal point
+/// `challenges[phase1_num_rounds .. phase1_num_rounds + (log_t + log_k - phase1_num_rounds)]`.
+fn stage2_batch_sumcheck_points<F: Field>(
+    config: Stage2BatchProverConfig,
+    challenges: &[F],
+) -> Result<Stage2BatchSumcheckPoints<F>, ProverError> {
+    let dimensions = read_write_dimensions(config);
+    let read_write_rounds = config.log_t + config.log_k;
+    if challenges.len() != read_write_rounds {
+        return Err(invalid_sumcheck_output(format!(
+            "Stage 2 regular batch returned {} challenges, expected {read_write_rounds}",
+            challenges.len()
+        )));
+    }
+
+    let product_offset = read_write_rounds - config.log_t;
+    let product = challenges[product_offset..].to_vec();
+    let instruction = product.clone();
+
+    let phase1_num_rounds = dimensions.phase1_num_rounds();
+    let terminal_rounds = read_write_rounds - phase1_num_rounds;
+    let terminal_end = phase1_num_rounds + terminal_rounds;
+    let terminal = challenges
+        .get(phase1_num_rounds..terminal_end)
+        .ok_or_else(|| {
+            invalid_sumcheck_output(format!(
+                "Stage 2 terminal point range {phase1_num_rounds}..{terminal_end} exceeds {} challenges",
+                challenges.len()
+            ))
+        })?
+        .to_vec();
+
+    Ok(Stage2BatchSumcheckPoints {
+        ram_read_write: challenges.to_vec(),
+        product,
+        instruction,
+        terminal,
+    })
+}
+
+fn validate_stage2_request(
+    checked: &CheckedInputs,
+    config: Stage2BatchProverConfig,
+    expected_zk: bool,
+    mode_label: &'static str,
+) -> Result<(), ProverError> {
+    if checked.zk != expected_zk {
+        let received = if checked.zk { "ZK" } else { "non-ZK" };
+        return Err(ProverError::InvalidStageRequest {
+            reason: format!("Stage 2 {mode_label} prover received {received} checked inputs"),
+        });
+    }
+    if checked.trace_length != (1usize << config.log_t) {
+        return Err(ProverError::InvalidStageRequest {
+            reason: format!(
+                "Stage 2 checked trace length {} does not match log_t {}",
+                checked.trace_length, config.log_t
+            ),
+        });
+    }
+    if checked.ram_K != (1usize << config.log_k) {
+        return Err(ProverError::InvalidStageRequest {
+            reason: format!(
+                "Stage 2 checked RAM K {} does not match log_k {}",
+                checked.ram_K, config.log_k
+            ),
+        });
+    }
+
+    Ok(())
+}
+
+struct PreparedStage2RegularBatch<F: Field> {
+    prefix: Stage2RegularBatchPrefixOutput<F>,
+    ram_read_write: SumcheckRamReadWriteStateRequest<F>,
+    ram_raf: SumcheckRamRafStateRequest<F>,
+    ram_output_check: SumcheckRamOutputCheckStateRequest<F>,
+    instances: Vec<SumcheckRegularBatchInstance<F>>,
+}
+
+struct Stage2RegularBatchPrepareInput<'a, F: Field, C> {
+    config: Stage2BatchProverConfig,
+    checked: &'a CheckedInputs,
+    stage1: &'a Stage1ClearOutput<F>,
+    rows: &'a [JoltVmStage2TraceRow],
+    initial_ram_state: &'a [u64],
+    final_ram_state: &'a [u64],
+    product_uniskip: &'a Stage2ProductUniSkipOutput<F, C>,
+}
+
+fn prepare_stage2_regular_batch<F, T, C>(
+    input: Stage2RegularBatchPrepareInput<'_, F, C>,
+    transcript: &mut T,
+) -> Result<PreparedStage2RegularBatch<F>, ProverError>
+where
+    F: Field,
+    T: Transcript<Challenge = F>,
+{
+    let prefix = derive_stage2_regular_batch_prefix(
+        input.config,
+        input.checked,
+        input.stage1,
+        input.product_uniskip,
+        transcript,
+    )?;
+    let backend_rows = ram_read_write_rows_from_trace(input.rows);
+    let ram_requests = build_ram_state_requests(
+        input.config,
+        input.checked,
+        backend_rows,
+        input.initial_ram_state,
+        input.final_ram_state,
+        input.product_uniskip,
+        &prefix,
+    )?;
+    let instances =
+        build_regular_batch_instances(input.config, input.rows, input.product_uniskip, &prefix)?;
+
+    Ok(PreparedStage2RegularBatch {
+        prefix,
+        ram_read_write: ram_requests.ram_read_write,
+        ram_raf: ram_requests.ram_raf,
+        ram_output_check: ram_requests.ram_output_check,
+        instances,
+    })
+}
+
+fn stage2_batch_output_claims<F: Field>(
+    ram_read_write: RamReadWriteOutputClaims<F>,
+    tail: Stage2TailOutputOpenings<F>,
+    terminal: Stage2RamTerminalOutputOpeningClaims<F>,
+) -> Stage2BatchOutputClaims<F> {
+    Stage2BatchOutputClaims {
+        ram_read_write,
+        product_remainder: tail.product_remainder,
+        instruction_claim_reduction: tail.instruction_claim_reduction,
+        ram_raf_evaluation: RamRafEvaluationOutputClaims {
+            ram_ra: terminal.ram_raf_evaluation,
+        },
+        ram_output_check: RamOutputCheckOutputClaims {
+            val_final: terminal.ram_output_check,
+        },
+    }
+}
+
+struct Stage2BatchAssembly<F: Field> {
+    claims: Stage2OutputClaims<F>,
+    verifier_output: Stage2ClearOutput<F>,
+    batch_output_claim_values: Vec<F>,
+}
+
+struct Stage2BatchAssemblyInput<'a, F: Field, C, P> {
+    config: Stage2BatchProverConfig,
+    checked: &'a CheckedInputs,
+    stage1: &'a Stage1ClearOutput<F>,
+    stage2_rows: &'a [JoltVmStage2TraceRow],
+    product_uniskip: &'a Stage2ProductUniSkipOutput<F, C>,
+    prefix: &'a Stage2RegularBatchPrefixOutput<F>,
+    batch: &'a RegularBatchProof<F, P>,
+}
+
+/// Mirror the verifier's `verify_regular_batch` clear arm: split the batch
+/// sumcheck point, build the five relations inline, derive each relation's
+/// opening claims, check the combined final claim against the prover's batch
+/// `output_claim`, and assemble the `Stage2ClearOutput` for later stages.
+///
+/// Shared by the clear `prove` and the committed `prove_committed_proof_component`
+/// paths; pure with respect to the transcript (no Fiat-Shamir appends).
+fn assemble_stage2_batch_output<F, C, P>(
+    input: Stage2BatchAssemblyInput<'_, F, C, P>,
+) -> Result<Stage2BatchAssembly<F>, ProverError>
+where
+    F: Field,
+{
+    let sumcheck_points = stage2_batch_sumcheck_points(input.config, &input.batch.challenges)?;
+    let relations = stage2_batch_relations(
+        input.config,
+        input.checked,
+        input.stage1,
+        input.product_uniskip,
+        input.prefix.ram_read_write_gamma,
+        input.prefix.instruction_gamma,
+        &input.prefix.output_address_challenges,
+    )?;
+    let opening_points = relations.derive_opening_points(&sumcheck_points)?;
+
+    let tail_openings = evaluate_stage2_tail_openings_from_rows(
+        input.config,
+        input.stage2_rows,
+        &opening_points.product_remainder.left_instruction_input,
+        &opening_points
+            .instruction_claim_reduction
+            .left_lookup_operand,
+    )?;
+    let terminal = Stage2RamTerminalOutputOpeningClaims {
+        ram_raf_evaluation: input.batch.ram_raf_evaluation,
+        ram_output_check: input.batch.ram_output_check,
+    };
+    let wire_claims =
+        stage2_batch_output_claims(input.batch.ram_read_write.clone(), tail_openings, terminal);
+    let batch_output_claim_values = wire_claims.opening_values();
+
+    let output_claims = stage2_batch_output_claims_with_points(&wire_claims, &opening_points);
+
+    let expected_final_claim = stage2_expected_final_claim(
+        &input.batch.batching_coefficients,
+        relations
+            .ram_read_write
+            .expected_output(
+                &relations.ram_read_write_inputs,
+                &output_claims.ram_read_write,
+            )
+            .map_err(to_prover_error)?,
+        relations
+            .product_remainder
+            .expected_output(
+                &relations.product_remainder_inputs,
+                &output_claims.product_remainder,
+            )
+            .map_err(to_prover_error)?,
+        relations
+            .instruction_reduction
+            .expected_output(
+                &relations.instruction_reduction_inputs,
+                &output_claims.instruction_claim_reduction,
+            )
+            .map_err(to_prover_error)?,
+        relations
+            .ram_raf
+            .expected_output(&relations.ram_raf_inputs, &output_claims.ram_raf_evaluation)
+            .map_err(to_prover_error)?,
+        relations
+            .ram_output
+            .expected_output(
+                &relations.ram_output_inputs,
+                &output_claims.ram_output_check,
+            )
+            .map_err(to_prover_error)?,
+    )
+    .map_err(to_prover_error)?;
+    if input.batch.output_claim != expected_final_claim {
+        return Err(invalid_sumcheck_output(format!(
+            "Stage 2 regular batch final claim did not match output openings: got {}, expected {}",
+            input.batch.output_claim, expected_final_claim,
+        )));
+    }
+
+    let claims = Stage2OutputClaims {
+        product_uniskip_output_claim: input.product_uniskip.output_claim,
+        batch_outputs: wire_claims,
+    };
+    let public = Stage2PublicOutput {
+        product_uniskip_challenge: input.product_uniskip.challenge,
+        product_tau_low: input.product_uniskip.tau_low.clone(),
+        product_tau_high: input.product_uniskip.tau_high,
+        ram_read_write_gamma: input.prefix.ram_read_write_gamma,
+        instruction_gamma: input.prefix.instruction_gamma,
+        output_address_challenges: input.prefix.output_address_challenges.clone(),
+    };
+    let verifier_output = Stage2ClearOutput {
+        public,
+        output_claims,
+        product_uniskip: VerifiedProductUniSkip {
+            tau_low: input.product_uniskip.tau_low.clone(),
+            tau_high: input.product_uniskip.tau_high,
+            sumcheck_point: Point::high_to_low(vec![input.product_uniskip.challenge]),
+        },
+    };
+
+    Ok(Stage2BatchAssembly {
+        claims,
+        verifier_output,
+        batch_output_claim_values,
+    })
+}
+
+pub fn prove<F, W, B, T, C>(
+    input: Stage2ProverInput<'_, F, W>,
+    backend: &mut B,
+    transcript: &mut T,
+) -> Result<Stage2ProofComponent<F, SumcheckProof<F, C>>, ProverError>
+where
+    F: Field,
+    W: JoltVmStage2Rows + WitnessProvider<F, JoltVmNamespace>,
+    B: SumcheckBackend<F, JoltVmNamespace> + RamReadWriteSumcheckBackend<F>,
+    T: Transcript<Challenge = F>,
+{
+    validate_stage2_request(input.checked, input.config, false, "clear")?;
+
+    let stage2_rows = input.witness.stage2_rows()?;
+    let initial_ram_state = input.witness.initial_ram_state_words()?;
+    let final_ram_state = input.witness.final_ram_state_words()?;
+
+    let product_input = Stage2ProductUniSkipInput::from_stage1(input.stage1);
+    let product_uniskip = prove_stage2_product_uniskip_from_stage2_rows::<F, B, T, C>(
+        Stage2ProverConfig::new(input.config.log_t),
+        &product_input,
+        &stage2_rows,
+        backend,
+        transcript,
+    )?;
+
+    let prepared = prepare_stage2_regular_batch(
+        Stage2RegularBatchPrepareInput {
+            config: input.config,
+            checked: input.checked,
+            stage1: input.stage1,
+            rows: &stage2_rows,
+            initial_ram_state: &initial_ram_state,
+            final_ram_state: &final_ram_state,
+            product_uniskip: &product_uniskip,
+        },
+        transcript,
+    )?;
+    let batch = prove_regular_batch_sumcheck::<F, T, C, B>(
+        prepared.ram_read_write,
+        prepared.ram_raf,
+        prepared.ram_output_check,
+        prepared.instances,
+        backend,
+        transcript,
+    )?;
+
+    let assembly = assemble_stage2_batch_output(Stage2BatchAssemblyInput {
+        config: input.config,
+        checked: input.checked,
+        stage1: input.stage1,
+        stage2_rows: &stage2_rows,
+        product_uniskip: &product_uniskip,
+        prefix: &prepared.prefix,
+        batch: &batch,
+    })?;
+
+    let recorded = batch
+        .proof
+        .finish(&assembly.batch_output_claim_values, transcript)?;
+
+    Ok(Stage2ProofComponent {
+        product_uniskip_proof: product_uniskip.proof,
+        regular_batch_proof: recorded.proof,
+        claims: assembly.claims,
+        verifier_output: assembly.verifier_output,
+    })
+}
+
+#[cfg(feature = "zk")]
+pub fn prove_committed_proof_component<F, W, B, T, VC>(
+    input: Stage2ProverInput<'_, F, W>,
+    backend: &mut B,
+    vc_setup: &VC::Setup,
+    transcript: &mut T,
+) -> Result<Stage2CommittedProofComponent<F, VC>, ProverError>
+where
+    F: Field,
+    W: JoltVmStage2Rows + WitnessProvider<F, JoltVmNamespace>,
+    B: SumcheckBackend<F, JoltVmNamespace> + RamReadWriteSumcheckBackend<F>,
+    T: Transcript<Challenge = F>,
+    VC: VectorCommitment<Field = F>,
+{
+    validate_stage2_request(input.checked, input.config, true, "committed")?;
+
+    let stage2_rows = input.witness.stage2_rows()?;
+    let initial_ram_state = input.witness.initial_ram_state_words()?;
+    let final_ram_state = input.witness.final_ram_state_words()?;
+
+    let product_input = Stage2ProductUniSkipInput::from_stage1(input.stage1);
+    let product_uniskip = prove_stage2_product_uniskip_committed_from_stage2_rows::<F, B, T, VC>(
+        Stage2ProverConfig::new(input.config.log_t),
+        &product_input,
+        &stage2_rows,
+        backend,
+        vc_setup,
+        transcript,
+    )?;
+
+    let prepared = prepare_stage2_regular_batch(
+        Stage2RegularBatchPrepareInput {
+            config: input.config,
+            checked: input.checked,
+            stage1: input.stage1,
+            rows: &stage2_rows,
+            initial_ram_state: &initial_ram_state,
+            final_ram_state: &final_ram_state,
+            product_uniskip: &product_uniskip.output,
+        },
+        transcript,
+    )?;
+    let batch = prove_regular_batch_sumcheck_committed::<F, T, B, VC>(
+        prepared.ram_read_write,
+        prepared.ram_raf,
+        prepared.ram_output_check,
+        prepared.instances,
+        backend,
+        vc_setup,
+        transcript,
+    )?;
+
+    let assembly = assemble_stage2_batch_output(Stage2BatchAssemblyInput {
+        config: input.config,
+        checked: input.checked,
+        stage1: input.stage1,
+        stage2_rows: &stage2_rows,
+        product_uniskip: &product_uniskip.output,
+        prefix: &prepared.prefix,
+        batch: &batch,
+    })?;
+
+    let batch_output_claim_values = assembly.batch_output_claim_values.clone();
+    let recorded = batch.proof.finish(&batch_output_claim_values, transcript)?;
+
+    Ok(Stage2CommittedProofComponent {
+        product_uniskip_proof: product_uniskip.output.proof,
+        regular_batch_proof: recorded.proof,
+        public: assembly.verifier_output.public.clone(),
+        verifier_output: assembly.verifier_output,
+        product_uniskip_output_claim_values: product_uniskip.output_claim_values,
+        batch_output_claim_values,
+        product_uniskip_committed_witness: product_uniskip.committed_witness,
+        batch_committed_witness: recorded.committed_witness.ok_or_else(|| {
+            invalid_sumcheck_output("Stage 2 committed batch witness material is missing")
+        })?,
+    })
+}
+
+fn prove_stage2_product_uniskip_from_stage2_rows<F, B, T, C>(
+    config: Stage2ProverConfig,
+    input: &Stage2ProductUniSkipInput<F>,
+    stage2_rows: &[JoltVmStage2TraceRow],
+    backend: &mut B,
+    transcript: &mut T,
+) -> Result<Stage2ProductUniSkipOutput<F, C>, ProverError>
+where
+    F: Field,
+    B: SumcheckBackend<F, JoltVmNamespace>,
+    T: Transcript<Challenge = F>,
+{
+    let base_evals = [input.product, input.should_branch, input.should_jump];
+    let extended_evals = product_uniskip_extended_evals_from_stage2_rows(
+        config,
+        stage2_rows,
+        backend,
+        &input.tau_low,
+    )?;
+    prove_stage2_product_uniskip_with_extended_evals(
+        input,
+        &base_evals,
+        &extended_evals,
+        transcript,
+    )
+}
+
+#[cfg(feature = "zk")]
+fn prove_stage2_product_uniskip_committed_from_stage2_rows<F, B, T, VC>(
+    config: Stage2ProverConfig,
+    input: &Stage2ProductUniSkipInput<F>,
+    stage2_rows: &[JoltVmStage2TraceRow],
+    backend: &mut B,
+    vc_setup: &VC::Setup,
+    transcript: &mut T,
+) -> Result<CommittedProductUniSkip<F, VC::Output>, ProverError>
+where
+    F: Field,
+    B: SumcheckBackend<F, JoltVmNamespace>,
+    T: Transcript<Challenge = F>,
+    VC: VectorCommitment<Field = F>,
+{
+    let base_evals = [input.product, input.should_branch, input.should_jump];
+    let extended_evals = product_uniskip_extended_evals_from_stage2_rows(
+        config,
+        stage2_rows,
+        backend,
+        &input.tau_low,
+    )?;
+    prove_stage2_product_uniskip_committed_with_extended_evals::<F, T, VC>(
+        input,
+        &base_evals,
+        &extended_evals,
+        vc_setup,
+        transcript,
+    )
+}
+
+fn prove_stage2_product_uniskip_with_extended_evals<F, T, C>(
+    input: &Stage2ProductUniSkipInput<F>,
+    base_evals: &[F; SPARTAN_PRODUCT_UNISKIP_DOMAIN_SIZE],
+    extended_evals: &[F],
+    transcript: &mut T,
+) -> Result<Stage2ProductUniSkipOutput<F, C>, ProverError>
+where
+    F: Field,
+    T: Transcript<Challenge = F>,
+{
+    let (tau_high, input_claim, polynomial) =
+        stage2_product_uniskip_round(input, base_evals, extended_evals, transcript)?;
+    LabeledRoundPoly::uniskip(&polynomial).append_to_transcript(transcript);
+    let challenge = transcript.challenge();
+    let output_claim = polynomial.evaluate(challenge);
+    transcript.append_labeled(b"opening_claim", &output_claim);
+
+    Ok(Stage2ProductUniSkipOutput {
+        proof: SumcheckProof::Clear(ClearProof::Full(ClearSumcheckProof {
+            round_polynomials: vec![polynomial],
+        })),
+        input_claim,
+        output_claim,
+        challenge,
+        tau_high,
+        tau_low: input.tau_low.clone(),
+    })
+}
+
+#[cfg(feature = "zk")]
+fn prove_stage2_product_uniskip_committed_with_extended_evals<F, T, VC>(
+    input: &Stage2ProductUniSkipInput<F>,
+    base_evals: &[F; SPARTAN_PRODUCT_UNISKIP_DOMAIN_SIZE],
+    extended_evals: &[F],
+    vc_setup: &VC::Setup,
+    transcript: &mut T,
+) -> Result<CommittedProductUniSkip<F, VC::Output>, ProverError>
+where
+    F: Field,
+    T: Transcript<Challenge = F>,
+    VC: VectorCommitment<Field = F>,
+{
+    let (tau_high, input_claim, polynomial) =
+        stage2_product_uniskip_round(input, base_evals, extended_evals, transcript)?;
+    let mut builder = CommittedSumcheckBuilder::<F, VC>::new(vc_setup, 1)?;
+    let challenge = builder.commit_round(&polynomial, transcript)?;
+    let output_claim = polynomial.evaluate(challenge);
+    let output_claim_values = vec![output_claim];
+    let built = builder.finish(&output_claim_values, transcript)?;
+
+    Ok(CommittedProductUniSkip {
+        output: Stage2ProductUniSkipOutput {
+            proof: built.proof,
+            input_claim,
+            output_claim,
+            challenge,
+            tau_high,
+            tau_low: input.tau_low.clone(),
+        },
+        output_claim_values,
+        committed_witness: built.witness,
+    })
+}
+
+fn stage2_product_uniskip_round<F, T>(
+    input: &Stage2ProductUniSkipInput<F>,
+    base_evals: &[F; SPARTAN_PRODUCT_UNISKIP_DOMAIN_SIZE],
+    extended_evals: &[F],
+    transcript: &mut T,
+) -> Result<(F, F, UnivariatePoly<F>), ProverError>
+where
+    F: Field,
+    T: Transcript<Challenge = F>,
+{
+    let tau_high = transcript.challenge();
+    let first_round = stage2_product_uniskip_first_round(&Stage2ProductUniskipFirstRoundRequest {
+        domain_size: SPARTAN_PRODUCT_UNISKIP_DOMAIN_SIZE,
+        first_round_degree: SPARTAN_PRODUCT_UNISKIP_FIRST_ROUND_DEGREE,
+        base_evals,
+        extended_evals,
+        tau_high,
+    })
+    .map_err(ProverError::from)?;
+
+    let input_claim =
+        product_uniskip_input_claim(input.input_values(), &first_round.lagrange_weights)?;
+    if first_round.round_sum != input_claim {
+        return Err(invalid_sumcheck_output(
+            "Stage 2 product uni-skip first-round polynomial does not sum to the input claim",
+        ));
+    }
+
+    Ok((tau_high, input_claim, first_round.polynomial))
+}
+
+pub fn derive_stage2_regular_batch_prefix<F, T, C>(
+    config: Stage2BatchProverConfig,
+    checked: &CheckedInputs,
+    stage1: &Stage1ClearOutput<F>,
+    product_uniskip: &Stage2ProductUniSkipOutput<F, C>,
+    transcript: &mut T,
+) -> Result<Stage2RegularBatchPrefixOutput<F>, ProverError>
+where
+    F: Field,
+    T: Transcript<Challenge = F>,
+{
+    let ram_read_write_gamma = transcript.challenge_scalar();
+    let instruction_gamma = transcript.challenge_scalar();
+    let output_address_challenges = (0..config.log_k)
+        .map(|_| transcript.challenge())
+        .collect::<Vec<_>>();
+
+    let input_claims = stage2_batch_relations(
+        config,
+        checked,
+        stage1,
+        product_uniskip,
+        ram_read_write_gamma,
+        instruction_gamma,
+        &output_address_challenges,
+    )?
+    .input_claims()?;
+
+    Ok(Stage2RegularBatchPrefixOutput {
+        input_claims,
+        ram_read_write_gamma,
+        instruction_gamma,
+        output_address_challenges,
+    })
+}
+
+/// Build the five stage 2 batch relation objects (bundled with their wired input
+/// claims) inline, exactly as the verifier's `verify_regular_batch` clear arm does.
+/// The prover constructs them twice — once for the input claims (before the batched
+/// sumcheck) and once for the opening points / expected outputs (after) — since the
+/// relations carry no proof state.
+fn stage2_batch_relations<F, C>(
+    config: Stage2BatchProverConfig,
+    checked: &CheckedInputs,
+    stage1: &Stage1ClearOutput<F>,
+    product_uniskip: &Stage2ProductUniSkipOutput<F, C>,
+    ram_read_write_gamma: F,
+    instruction_gamma: F,
+    output_address_challenges: &[F],
+) -> Result<Stage2BatchRelations<F>, ProverError>
+where
+    F: Field,
+{
+    let log_t = config.log_t;
+    let log_k = config.log_k;
+    let trace_dimensions = TraceDimensions::new(log_t);
+    let rw_dimensions = read_write_dimensions(config);
+    let product_dimensions = SpartanProductDimensions::new(log_t);
+    let raf_dimensions = RamRafEvaluationDimensions::try_from(rw_dimensions).map_err(|error| {
+        invalid_sumcheck_output(format!("Stage 2 RAM RAF dimensions invalid: {error}"))
+    })?;
+
+    let lowest_address = checked.public_io.memory_layout.get_lowest_address();
+    let public_memory = PublicIoMemory::new(&checked.public_io).map_err(|error| {
+        ProverError::InvalidStageRequest {
+            reason: format!("invalid public IO memory for Stage 2 output check: {error}"),
+        }
+    })?;
+
+    let ram_read_write = RamReadWriteChecking::new(
+        rw_dimensions,
+        log_k,
+        ram_read_write_gamma,
+        product_uniskip.tau_low.clone(),
+    );
+    let product_remainder = ProductRemainder::new(
+        product_dimensions,
+        product_uniskip.challenge,
+        product_uniskip.tau_high,
+        product_uniskip.tau_low.clone(),
+    );
+    let instruction_reduction = InstructionClaimReduction::new(
+        trace_dimensions,
+        instruction_gamma,
+        product_uniskip.tau_low.clone(),
+    );
+    let ram_raf = RamRafEvaluation::new(
+        rw_dimensions,
+        raf_dimensions,
+        log_k,
+        lowest_address,
+        product_uniskip.tau_low.clone(),
+    );
+    let ram_output = RamOutputCheck::new(
+        rw_dimensions,
+        output_address_challenges.to_vec(),
+        public_memory,
+    );
+
+    Ok(Stage2BatchRelations {
+        ram_read_write,
+        product_remainder,
+        instruction_reduction,
+        ram_raf,
+        ram_output,
+        ram_read_write_inputs: RamReadWriteInputClaims::from_upstream(stage1),
+        product_remainder_inputs: ProductRemainderInputClaims::from_uniskip_output(
+            product_uniskip.output_claim,
+        ),
+        instruction_reduction_inputs: InstructionClaimReductionInputClaims::from_upstream(stage1),
+        ram_raf_inputs: RamRafEvaluationInputClaims::from_upstream(stage1),
+        ram_output_inputs: RamOutputCheckInputClaims::from_upstream(),
+    })
+}
+
+fn evaluate_stage2_tail_openings_from_rows<F>(
+    config: Stage2BatchProverConfig,
+    rows: &[JoltVmStage2TraceRow],
+    product_opening_point: &[F],
+    instruction_opening_point: &[F],
+) -> Result<Stage2TailOutputOpenings<F>, ProverError>
+where
+    F: Field,
+{
+    let openings = stage2_product_instruction_openings_from_rows(
+        config.log_t,
+        rows,
+        product_opening_point,
+        instruction_opening_point,
+    )?;
+
+    Ok(Stage2TailOutputOpenings {
+        product_remainder: ProductRemainderOutputClaims {
+            left_instruction_input: openings.product_remainder.left_instruction_input,
+            right_instruction_input: openings.product_remainder.right_instruction_input,
+            jump_flag: openings.product_remainder.jump_flag,
+            write_lookup_output_to_rd: openings.product_remainder.write_lookup_output_to_rd,
+            lookup_output: openings.product_remainder.lookup_output,
+            branch_flag: openings.product_remainder.branch_flag,
+            next_is_noop: openings.product_remainder.next_is_noop,
+            virtual_instruction: openings.product_remainder.virtual_instruction,
+        },
+        instruction_claim_reduction: InstructionClaimReductionOutputClaims {
+            lookup_output: None,
+            left_lookup_operand: openings.instruction_claim_reduction.left_lookup_operand,
+            right_lookup_operand: openings.instruction_claim_reduction.right_lookup_operand,
+            left_instruction_input: None,
+            right_instruction_input: None,
+        },
+    })
+}
+
+struct RegularBatchProof<F: Field, Proof> {
+    proof: Proof,
+    challenges: Vec<F>,
+    batching_coefficients: Vec<F>,
+    output_claim: F,
+    ram_read_write: RamReadWriteOutputClaims<F>,
+    ram_raf_evaluation: F,
+    ram_output_check: F,
+}
+
+#[derive(Clone)]
+struct Stage2TailOutputOpenings<F: Field> {
+    product_remainder: ProductRemainderOutputClaims<F>,
+    instruction_claim_reduction: InstructionClaimReductionOutputClaims<F>,
+}
+
+#[cfg(feature = "zk")]
+struct CommittedProductUniSkip<F: Field, C> {
+    output: Stage2ProductUniSkipOutput<F, C>,
+    output_claim_values: Vec<F>,
+    committed_witness: CommittedSumcheckWitness<F>,
+}
+
+fn prove_regular_batch_sumcheck<F, T, C, B>(
+    ram_read_write: SumcheckRamReadWriteStateRequest<F>,
+    ram_raf: SumcheckRamRafStateRequest<F>,
+    ram_output_check: SumcheckRamOutputCheckStateRequest<F>,
+    instances: Vec<SumcheckRegularBatchInstance<F>>,
+    backend: &mut B,
+    transcript: &mut T,
+) -> Result<RegularBatchProof<F, ClearSumcheckRecorder<F, C>>, ProverError>
+where
+    F: Field,
+    T: Transcript<Challenge = F>,
+    B: SumcheckBackend<F, JoltVmNamespace> + RamReadWriteSumcheckBackend<F>,
+{
+    prove_regular_batch_sumcheck_with_recorder(
+        ram_read_write,
+        ram_raf,
+        ram_output_check,
+        instances,
+        backend,
+        transcript,
+        ClearSumcheckRecorder::<F, C>::new(0),
+    )
+}
+
+fn prove_regular_batch_sumcheck_with_recorder<F, T, B, S>(
+    ram_read_write: SumcheckRamReadWriteStateRequest<F>,
+    ram_raf: SumcheckRamRafStateRequest<F>,
+    ram_output_check: SumcheckRamOutputCheckStateRequest<F>,
+    instances: Vec<SumcheckRegularBatchInstance<F>>,
+    backend: &mut B,
+    transcript: &mut T,
+    mut proof_recorder: S,
+) -> Result<RegularBatchProof<F, S>, ProverError>
+where
+    F: Field,
+    T: Transcript<Challenge = F>,
+    B: SumcheckBackend<F, JoltVmNamespace> + RamReadWriteSumcheckBackend<F>,
+    S: SumcheckRecorder<F>,
+{
+    let mut ram_state = backend.materialize_sumcheck_ram_read_write_state(&ram_read_write)?;
+    let mut ram_raf_state = backend.materialize_sumcheck_ram_raf_state(&ram_raf)?;
+    let mut ram_output_check_state =
+        backend.materialize_sumcheck_ram_output_check_state(&ram_output_check)?;
+    let mut state = SumcheckRegularBatchState::new("stage2.regular_batch.tail", instances);
+    let ram_read_write_rounds = ram_read_write.log_t + ram_read_write.log_k;
+    let ram_raf_rounds = ram_raf.log_t + ram_raf.log_k - ram_raf.phase1_num_rounds;
+    let ram_output_check_rounds =
+        ram_output_check.log_t + ram_output_check.log_k - ram_output_check.phase1_num_rounds;
+    let max_num_rounds = std::iter::once(ram_read_write_rounds)
+        .chain(
+            state
+                .instances
+                .iter()
+                .map(SumcheckRegularBatchInstance::num_rounds),
+        )
+        .chain([ram_raf_rounds, ram_output_check_rounds])
+        .max()
+        .ok_or_else(|| invalid_sumcheck_output("Stage 2 regular batch has no instances"))?;
+    let ram_raf_offset = max_num_rounds - ram_raf_rounds;
+    let ram_output_check_offset = max_num_rounds - ram_output_check_rounds;
+
+    // Canonical Stage 2 regular-batch input-claim order: RAM read-write, then
+    // each tail instance, then RAM RAF, then the RAM output-check (claim zero).
+    let mut input_claim_values = Vec::with_capacity(state.instances.len() + 3);
+    input_claim_values.push(ram_read_write.input_claim);
+    input_claim_values.extend(state.instances.iter().map(|instance| instance.input_claim));
+    input_claim_values.push(ram_raf.input_claim);
+    input_claim_values.push(F::zero());
+    proof_recorder.absorb_input_claims(&input_claim_values, transcript);
+
+    let tail_start = 1;
+    let terminal_start = tail_start + state.instances.len();
+    let ram_raf_index = terminal_start;
+    let ram_output_check_index = terminal_start + 1;
+    let instance_count = state.instances.len() + 3;
+    let batching_coefficients = (0..instance_count)
+        .map(|_| transcript.challenge_scalar())
+        .collect::<Vec<_>>();
+    let mut individual_claims = std::iter::once(ram_read_write.input_claim)
+        .chain(state.instances.iter().map(|instance| {
+            instance
+                .input_claim
+                .mul_pow_2(max_num_rounds - instance.num_rounds())
+        }))
+        .chain([
+            ram_raf.input_claim.mul_pow_2(ram_raf_offset),
+            F::zero().mul_pow_2(ram_output_check_offset),
+        ])
+        .collect::<Vec<_>>();
+    let mut running_claim = individual_claims
+        .iter()
+        .zip(&batching_coefficients)
+        .map(|(claim, coefficient)| *claim * *coefficient)
+        .sum::<F>();
+    let two_inv = F::from_u64(2).inv_or_zero();
+
+    let mut challenges = Vec::with_capacity(max_num_rounds);
+    for round in 0..max_num_rounds {
+        let ram_poly =
+            backend.evaluate_sumcheck_ram_read_write_round(&ram_state, individual_claims[0])?;
+        let tail_messages = backend
+            .evaluate_sumcheck_regular_batch_round(
+                &mut state,
+                round,
+                max_num_rounds,
+                &individual_claims[tail_start..terminal_start],
+            )?
+            .into_iter()
+            .collect::<Vec<_>>();
+        if tail_messages.len() != state.instances.len() {
+            return Err(invalid_sumcheck_output(format!(
+                "Stage 2 regular batch round {round} returned {} instance messages, expected {}",
+                tail_messages.len() + 1,
+                state.instances.len() + 1
+            )));
+        }
+        let mut univariate_polys = Vec::with_capacity(instance_count);
+        univariate_polys.push(ram_poly);
+        for (expected_index, round_message) in tail_messages.into_iter().enumerate() {
+            if round_message.instance_index != expected_index {
+                return Err(invalid_sumcheck_output(format!(
+                    "Stage 2 regular batch round {round} returned instance {}, expected {expected_index}",
+                    round_message.instance_index
+                )));
+            }
+            univariate_polys.push(round_message.polynomial);
+        }
+        if round < ram_raf_offset {
+            univariate_polys.push(UnivariatePoly::new(vec![
+                individual_claims[ram_raf_index] * two_inv,
+            ]));
+        } else {
+            univariate_polys.push(backend.evaluate_sumcheck_ram_raf_round(
+                &ram_raf_state,
+                individual_claims[ram_raf_index],
+            )?);
+        }
+        if round < ram_output_check_offset {
+            univariate_polys.push(UnivariatePoly::new(vec![
+                individual_claims[ram_output_check_index] * two_inv,
+            ]));
+        } else {
+            univariate_polys.push(backend.evaluate_sumcheck_ram_output_check_round(
+                &ram_output_check_state,
+                individual_claims[ram_output_check_index],
+            )?);
+        }
+
+        let mut batched_poly = UnivariatePoly::zero();
+        for (poly, coefficient) in univariate_polys.iter().zip(&batching_coefficients) {
+            batched_poly += &(poly * *coefficient);
+        }
+        let round_sum = batched_poly.evaluate(F::zero()) + batched_poly.evaluate(F::one());
+        if round_sum != running_claim {
+            return Err(invalid_sumcheck_output(format!(
+                "Stage 2 regular batch round {round} sumcheck invariant failed"
+            )));
+        }
+        let batched_poly = trim_round_polynomial(batched_poly);
+        let challenge = proof_recorder.absorb_round(&batched_poly, transcript)?;
+        running_claim = batched_poly.evaluate(challenge);
+        challenges.push(challenge);
+
+        for (claim, poly) in individual_claims.iter_mut().zip(univariate_polys) {
+            *claim = poly.evaluate(challenge);
+        }
+        backend.bind_sumcheck_ram_read_write_state(&mut ram_state, challenge)?;
+        backend.bind_sumcheck_regular_batch_state(&mut state, round, max_num_rounds, challenge)?;
+        if round >= ram_raf_offset {
+            backend.bind_sumcheck_ram_raf_state(&mut ram_raf_state, challenge)?;
+        }
+        if round >= ram_output_check_offset {
+            backend.bind_sumcheck_ram_output_check_state(&mut ram_output_check_state, challenge)?;
+        }
+    }
+    let [val, ra, inc] = backend.output_sumcheck_ram_read_write_state(&ram_state)?;
+    let ram_raf_evaluation = backend.output_sumcheck_ram_raf_state(&ram_raf_state)?;
+    let ram_output_check =
+        backend.output_sumcheck_ram_output_check_state(&ram_output_check_state)?;
+
+    // The output-claim values span batch results plus caller-assembled
+    // components (product remainder, instruction claim reduction, ...), so the
+    // recorder is finished by the caller via `RegularBatchProof::proof.finish`.
+    Ok(RegularBatchProof {
+        proof: proof_recorder,
+        challenges,
+        batching_coefficients,
+        output_claim: running_claim,
+        ram_read_write: RamReadWriteOutputClaims { val, ra, inc },
+        ram_raf_evaluation,
+        ram_output_check,
+    })
+}
+
+#[cfg(feature = "zk")]
+fn prove_regular_batch_sumcheck_committed<'a, F, T, B, VC>(
+    ram_read_write: SumcheckRamReadWriteStateRequest<F>,
+    ram_raf: SumcheckRamRafStateRequest<F>,
+    ram_output_check: SumcheckRamOutputCheckStateRequest<F>,
+    instances: Vec<SumcheckRegularBatchInstance<F>>,
+    backend: &mut B,
+    vc_setup: &'a VC::Setup,
+    transcript: &mut T,
+) -> Result<RegularBatchProof<F, CommittedSumcheckRecorder<'a, F, VC>>, ProverError>
+where
+    F: Field,
+    T: Transcript<Challenge = F>,
+    B: SumcheckBackend<F, JoltVmNamespace> + RamReadWriteSumcheckBackend<F>,
+    VC: VectorCommitment<Field = F>,
+{
+    prove_regular_batch_sumcheck_with_recorder(
+        ram_read_write,
+        ram_raf,
+        ram_output_check,
+        instances,
+        backend,
+        transcript,
+        CommittedSumcheckRecorder::<F, VC>::new(vc_setup)?,
+    )
+}
+
+fn trim_round_polynomial<F: Field>(poly: UnivariatePoly<F>) -> UnivariatePoly<F> {
+    let mut coefficients = poly.into_coefficients();
+    while coefficients.len() > 2 && coefficients.last().is_some_and(|value| *value == F::zero()) {
+        let _ = coefficients.pop();
+    }
+    UnivariatePoly::new(coefficients)
+}
+
+fn build_regular_batch_instances<F, C>(
+    config: Stage2BatchProverConfig,
+    rows: &[JoltVmStage2TraceRow],
+    product_uniskip: &Stage2ProductUniSkipOutput<F, C>,
+    prefix: &Stage2RegularBatchPrefixOutput<F>,
+) -> Result<Vec<SumcheckRegularBatchInstance<F>>, ProverError>
+where
+    F: Field,
+{
+    let request = Stage2RegularBatchInstanceRequest {
+        log_t: config.log_t,
+        rows,
+        tau_low: &product_uniskip.tau_low,
+        tau_high: product_uniskip.tau_high,
+        product_challenge: product_uniskip.challenge,
+        product_output_claim: product_uniskip.output_claim,
+        instruction_claim_reduction_input_claim: prefix.input_claims.instruction_claim_reduction,
+        instruction_gamma: prefix.instruction_gamma,
+    };
+    stage2_regular_batch_instances(&request).map_err(ProverError::from)
+}
+
+fn build_ram_state_requests<F: Field>(
+    config: Stage2BatchProverConfig,
+    checked: &CheckedInputs,
+    rows: Vec<SumcheckRamReadWriteRow>,
+    initial_ram_state: &[u64],
+    final_ram_state: &[u64],
+    product_uniskip: &Stage2ProductUniSkipOutput<F, impl Sized>,
+    prefix: &Stage2RegularBatchPrefixOutput<F>,
+) -> Result<Stage2RamStateRequests<F>, ProverError> {
+    let public_memory = PublicIoMemory::new(&checked.public_io).map_err(|error| {
+        ProverError::InvalidStageRequest {
+            reason: format!("invalid public IO memory for Stage 2 output check: {error}"),
+        }
+    })?;
+    stage2_ram_state_requests(&Stage2RamStateRequestsRequest {
+        log_t: config.log_t,
+        log_k: config.log_k,
+        phase1_num_rounds: config.rw_config.ram_rw_phase1_num_rounds as usize,
+        phase2_num_rounds: config.rw_config.ram_rw_phase2_num_rounds as usize,
+        rows: &rows,
+        initial_ram_state,
+        final_ram_state,
+        tau_low: &product_uniskip.tau_low,
+        ram_read_write_gamma: prefix.ram_read_write_gamma,
+        ram_read_write_input_claim: prefix.input_claims.ram_read_write,
+        ram_raf_input_claim: prefix.input_claims.ram_raf_evaluation,
+        start_address: checked.public_io.memory_layout.get_lowest_address(),
+        public_memory: &public_memory,
+        output_address_challenges: &prefix.output_address_challenges,
+    })
+    .map_err(ProverError::from)
+}
+
+fn product_uniskip_extended_evals_from_stage2_rows<F, B>(
+    config: Stage2ProverConfig,
+    stage2_rows: &[JoltVmStage2TraceRow],
+    backend: &mut B,
+    tau_low: &[F],
+) -> Result<Vec<F>, ProverError>
+where
+    F: Field,
+    B: SumcheckBackend<F, JoltVmNamespace>,
+{
+    let product_rows = stage2_product_uniskip_rows_from_stage2_trace(config.log_t, stage2_rows)?;
+    let request =
+        stage2_product_uniskip_extended_eval_request(config.log_t, &product_rows, tau_low)?;
+    let outputs = backend.evaluate_sumcheck_product_uniskip_rows(&request)?;
+    stage2_product_uniskip_extended_eval_outputs(outputs, PRODUCT_UNISKIP_EXTENDED_EVAL_COUNT)
+        .map_err(ProverError::from)
+}

--- a/crates/jolt-prover/src/stages/stage2/tests.rs
+++ b/crates/jolt-prover/src/stages/stage2/tests.rs
@@ -1,0 +1,433 @@
+#[cfg(feature = "zk")]
+use common::jolt_device::{JoltDevice, MemoryConfig};
+#[cfg(feature = "zk")]
+use jolt_backends::cpu::CpuBackend;
+#[cfg(feature = "zk")]
+use jolt_crypto::{
+    Bn254, Bn254G1, Commitment, JoltGroup, Pedersen, PedersenSetup, VectorCommitment,
+};
+#[cfg(feature = "zk")]
+use jolt_field::{Fr, FromPrimitiveInt};
+#[cfg(feature = "zk")]
+use jolt_openings::CommitmentScheme;
+#[cfg(feature = "zk")]
+use jolt_poly::Polynomial;
+#[cfg(feature = "zk")]
+use jolt_sumcheck::{ClearProof, ClearSumcheckProof, SumcheckProof};
+#[cfg(feature = "zk")]
+use jolt_transcript::{Blake2bTranscript, Transcript};
+#[cfg(feature = "zk")]
+use jolt_witness::protocols::jolt_vm::{JoltVmNamespace, JoltVmStage2Rows, JoltVmStage2TraceRow};
+#[cfg(feature = "zk")]
+use jolt_witness::protocols::jolt_vm::{JoltVmSpartanOuterRow, JoltVmSpartanOuterRows};
+#[cfg(feature = "zk")]
+use jolt_witness::{
+    MaterializationPolicy, OracleDescriptor, OracleRef, PolynomialEncoding, PolynomialView,
+    RetentionHint, ViewRequirement, WitnessDimensions, WitnessError, WitnessProvider,
+};
+
+#[cfg(feature = "zk")]
+use super::prove::{
+    prove_committed_proof_component as prove_stage2_committed_proof_component,
+    Stage2BatchProverConfig, Stage2ProverInput,
+};
+#[cfg(feature = "zk")]
+use crate::stages::stage1::prove::{
+    prove_committed_proof_component as prove_stage1_committed_proof_component, Stage1ProverConfig,
+    Stage1ProverInput,
+};
+
+#[test]
+#[cfg(feature = "zk")]
+fn stage2_committed_proof_component_produces_native_verifier_output(
+) -> Result<(), Box<dyn std::error::Error>> {
+    let public_io = test_public_io();
+    let trace_length = 16;
+    let ram_k = 16;
+    let witness = SatisfyingStage2Witness {
+        final_ram_state: public_io_ram_state(&public_io, ram_k)?,
+    };
+    let mut backend = CpuBackend::default();
+    let vc_setup = pedersen_setup(64);
+    let checked = checked_inputs(public_io.clone(), trace_length, ram_k, &vc_setup);
+    let mut prover_transcript = Blake2bTranscript::<Fr>::new(b"stage2-zk-test");
+
+    let stage1 = prove_stage1_committed_proof_component::<Fr, _, _, _, Pedersen<Bn254G1>>(
+        Stage1ProverInput::new(Stage1ProverConfig::new(4), &witness),
+        &mut backend,
+        &mut prover_transcript,
+        &vc_setup,
+    )?;
+    let stage2 = prove_stage2_committed_proof_component::<Fr, _, _, _, Pedersen<Bn254G1>>(
+        Stage2ProverInput::new(stage2_config(), &checked, &stage1.verifier_output, &witness),
+        &mut backend,
+        &vc_setup,
+        &mut prover_transcript,
+    )?;
+
+    assert_eq!(stage2.product_uniskip_output_claim_values.len(), 1);
+    assert_eq!(stage2.batch_output_claim_values.len(), 15);
+    assert_eq!(
+        stage2
+            .product_uniskip_committed_witness
+            .round_coefficients
+            .len(),
+        1
+    );
+    assert_eq!(
+        stage2.batch_committed_witness.round_coefficients.len(),
+        stage2_config().log_t + stage2_config().log_k
+    );
+
+    let proof = stage2_zk_proof(
+        stage1.uniskip_proof.clone(),
+        stage1.remainder_proof.clone(),
+        stage2.product_uniskip_proof.clone(),
+        stage2.regular_batch_proof.clone(),
+        trace_length,
+        ram_k,
+    );
+    let mut verifier_transcript = Blake2bTranscript::<Fr>::new(b"stage2-zk-test");
+    let stage1_native =
+        jolt_verifier::stages::stage1::verify(&checked, &proof, &mut verifier_transcript)?;
+    let stage2_native = jolt_verifier::stages::stage2::verify(
+        &checked,
+        &proof,
+        &mut verifier_transcript,
+        &stage1_native,
+    )?;
+    let jolt_verifier::stages::stage2::Stage2Output::Zk(stage2_native) = stage2_native else {
+        return Err("Stage 2 verifier did not return ZK output".into());
+    };
+
+    assert_eq!(stage2_native.public, stage2.public);
+    assert_eq!(
+        stage2_native
+            .product_uniskip_output_claims
+            .shape
+            .output_claim_count,
+        stage2.product_uniskip_output_claim_values.len()
+    );
+    assert_eq!(
+        stage2_native.batch_output_claims.shape.output_claim_count,
+        stage2.batch_output_claim_values.len()
+    );
+    assert_eq!(verifier_transcript.state(), prover_transcript.state());
+
+    Ok(())
+}
+
+#[cfg(feature = "zk")]
+fn stage2_config() -> Stage2BatchProverConfig {
+    Stage2BatchProverConfig::new(
+        4,
+        4,
+        jolt_claims::protocols::jolt::JoltReadWriteConfig {
+            ram_rw_phase1_num_rounds: 1,
+            ram_rw_phase2_num_rounds: 1,
+            registers_rw_phase1_num_rounds: 1,
+            registers_rw_phase2_num_rounds: 1,
+        },
+    )
+}
+
+#[cfg(feature = "zk")]
+fn test_public_io() -> JoltDevice {
+    JoltDevice::new(&MemoryConfig {
+        program_size: Some(1024),
+        max_trusted_advice_size: 0,
+        max_untrusted_advice_size: 0,
+        max_input_size: 0,
+        max_output_size: 0,
+        ..Default::default()
+    })
+}
+
+#[cfg(feature = "zk")]
+fn public_io_ram_state(
+    public_io: &JoltDevice,
+    ram_k: usize,
+) -> Result<Vec<u64>, Box<dyn std::error::Error>> {
+    let public_memory = jolt_program::preprocess::PublicIoMemory::new(public_io)
+        .map_err(|error| format!("{error:?}"))?;
+    let mut state = vec![0; ram_k];
+    for segment in public_memory.segments {
+        let end = segment.start_index + segment.words.len();
+        state[segment.start_index..end].copy_from_slice(&segment.words);
+    }
+    Ok(state)
+}
+
+/// A schedule with no committed program and no advice: every layout is `None`,
+/// so the log_t/log_k_chunk inputs do not affect the resulting value.
+#[cfg(feature = "zk")]
+#[expect(
+    clippy::expect_used,
+    reason = "Test helper; the empty schedule is infallible."
+)]
+fn empty_precommitted_schedule(trace_length: usize) -> jolt_verifier::stages::PrecommittedSchedule {
+    jolt_verifier::stages::PrecommittedSchedule::new(
+        jolt_claims::protocols::jolt::TracePolynomialOrder::default(),
+        trace_length.ilog2() as usize,
+        0,
+        None,
+        None,
+        None,
+    )
+    .expect("empty precommitted schedule has no candidates and cannot fail")
+}
+
+#[cfg(feature = "zk")]
+fn checked_inputs(
+    public_io: JoltDevice,
+    trace_length: usize,
+    ram_k: usize,
+    vc_setup: &PedersenSetup<Bn254G1>,
+) -> jolt_verifier::CheckedInputs {
+    jolt_verifier::CheckedInputs {
+        public_io,
+        zk: true,
+        trace_length,
+        ram_K: ram_k,
+        entry_address: 0,
+        preprocessing_digest: [0; 32],
+        trusted_advice_commitment_present: false,
+        vc_capacity: Some(Pedersen::<Bn254G1>::capacity(vc_setup)),
+        precommitted: empty_precommitted_schedule(trace_length),
+    }
+}
+
+#[cfg(feature = "zk")]
+fn stage2_zk_proof(
+    stage1_uniskip_proof: SumcheckProof<Fr, Bn254G1>,
+    stage1_remainder_proof: SumcheckProof<Fr, Bn254G1>,
+    stage2_uniskip_proof: SumcheckProof<Fr, Bn254G1>,
+    stage2_batch_proof: SumcheckProof<Fr, Bn254G1>,
+    trace_length: usize,
+    ram_k: usize,
+) -> jolt_verifier::proof::JoltProof<
+    jolt_openings::mock::MockCommitmentScheme<Fr>,
+    Pedersen<Bn254G1>,
+    (),
+> {
+    type MockPcs = jolt_openings::mock::MockCommitmentScheme<Fr>;
+    let commitment = <MockPcs as Commitment>::Output::default();
+    let commitments = jolt_verifier::proof::JoltCommitments::new(
+        commitment.clone(),
+        commitment,
+        jolt_verifier::proof::JoltRaCommitments::new(Vec::new(), Vec::new(), Vec::new()),
+    );
+    stage2_zk_proof_with_commitments(
+        commitments,
+        stage1_uniskip_proof,
+        stage1_remainder_proof,
+        stage2_uniskip_proof,
+        stage2_batch_proof,
+        trace_length,
+        ram_k,
+    )
+}
+
+#[cfg(feature = "zk")]
+fn stage2_zk_proof_with_commitments(
+    commitments: jolt_verifier::proof::JoltCommitments<
+        <jolt_openings::mock::MockCommitmentScheme<Fr> as Commitment>::Output,
+    >,
+    stage1_uniskip_proof: SumcheckProof<Fr, Bn254G1>,
+    stage1_remainder_proof: SumcheckProof<Fr, Bn254G1>,
+    stage2_uniskip_proof: SumcheckProof<Fr, Bn254G1>,
+    stage2_batch_proof: SumcheckProof<Fr, Bn254G1>,
+    trace_length: usize,
+    ram_k: usize,
+) -> jolt_verifier::proof::JoltProof<
+    jolt_openings::mock::MockCommitmentScheme<Fr>,
+    Pedersen<Bn254G1>,
+    (),
+> {
+    type MockPcs = jolt_openings::mock::MockCommitmentScheme<Fr>;
+    let empty = SumcheckProof::Clear(ClearProof::Full(ClearSumcheckProof::default()));
+    let stages = jolt_verifier::proof::JoltStageProofs {
+        stage1_uni_skip_first_round_proof: stage1_uniskip_proof,
+        stage1_sumcheck_proof: stage1_remainder_proof,
+        stage2_uni_skip_first_round_proof: stage2_uniskip_proof,
+        stage2_sumcheck_proof: stage2_batch_proof,
+        stage3_sumcheck_proof: empty.clone(),
+        stage4_sumcheck_proof: empty.clone(),
+        stage5_sumcheck_proof: empty.clone(),
+        stage6a_sumcheck_proof: empty.clone(),
+        stage6b_sumcheck_proof: empty.clone(),
+        stage7_sumcheck_proof: empty,
+    };
+    let poly = Polynomial::new(vec![Fr::from_u64(0)]);
+    let mut transcript = Blake2bTranscript::<Fr>::new(b"stage2-zk-opening");
+    let opening_proof = MockPcs::open(&poly, &[], Fr::from_u64(0), &(), None, &mut transcript);
+    jolt_verifier::proof::JoltProof::<MockPcs, Pedersen<Bn254G1>, ()>::new(
+        commitments,
+        stages,
+        opening_proof,
+        None,
+        jolt_verifier::proof::JoltProofClaims::Zk {
+            blindfold_proof: (),
+        },
+        trace_length,
+        ram_k,
+        stage2_config().rw_config,
+        jolt_claims::protocols::jolt::JoltOneHotConfig {
+            log_k_chunk: 4,
+            lookups_ra_virtual_log_k_chunk: 16,
+        },
+        jolt_verifier::proof::TracePolynomialOrder::AddressMajor,
+    )
+}
+
+#[cfg(feature = "zk")]
+fn pedersen_setup(capacity: usize) -> PedersenSetup<Bn254G1> {
+    let generator = Bn254::g1_generator();
+    let message_generators = (1..=capacity)
+        .map(|index| generator.scalar_mul(&Fr::from_u64(index as u64)))
+        .collect();
+    PedersenSetup::new(message_generators, generator.scalar_mul(&Fr::from_u64(99)))
+}
+
+#[cfg(feature = "zk")]
+#[derive(Clone, Debug)]
+struct SatisfyingStage2Witness {
+    final_ram_state: Vec<u64>,
+}
+
+#[cfg(feature = "zk")]
+impl WitnessProvider<Fr, JoltVmNamespace> for SatisfyingStage2Witness {
+    fn describe_oracle(
+        &self,
+        oracle: OracleRef<JoltVmNamespace>,
+    ) -> Result<OracleDescriptor<JoltVmNamespace>, WitnessError> {
+        let dimensions = match oracle {
+            OracleRef::Virtual(
+                jolt_claims::protocols::jolt::JoltVirtualPolynomial::RamVal
+                | jolt_claims::protocols::jolt::JoltVirtualPolynomial::RamRa,
+            ) => WitnessDimensions::new(8),
+            OracleRef::Committed(_) | OracleRef::Virtual(_) => WitnessDimensions::new(4),
+        };
+        Ok(OracleDescriptor::new(
+            oracle,
+            dimensions,
+            PolynomialEncoding::Dense,
+        ))
+    }
+
+    fn view_requirements(
+        &self,
+        oracle: OracleRef<JoltVmNamespace>,
+    ) -> Result<Vec<ViewRequirement<JoltVmNamespace>>, WitnessError> {
+        let descriptor = self.describe_oracle(oracle)?;
+        Ok(vec![ViewRequirement::new(
+            descriptor.reference,
+            descriptor.encoding,
+            MaterializationPolicy::BackendChoice,
+            RetentionHint::ThroughStage8,
+        )])
+    }
+
+    fn oracle_view(
+        &self,
+        requirement: ViewRequirement<JoltVmNamespace>,
+    ) -> Result<PolynomialView<'_, Fr, JoltVmNamespace>, WitnessError> {
+        let descriptor = self.describe_oracle(requirement.oracle)?;
+        let rows = descriptor.dimensions.rows();
+        let values = match requirement.oracle {
+            OracleRef::Virtual(
+                jolt_claims::protocols::jolt::JoltVirtualPolynomial::NextUnexpandedPC,
+            ) => vec![Fr::from_u64(4); rows],
+            OracleRef::Virtual(
+                jolt_claims::protocols::jolt::JoltVirtualPolynomial::RamValFinal,
+            ) => self
+                .final_ram_state
+                .iter()
+                .copied()
+                .map(Fr::from_u64)
+                .collect(),
+            _ => vec![Fr::from_u64(0); rows],
+        };
+        Ok(PolynomialView::owned(descriptor, values))
+    }
+}
+
+#[cfg(feature = "zk")]
+impl JoltVmSpartanOuterRows for SatisfyingStage2Witness {
+    fn spartan_outer_rows(&self) -> Result<Vec<JoltVmSpartanOuterRow>, WitnessError> {
+        Ok(vec![
+            JoltVmSpartanOuterRow {
+                left_instruction_input: 0,
+                right_instruction_input: 0,
+                product_magnitude: 0,
+                product_is_positive: false,
+                should_branch: false,
+                pc: 0,
+                unexpanded_pc: 0,
+                imm: 0,
+                ram_address: 0,
+                rs1_value: 0,
+                rs2_value: 0,
+                rd_write_value: 0,
+                ram_read_value: 0,
+                ram_write_value: 0,
+                left_lookup_operand: 0,
+                right_lookup_operand: 0,
+                next_unexpanded_pc: 4,
+                next_pc: 0,
+                next_is_virtual: false,
+                next_is_first_in_sequence: false,
+                lookup_output: 0,
+                should_jump: false,
+                flag_add_operands: false,
+                flag_subtract_operands: false,
+                flag_multiply_operands: false,
+                flag_load: false,
+                flag_store: false,
+                flag_jump: false,
+                flag_write_lookup_output_to_rd: false,
+                flag_virtual_instruction: false,
+                flag_assert: false,
+                flag_do_not_update_unexpanded_pc: false,
+                flag_advice: false,
+                flag_is_compressed: false,
+                flag_is_first_in_sequence: false,
+                flag_is_last_in_sequence: false,
+            };
+            16
+        ])
+    }
+}
+
+#[cfg(feature = "zk")]
+impl JoltVmStage2Rows for SatisfyingStage2Witness {
+    fn stage2_rows(&self) -> Result<Vec<JoltVmStage2TraceRow>, WitnessError> {
+        Ok(vec![
+            JoltVmStage2TraceRow {
+                remapped_ram_address: None,
+                ram_read_value: 0,
+                ram_write_value: 0,
+                ram_increment: 0,
+                left_instruction_input: 0,
+                right_instruction_input: 0,
+                lookup_output: 0,
+                left_lookup_operand: 0,
+                right_lookup_operand: 0,
+                branch_flag: false,
+                jump_flag: false,
+                write_lookup_output_to_rd_flag: false,
+                virtual_instruction_flag: false,
+                next_is_noop: false,
+            };
+            16
+        ])
+    }
+
+    fn initial_ram_state_words(&self) -> Result<Vec<u64>, WitnessError> {
+        Ok(vec![0; 16])
+    }
+
+    fn final_ram_state_words(&self) -> Result<Vec<u64>, WitnessError> {
+        Ok(self.final_ram_state.clone())
+    }
+}

--- a/crates/jolt-prover/src/stages/stage3/mod.rs
+++ b/crates/jolt-prover/src/stages/stage3/mod.rs
@@ -1,0 +1,1 @@
+pub mod prove;

--- a/crates/jolt-prover/src/stages/stage3/prove.rs
+++ b/crates/jolt-prover/src/stages/stage3/prove.rs
@@ -1,0 +1,973 @@
+use jolt_backends::{
+    stage3_shift_rows, Stage3SpartanSumcheckBackend, SumcheckBackend, SumcheckRegularBatchInstance,
+    SumcheckRegularBatchLinearFactor, SumcheckRegularBatchLinearTerm, SumcheckRegularBatchProduct,
+    SumcheckRegularBatchState, SumcheckStage3ShiftStateRequest,
+};
+use jolt_claims::protocols::jolt::TraceDimensions;
+#[cfg(feature = "zk")]
+use jolt_crypto::VectorCommitment;
+use jolt_field::Field;
+use jolt_poly::{thread::unsafe_allocate_zero_vec, EqPolynomial, Polynomial, UnivariatePoly};
+use jolt_sumcheck::SumcheckProof;
+use jolt_transcript::Transcript;
+use jolt_verifier::stages::relations::SumcheckInstance;
+use jolt_verifier::stages::{
+    stage1::Stage1ClearOutput,
+    stage2::Stage2ClearOutput,
+    stage3::instruction_input::{InstructionInput, InstructionInputInputClaims},
+    stage3::outputs::{
+        InstructionInputOutputClaims, RegistersClaimReductionOutputClaims,
+        SpartanShiftOutputClaims, Stage3OutputClaims,
+    },
+    stage3::outputs::{Stage3Challenges, Stage3ClearOutput},
+    stage3::registers_claim_reduction::{
+        RegistersClaimReduction, RegistersClaimReductionInputClaims,
+    },
+    stage3::spartan_shift::{SpartanShift, SpartanShiftInputClaims},
+    stage3::{stage3_expected_final_claim, stage3_output_claims_with_points},
+};
+use jolt_verifier::{CheckedInputs, VerifierError};
+use jolt_witness::{
+    protocols::jolt_vm::{
+        JoltVmNamespace, JoltVmStage3InstructionRegisterRows, JoltVmStage3ShiftRows,
+    },
+    WitnessProvider,
+};
+use rayon::prelude::*;
+
+#[cfg(feature = "zk")]
+use crate::committed::CommittedSumcheckWitness;
+use crate::stages::invalid_sumcheck_output;
+#[cfg(feature = "zk")]
+use crate::stages::recorder::CommittedSumcheckRecorder;
+use crate::stages::recorder::{ClearSumcheckRecorder, SumcheckRecorder};
+use crate::ProverError;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Stage3ProverConfig {
+    pub log_t: usize,
+}
+
+impl Stage3ProverConfig {
+    pub const fn new(log_t: usize) -> Self {
+        Self { log_t }
+    }
+}
+
+/// Canonical Stage 3 prover input.
+#[derive(Clone, Copy, Debug)]
+pub struct Stage3ProverInput<'a, F: Field, W> {
+    pub config: Stage3ProverConfig,
+    pub checked: &'a CheckedInputs,
+    pub stage1: &'a Stage1ClearOutput<F>,
+    pub stage2: &'a Stage2ClearOutput<F>,
+    pub witness: &'a W,
+}
+
+impl<'a, F: Field, W> Stage3ProverInput<'a, F, W> {
+    pub const fn new(
+        config: Stage3ProverConfig,
+        checked: &'a CheckedInputs,
+        stage1: &'a Stage1ClearOutput<F>,
+        stage2: &'a Stage2ClearOutput<F>,
+        witness: &'a W,
+    ) -> Self {
+        Self {
+            config,
+            checked,
+            stage1,
+            stage2,
+            witness,
+        }
+    }
+}
+
+/// The three Stage 3 sumcheck input claims (claimed sums), one per batched
+/// relation. Computed via the relation objects' `input_claim` so prover and
+/// verifier derive them identically.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct Stage3InputClaims<F: Field> {
+    shift: F,
+    instruction_input: F,
+    registers_claim_reduction: F,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct Stage3RegularBatchPrefixOutput<F: Field> {
+    input_claims: Stage3InputClaims<F>,
+    shift_gamma: F,
+    instruction_gamma: F,
+    registers_gamma: F,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Stage3ProofComponent<F: Field, Proof> {
+    pub stage3_sumcheck_proof: Proof,
+    pub claims: Stage3OutputClaims<F>,
+    pub verifier_output: Stage3ClearOutput<F>,
+}
+
+#[cfg(feature = "zk")]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Stage3CommittedProofComponent<F, VC>
+where
+    F: Field,
+    VC: VectorCommitment<Field = F>,
+{
+    pub stage3_sumcheck_proof: SumcheckProof<F, VC::Output>,
+    pub verifier_output: Stage3ClearOutput<F>,
+    pub output_claim_values: Vec<F>,
+    pub(crate) committed_witness: CommittedSumcheckWitness<F>,
+}
+
+const STAGE3_INSTRUCTION_REGISTER_MATERIALIZE_CHUNK_ROWS: usize = 1 << 14;
+
+/// Canonical Stage 3 prover entrypoint.
+///
+/// Mirrors `jolt-verifier/src/stages/stage3/verify.rs` in prover execution order:
+/// derive the shift/instruction/registers gammas, prove the regular batched
+/// Boolean sumcheck over the three Stage 3 statements, evaluate the output
+/// openings, then assemble the verifier-owned `stage3_sumcheck_proof`,
+/// [`Stage3OutputClaims`], and [`Stage3ClearOutput`] for Stage 4 and later stages.
+///
+/// This single entrypoint is shared across feature modes. ZK committed proof
+/// component assembly is layered on top of the same gamma derivation and
+/// statement order.
+struct Stage3RegularBatchProofOutput<F: Field, C> {
+    proof: SumcheckProof<F, C>,
+    #[cfg(feature = "zk")]
+    committed_witness: Option<CommittedSumcheckWitness<F>>,
+    #[cfg(feature = "zk")]
+    output_claim_values: Option<Vec<F>>,
+    claims: Stage3OutputClaims<F>,
+    verifier_output: Stage3ClearOutput<F>,
+}
+
+fn prove_stage3_regular_batch_sumcheck_with_recorder<F, W, B, T, S>(
+    input: &Stage3ProverInput<'_, F, W>,
+    prefix: &Stage3RegularBatchPrefixOutput<F>,
+    transcript: &mut T,
+    backend: &mut B,
+    mut proof_recorder: S,
+) -> Result<Stage3RegularBatchProofOutput<F, S::Commitment>, ProverError>
+where
+    F: Field,
+    W: WitnessProvider<F, JoltVmNamespace>
+        + JoltVmStage3ShiftRows
+        + JoltVmStage3InstructionRegisterRows,
+    B: SumcheckBackend<F, JoltVmNamespace> + Stage3SpartanSumcheckBackend<F>,
+    T: Transcript<Challenge = F>,
+    S: SumcheckRecorder<F>,
+{
+    let shift_request =
+        build_stage3_shift_state_request(input.config, input.stage2, prefix, input.witness)?;
+    let mut shift_state = backend.materialize_sumcheck_stage3_shift_state(&shift_request)?;
+    let instances = build_stage3_instruction_registers_regular_batch_instances(
+        input.config,
+        input.stage2,
+        prefix,
+        input.witness,
+        backend,
+    )?;
+    let mut regular_state =
+        SumcheckRegularBatchState::new("stage3.instruction_registers_regular_batch", instances);
+    let max_num_rounds = input.config.log_t;
+    for instance in &regular_state.instances {
+        if instance.num_rounds() != max_num_rounds {
+            return Err(invalid_sumcheck_output(format!(
+                "Stage 3 instance {} has {} rounds, expected {max_num_rounds}",
+                instance.label,
+                instance.num_rounds()
+            )));
+        }
+    }
+
+    proof_recorder.absorb_input_claims(
+        &[
+            prefix.input_claims.shift,
+            prefix.input_claims.instruction_input,
+            prefix.input_claims.registers_claim_reduction,
+        ],
+        transcript,
+    );
+    let batching_coefficients = (0..3)
+        .map(|_| transcript.challenge_scalar())
+        .collect::<Vec<_>>();
+    let [shift_coefficient, instruction_coefficient, registers_coefficient] =
+        batching_coefficients.as_slice()
+    else {
+        return Err(invalid_sumcheck_output(
+            "Stage 3 batch expected exactly three batching coefficients",
+        ));
+    };
+
+    let mut shift_claim = prefix.input_claims.shift;
+    let mut regular_claims = vec![
+        prefix.input_claims.instruction_input,
+        prefix.input_claims.registers_claim_reduction,
+    ];
+    let mut running_claim = *shift_coefficient * shift_claim
+        + *instruction_coefficient * regular_claims[0]
+        + *registers_coefficient * regular_claims[1];
+
+    let mut challenges = Vec::with_capacity(max_num_rounds);
+    for round in 0..max_num_rounds {
+        let shift_poly = backend.evaluate_sumcheck_stage3_shift_round(&shift_state, shift_claim)?;
+        let messages = backend.evaluate_sumcheck_regular_batch_round(
+            &mut regular_state,
+            round,
+            max_num_rounds,
+            &regular_claims,
+        )?;
+        if messages.len() != regular_claims.len() {
+            return Err(invalid_sumcheck_output(format!(
+                "Stage 3 instruction/register batch round {round} returned {} messages, expected {}",
+                messages.len(),
+                regular_claims.len()
+            )));
+        }
+        let mut regular_polys = Vec::with_capacity(regular_claims.len());
+        for (expected_index, message) in messages.into_iter().enumerate() {
+            if message.instance_index != expected_index {
+                return Err(invalid_sumcheck_output(format!(
+                    "Stage 3 instruction/register batch round {round} returned instance {}, expected {expected_index}",
+                    message.instance_index
+                )));
+            }
+            regular_polys.push(message.polynomial);
+        }
+
+        let mut batched_poly = &shift_poly * *shift_coefficient;
+        batched_poly += &(&regular_polys[0] * *instruction_coefficient);
+        batched_poly += &(&regular_polys[1] * *registers_coefficient);
+        let round_sum = batched_poly.evaluate(F::zero()) + batched_poly.evaluate(F::one());
+        if round_sum != running_claim {
+            return Err(invalid_sumcheck_output(format!(
+                "Stage 3 regular batch round {round} sumcheck invariant failed"
+            )));
+        }
+
+        let batched_poly = trim_round_polynomial(batched_poly);
+        let challenge = proof_recorder.absorb_round(&batched_poly, transcript)?;
+        running_claim = batched_poly.evaluate(challenge);
+        challenges.push(challenge);
+
+        shift_claim = shift_poly.evaluate(challenge);
+        for (claim, poly) in regular_claims.iter_mut().zip(regular_polys) {
+            *claim = poly.evaluate(challenge);
+        }
+        backend.bind_sumcheck_stage3_shift_state(&mut shift_state, challenge)?;
+        backend.bind_sumcheck_regular_batch_state(
+            &mut regular_state,
+            round,
+            max_num_rounds,
+            challenge,
+        )?;
+    }
+
+    let output_openings =
+        stage3_output_openings_from_bound_states(backend, &shift_state, &regular_state)?;
+
+    let dimensions = TraceDimensions::new(input.config.log_t);
+    let shift_relation = SpartanShift::new(
+        dimensions,
+        prefix.shift_gamma,
+        input.stage2.product_uniskip.tau_low.clone(),
+        input
+            .stage2
+            .output_claims
+            .product_remainder_point()
+            .to_vec(),
+    );
+    let instruction_relation = InstructionInput::new(
+        dimensions,
+        prefix.instruction_gamma,
+        input
+            .stage2
+            .output_claims
+            .product_remainder_point()
+            .to_vec(),
+    );
+    let registers_relation = RegistersClaimReduction::new(
+        dimensions,
+        prefix.registers_gamma,
+        input.stage2.product_uniskip.tau_low.clone(),
+    );
+    let shift_inputs = SpartanShiftInputClaims::from_upstream(input.stage1, input.stage2);
+    let instruction_inputs = InstructionInputInputClaims::from_upstream(input.stage2);
+    let registers_inputs = RegistersClaimReductionInputClaims::from_upstream(input.stage1);
+
+    let to_prover_error = |error: VerifierError| invalid_sumcheck_output(error.to_string());
+    let points = Stage3OutputClaims {
+        shift: shift_relation
+            .derive_opening_points(&challenges, &shift_inputs)
+            .map_err(to_prover_error)?,
+        instruction_input: instruction_relation
+            .derive_opening_points(&challenges, &instruction_inputs)
+            .map_err(to_prover_error)?,
+        registers_claim_reduction: registers_relation
+            .derive_opening_points(&challenges, &registers_inputs)
+            .map_err(to_prover_error)?,
+    };
+    let output_claims = stage3_output_claims_with_points(&output_openings, &points);
+
+    let shift_output = shift_relation
+        .expected_output(&shift_inputs, &output_claims.shift)
+        .map_err(to_prover_error)?;
+    let instruction_output = instruction_relation
+        .expected_output(&instruction_inputs, &output_claims.instruction_input)
+        .map_err(to_prover_error)?;
+    let registers_output = registers_relation
+        .expected_output(&registers_inputs, &output_claims.registers_claim_reduction)
+        .map_err(to_prover_error)?;
+    let expected_final_claim = stage3_expected_final_claim(
+        &batching_coefficients,
+        shift_output,
+        instruction_output,
+        registers_output,
+    )
+    .map_err(to_prover_error)?;
+    if running_claim != expected_final_claim {
+        return Err(invalid_sumcheck_output(
+            "Stage 3 batch final claim did not match output openings",
+        ));
+    }
+
+    // Enforce the cross-relation opening aliases (mirrors the verifier's validate).
+    output_openings.validate().map_err(to_prover_error)?;
+
+    let output_claim_values = output_openings.opening_values();
+    let verifier_output = Stage3ClearOutput {
+        challenges: Stage3Challenges {
+            shift_gamma: prefix.shift_gamma,
+            instruction_gamma: prefix.instruction_gamma,
+            registers_gamma: prefix.registers_gamma,
+        },
+        output_claims,
+    };
+    let recorded = proof_recorder.finish(&output_claim_values, transcript)?;
+
+    Ok(Stage3RegularBatchProofOutput {
+        proof: recorded.proof,
+        #[cfg(feature = "zk")]
+        committed_witness: recorded.committed_witness,
+        #[cfg(feature = "zk")]
+        output_claim_values: recorded.output_claim_values,
+        claims: output_openings,
+        verifier_output,
+    })
+}
+
+pub fn prove<F, W, B, T, C>(
+    input: Stage3ProverInput<'_, F, W>,
+    backend: &mut B,
+    transcript: &mut T,
+) -> Result<Stage3ProofComponent<F, SumcheckProof<F, C>>, ProverError>
+where
+    F: Field,
+    W: WitnessProvider<F, JoltVmNamespace>
+        + JoltVmStage3ShiftRows
+        + JoltVmStage3InstructionRegisterRows,
+    B: SumcheckBackend<F, JoltVmNamespace> + Stage3SpartanSumcheckBackend<F>,
+    T: Transcript<Challenge = F>,
+{
+    if input.checked.zk {
+        return Err(ProverError::InvalidStageRequest {
+            reason: "Stage 3 clear prover received ZK checked inputs".to_owned(),
+        });
+    }
+    if input.checked.trace_length != (1usize << input.config.log_t) {
+        return Err(ProverError::InvalidStageRequest {
+            reason: format!(
+                "Stage 3 checked trace length {} does not match log_t {}",
+                input.checked.trace_length, input.config.log_t
+            ),
+        });
+    }
+
+    let prefix =
+        derive_stage3_regular_batch_prefix(input.config, input.stage1, input.stage2, transcript)?;
+    let output = prove_stage3_regular_batch_sumcheck_with_recorder(
+        &input,
+        &prefix,
+        transcript,
+        backend,
+        ClearSumcheckRecorder::<F, C>::new(input.config.log_t),
+    )?;
+
+    Ok(Stage3ProofComponent {
+        stage3_sumcheck_proof: output.proof,
+        claims: output.claims,
+        verifier_output: output.verifier_output,
+    })
+}
+
+#[cfg(feature = "zk")]
+pub fn prove_committed_proof_component<F, W, B, T, VC>(
+    input: Stage3ProverInput<'_, F, W>,
+    backend: &mut B,
+    transcript: &mut T,
+    vc_setup: &VC::Setup,
+) -> Result<Stage3CommittedProofComponent<F, VC>, ProverError>
+where
+    F: Field,
+    W: WitnessProvider<F, JoltVmNamespace>
+        + JoltVmStage3ShiftRows
+        + JoltVmStage3InstructionRegisterRows,
+    B: SumcheckBackend<F, JoltVmNamespace> + Stage3SpartanSumcheckBackend<F>,
+    T: Transcript<Challenge = F>,
+    VC: VectorCommitment<Field = F>,
+{
+    if !input.checked.zk {
+        return Err(ProverError::InvalidStageRequest {
+            reason: "Stage 3 committed proof component prover received transparent checked inputs"
+                .to_owned(),
+        });
+    }
+    if input.checked.trace_length != (1usize << input.config.log_t) {
+        return Err(ProverError::InvalidStageRequest {
+            reason: format!(
+                "Stage 3 checked trace length {} does not match log_t {}",
+                input.checked.trace_length, input.config.log_t
+            ),
+        });
+    }
+
+    let prefix =
+        derive_stage3_regular_batch_prefix(input.config, input.stage1, input.stage2, transcript)?;
+    let output = prove_stage3_regular_batch_sumcheck_with_recorder(
+        &input,
+        &prefix,
+        transcript,
+        backend,
+        CommittedSumcheckRecorder::<F, VC>::new(vc_setup)?,
+    )?;
+
+    Ok(Stage3CommittedProofComponent {
+        stage3_sumcheck_proof: output.proof,
+        output_claim_values: output.output_claim_values.ok_or_else(|| {
+            invalid_sumcheck_output("Stage 3 committed output claim values are missing")
+        })?,
+        verifier_output: output.verifier_output,
+        committed_witness: output.committed_witness.ok_or_else(|| {
+            invalid_sumcheck_output("Stage 3 committed witness material is missing")
+        })?,
+    })
+}
+
+fn build_stage3_shift_state_request<F, W>(
+    config: Stage3ProverConfig,
+    stage2: &Stage2ClearOutput<F>,
+    prefix: &Stage3RegularBatchPrefixOutput<F>,
+    witness: &W,
+) -> Result<SumcheckStage3ShiftStateRequest<F>, ProverError>
+where
+    F: Field,
+    W: JoltVmStage3ShiftRows,
+{
+    let rows = stage3_shift_rows(witness, config.log_t)?;
+    Ok(SumcheckStage3ShiftStateRequest::new(
+        "stage3.shift.prefix_suffix",
+        config.log_t,
+        stage2.product_uniskip.tau_low.clone(),
+        stage2.output_claims.product_remainder_point().to_vec(),
+        prefix.shift_gamma,
+        rows,
+    ))
+}
+
+fn stage3_instruction_register_reversed_columns_from_rows<F, W>(
+    config: Stage3ProverConfig,
+    witness: &W,
+    bit_reversed_indices: &[usize],
+    eq_product: &[F],
+    eq_spartan: &[F],
+) -> Result<Vec<Vec<F>>, ProverError>
+where
+    F: Field,
+    W: JoltVmStage3InstructionRegisterRows,
+{
+    let rows = witness.stage3_instruction_register_rows(config.log_t)?;
+    let row_count = checked_stage3_len(config.log_t, "Stage 3 instruction/register trace length")?;
+    validate_stage3_row_count(config, rows.len(), "instruction/register row cache")?;
+    if bit_reversed_indices.len() != row_count {
+        return Err(invalid_sumcheck_output(format!(
+            "Stage 3 instruction/register bit-reversal table has {} entries, expected {row_count}",
+            bit_reversed_indices.len()
+        )));
+    }
+    if eq_product.len() != row_count || eq_spartan.len() != row_count {
+        return Err(invalid_sumcheck_output(format!(
+            "Stage 3 instruction/register eq tables have lengths {} and {}, expected {row_count}",
+            eq_product.len(),
+            eq_spartan.len()
+        )));
+    }
+    let mut instruction_eq_product = unsafe_allocate_zero_vec(row_count);
+    let mut right_operand_is_rs2 = unsafe_allocate_zero_vec(row_count);
+    let mut rs2_value = unsafe_allocate_zero_vec(row_count);
+    let mut right_operand_is_imm = unsafe_allocate_zero_vec(row_count);
+    let mut imm = unsafe_allocate_zero_vec(row_count);
+    let mut left_operand_is_rs1 = unsafe_allocate_zero_vec(row_count);
+    let mut rs1_value = unsafe_allocate_zero_vec(row_count);
+    let mut left_operand_is_pc = unsafe_allocate_zero_vec(row_count);
+    let mut unexpanded_pc = unsafe_allocate_zero_vec(row_count);
+    let mut registers_eq_spartan = unsafe_allocate_zero_vec(row_count);
+    let mut rd_write_value = unsafe_allocate_zero_vec(row_count);
+    let mut registers_rs1_value = unsafe_allocate_zero_vec(row_count);
+    let mut registers_rs2_value = unsafe_allocate_zero_vec(row_count);
+
+    instruction_eq_product
+        .par_chunks_mut(STAGE3_INSTRUCTION_REGISTER_MATERIALIZE_CHUNK_ROWS)
+        .zip(
+            right_operand_is_rs2.par_chunks_mut(STAGE3_INSTRUCTION_REGISTER_MATERIALIZE_CHUNK_ROWS),
+        )
+        .zip(rs2_value.par_chunks_mut(STAGE3_INSTRUCTION_REGISTER_MATERIALIZE_CHUNK_ROWS))
+        .zip(
+            right_operand_is_imm.par_chunks_mut(STAGE3_INSTRUCTION_REGISTER_MATERIALIZE_CHUNK_ROWS),
+        )
+        .zip(imm.par_chunks_mut(STAGE3_INSTRUCTION_REGISTER_MATERIALIZE_CHUNK_ROWS))
+        .zip(left_operand_is_rs1.par_chunks_mut(STAGE3_INSTRUCTION_REGISTER_MATERIALIZE_CHUNK_ROWS))
+        .zip(rs1_value.par_chunks_mut(STAGE3_INSTRUCTION_REGISTER_MATERIALIZE_CHUNK_ROWS))
+        .zip(left_operand_is_pc.par_chunks_mut(STAGE3_INSTRUCTION_REGISTER_MATERIALIZE_CHUNK_ROWS))
+        .zip(unexpanded_pc.par_chunks_mut(STAGE3_INSTRUCTION_REGISTER_MATERIALIZE_CHUNK_ROWS))
+        .zip(
+            registers_eq_spartan.par_chunks_mut(STAGE3_INSTRUCTION_REGISTER_MATERIALIZE_CHUNK_ROWS),
+        )
+        .zip(rd_write_value.par_chunks_mut(STAGE3_INSTRUCTION_REGISTER_MATERIALIZE_CHUNK_ROWS))
+        .zip(registers_rs1_value.par_chunks_mut(STAGE3_INSTRUCTION_REGISTER_MATERIALIZE_CHUNK_ROWS))
+        .zip(registers_rs2_value.par_chunks_mut(STAGE3_INSTRUCTION_REGISTER_MATERIALIZE_CHUNK_ROWS))
+        .enumerate()
+        .for_each(|(chunk_index, chunks)| {
+            let (
+                (
+                    (
+                        (
+                            (
+                                (
+                                    (
+                                        (
+                                            (
+                                                (
+                                                    (
+                                                        (
+                                                            instruction_eq_product,
+                                                            right_operand_is_rs2,
+                                                        ),
+                                                        rs2_value,
+                                                    ),
+                                                    right_operand_is_imm,
+                                                ),
+                                                imm,
+                                            ),
+                                            left_operand_is_rs1,
+                                        ),
+                                        rs1_value,
+                                    ),
+                                    left_operand_is_pc,
+                                ),
+                                unexpanded_pc,
+                            ),
+                            registers_eq_spartan,
+                        ),
+                        rd_write_value,
+                    ),
+                    registers_rs1_value,
+                ),
+                registers_rs2_value,
+            ) = chunks;
+            let start = chunk_index * STAGE3_INSTRUCTION_REGISTER_MATERIALIZE_CHUNK_ROWS;
+            for offset in 0..instruction_eq_product.len() {
+                let cycle = bit_reversed_indices[start + offset];
+                let row = &rows[cycle];
+                let rs2 = F::from_u64(row.rs2_value);
+                let rs1 = F::from_u64(row.rs1_value);
+
+                instruction_eq_product[offset] = eq_product[cycle];
+                right_operand_is_rs2[offset] = F::from_bool(row.right_operand_is_rs2);
+                rs2_value[offset] = rs2;
+                right_operand_is_imm[offset] = F::from_bool(row.right_operand_is_imm);
+                imm[offset] = F::from_i128(row.imm);
+                left_operand_is_rs1[offset] = F::from_bool(row.left_operand_is_rs1);
+                rs1_value[offset] = rs1;
+                left_operand_is_pc[offset] = F::from_bool(row.left_operand_is_pc);
+                unexpanded_pc[offset] = F::from_u64(row.unexpanded_pc);
+                registers_eq_spartan[offset] = eq_spartan[cycle];
+                rd_write_value[offset] = F::from_u64(row.rd_write_value);
+                registers_rs1_value[offset] = rs1;
+                registers_rs2_value[offset] = rs2;
+            }
+        });
+
+    Ok(vec![
+        instruction_eq_product,
+        right_operand_is_rs2,
+        rs2_value,
+        right_operand_is_imm,
+        imm,
+        left_operand_is_rs1,
+        rs1_value,
+        left_operand_is_pc,
+        unexpanded_pc,
+        registers_eq_spartan,
+        rd_write_value,
+        registers_rs1_value,
+        registers_rs2_value,
+    ])
+}
+
+fn build_stage3_instruction_registers_regular_batch_instances<F, W, B>(
+    config: Stage3ProverConfig,
+    stage2: &Stage2ClearOutput<F>,
+    prefix: &Stage3RegularBatchPrefixOutput<F>,
+    witness: &W,
+    _backend: &mut B,
+) -> Result<Vec<SumcheckRegularBatchInstance<F>>, ProverError>
+where
+    F: Field,
+    W: JoltVmStage3InstructionRegisterRows,
+    B: SumcheckBackend<F, JoltVmNamespace>,
+{
+    let bit_reversed_indices = stage3_bit_reversed_indices(config)?;
+
+    let eq_product =
+        EqPolynomial::new(stage2.output_claims.product_remainder_point().to_vec()).evaluations();
+    let eq_spartan = EqPolynomial::new(stage2.product_uniskip.tau_low.clone()).evaluations();
+    let mut columns = stage3_instruction_register_reversed_columns_from_rows(
+        config,
+        witness,
+        &bit_reversed_indices,
+        &eq_product,
+        &eq_spartan,
+    )?
+    .into_iter();
+    let mut next_column = |label: &'static str| {
+        columns.next().ok_or_else(|| {
+            invalid_sumcheck_output(format!("Stage 3 missing materialized column {label}"))
+        })
+    };
+    let instruction_gamma = prefix.instruction_gamma;
+    let registers_gamma = prefix.registers_gamma;
+    let registers_gamma2 = registers_gamma * registers_gamma;
+
+    let instruction_input = SumcheckRegularBatchInstance::new_products(
+        "stage3.instruction_input",
+        prefix.input_claims.instruction_input,
+        vec![
+            Polynomial::new(next_column("instruction product eq")?),
+            Polynomial::new(next_column("instruction right operand is rs2")?),
+            Polynomial::new(next_column("instruction rs2 value")?),
+            Polynomial::new(next_column("instruction right operand is imm")?),
+            Polynomial::new(next_column("instruction immediate")?),
+            Polynomial::new(next_column("instruction left operand is rs1")?),
+            Polynomial::new(next_column("instruction rs1 value")?),
+            Polynomial::new(next_column("instruction left operand is PC")?),
+            Polynomial::new(next_column("instruction unexpanded PC")?),
+        ],
+        vec![
+            SumcheckRegularBatchProduct::new(
+                F::one(),
+                vec![
+                    batch_factor(vec![batch_term(0, F::one())]),
+                    batch_factor(vec![batch_term(1, F::one())]),
+                    batch_factor(vec![batch_term(2, F::one())]),
+                ],
+            ),
+            SumcheckRegularBatchProduct::new(
+                F::one(),
+                vec![
+                    batch_factor(vec![batch_term(0, F::one())]),
+                    batch_factor(vec![batch_term(3, F::one())]),
+                    batch_factor(vec![batch_term(4, F::one())]),
+                ],
+            ),
+            SumcheckRegularBatchProduct::new(
+                instruction_gamma,
+                vec![
+                    batch_factor(vec![batch_term(0, F::one())]),
+                    batch_factor(vec![batch_term(5, F::one())]),
+                    batch_factor(vec![batch_term(6, F::one())]),
+                ],
+            ),
+            SumcheckRegularBatchProduct::new(
+                instruction_gamma,
+                vec![
+                    batch_factor(vec![batch_term(0, F::one())]),
+                    batch_factor(vec![batch_term(7, F::one())]),
+                    batch_factor(vec![batch_term(8, F::one())]),
+                ],
+            ),
+        ],
+    );
+
+    let registers_claim_reduction = SumcheckRegularBatchInstance::new_products(
+        "stage3.registers_claim_reduction",
+        prefix.input_claims.registers_claim_reduction,
+        vec![
+            Polynomial::new(next_column("registers Spartan eq")?),
+            Polynomial::new(next_column("registers rd write value")?),
+            Polynomial::new(next_column("registers rs1 value")?),
+            Polynomial::new(next_column("registers rs2 value")?),
+        ],
+        vec![SumcheckRegularBatchProduct::new(
+            F::one(),
+            vec![
+                batch_factor(vec![batch_term(0, F::one())]),
+                batch_factor(vec![
+                    batch_term(1, F::one()),
+                    batch_term(2, registers_gamma),
+                    batch_term(3, registers_gamma2),
+                ]),
+            ],
+        )],
+    );
+
+    Ok(vec![instruction_input, registers_claim_reduction])
+}
+
+fn stage3_output_openings_from_bound_states<F, B>(
+    backend: &mut B,
+    shift_state: &B::Stage3ShiftState,
+    regular_state: &SumcheckRegularBatchState<F>,
+) -> Result<Stage3OutputClaims<F>, ProverError>
+where
+    F: Field,
+    B: Stage3SpartanSumcheckBackend<F>,
+{
+    let [unexpanded_pc, pc, is_virtual, is_first_in_sequence, is_noop] =
+        backend.stage3_shift_output_openings(shift_state)?;
+    let instruction_instance = regular_state.instances.first().ok_or_else(|| {
+        invalid_sumcheck_output("Stage 3 regular state is missing instruction input instance")
+    })?;
+    let registers_instance = regular_state.instances.get(1).ok_or_else(|| {
+        invalid_sumcheck_output("Stage 3 regular state is missing registers instance")
+    })?;
+
+    Ok(Stage3OutputClaims {
+        shift: SpartanShiftOutputClaims {
+            unexpanded_pc,
+            pc,
+            is_virtual,
+            is_first_in_sequence,
+            is_noop,
+        },
+        instruction_input: InstructionInputOutputClaims {
+            right_operand_is_rs2: final_regular_polynomial_value(
+                instruction_instance,
+                1,
+                "instruction right operand is rs2",
+            )?,
+            rs2_value: final_regular_polynomial_value(
+                instruction_instance,
+                2,
+                "instruction rs2 value",
+            )?,
+            right_operand_is_imm: final_regular_polynomial_value(
+                instruction_instance,
+                3,
+                "instruction right operand is imm",
+            )?,
+            imm: final_regular_polynomial_value(instruction_instance, 4, "instruction immediate")?,
+            left_operand_is_rs1: final_regular_polynomial_value(
+                instruction_instance,
+                5,
+                "instruction left operand is rs1",
+            )?,
+            rs1_value: final_regular_polynomial_value(
+                instruction_instance,
+                6,
+                "instruction rs1 value",
+            )?,
+            left_operand_is_pc: final_regular_polynomial_value(
+                instruction_instance,
+                7,
+                "instruction left operand is PC",
+            )?,
+            unexpanded_pc: final_regular_polynomial_value(
+                instruction_instance,
+                8,
+                "instruction unexpanded PC",
+            )?,
+        },
+        registers_claim_reduction: RegistersClaimReductionOutputClaims {
+            rd_write_value: final_regular_polynomial_value(
+                registers_instance,
+                1,
+                "registers rd write value",
+            )?,
+            rs1_value: final_regular_polynomial_value(
+                registers_instance,
+                2,
+                "registers rs1 value",
+            )?,
+            rs2_value: final_regular_polynomial_value(
+                registers_instance,
+                3,
+                "registers rs2 value",
+            )?,
+        },
+    })
+}
+
+fn final_regular_polynomial_value<F: Field>(
+    instance: &SumcheckRegularBatchInstance<F>,
+    polynomial_index: usize,
+    label: &'static str,
+) -> Result<F, ProverError> {
+    let polynomial = instance.polynomials.get(polynomial_index).ok_or_else(|| {
+        invalid_sumcheck_output(format!(
+            "Stage 3 regular instance {} is missing polynomial {polynomial_index} ({label})",
+            instance.label
+        ))
+    })?;
+    let [value] = polynomial.evaluations() else {
+        return Err(invalid_sumcheck_output(format!(
+            "Stage 3 regular instance {} polynomial {polynomial_index} ({label}) has {} evaluations, expected 1",
+            instance.label,
+            polynomial.len()
+        )));
+    };
+    Ok(*value)
+}
+
+/// Dense/materialized Stage 3 batch driver retained as a reference path for
+/// correctness tests. Production proving should use the prefix/suffix shift
+/// path above.
+fn batch_term<F: Field>(polynomial: usize, coefficient: F) -> SumcheckRegularBatchLinearTerm<F> {
+    SumcheckRegularBatchLinearTerm::new(polynomial, coefficient)
+}
+
+fn batch_factor<F: Field>(
+    terms: Vec<SumcheckRegularBatchLinearTerm<F>>,
+) -> SumcheckRegularBatchLinearFactor<F> {
+    SumcheckRegularBatchLinearFactor::from_terms(terms)
+}
+
+fn stage3_bit_reversed_indices(config: Stage3ProverConfig) -> Result<Vec<usize>, ProverError> {
+    let expected_len = 1usize.checked_shl(config.log_t as u32).ok_or_else(|| {
+        invalid_sumcheck_output(format!(
+            "Stage 3 trace length overflows for log_t={}",
+            config.log_t
+        ))
+    })?;
+    Ok((0..expected_len)
+        .map(|index| bit_reverse(index, config.log_t))
+        .collect())
+}
+
+fn bit_reverse(index: usize, bits: usize) -> usize {
+    let mut reversed = 0usize;
+    for position in 0..bits {
+        reversed <<= 1;
+        reversed |= (index >> position) & 1;
+    }
+    reversed
+}
+
+fn trim_round_polynomial<F: Field>(poly: UnivariatePoly<F>) -> UnivariatePoly<F> {
+    let mut coefficients = poly.into_coefficients();
+    while coefficients.len() > 2 && coefficients.last().is_some_and(|value| *value == F::zero()) {
+        let _ = coefficients.pop();
+    }
+    UnivariatePoly::new(coefficients)
+}
+
+fn derive_stage3_regular_batch_prefix<F, T>(
+    config: Stage3ProverConfig,
+    stage1: &Stage1ClearOutput<F>,
+    stage2: &Stage2ClearOutput<F>,
+    transcript: &mut T,
+) -> Result<Stage3RegularBatchPrefixOutput<F>, ProverError>
+where
+    F: Field,
+    T: Transcript<Challenge = F>,
+{
+    let expected_rounds = config.log_t;
+    if stage2.output_claims.product_remainder_point().len() != expected_rounds {
+        return Err(ProverError::InvalidStageRequest {
+            reason: format!(
+                "Stage 3 product-remainder dependency has {} variables, expected {expected_rounds}",
+                stage2.output_claims.product_remainder_point().len()
+            ),
+        });
+    }
+    if stage2.output_claims.instruction_claim_reduction_point()
+        != stage2.output_claims.product_remainder_point()
+    {
+        return Err(ProverError::InvalidStageRequest {
+            reason: "Stage 3 instruction input dependencies use different opening points"
+                .to_owned(),
+        });
+    }
+    if stage2.product_uniskip.tau_low.len() != expected_rounds {
+        return Err(ProverError::InvalidStageRequest {
+            reason: format!(
+                "Stage 3 product uni-skip dependency has {} variables, expected {expected_rounds}",
+                stage2.product_uniskip.tau_low.len()
+            ),
+        });
+    }
+
+    let shift_gamma = transcript.challenge_scalar();
+    let instruction_gamma = transcript.challenge_scalar();
+    let registers_gamma = transcript.challenge_scalar();
+
+    let dimensions = TraceDimensions::new(expected_rounds);
+    let shift_relation = SpartanShift::new(
+        dimensions,
+        shift_gamma,
+        stage2.product_uniskip.tau_low.clone(),
+        stage2.output_claims.product_remainder_point().to_vec(),
+    );
+    let instruction_relation = InstructionInput::new(
+        dimensions,
+        instruction_gamma,
+        stage2.output_claims.product_remainder_point().to_vec(),
+    );
+    let registers_relation = RegistersClaimReduction::new(
+        dimensions,
+        registers_gamma,
+        stage2.product_uniskip.tau_low.clone(),
+    );
+    let to_prover_error = |error: VerifierError| invalid_sumcheck_output(error.to_string());
+    let input_claims = Stage3InputClaims {
+        shift: shift_relation
+            .input_claim(&SpartanShiftInputClaims::from_upstream(stage1, stage2))
+            .map_err(to_prover_error)?,
+        instruction_input: instruction_relation
+            .input_claim(&InstructionInputInputClaims::from_upstream(stage2))
+            .map_err(to_prover_error)?,
+        registers_claim_reduction: registers_relation
+            .input_claim(&RegistersClaimReductionInputClaims::from_upstream(stage1))
+            .map_err(to_prover_error)?,
+    };
+
+    Ok(Stage3RegularBatchPrefixOutput {
+        input_claims,
+        shift_gamma,
+        instruction_gamma,
+        registers_gamma,
+    })
+}
+
+fn validate_stage3_row_count(
+    config: Stage3ProverConfig,
+    actual: usize,
+    label: &'static str,
+) -> Result<(), ProverError> {
+    let expected = checked_stage3_len(config.log_t, "Stage 3 trace length")?;
+    if actual == expected {
+        return Ok(());
+    }
+    Err(ProverError::InvalidStageRequest {
+        reason: format!("Stage 3 {label} has {actual} rows, expected {expected}"),
+    })
+}
+
+fn checked_stage3_len(log_len: usize, label: &str) -> Result<usize, ProverError> {
+    1usize
+        .checked_shl(log_len as u32)
+        .ok_or_else(|| ProverError::InvalidStageRequest {
+            reason: format!("{label} overflows for log length {log_len}"),
+        })
+}

--- a/crates/jolt-prover/src/stages/stage4/mod.rs
+++ b/crates/jolt-prover/src/stages/stage4/mod.rs
@@ -1,0 +1,2 @@
+pub(crate) mod prepare;
+pub mod prove;

--- a/crates/jolt-prover/src/stages/stage4/prepare.rs
+++ b/crates/jolt-prover/src/stages/stage4/prepare.rs
@@ -1,0 +1,144 @@
+use jolt_claims::protocols::jolt::JoltAdviceKind;
+use jolt_crypto::VectorCommitment;
+use jolt_field::Field;
+use jolt_openings::CommitmentScheme;
+use jolt_poly::sparse_segments_mle_msb;
+use jolt_program::preprocess::PublicInitialRam;
+use jolt_verifier::stages::relations::OpeningClaim;
+use jolt_verifier::stages::stage4::{
+    ram_val_check_advice_block, RamValCheckInitialEvaluation, VerifiedRamValCheckAdviceContribution,
+};
+use jolt_verifier::{stages::stage2::outputs::Stage2ClearOutput, CheckedInputs};
+
+use crate::{JoltProverPreprocessing, ProverError};
+
+pub(crate) fn ram_val_check_initial_evaluation<PCS, VC>(
+    preprocessing: &JoltProverPreprocessing<PCS, VC>,
+    checked: &CheckedInputs,
+    stage2: &Stage2ClearOutput<PCS::Field>,
+    log_k: usize,
+) -> Result<RamValCheckInitialEvaluation<PCS::Field>, ProverError>
+where
+    PCS: CommitmentScheme,
+    VC: VectorCommitment<Field = PCS::Field>,
+{
+    let opening_point = stage2.output_claims.ram_read_write_point();
+    if opening_point.len() < log_k {
+        return Err(ProverError::InvalidStageRequest {
+            reason: format!(
+                "Stage 4 RAM read-write opening point has {} variables, fewer than log_k {log_k}",
+                opening_point.len()
+            ),
+        });
+    }
+    let (r_address, _) = opening_point.split_at(log_k);
+    let full_program = preprocessing.verifier.program.as_full().ok_or_else(|| {
+        ProverError::InvalidStageRequest {
+            reason: "Stage 4 requires full program preprocessing (committed-program mode is not supported by the prover)".to_string(),
+        }
+    })?;
+    let public_initial_ram =
+        PublicInitialRam::new(&full_program.ram, &checked.public_io).map_err(|error| {
+            ProverError::InvalidStageRequest {
+                reason: format!("Stage 4 public initial RAM construction failed: {error}"),
+            }
+        })?;
+    for segment in &public_initial_ram.segments {
+        let end = segment.start_index + segment.words.len() as u128;
+        if end > checked.ram_K as u128 {
+            return Err(ProverError::InvalidStageRequest {
+                reason: format!(
+                    "Stage 4 public initial RAM segment [{}, {}) exceeds RAM domain {}",
+                    segment.start_index, end, checked.ram_K
+                ),
+            });
+        }
+    }
+
+    let public_eval = sparse_segments_mle_msb(
+        public_initial_ram
+            .segments
+            .iter()
+            .map(|segment| (segment.start_index, segment.words.as_slice())),
+        r_address,
+    );
+    let mut advice_contributions = Vec::new();
+    collect_advice_contribution(
+        JoltAdviceKind::Untrusted,
+        !checked.public_io.untrusted_advice.is_empty(),
+        &checked.public_io.untrusted_advice,
+        checked,
+        r_address,
+        &mut advice_contributions,
+    )?;
+    collect_advice_contribution(
+        JoltAdviceKind::Trusted,
+        checked.trusted_advice_commitment_present,
+        &checked.public_io.trusted_advice,
+        checked,
+        r_address,
+        &mut advice_contributions,
+    )?;
+
+    Ok(RamValCheckInitialEvaluation {
+        public_eval,
+        program_image_contribution: None,
+        advice_contributions,
+    })
+}
+
+fn collect_advice_contribution<F: Field>(
+    kind: JoltAdviceKind,
+    present: bool,
+    bytes: &[u8],
+    checked: &CheckedInputs,
+    r_address: &[F],
+    contributions: &mut Vec<VerifiedRamValCheckAdviceContribution<F>>,
+) -> Result<(), ProverError> {
+    if !present {
+        return Ok(());
+    }
+
+    let max_size = match kind {
+        JoltAdviceKind::Trusted => checked.public_io.memory_layout.max_trusted_advice_size,
+        JoltAdviceKind::Untrusted => checked.public_io.memory_layout.max_untrusted_advice_size,
+    };
+    if bytes.len() > max_size as usize {
+        return Err(ProverError::InvalidStageRequest {
+            reason: format!(
+                "Stage 4 {kind:?} advice has {} bytes, exceeding configured max {max_size}",
+                bytes.len()
+            ),
+        });
+    }
+
+    // The selector and opening point are the shared advice-block geometry the
+    // verifier checks against; compute the opening value here from the witness bytes.
+    let block = ram_val_check_advice_block(kind, checked, r_address).map_err(|error| {
+        ProverError::InvalidStageRequest {
+            reason: error.to_string(),
+        }
+    })?;
+    let words = advice_words_le(bytes);
+    let opening_claim = sparse_segments_mle_msb([(0, words.as_slice())], &block.opening_point);
+    contributions.push(VerifiedRamValCheckAdviceContribution {
+        kind,
+        selector: block.selector,
+        opening: OpeningClaim {
+            point: block.opening_point,
+            value: opening_claim,
+        },
+    });
+    Ok(())
+}
+
+fn advice_words_le(bytes: &[u8]) -> Vec<u64> {
+    bytes
+        .chunks(8)
+        .map(|chunk| {
+            let mut word = [0_u8; 8];
+            word[..chunk.len()].copy_from_slice(chunk);
+            u64::from_le_bytes(word)
+        })
+        .collect()
+}

--- a/crates/jolt-prover/src/stages/stage4/prove.rs
+++ b/crates/jolt-prover/src/stages/stage4/prove.rs
@@ -1,0 +1,722 @@
+use jolt_backends::{
+    ram_read_write_rows, register_read_write_rows, Stage4ReadWriteSumcheckBackend, SumcheckBackend,
+    SumcheckRamValCheckStateRequest, SumcheckRegistersReadWriteStateRequest,
+};
+use jolt_claims::protocols::jolt::{
+    formulas::dimensions::{TraceDimensions, REGISTER_ADDRESS_BITS},
+    JoltAdviceKind, JoltReadWriteConfig,
+};
+#[cfg(feature = "zk")]
+use jolt_crypto::VectorCommitment;
+use jolt_field::Field;
+use jolt_poly::UnivariatePoly;
+use jolt_sumcheck::SumcheckProof;
+use jolt_transcript::Transcript;
+use jolt_verifier::stages::relations::SumcheckInstance;
+use jolt_verifier::stages::stage4::outputs::{Stage4Challenges, Stage4ClearOutput};
+use jolt_verifier::stages::stage4::{
+    append_ram_val_check_gamma_domain_separator, stage4_expected_final_claim,
+    stage4_output_claims_with_points, RamValCheck, RamValCheckAdviceClaims,
+    RamValCheckInitialEvaluation, RamValCheckInputClaims, RamValCheckOutputClaims,
+    RegistersReadWriteChecking, RegistersReadWriteInputClaims, RegistersReadWriteOutputClaims,
+    Stage4OutputClaims,
+};
+use jolt_verifier::stages::{stage2::Stage2ClearOutput, stage3::Stage3ClearOutput};
+use jolt_verifier::CheckedInputs;
+use jolt_witness::protocols::jolt_vm::{JoltVmRegisterReadWriteRows, JoltVmStage2Rows};
+use jolt_witness::{protocols::jolt_vm::JoltVmNamespace, WitnessProvider};
+
+#[cfg(feature = "zk")]
+use crate::committed::CommittedSumcheckWitness;
+use crate::stages::invalid_sumcheck_output;
+#[cfg(feature = "zk")]
+use crate::stages::recorder::CommittedSumcheckRecorder;
+use crate::stages::recorder::{ClearSumcheckRecorder, SumcheckRecorder};
+use crate::ProverError;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Stage4ProverConfig {
+    pub log_t: usize,
+    pub log_k: usize,
+    pub rw_config: JoltReadWriteConfig,
+}
+
+impl Stage4ProverConfig {
+    pub const fn new(log_t: usize, log_k: usize, rw_config: JoltReadWriteConfig) -> Self {
+        Self {
+            log_t,
+            log_k,
+            rw_config,
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct Stage4ProverInput<'a, F: Field, W> {
+    pub config: Stage4ProverConfig,
+    pub checked: &'a CheckedInputs,
+    pub stage2: &'a Stage2ClearOutput<F>,
+    pub stage3: &'a Stage3ClearOutput<F>,
+    pub ram_val_check_init: RamValCheckInitialEvaluation<F>,
+    pub witness: &'a W,
+}
+
+impl<'a, F: Field, W> Stage4ProverInput<'a, F, W> {
+    pub const fn new(
+        config: Stage4ProverConfig,
+        checked: &'a CheckedInputs,
+        stage2: &'a Stage2ClearOutput<F>,
+        stage3: &'a Stage3ClearOutput<F>,
+        ram_val_check_init: RamValCheckInitialEvaluation<F>,
+        witness: &'a W,
+    ) -> Self {
+        Self {
+            config,
+            checked,
+            stage2,
+            stage3,
+            ram_val_check_init,
+            witness,
+        }
+    }
+}
+
+/// The two stage 4 batch input claims, in canonical batch order (registers
+/// read-write, then RAM value-check). Computed once via the shared relation
+/// objects and reused for the sumcheck setup and the verifier output.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct Stage4InputClaims<F: Field> {
+    registers_read_write: F,
+    ram_val_check: F,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct Stage4RegularBatchPrefixOutput<F: Field> {
+    input_claims: Stage4InputClaims<F>,
+    registers_gamma: F,
+    ram_val_check_gamma: F,
+    ram_val_check_init: RamValCheckInitialEvaluation<F>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct Stage4RegularBatchProofOutput<F: Field, C> {
+    prefix: Stage4RegularBatchPrefixOutput<F>,
+    proof: SumcheckProof<F, C>,
+    #[cfg(feature = "zk")]
+    committed_witness: Option<CommittedSumcheckWitness<F>>,
+    #[cfg(feature = "zk")]
+    output_claim_values: Option<Vec<F>>,
+    output_openings: Stage4OutputClaims<F>,
+    registers_read_write_opening_point: Vec<F>,
+    ram_val_check_opening_point: Vec<F>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Stage4ProofComponent<F: Field, Proof> {
+    pub stage4_sumcheck_proof: Proof,
+    pub claims: Stage4OutputClaims<F>,
+    pub verifier_output: Stage4ClearOutput<F>,
+}
+
+#[cfg(feature = "zk")]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Stage4CommittedProofComponent<F, VC>
+where
+    F: Field,
+    VC: VectorCommitment<Field = F>,
+{
+    pub stage4_sumcheck_proof: SumcheckProof<F, VC::Output>,
+    pub challenges: Stage4Challenges<F>,
+    pub verifier_output: Stage4ClearOutput<F>,
+    pub output_claim_values: Vec<F>,
+    pub(crate) committed_witness: CommittedSumcheckWitness<F>,
+}
+
+fn stage4_advice_claims_from_prefix<F: Field>(
+    prefix: &Stage4RegularBatchPrefixOutput<F>,
+) -> Result<RamValCheckAdviceClaims<F>, ProverError> {
+    let mut untrusted = None;
+    let mut trusted = None;
+    for contribution in &prefix.ram_val_check_init.advice_contributions {
+        let target = match contribution.kind {
+            JoltAdviceKind::Trusted => &mut trusted,
+            JoltAdviceKind::Untrusted => &mut untrusted,
+        };
+        if target.replace(contribution.opening.value).is_some() {
+            return Err(invalid_sumcheck_output(format!(
+                "duplicate Stage 4 RAM value-check {:?} advice contribution",
+                contribution.kind
+            )));
+        }
+    }
+    Ok(RamValCheckAdviceClaims { untrusted, trusted })
+}
+
+/// Canonical Stage 4 prover entrypoint (transparent path).
+///
+/// Mirrors `jolt-verifier/src/stages/stage4/verify.rs` in prover order: derive
+/// the register/RAM value-check gammas (with the `ram_val_check_gamma` domain
+/// separator), prove the registers read-write + RAM value-check batched
+/// sumcheck, evaluate output openings, and assemble the verifier-owned
+/// `stage4_sumcheck_proof`, [`Stage4OutputClaims`], and [`Stage4ClearOutput`] for
+/// Stage 5 and later stages.
+///
+/// `ram_val_check_init` is supplied via the input bundle; computing it prover-side
+/// from preprocessing and the advice witness is a tracked self-containment
+/// follow-up. The ZK Stage 4 prover path is not yet implemented.
+pub fn prove<F, W, B, T, C>(
+    input: Stage4ProverInput<'_, F, W>,
+    backend: &mut B,
+    transcript: &mut T,
+) -> Result<Stage4ProofComponent<F, SumcheckProof<F, C>>, ProverError>
+where
+    F: Field,
+    W: WitnessProvider<F, JoltVmNamespace> + JoltVmStage2Rows + JoltVmRegisterReadWriteRows,
+    B: SumcheckBackend<F, JoltVmNamespace> + Stage4ReadWriteSumcheckBackend<F>,
+    T: Transcript<Challenge = F>,
+{
+    if input.checked.zk {
+        return Err(ProverError::InvalidStageRequest {
+            reason: "Stage 4 clear prover received ZK checked inputs".to_owned(),
+        });
+    }
+    if input.checked.trace_length != (1usize << input.config.log_t) {
+        return Err(ProverError::InvalidStageRequest {
+            reason: format!(
+                "Stage 4 checked trace length {} does not match log_t {}",
+                input.checked.trace_length, input.config.log_t
+            ),
+        });
+    }
+    if input.checked.ram_K != (1usize << input.config.log_k) {
+        return Err(ProverError::InvalidStageRequest {
+            reason: format!(
+                "Stage 4 checked RAM K {} does not match log_k {}",
+                input.checked.ram_K, input.config.log_k
+            ),
+        });
+    }
+
+    let prefix = derive_stage4_regular_batch_prefix(
+        input.config,
+        input.stage2,
+        input.stage3,
+        input.ram_val_check_init.clone(),
+        transcript,
+    )?;
+    let proof_output = prove_stage4_specialized_regular_batch_sumcheck::<F, W, B, T, C>(
+        input.config,
+        input.witness,
+        backend,
+        input.stage2,
+        input.stage3,
+        &prefix,
+        transcript,
+    )?;
+
+    let claims = Stage4OutputClaims {
+        advice: proof_output.output_openings.advice.clone(),
+        program_image_contribution: None,
+        registers_read_write: proof_output.output_openings.registers_read_write.clone(),
+        ram_val_check: proof_output.output_openings.ram_val_check.clone(),
+    };
+    let challenges = Stage4Challenges {
+        registers_gamma: prefix.registers_gamma,
+        ram_val_check_gamma: prefix.ram_val_check_gamma,
+    };
+    let ram_val_check_init = prefix.ram_val_check_init.clone();
+    let output_claims = stage4_output_claims_with_points(
+        &claims,
+        &proof_output.registers_read_write_opening_point,
+        &proof_output.ram_val_check_opening_point,
+        &ram_val_check_init,
+    );
+    let verifier_output = Stage4ClearOutput {
+        challenges,
+        output_claims,
+        ram_val_check_init,
+    };
+
+    Ok(Stage4ProofComponent {
+        stage4_sumcheck_proof: proof_output.proof,
+        claims,
+        verifier_output,
+    })
+}
+
+#[cfg(feature = "zk")]
+pub fn prove_committed_proof_component<F, W, B, T, VC>(
+    input: Stage4ProverInput<'_, F, W>,
+    backend: &mut B,
+    transcript: &mut T,
+    vc_setup: &VC::Setup,
+) -> Result<Stage4CommittedProofComponent<F, VC>, ProverError>
+where
+    F: Field,
+    W: WitnessProvider<F, JoltVmNamespace> + JoltVmStage2Rows + JoltVmRegisterReadWriteRows,
+    B: SumcheckBackend<F, JoltVmNamespace> + Stage4ReadWriteSumcheckBackend<F>,
+    T: Transcript<Challenge = F>,
+    VC: VectorCommitment<Field = F>,
+{
+    validate_stage4_committed_checked(input.config, input.checked)?;
+    let prefix = derive_stage4_regular_batch_prefix(
+        input.config,
+        input.stage2,
+        input.stage3,
+        input.ram_val_check_init.clone(),
+        transcript,
+    )?;
+    let output = prove_stage4_committed_specialized_regular_batch_sumcheck::<F, W, B, T, VC>(
+        input.config,
+        input.witness,
+        backend,
+        input.stage2,
+        input.stage3,
+        &prefix,
+        transcript,
+        vc_setup,
+    )?;
+    Ok(output)
+}
+
+fn derive_stage4_regular_batch_prefix<F, T>(
+    config: Stage4ProverConfig,
+    stage2: &Stage2ClearOutput<F>,
+    stage3: &Stage3ClearOutput<F>,
+    ram_val_check_init: RamValCheckInitialEvaluation<F>,
+    transcript: &mut T,
+) -> Result<Stage4RegularBatchPrefixOutput<F>, ProverError>
+where
+    F: Field,
+    T: Transcript<Challenge = F>,
+{
+    validate_stage4_dependencies(config, stage2, stage3)?;
+
+    let registers_gamma = transcript.challenge_scalar();
+
+    append_ram_val_check_gamma_domain_separator(transcript);
+    let ram_val_check_gamma = transcript.challenge_scalar();
+
+    let register_dimensions = config
+        .rw_config
+        .register_dimensions(config.log_t, REGISTER_ADDRESS_BITS);
+    let registers_relation = RegistersReadWriteChecking::new(register_dimensions, registers_gamma);
+    let ram_relation = RamValCheck::new(
+        TraceDimensions::new(config.log_t),
+        config.log_k,
+        ram_val_check_gamma,
+        ram_val_check_init.decomposition(),
+    );
+    let input_claims = Stage4InputClaims {
+        registers_read_write: registers_relation
+            .input_claim(&RegistersReadWriteInputClaims::from_upstream(stage3))
+            .map_err(|error| invalid_sumcheck_output(error.to_string()))?,
+        ram_val_check: ram_relation
+            .input_claim(&RamValCheckInputClaims::from_upstream(
+                stage2,
+                &ram_val_check_init,
+            ))
+            .map_err(|error| invalid_sumcheck_output(error.to_string()))?,
+    };
+
+    Ok(Stage4RegularBatchPrefixOutput {
+        input_claims,
+        registers_gamma,
+        ram_val_check_gamma,
+        ram_val_check_init,
+    })
+}
+
+fn stage4_expected_batch_final_claim<F: Field>(
+    coefficients: &[F],
+    registers_read_write: F,
+    ram_val_check: F,
+) -> Result<F, ProverError> {
+    stage4_expected_final_claim(coefficients, registers_read_write, ram_val_check)
+        .map_err(|error| invalid_sumcheck_output(error.to_string()))
+}
+
+#[derive(Clone, Copy)]
+struct Stage4RegularBatchRunInput<'a, F: Field> {
+    config: Stage4ProverConfig,
+    stage2: &'a Stage2ClearOutput<F>,
+    stage3: &'a Stage3ClearOutput<F>,
+    prefix: &'a Stage4RegularBatchPrefixOutput<F>,
+}
+
+fn prove_stage4_specialized_regular_batch_sumcheck<F, W, B, T, C>(
+    config: Stage4ProverConfig,
+    witness: &W,
+    backend: &mut B,
+    stage2: &Stage2ClearOutput<F>,
+    stage3: &Stage3ClearOutput<F>,
+    prefix: &Stage4RegularBatchPrefixOutput<F>,
+    transcript: &mut T,
+) -> Result<Stage4RegularBatchProofOutput<F, C>, ProverError>
+where
+    F: Field,
+    W: WitnessProvider<F, JoltVmNamespace> + JoltVmStage2Rows + JoltVmRegisterReadWriteRows,
+    B: Stage4ReadWriteSumcheckBackend<F>,
+    T: Transcript<Challenge = F>,
+{
+    prove_stage4_specialized_regular_batch_sumcheck_with_recorder(
+        Stage4RegularBatchRunInput {
+            config,
+            stage2,
+            stage3,
+            prefix,
+        },
+        witness,
+        backend,
+        transcript,
+        ClearSumcheckRecorder::<F, C>::new(0),
+    )
+}
+
+fn prove_stage4_specialized_regular_batch_sumcheck_with_recorder<F, W, B, T, S>(
+    input: Stage4RegularBatchRunInput<'_, F>,
+    witness: &W,
+    backend: &mut B,
+    transcript: &mut T,
+    mut proof_recorder: S,
+) -> Result<Stage4RegularBatchProofOutput<F, S::Commitment>, ProverError>
+where
+    F: Field,
+    W: WitnessProvider<F, JoltVmNamespace> + JoltVmStage2Rows + JoltVmRegisterReadWriteRows,
+    B: Stage4ReadWriteSumcheckBackend<F>,
+    T: Transcript<Challenge = F>,
+    S: SumcheckRecorder<F>,
+{
+    let config = input.config;
+    let stage2 = input.stage2;
+    let stage3 = input.stage3;
+    let prefix = input.prefix;
+    let register_dimensions = config
+        .rw_config
+        .register_dimensions(config.log_t, REGISTER_ADDRESS_BITS);
+    let fixed_register_cycle_point = stage3.output_claims.registers_opening_point().to_vec();
+    if fixed_register_cycle_point.len() != config.log_t {
+        return Err(invalid_sumcheck_output(format!(
+            "Stage 4 fixed register cycle point has {} variables, expected {}",
+            fixed_register_cycle_point.len(),
+            config.log_t
+        )));
+    }
+    let (fixed_ram_address_point, fixed_ram_cycle_point) = stage2
+        .output_claims
+        .ram_read_write_point()
+        .split_at(config.log_k);
+
+    let register_request = SumcheckRegistersReadWriteStateRequest::new(
+        "stage4.registers_read_write",
+        register_read_write_rows(witness)?,
+        fixed_register_cycle_point.clone(),
+        prefix.registers_gamma,
+        prefix.input_claims.registers_read_write,
+        config.log_t,
+        REGISTER_ADDRESS_BITS,
+        register_dimensions.phase1_num_rounds(),
+        register_dimensions.phase2_num_rounds(),
+    )
+    .with_optimization_ids(&["cpu_stage4_regular_batch_sumcheck"]);
+    let ram_request = SumcheckRamValCheckStateRequest::new(
+        "stage4.ram_val_check",
+        ram_read_write_rows(witness)?,
+        fixed_ram_address_point.to_vec(),
+        fixed_ram_cycle_point.to_vec(),
+        prefix.ram_val_check_gamma,
+        prefix.input_claims.ram_val_check,
+        config.log_t,
+    )
+    .with_optimization_ids(&["cpu_stage4_regular_batch_sumcheck"]);
+    let mut register_state =
+        backend.materialize_sumcheck_registers_read_write_state(&register_request)?;
+    let mut ram_state = backend.materialize_sumcheck_ram_val_check_state(&ram_request)?;
+
+    proof_recorder.absorb_input_claims(
+        &[
+            prefix.input_claims.registers_read_write,
+            prefix.input_claims.ram_val_check,
+        ],
+        transcript,
+    );
+    let batching_coefficients = [transcript.challenge_scalar(), transcript.challenge_scalar()];
+    let max_num_rounds = config.log_t + REGISTER_ADDRESS_BITS;
+    let ram_offset = REGISTER_ADDRESS_BITS;
+    let two_inv = F::from_u64(2).inv_or_zero();
+    let mut individual_claims = [
+        prefix.input_claims.registers_read_write,
+        prefix.input_claims.ram_val_check.mul_pow_2(ram_offset),
+    ];
+    let mut running_claim = individual_claims[0] * batching_coefficients[0]
+        + individual_claims[1] * batching_coefficients[1];
+    let mut challenges = Vec::with_capacity(max_num_rounds);
+
+    for round in 0..max_num_rounds {
+        let register_poly = backend
+            .evaluate_sumcheck_registers_read_write_round(&register_state, individual_claims[0])?;
+        let ram_poly = if round < ram_offset {
+            UnivariatePoly::new(vec![individual_claims[1] * two_inv])
+        } else {
+            backend.evaluate_sumcheck_ram_val_check_round(&ram_state, individual_claims[1])?
+        };
+        let mut round_poly = UnivariatePoly::zero();
+        round_poly += &(&register_poly * batching_coefficients[0]);
+        round_poly += &(&ram_poly * batching_coefficients[1]);
+        let round_sum = round_poly.evaluate(F::zero()) + round_poly.evaluate(F::one());
+        if round_sum != running_claim {
+            return Err(invalid_sumcheck_output(format!(
+                "Stage 4 specialized regular batch round {round} sumcheck invariant failed"
+            )));
+        }
+
+        let challenge = proof_recorder.absorb_round(&round_poly, transcript)?;
+        running_claim = round_poly.evaluate(challenge);
+        challenges.push(challenge);
+        individual_claims[0] = register_poly.evaluate(challenge);
+        individual_claims[1] = if round < ram_offset {
+            individual_claims[1] * two_inv
+        } else {
+            ram_poly.evaluate(challenge)
+        };
+        backend.bind_sumcheck_registers_read_write_state(&mut register_state, challenge)?;
+        if round >= ram_offset {
+            backend.bind_sumcheck_ram_val_check_state(&mut ram_state, challenge)?;
+        }
+    }
+
+    let registers_relation =
+        RegistersReadWriteChecking::new(register_dimensions, prefix.registers_gamma);
+    let ram_relation = RamValCheck::new(
+        TraceDimensions::new(config.log_t),
+        config.log_k,
+        prefix.ram_val_check_gamma,
+        prefix.ram_val_check_init.decomposition(),
+    );
+    let registers_inputs = RegistersReadWriteInputClaims::from_upstream(stage3);
+    let ram_inputs = RamValCheckInputClaims::from_upstream(stage2, &prefix.ram_val_check_init);
+
+    let registers_read_write_opening_point = registers_relation
+        .derive_opening_points(&challenges, &registers_inputs)
+        .map_err(|error| invalid_sumcheck_output(error.to_string()))?
+        .registers_val;
+    let ram_val_check_opening_point = ram_relation
+        .derive_opening_points(&challenges[ram_offset..], &ram_inputs)
+        .map_err(|error| invalid_sumcheck_output(error.to_string()))?
+        .ram_ra;
+
+    let registers_output = backend.output_sumcheck_registers_read_write_state(
+        &register_state,
+        &registers_read_write_opening_point,
+    )?;
+    let ram_output = backend.output_sumcheck_ram_val_check_state(&ram_state)?;
+    let output_openings = Stage4OutputClaims {
+        advice: stage4_advice_claims_from_prefix(prefix)?,
+        program_image_contribution: None,
+        registers_read_write: RegistersReadWriteOutputClaims {
+            registers_val: registers_output.registers_val,
+            rs1_ra: registers_output.rs1_ra,
+            rs2_ra: registers_output.rs2_ra,
+            rd_wa: registers_output.rd_wa,
+            rd_inc: registers_output.rd_inc,
+        },
+        ram_val_check: RamValCheckOutputClaims {
+            ram_ra: ram_output.ram_ra,
+            ram_inc: ram_output.ram_inc,
+        },
+    };
+
+    // Pair the produced openings with their points via the shared helper for the
+    // output-algebra check — the same form the verifier builds.
+    let claims_with_points = stage4_output_claims_with_points(
+        &output_openings,
+        &registers_read_write_opening_point,
+        &ram_val_check_opening_point,
+        &prefix.ram_val_check_init,
+    );
+    let registers_expected = registers_relation
+        .expected_output(&registers_inputs, &claims_with_points.registers_read_write)
+        .map_err(|error| invalid_sumcheck_output(error.to_string()))?;
+    let ram_expected = ram_relation
+        .expected_output(&ram_inputs, &claims_with_points.ram_val_check)
+        .map_err(|error| invalid_sumcheck_output(error.to_string()))?;
+    let expected_final_claim = stage4_expected_batch_final_claim(
+        &batching_coefficients,
+        registers_expected,
+        ram_expected,
+    )?;
+    if running_claim != expected_final_claim {
+        return Err(invalid_sumcheck_output(
+            "Stage 4 batch final claim did not match output openings",
+        ));
+    }
+    let output_claim_values = output_openings.opening_values();
+    let recorded = proof_recorder.finish(&output_claim_values, transcript)?;
+
+    Ok(Stage4RegularBatchProofOutput {
+        prefix: prefix.clone(),
+        proof: recorded.proof,
+        #[cfg(feature = "zk")]
+        committed_witness: recorded.committed_witness,
+        #[cfg(feature = "zk")]
+        output_claim_values: recorded.output_claim_values,
+        output_openings,
+        registers_read_write_opening_point,
+        ram_val_check_opening_point,
+    })
+}
+
+#[cfg(feature = "zk")]
+#[expect(clippy::too_many_arguments)]
+fn prove_stage4_committed_specialized_regular_batch_sumcheck<F, W, B, T, VC>(
+    config: Stage4ProverConfig,
+    witness: &W,
+    backend: &mut B,
+    stage2: &Stage2ClearOutput<F>,
+    stage3: &Stage3ClearOutput<F>,
+    prefix: &Stage4RegularBatchPrefixOutput<F>,
+    transcript: &mut T,
+    vc_setup: &VC::Setup,
+) -> Result<Stage4CommittedProofComponent<F, VC>, ProverError>
+where
+    F: Field,
+    W: WitnessProvider<F, JoltVmNamespace> + JoltVmStage2Rows + JoltVmRegisterReadWriteRows,
+    B: Stage4ReadWriteSumcheckBackend<F>,
+    T: Transcript<Challenge = F>,
+    VC: VectorCommitment<Field = F>,
+{
+    let batch = prove_stage4_specialized_regular_batch_sumcheck_with_recorder(
+        Stage4RegularBatchRunInput {
+            config,
+            stage2,
+            stage3,
+            prefix,
+        },
+        witness,
+        backend,
+        transcript,
+        CommittedSumcheckRecorder::<F, VC>::new(vc_setup)?,
+    )?;
+
+    let claims = Stage4OutputClaims {
+        advice: batch.output_openings.advice.clone(),
+        program_image_contribution: None,
+        registers_read_write: batch.output_openings.registers_read_write.clone(),
+        ram_val_check: batch.output_openings.ram_val_check.clone(),
+    };
+    let challenges = Stage4Challenges {
+        registers_gamma: batch.prefix.registers_gamma,
+        ram_val_check_gamma: batch.prefix.ram_val_check_gamma,
+    };
+    let ram_val_check_init = batch.prefix.ram_val_check_init.clone();
+    let output_claims = stage4_output_claims_with_points(
+        &claims,
+        &batch.registers_read_write_opening_point,
+        &batch.ram_val_check_opening_point,
+        &ram_val_check_init,
+    );
+    let verifier_output = Stage4ClearOutput {
+        challenges: challenges.clone(),
+        output_claims,
+        ram_val_check_init,
+    };
+    Ok(Stage4CommittedProofComponent {
+        stage4_sumcheck_proof: batch.proof,
+        challenges,
+        verifier_output,
+        output_claim_values: batch.output_claim_values.ok_or_else(|| {
+            invalid_sumcheck_output("Stage 4 committed output claim values are missing".to_owned())
+        })?,
+        committed_witness: batch.committed_witness.ok_or_else(|| {
+            invalid_sumcheck_output("Stage 4 committed witness material is missing".to_owned())
+        })?,
+    })
+}
+
+fn validate_stage4_dependencies<F: Field>(
+    config: Stage4ProverConfig,
+    stage2: &Stage2ClearOutput<F>,
+    stage3: &Stage3ClearOutput<F>,
+) -> Result<(), ProverError> {
+    let expected_ram_read_write_vars = config.log_k + config.log_t;
+    if stage2.output_claims.ram_read_write_point().len() != expected_ram_read_write_vars {
+        return Err(ProverError::InvalidStageRequest {
+            reason: format!(
+                "Stage 4 RAM read-write opening point has {} variables, expected {expected_ram_read_write_vars}",
+                stage2.output_claims.ram_read_write_point().len()
+            ),
+        });
+    }
+    if stage2.output_claims.ram_output_check_point().len() != config.log_k {
+        return Err(ProverError::InvalidStageRequest {
+            reason: format!(
+                "Stage 4 RAM output-check opening point has {} variables, expected {}",
+                stage2.output_claims.ram_output_check_point().len(),
+                config.log_k
+            ),
+        });
+    }
+    let (ram_address_point, _) = stage2
+        .output_claims
+        .ram_read_write_point()
+        .split_at(config.log_k);
+    if stage2.output_claims.ram_output_check_point() != ram_address_point {
+        return Err(ProverError::InvalidStageRequest {
+            reason: "Stage 4 RAM value-check dependencies use different address opening points"
+                .to_owned(),
+        });
+    }
+    if stage3
+        .output_claims
+        .registers_claim_reduction
+        .rs1_value
+        .value
+        != stage3.output_claims.instruction_input.rs1_value.value
+    {
+        return Err(ProverError::InvalidStageRequest {
+            reason: "Stage 4 register dependencies disagree on rs1 value".to_owned(),
+        });
+    }
+    if stage3
+        .output_claims
+        .registers_claim_reduction
+        .rs2_value
+        .value
+        != stage3.output_claims.instruction_input.rs2_value.value
+    {
+        return Err(ProverError::InvalidStageRequest {
+            reason: "Stage 4 register dependencies disagree on rs2 value".to_owned(),
+        });
+    }
+    Ok(())
+}
+
+#[cfg(feature = "zk")]
+fn validate_stage4_committed_checked(
+    config: Stage4ProverConfig,
+    checked: &jolt_verifier::CheckedInputs,
+) -> Result<(), ProverError> {
+    if !checked.zk {
+        return Err(ProverError::InvalidStageRequest {
+            reason: "Stage 4 committed proof component prover received transparent checked inputs"
+                .to_owned(),
+        });
+    }
+    if checked.trace_length != (1usize << config.log_t) {
+        return Err(ProverError::InvalidStageRequest {
+            reason: format!(
+                "Stage 4 checked trace length {} does not match log_t {}",
+                checked.trace_length, config.log_t
+            ),
+        });
+    }
+    if checked.ram_K != (1usize << config.log_k) {
+        return Err(ProverError::InvalidStageRequest {
+            reason: format!(
+                "Stage 4 checked RAM K {} does not match log_k {}",
+                checked.ram_K, config.log_k
+            ),
+        });
+    }
+    Ok(())
+}

--- a/crates/jolt-prover/src/stages/stage5/mod.rs
+++ b/crates/jolt-prover/src/stages/stage5/mod.rs
@@ -1,0 +1,1 @@
+pub mod prove;

--- a/crates/jolt-prover/src/stages/stage5/prove.rs
+++ b/crates/jolt-prover/src/stages/stage5/prove.rs
@@ -1,0 +1,669 @@
+use common::constants::INSTRUCTION_PHASES_THRESHOLD_LOG_T;
+use jolt_backends::{
+    instruction_read_raf_rows, ram_read_write_rows, register_read_write_rows,
+    Stage5ValueEvaluationSumcheckBackend, SumcheckBackend, SumcheckInstructionReadRafStateRequest,
+    SumcheckRamRaClaimReductionStateRequest, SumcheckRegistersValEvaluationStateRequest,
+};
+use jolt_claims::protocols::jolt::formulas::{
+    dimensions::{TraceDimensions, REGISTER_ADDRESS_BITS},
+    instruction::InstructionReadRafDimensions,
+};
+#[cfg(feature = "zk")]
+use jolt_crypto::VectorCommitment;
+use jolt_field::Field;
+use jolt_poly::UnivariatePoly;
+use jolt_sumcheck::SumcheckProof;
+use jolt_transcript::Transcript;
+use jolt_verifier::stages::relations::SumcheckInstance;
+use jolt_verifier::stages::stage5::outputs::{Stage5Challenges, Stage5ClearOutput};
+use jolt_verifier::stages::stage5::{
+    stage5_expected_final_claim, stage5_output_claims_with_points, InstructionReadRaf,
+    InstructionReadRafInputClaims, InstructionReadRafOutputClaims, RamRaClaimReduction,
+    RamRaClaimReductionInputClaims, RamRaClaimReductionOutputClaims, RegistersValEvaluation,
+    RegistersValEvaluationInputClaims, RegistersValEvaluationOutputClaims, Stage5OutputClaims,
+};
+use jolt_verifier::stages::{stage2::Stage2ClearOutput, stage4::Stage4ClearOutput};
+use jolt_verifier::{CheckedInputs, VerifierError};
+use jolt_witness::protocols::jolt_vm::{
+    JoltVmRegisterReadWriteRows, JoltVmStage2Rows, JoltVmStage5InstructionReadRafRows,
+};
+use jolt_witness::{protocols::jolt_vm::JoltVmNamespace, WitnessProvider};
+
+#[cfg(feature = "zk")]
+use crate::committed::CommittedSumcheckWitness;
+use crate::stages::invalid_sumcheck_output;
+#[cfg(feature = "zk")]
+use crate::stages::recorder::CommittedSumcheckRecorder;
+use crate::stages::recorder::{ClearSumcheckRecorder, SumcheckRecorder};
+use crate::ProverError;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Stage5ProverConfig {
+    pub log_t: usize,
+    pub log_k: usize,
+    pub instruction_read_raf_dimensions: InstructionReadRafDimensions,
+}
+
+impl Stage5ProverConfig {
+    pub const fn new(
+        log_t: usize,
+        log_k: usize,
+        instruction_read_raf_dimensions: InstructionReadRafDimensions,
+    ) -> Self {
+        Self {
+            log_t,
+            log_k,
+            instruction_read_raf_dimensions,
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct Stage5ProverInput<'a, F: Field, W> {
+    pub config: Stage5ProverConfig,
+    pub checked: &'a CheckedInputs,
+    pub stage2: &'a Stage2ClearOutput<F>,
+    pub stage4: &'a Stage4ClearOutput<F>,
+    pub witness: &'a W,
+}
+
+impl<'a, F: Field, W> Stage5ProverInput<'a, F, W> {
+    pub const fn new(
+        config: Stage5ProverConfig,
+        checked: &'a CheckedInputs,
+        stage2: &'a Stage2ClearOutput<F>,
+        stage4: &'a Stage4ClearOutput<F>,
+        witness: &'a W,
+    ) -> Self {
+        Self {
+            config,
+            checked,
+            stage2,
+            stage4,
+            witness,
+        }
+    }
+}
+
+/// The three stage 5 batch input claims, in canonical batch order (instruction
+/// read-RAF, RAM-RA reduction, register value-evaluation). Computed once via the
+/// shared relation objects so prover and verifier derive them identically.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct Stage5InputClaims<F: Field> {
+    instruction_read_raf: F,
+    ram_ra_claim_reduction: F,
+    registers_val_evaluation: F,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct Stage5RegularBatchPrefixOutput<F: Field> {
+    input_claims: Stage5InputClaims<F>,
+    instruction_gamma: F,
+    ram_gamma: F,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Stage5ProofComponent<F: Field, Proof> {
+    pub stage5_sumcheck_proof: Proof,
+    pub claims: Stage5OutputClaims<F>,
+    pub verifier_output: Stage5ClearOutput<F>,
+}
+
+#[cfg(feature = "zk")]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Stage5CommittedProofComponent<F, VC>
+where
+    F: Field,
+    VC: VectorCommitment<Field = F>,
+{
+    pub stage5_sumcheck_proof: SumcheckProof<F, VC::Output>,
+    pub challenges: Stage5Challenges<F>,
+    pub output_claim_values: Vec<F>,
+    pub verifier_output: Stage5ClearOutput<F>,
+    pub(crate) committed_witness: CommittedSumcheckWitness<F>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct Stage5RegularBatchProofOutput<F: Field, C> {
+    proof: SumcheckProof<F, C>,
+    #[cfg(feature = "zk")]
+    committed_witness: Option<CommittedSumcheckWitness<F>>,
+    #[cfg(feature = "zk")]
+    output_claim_values: Option<Vec<F>>,
+    claims: Stage5OutputClaims<F>,
+    verifier_output: Stage5ClearOutput<F>,
+}
+
+const STAGE5_BATCH_COEFFICIENTS: usize = 3;
+
+#[derive(Clone, Copy)]
+struct Stage5BatchCoefficients<F: Field> {
+    instruction_read_raf: F,
+    ram_ra_claim_reduction: F,
+    registers_val_evaluation: F,
+}
+
+/// Build the three stage 5 relation objects from the batch gammas. Shared by the
+/// prefix (input claims) and the batch sumcheck (opening points, expected output)
+/// so prover and verifier drive identical relations.
+fn stage5_relations<F: Field>(
+    config: Stage5ProverConfig,
+    instruction_gamma: F,
+    ram_gamma: F,
+) -> (
+    InstructionReadRaf<F>,
+    RamRaClaimReduction<F>,
+    RegistersValEvaluation<F>,
+) {
+    let trace_dimensions = TraceDimensions::new(config.log_t);
+    (
+        InstructionReadRaf::new(config.instruction_read_raf_dimensions, instruction_gamma),
+        RamRaClaimReduction::new(trace_dimensions, config.log_k, ram_gamma),
+        RegistersValEvaluation::new(trace_dimensions),
+    )
+}
+
+/// Canonical Stage 5 prover entrypoint (transparent path).
+///
+/// Mirrors `jolt-verifier/src/stages/stage5/verify.rs` in prover order: derive
+/// the instruction/RAM gammas, prove the instruction read-RAF, RAM-RA reduction,
+/// and register value-evaluation batched sumcheck, then assemble the
+/// verifier-owned Stage 5 proof, claims, and clear output for Stage 6 and later
+/// stages. ZK Stage 5 prover assembly is a separate committed proof component
+/// path.
+pub fn prove<F, W, B, T, C>(
+    input: Stage5ProverInput<'_, F, W>,
+    backend: &mut B,
+    transcript: &mut T,
+) -> Result<Stage5ProofComponent<F, SumcheckProof<F, C>>, ProverError>
+where
+    F: Field,
+    W: WitnessProvider<F, JoltVmNamespace>
+        + JoltVmStage2Rows
+        + JoltVmRegisterReadWriteRows
+        + JoltVmStage5InstructionReadRafRows,
+    B: SumcheckBackend<F, JoltVmNamespace> + Stage5ValueEvaluationSumcheckBackend<F>,
+    T: Transcript<Challenge = F>,
+{
+    if input.checked.zk {
+        return Err(ProverError::InvalidStageRequest {
+            reason: "Stage 5 clear prover received ZK checked inputs".to_owned(),
+        });
+    }
+    if input.checked.trace_length != (1usize << input.config.log_t) {
+        return Err(ProverError::InvalidStageRequest {
+            reason: format!(
+                "Stage 5 checked trace length {} does not match log_t {}",
+                input.checked.trace_length, input.config.log_t
+            ),
+        });
+    }
+
+    let prefix =
+        derive_stage5_regular_batch_prefix(input.config, input.stage2, input.stage4, transcript)?;
+    let proof_output = prove_stage5_specialized_regular_batch_sumcheck_with_recorder(
+        input.config,
+        input.witness,
+        backend,
+        input.stage2,
+        input.stage4,
+        &prefix,
+        transcript,
+        ClearSumcheckRecorder::<F, C>::new(0),
+    )?;
+
+    Ok(Stage5ProofComponent {
+        stage5_sumcheck_proof: proof_output.proof,
+        claims: proof_output.claims,
+        verifier_output: proof_output.verifier_output,
+    })
+}
+
+#[cfg(feature = "zk")]
+pub fn prove_committed_proof_component<F, W, B, T, VC>(
+    input: Stage5ProverInput<'_, F, W>,
+    backend: &mut B,
+    transcript: &mut T,
+    vc_setup: &VC::Setup,
+) -> Result<Stage5CommittedProofComponent<F, VC>, ProverError>
+where
+    F: Field,
+    W: WitnessProvider<F, JoltVmNamespace>
+        + JoltVmStage2Rows
+        + JoltVmRegisterReadWriteRows
+        + JoltVmStage5InstructionReadRafRows,
+    B: SumcheckBackend<F, JoltVmNamespace> + Stage5ValueEvaluationSumcheckBackend<F>,
+    T: Transcript<Challenge = F>,
+    VC: VectorCommitment<Field = F>,
+{
+    validate_stage5_committed_checked(input.config, input.checked)?;
+    let prefix =
+        derive_stage5_regular_batch_prefix(input.config, input.stage2, input.stage4, transcript)?;
+    let output = prove_stage5_specialized_regular_batch_sumcheck_with_recorder(
+        input.config,
+        input.witness,
+        backend,
+        input.stage2,
+        input.stage4,
+        &prefix,
+        transcript,
+        CommittedSumcheckRecorder::<F, VC>::new(vc_setup)?,
+    )?;
+
+    let challenges = output.verifier_output.challenges.clone();
+    Ok(Stage5CommittedProofComponent {
+        stage5_sumcheck_proof: output.proof,
+        challenges,
+        output_claim_values: output.output_claim_values.ok_or_else(|| {
+            invalid_sumcheck_output("Stage 5 committed output claim values are missing")
+        })?,
+        verifier_output: output.verifier_output,
+        committed_witness: output.committed_witness.ok_or_else(|| {
+            invalid_sumcheck_output("Stage 5 committed witness material is missing")
+        })?,
+    })
+}
+
+fn derive_stage5_regular_batch_prefix<F, T>(
+    config: Stage5ProverConfig,
+    stage2: &Stage2ClearOutput<F>,
+    stage4: &Stage4ClearOutput<F>,
+    transcript: &mut T,
+) -> Result<Stage5RegularBatchPrefixOutput<F>, ProverError>
+where
+    F: Field,
+    T: Transcript<Challenge = F>,
+{
+    validate_stage5_dependencies(config, stage2)?;
+
+    let instruction_gamma = transcript.challenge_scalar();
+    let ram_gamma = transcript.challenge_scalar();
+
+    let (instruction_relation, ram_relation, registers_relation) =
+        stage5_relations(config, instruction_gamma, ram_gamma);
+    let to_prover_error = |error: VerifierError| invalid_sumcheck_output(error.to_string());
+    let input_claims = Stage5InputClaims {
+        instruction_read_raf: instruction_relation
+            .input_claim(&InstructionReadRafInputClaims::from_upstream(stage2))
+            .map_err(to_prover_error)?,
+        ram_ra_claim_reduction: ram_relation
+            .input_claim(&RamRaClaimReductionInputClaims::from_upstream(
+                stage2, stage4,
+            ))
+            .map_err(to_prover_error)?,
+        registers_val_evaluation: registers_relation
+            .input_claim(&RegistersValEvaluationInputClaims::from_upstream(stage4))
+            .map_err(to_prover_error)?,
+    };
+
+    Ok(Stage5RegularBatchPrefixOutput {
+        input_claims,
+        instruction_gamma,
+        ram_gamma,
+    })
+}
+
+#[expect(clippy::too_many_arguments)]
+fn prove_stage5_specialized_regular_batch_sumcheck_with_recorder<F, W, B, T, S>(
+    config: Stage5ProverConfig,
+    witness: &W,
+    backend: &mut B,
+    stage2: &Stage2ClearOutput<F>,
+    stage4: &Stage4ClearOutput<F>,
+    prefix: &Stage5RegularBatchPrefixOutput<F>,
+    transcript: &mut T,
+    mut proof_recorder: S,
+) -> Result<Stage5RegularBatchProofOutput<F, S::Commitment>, ProverError>
+where
+    F: Field,
+    W: WitnessProvider<F, JoltVmNamespace>
+        + JoltVmStage2Rows
+        + JoltVmRegisterReadWriteRows
+        + JoltVmStage5InstructionReadRafRows,
+    B: SumcheckBackend<F, JoltVmNamespace> + Stage5ValueEvaluationSumcheckBackend<F>,
+    T: Transcript<Challenge = F>,
+    S: SumcheckRecorder<F>,
+{
+    let (instruction_relation, ram_relation, registers_relation) =
+        stage5_relations(config, prefix.instruction_gamma, prefix.ram_gamma);
+    let to_prover_error = |error: VerifierError| invalid_sumcheck_output(error.to_string());
+
+    let instruction_layout = config
+        .instruction_read_raf_dimensions
+        .u128_address_layout()
+        .map_err(invalid_sumcheck_output)?;
+
+    let instruction_rows = instruction_read_raf_rows(witness, config.log_t)?;
+    let instruction_request = SumcheckInstructionReadRafStateRequest::new(
+        "stage5.instruction_read_raf",
+        instruction_rows,
+        stage2
+            .output_claims
+            .instruction_claim_reduction_point()
+            .to_vec(),
+        prefix.instruction_gamma,
+        prefix.input_claims.instruction_read_raf,
+        config.log_t,
+        instruction_layout.address_bits(),
+        instruction_layout.virtual_ra_chunk_bits(),
+        instruction_sumcheck_phases(config.log_t),
+    )
+    .with_optimization_ids(&["cpu_stage5_regular_batch_sumcheck"]);
+
+    // Split the upstream RAM/register opening points into the fixed address prefix
+    // and fixed cycle suffixes the backend witness materialization needs. The
+    // address-agreement and length invariants are re-checked by each relation's
+    // `derive_opening_points` when the output openings are paired with points below.
+    let ram_read_write_opening_point = stage2.output_claims.ram_read_write_point();
+    let ram_raf_opening_point = stage2.output_claims.ram_raf_evaluation_point();
+    let ram_val_check_opening_point = stage4.output_claims.ram_val_check.ram_ra.point.as_slice();
+    let registers_opening_point = stage4
+        .output_claims
+        .registers_read_write
+        .registers_val
+        .point
+        .as_slice();
+    let ram_address_point = &ram_read_write_opening_point[..config.log_k];
+    let ram_raf_fixed_cycle_point = &ram_raf_opening_point[config.log_k..];
+    let ram_read_write_fixed_cycle_point = &ram_read_write_opening_point[config.log_k..];
+    let ram_val_check_fixed_cycle_point = &ram_val_check_opening_point[config.log_k..];
+    let (register_address_point, register_fixed_cycle_point) =
+        registers_opening_point.split_at(REGISTER_ADDRESS_BITS);
+
+    let ram_rows = ram_read_write_rows(witness)?;
+    let ram_request = SumcheckRamRaClaimReductionStateRequest::new(
+        "stage5.ram_ra_claim_reduction",
+        ram_rows,
+        ram_address_point.to_vec(),
+        ram_raf_fixed_cycle_point.to_vec(),
+        ram_read_write_fixed_cycle_point.to_vec(),
+        ram_val_check_fixed_cycle_point.to_vec(),
+        prefix.ram_gamma,
+        prefix.input_claims.ram_ra_claim_reduction,
+        config.log_t,
+        config.log_k,
+    )
+    .with_optimization_ids(&["cpu_stage5_regular_batch_sumcheck"]);
+    let register_rows = register_read_write_rows(witness)?;
+    let registers_request = SumcheckRegistersValEvaluationStateRequest::new(
+        "stage5.registers_val_evaluation",
+        register_rows,
+        register_address_point.to_vec(),
+        register_fixed_cycle_point.to_vec(),
+        prefix.input_claims.registers_val_evaluation,
+        config.log_t,
+        REGISTER_ADDRESS_BITS,
+    )
+    .with_optimization_ids(&["cpu_stage5_regular_batch_sumcheck"]);
+    let mut instruction_state =
+        backend.materialize_sumcheck_instruction_read_raf_state(&instruction_request)?;
+    let mut ram_state = backend.materialize_sumcheck_ram_ra_claim_reduction_state(&ram_request)?;
+    let mut registers_state =
+        backend.materialize_sumcheck_registers_val_evaluation_state(&registers_request)?;
+
+    proof_recorder.absorb_input_claims(
+        &[
+            prefix.input_claims.instruction_read_raf,
+            prefix.input_claims.ram_ra_claim_reduction,
+            prefix.input_claims.registers_val_evaluation,
+        ],
+        transcript,
+    );
+    let batching_coefficients = (0..STAGE5_BATCH_COEFFICIENTS)
+        .map(|_| transcript.challenge_scalar())
+        .collect::<Vec<_>>();
+    let [instruction_coefficient, ram_coefficient, registers_coefficient] =
+        batching_coefficients.as_slice()
+    else {
+        return Err(invalid_sumcheck_output(
+            "Stage 5 batch expected exactly three batching coefficients",
+        ));
+    };
+    let coefficients = Stage5BatchCoefficients {
+        instruction_read_raf: *instruction_coefficient,
+        ram_ra_claim_reduction: *ram_coefficient,
+        registers_val_evaluation: *registers_coefficient,
+    };
+
+    let front_padding_rounds = instruction_layout.address_bits();
+    let mut individual_claims = [
+        prefix.input_claims.instruction_read_raf,
+        prefix
+            .input_claims
+            .ram_ra_claim_reduction
+            .mul_pow_2(front_padding_rounds),
+        prefix
+            .input_claims
+            .registers_val_evaluation
+            .mul_pow_2(front_padding_rounds),
+    ];
+    let mut running_claim = coefficients.instruction_read_raf * individual_claims[0]
+        + coefficients.ram_ra_claim_reduction * individual_claims[1]
+        + coefficients.registers_val_evaluation * individual_claims[2];
+    let max_rounds = front_padding_rounds + config.log_t;
+    let mut sumcheck_point = Vec::with_capacity(max_rounds);
+    let two_inv = F::from_u64(2).inv_or_zero();
+
+    for round in 0..max_rounds {
+        let instruction_poly = backend.evaluate_sumcheck_instruction_read_raf_round(
+            &instruction_state,
+            individual_claims[0],
+        )?;
+        let ram_poly = if round < front_padding_rounds {
+            UnivariatePoly::new(vec![individual_claims[1] * two_inv])
+        } else {
+            backend
+                .evaluate_sumcheck_ram_ra_claim_reduction_round(&ram_state, individual_claims[1])?
+        };
+        let registers_poly = if round < front_padding_rounds {
+            UnivariatePoly::new(vec![individual_claims[2] * two_inv])
+        } else {
+            backend.evaluate_sumcheck_registers_val_evaluation_round(
+                &registers_state,
+                individual_claims[2],
+            )?
+        };
+        let mut round_poly = UnivariatePoly::zero();
+        round_poly += &(&instruction_poly * coefficients.instruction_read_raf);
+        round_poly += &(&ram_poly * coefficients.ram_ra_claim_reduction);
+        round_poly += &(&registers_poly * coefficients.registers_val_evaluation);
+        let round_sum = round_poly.evaluate(F::zero()) + round_poly.evaluate(F::one());
+        if round_sum != running_claim {
+            return Err(invalid_sumcheck_output(format!(
+                "Stage 5 batch round {round} sumcheck invariant failed"
+            )));
+        }
+
+        let challenge = proof_recorder.absorb_round(&round_poly, transcript)?;
+        running_claim = round_poly.evaluate(challenge);
+        sumcheck_point.push(challenge);
+        individual_claims[0] = instruction_poly.evaluate(challenge);
+        individual_claims[1] = if round < front_padding_rounds {
+            individual_claims[1] * two_inv
+        } else {
+            ram_poly.evaluate(challenge)
+        };
+        individual_claims[2] = if round < front_padding_rounds {
+            individual_claims[2] * two_inv
+        } else {
+            registers_poly.evaluate(challenge)
+        };
+        backend.bind_sumcheck_instruction_read_raf_state(&mut instruction_state, challenge)?;
+        if round >= front_padding_rounds {
+            backend.bind_sumcheck_ram_ra_claim_reduction_state(&mut ram_state, challenge)?;
+            backend
+                .bind_sumcheck_registers_val_evaluation_state(&mut registers_state, challenge)?;
+        }
+    }
+
+    let instruction_inputs = InstructionReadRafInputClaims::from_upstream(stage2);
+    let ram_inputs = RamRaClaimReductionInputClaims::from_upstream(stage2, stage4);
+    let registers_inputs = RegistersValEvaluationInputClaims::from_upstream(stage4);
+    let points = Stage5OutputClaims {
+        instruction_read_raf: instruction_relation
+            .derive_opening_points(&sumcheck_point, &instruction_inputs)
+            .map_err(to_prover_error)?,
+        ram_ra_claim_reduction: ram_relation
+            .derive_opening_points(&sumcheck_point[front_padding_rounds..], &ram_inputs)
+            .map_err(to_prover_error)?,
+        registers_val_evaluation: registers_relation
+            .derive_opening_points(&sumcheck_point[front_padding_rounds..], &registers_inputs)
+            .map_err(to_prover_error)?,
+    };
+
+    let instruction_output =
+        backend.output_sumcheck_instruction_read_raf_state(&instruction_state)?;
+    let instruction_internal_final = instruction_output.final_claim;
+    let ram_output = backend.output_sumcheck_ram_ra_claim_reduction_state(&ram_state)?;
+    let registers_output =
+        backend.output_sumcheck_registers_val_evaluation_state(&registers_state)?;
+    let output_openings = Stage5OutputClaims {
+        instruction_read_raf: InstructionReadRafOutputClaims {
+            lookup_table_flags: instruction_output.lookup_table_flags,
+            instruction_ra: instruction_output.instruction_ra,
+            instruction_raf_flag: instruction_output.instruction_raf_flag,
+        },
+        ram_ra_claim_reduction: RamRaClaimReductionOutputClaims {
+            ram_ra: ram_output.ram_ra,
+        },
+        registers_val_evaluation: RegistersValEvaluationOutputClaims {
+            rd_inc: registers_output.rd_inc,
+            rd_wa: registers_output.rd_wa,
+        },
+    };
+
+    let output_claims = stage5_output_claims_with_points(&output_openings, &points);
+    let instruction_expected = instruction_relation
+        .expected_output(&instruction_inputs, &output_claims.instruction_read_raf)
+        .map_err(to_prover_error)?;
+    let ram_expected = ram_relation
+        .expected_output(&ram_inputs, &output_claims.ram_ra_claim_reduction)
+        .map_err(to_prover_error)?;
+    let registers_expected = registers_relation
+        .expected_output(&registers_inputs, &output_claims.registers_val_evaluation)
+        .map_err(to_prover_error)?;
+    let expected_final_claim = stage5_expected_final_claim(
+        &batching_coefficients,
+        instruction_expected,
+        ram_expected,
+        registers_expected,
+    )
+    .map_err(to_prover_error)?;
+    if running_claim != expected_final_claim {
+        return Err(invalid_sumcheck_output(format!(
+            "Stage 5 batch final claim did not match output openings: instruction={}, ram={}, registers={}, instruction_internal={}, instruction_expected_internal={}",
+            individual_claims[0] == instruction_expected,
+            individual_claims[1] == ram_expected,
+            individual_claims[2] == registers_expected,
+            instruction_internal_final == individual_claims[0],
+            instruction_internal_final == instruction_expected,
+        )));
+    }
+
+    let instruction_r_address = output_claims.instruction_r_address();
+    let verifier_output = Stage5ClearOutput {
+        challenges: Stage5Challenges {
+            instruction_gamma: prefix.instruction_gamma,
+            ram_gamma: prefix.ram_gamma,
+        },
+        output_claims,
+        instruction_r_address,
+    };
+
+    let output_claim_values = output_openings.opening_values();
+    let recorded = proof_recorder.finish(&output_claim_values, transcript)?;
+    Ok(Stage5RegularBatchProofOutput {
+        proof: recorded.proof,
+        #[cfg(feature = "zk")]
+        committed_witness: recorded.committed_witness,
+        #[cfg(feature = "zk")]
+        output_claim_values: recorded.output_claim_values,
+        claims: output_openings,
+        verifier_output,
+    })
+}
+
+const fn instruction_sumcheck_phases(log_t: usize) -> usize {
+    if log_t < INSTRUCTION_PHASES_THRESHOLD_LOG_T {
+        16
+    } else {
+        8
+    }
+}
+
+/// Enforce the cross-relation opening aliases the instruction read-RAF input
+/// wiring relies on: the product-remainder and instruction-claim-reduction share
+/// the trace-length opening point and agree on the reduced lookup output. Mirrors
+/// the verifier's clear-path check.
+fn validate_stage5_dependencies<F: Field>(
+    config: Stage5ProverConfig,
+    stage2: &Stage2ClearOutput<F>,
+) -> Result<(), ProverError> {
+    let expected_trace_vars = config.log_t;
+    let product_point = stage2.output_claims.product_remainder_point();
+    let reduced_point = stage2.output_claims.instruction_claim_reduction_point();
+    for (label, point) in [
+        ("product remainder", product_point),
+        ("instruction claim reduction", reduced_point),
+    ] {
+        if point.len() != expected_trace_vars {
+            return Err(ProverError::InvalidStageRequest {
+                reason: format!(
+                    "Stage 5 {label} opening point has {} variables, expected {expected_trace_vars}",
+                    point.len()
+                ),
+            });
+        }
+    }
+    if product_point != reduced_point {
+        return Err(ProverError::InvalidStageRequest {
+            reason: "Stage 5 instruction read-RAF dependencies use different opening points"
+                .to_owned(),
+        });
+    }
+    let product_lookup_output = stage2.output_claims.product_remainder.lookup_output.value;
+    let reduced_lookup_output = stage2
+        .output_claims
+        .instruction_claim_reduction
+        .lookup_output
+        .as_ref()
+        .map_or(product_lookup_output, |claim| claim.value);
+    if reduced_lookup_output != product_lookup_output {
+        return Err(ProverError::InvalidStageRequest {
+            reason:
+                "Stage 5 instruction read-RAF dependencies disagree on the reduced lookup output"
+                    .to_owned(),
+        });
+    }
+    Ok(())
+}
+
+#[cfg(feature = "zk")]
+fn validate_stage5_committed_checked(
+    config: Stage5ProverConfig,
+    checked: &jolt_verifier::CheckedInputs,
+) -> Result<(), ProverError> {
+    if !checked.zk {
+        return Err(ProverError::InvalidStageRequest {
+            reason: "Stage 5 committed proof component prover received transparent checked inputs"
+                .to_owned(),
+        });
+    }
+    if checked.trace_length != (1usize << config.log_t) {
+        return Err(ProverError::InvalidStageRequest {
+            reason: format!(
+                "Stage 5 checked trace length {} does not match log_t {}",
+                checked.trace_length, config.log_t
+            ),
+        });
+    }
+    if checked.ram_K != (1usize << config.log_k) {
+        return Err(ProverError::InvalidStageRequest {
+            reason: format!(
+                "Stage 5 checked RAM K {} does not match log_k {}",
+                checked.ram_K, config.log_k
+            ),
+        });
+    }
+    Ok(())
+}

--- a/crates/jolt-prover/src/stages/stage6/batch.rs
+++ b/crates/jolt-prover/src/stages/stage6/batch.rs
@@ -1,0 +1,776 @@
+use jolt_claims::protocols::jolt::{
+    formulas::{booleanity, bytecode},
+    JoltCommittedPolynomial,
+};
+use jolt_claims::protocols::jolt::{
+    formulas::{claim_reductions::advice, claim_reductions::increments, instruction, ram},
+    AdviceClaimReductionLayout, JoltAdviceKind, PrecommittedReductionLayout,
+};
+use jolt_field::Field;
+use jolt_verifier::stages::relations::{zip_openings, SumcheckInstance};
+use jolt_verifier::stages::stage6::batch::{Stage6Relations, Stage6RelationsParams};
+use jolt_verifier::stages::stage6::outputs::{
+    AdviceCyclePhaseOutputClaim, Stage6AddressPhaseClaims, Stage6AdviceCyclePhaseClaims,
+    Stage6OutputClaims,
+};
+use jolt_verifier::stages::stage6::{
+    stage6_advice_cycle_phase_reference, stage6_bytecode_cycle_points,
+    stage6_bytecode_register_points, stage6_inc_claim_reduction_cycle_points,
+    stage6_instruction_read_raf_point, stage6_stage1_cycle_binding,
+    stage6_stage5_ram_reduced_opening_point, AdviceCyclePhaseOutputClaims,
+    Stage6AdviceCyclePhaseReference, Stage6BatchExpectedOutputClaims, Stage6BatchInputClaims,
+};
+use jolt_verifier::stages::{
+    stage1::Stage1ClearOutput, stage2::Stage2ClearOutput, stage3::Stage3ClearOutput,
+    stage4::Stage4ClearOutput, stage5::Stage5ClearOutput,
+};
+use jolt_witness::protocols::jolt_vm::JoltVmNamespace;
+use jolt_witness::{OracleRef, WitnessProvider};
+
+use super::io::{Stage6ProverConfig, Stage6RegularBatchPrefixOutput};
+use super::relation_state::{AdviceCyclePhaseRelationState, Stage6RelationState};
+use crate::stages::invalid_sumcheck_output;
+use crate::ProverError;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum Stage6InstanceKind {
+    BytecodeReadRaf,
+    Booleanity,
+    RamHammingBooleanity,
+    RamRaVirtualization,
+    InstructionRaVirtualization,
+    IncClaimReduction,
+    AdviceCyclePhase(JoltAdviceKind),
+}
+
+#[derive(Clone, Debug)]
+pub(super) struct Stage6BatchInstance<F: Field> {
+    pub(super) kind: Stage6InstanceKind,
+    pub(super) input_claim: F,
+    pub(super) num_vars: usize,
+    pub(super) degree: usize,
+    pub(super) offset: usize,
+}
+
+impl<F: Field> Stage6BatchInstance<F> {
+    pub(super) fn is_active(&self, round: usize) -> bool {
+        (self.offset..self.offset + self.num_vars).contains(&round)
+    }
+}
+
+pub(super) struct Stage6BatchContext<'a, F: Field, W> {
+    pub(super) config: Stage6ProverConfig,
+    pub(super) witness: &'a W,
+    pub(super) stage1: &'a Stage1ClearOutput<F>,
+    pub(super) stage2: &'a Stage2ClearOutput<F>,
+    pub(super) stage3: &'a Stage3ClearOutput<F>,
+    pub(super) stage4: &'a Stage4ClearOutput<F>,
+    pub(super) stage5: &'a Stage5ClearOutput<F>,
+    pub(super) prefix: &'a Stage6RegularBatchPrefixOutput<F>,
+    pub(super) instances: Vec<Stage6BatchInstance<F>>,
+    pub(super) max_num_vars: usize,
+    /// Stage 6a address-phase output openings used as the bytecode/booleanity
+    /// cycle-phase input claims.
+    address_phase: Stage6AddressPhaseClaims<F>,
+    /// Stage 6a bytecode address-phase sumcheck challenges; reversed, they are the
+    /// bytecode cycle relation's `r_address`.
+    bytecode_address_challenges: Vec<F>,
+    /// Stage 6a booleanity address-phase sumcheck challenges; reversed, they are
+    /// the booleanity cycle relation's `r_address`.
+    booleanity_address_challenges: Vec<F>,
+}
+
+struct Stage6InstanceSpec<F: Field> {
+    kind: Stage6InstanceKind,
+    input_claim: F,
+    num_vars: usize,
+    degree: usize,
+}
+
+impl<'a, F, W> Stage6BatchContext<'a, F, W>
+where
+    F: Field,
+    W: WitnessProvider<F, JoltVmNamespace>,
+{
+    /// Builds the metadata for the stage 6b **cycle-phase** batch.
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "Stage 6 context owns verifier-aligned dependencies from stages 1-5."
+    )]
+    pub(super) fn new_metadata(
+        config: Stage6ProverConfig,
+        witness: &'a W,
+        stage1: &'a Stage1ClearOutput<F>,
+        stage2: &'a Stage2ClearOutput<F>,
+        stage3: &'a Stage3ClearOutput<F>,
+        stage4: &'a Stage4ClearOutput<F>,
+        stage5: &'a Stage5ClearOutput<F>,
+        prefix: &'a Stage6RegularBatchPrefixOutput<F>,
+        address_phase: &Stage6AddressPhaseClaims<F>,
+        bytecode_address_challenges: &[F],
+        booleanity_address_challenges: &[F],
+    ) -> Result<Self, ProverError> {
+        let bytecode_claims =
+            bytecode::read_raf_cycle_phase::<F>(config.bytecode_read_raf_dimensions);
+        let booleanity_claims =
+            booleanity::booleanity_cycle_phase::<F>(config.booleanity_dimensions);
+        let ram_hamming_claims = ram::hamming_booleanity::<F>(config.trace_dimensions());
+        let ram_ra_claims = ram::ra_virtualization::<F>(config.ram_ra_virtualization_dimensions);
+        let instruction_ra_claims =
+            instruction::ra_virtualization::<F>(config.instruction_ra_virtualization_dimensions);
+        let inc_claims = increments::claim_reduction::<F>(config.trace_dimensions());
+
+        let mut specs = vec![
+            Stage6InstanceSpec {
+                kind: Stage6InstanceKind::BytecodeReadRaf,
+                input_claim: address_phase.bytecode_read_raf,
+                num_vars: bytecode_claims.sumcheck.rounds,
+                degree: bytecode_claims.sumcheck.degree,
+            },
+            Stage6InstanceSpec {
+                kind: Stage6InstanceKind::Booleanity,
+                input_claim: address_phase.booleanity,
+                num_vars: booleanity_claims.sumcheck.rounds,
+                degree: booleanity_claims.sumcheck.degree,
+            },
+            Stage6InstanceSpec {
+                kind: Stage6InstanceKind::RamHammingBooleanity,
+                input_claim: prefix.input_claims.ram_hamming_booleanity,
+                num_vars: ram_hamming_claims.sumcheck.rounds,
+                degree: ram_hamming_claims.sumcheck.degree,
+            },
+            Stage6InstanceSpec {
+                kind: Stage6InstanceKind::RamRaVirtualization,
+                input_claim: prefix.input_claims.ram_ra_virtualization,
+                num_vars: ram_ra_claims.sumcheck.rounds,
+                degree: ram_ra_claims.sumcheck.degree,
+            },
+            Stage6InstanceSpec {
+                kind: Stage6InstanceKind::InstructionRaVirtualization,
+                input_claim: prefix.input_claims.instruction_ra_virtualization,
+                num_vars: instruction_ra_claims.sumcheck.rounds,
+                degree: instruction_ra_claims.sumcheck.degree,
+            },
+            Stage6InstanceSpec {
+                kind: Stage6InstanceKind::IncClaimReduction,
+                input_claim: prefix.input_claims.inc_claim_reduction,
+                num_vars: inc_claims.sumcheck.rounds,
+                degree: inc_claims.sumcheck.degree,
+            },
+        ];
+
+        if let Some(input_claim) = prefix.input_claims.trusted_advice_cycle_phase {
+            let layout = config.trusted_advice_layout.as_ref().ok_or_else(|| {
+                invalid_stage_request("Stage 6 trusted advice input has no configured layout")
+            })?;
+            let claims = advice::cycle_phase::<F>(JoltAdviceKind::Trusted, layout.dimensions());
+            specs.push(Stage6InstanceSpec {
+                kind: Stage6InstanceKind::AdviceCyclePhase(JoltAdviceKind::Trusted),
+                input_claim,
+                num_vars: claims.sumcheck.rounds,
+                degree: claims.sumcheck.degree,
+            });
+        }
+        if let Some(input_claim) = prefix.input_claims.untrusted_advice_cycle_phase {
+            let layout = config.untrusted_advice_layout.as_ref().ok_or_else(|| {
+                invalid_stage_request("Stage 6 untrusted advice input has no configured layout")
+            })?;
+            let claims = advice::cycle_phase::<F>(JoltAdviceKind::Untrusted, layout.dimensions());
+            specs.push(Stage6InstanceSpec {
+                kind: Stage6InstanceKind::AdviceCyclePhase(JoltAdviceKind::Untrusted),
+                input_claim,
+                num_vars: claims.sumcheck.rounds,
+                degree: claims.sumcheck.degree,
+            });
+        }
+
+        let first = specs
+            .first()
+            .ok_or_else(|| invalid_stage_request("Stage 6 batch has no sumcheck instances"))?;
+        let max_num_vars = specs
+            .iter()
+            .fold(first.num_vars, |max: usize, spec| max.max(spec.num_vars));
+
+        let mut instances = Vec::with_capacity(specs.len());
+        for spec in specs {
+            let offset = match spec.kind {
+                Stage6InstanceKind::AdviceCyclePhase(kind) => {
+                    advice_cycle_phase_offset(&config, kind, max_num_vars)?
+                }
+                _ => max_num_vars.checked_sub(spec.num_vars).ok_or_else(|| {
+                    invalid_stage_request("Stage 6 instance has more variables than batch")
+                })?,
+            };
+            if offset + spec.num_vars > max_num_vars {
+                return Err(invalid_stage_request(format!(
+                    "Stage 6 instance {:?} at offset {offset} with {} variables exceeds batch size {max_num_vars}",
+                    spec.kind, spec.num_vars
+                )));
+            }
+            instances.push(Stage6BatchInstance {
+                kind: spec.kind,
+                input_claim: spec.input_claim,
+                num_vars: spec.num_vars,
+                degree: spec.degree,
+                offset,
+            });
+        }
+
+        Ok(Self {
+            config,
+            witness,
+            stage1,
+            stage2,
+            stage3,
+            stage4,
+            stage5,
+            prefix,
+            instances,
+            max_num_vars,
+            address_phase: address_phase.clone(),
+            bytecode_address_challenges: bytecode_address_challenges.to_vec(),
+            booleanity_address_challenges: booleanity_address_challenges.to_vec(),
+        })
+    }
+
+    /// Builds the stage-6b cycle relation bundle shared with the verifier, sourcing
+    /// its construction points from the prover's config and the stage-1..5 clear
+    /// outputs. The bytecode/booleanity `r_address` are the reversed stage-6a
+    /// address challenges (matching the verifier's reversed address opening point).
+    /// The modular prover only supports full programs, so there are no committed
+    /// claim reductions.
+    fn cycle_relations(&self) -> Result<Stage6Relations<'_, F>, ProverError> {
+        let config = &self.config;
+        let bytecode_context = config.bytecode_context.as_ref().ok_or_else(|| {
+            invalid_stage_request("Stage 6 bytecode context is required for the cycle relations")
+        })?;
+        let stage_cycle_points = stage6_bytecode_cycle_points(
+            self.stage1,
+            self.stage2,
+            self.stage3,
+            self.stage4,
+            self.stage5,
+        )
+        .map_err(invalid_stage_request)?;
+        let register_points = stage6_bytecode_register_points(self.stage4, self.stage5)
+            .map_err(invalid_stage_request)?;
+        let ram_reduced =
+            stage6_stage5_ram_reduced_opening_point(self.stage5, config.log_k, config.log_t)
+                .map_err(invalid_stage_request)?;
+        let instruction_read_raf = stage6_instruction_read_raf_point(self.stage5);
+        let inc_cycles = stage6_inc_claim_reduction_cycle_points(
+            self.stage2,
+            self.stage4,
+            self.stage5,
+            config.log_k,
+        )
+        .map_err(invalid_stage_request)?;
+        let challenges = &self.prefix.challenges;
+        let reversed = |challenges: &[F]| challenges.iter().rev().copied().collect::<Vec<_>>();
+
+        Stage6Relations::build(
+            Stage6RelationsParams {
+                bytecode_dimensions: config.bytecode_read_raf_dimensions,
+                booleanity_dimensions: config.booleanity_dimensions,
+                trace_dimensions: config.trace_dimensions(),
+                ram_ra_dimensions: config.ram_ra_virtualization_dimensions,
+                instruction_ra_dimensions: config.instruction_ra_virtualization_dimensions,
+                committed_chunk_bits: config.committed_chunk_bits,
+                bytecode_table: Some(&bytecode_context.rows),
+                entry_bytecode_index: bytecode_context.entry_bytecode_index,
+                bytecode_r_address: reversed(&self.bytecode_address_challenges),
+                booleanity_r_address: reversed(&self.booleanity_address_challenges),
+                address_bytecode_read_raf: self.address_phase.bytecode_read_raf,
+                address_booleanity: self.address_phase.booleanity,
+                address_val_stages: self
+                    .address_phase
+                    .bytecode_val_stages
+                    .map_or_else(Vec::new, |stages| stages.to_vec()),
+                bytecode_gamma: challenges.bytecode_gamma_powers[1],
+                instruction_ra_gamma: challenges.instruction_ra_gamma,
+                inc_gamma: challenges.inc_gamma,
+                booleanity_gamma: challenges.booleanity_gamma,
+                eta: None,
+                stage_cycle_points,
+                register_read_write_point: register_points.register_read_write_address.to_vec(),
+                register_val_evaluation_point: register_points
+                    .register_val_evaluation_address
+                    .to_vec(),
+                stage_gammas: [
+                    challenges.stage1_gammas.clone(),
+                    challenges.stage2_gammas.clone(),
+                    challenges.stage3_gammas.clone(),
+                    challenges.stage4_gammas.clone(),
+                    challenges.stage5_gammas.clone(),
+                ],
+                booleanity_reference_address: challenges.booleanity_reference.address.clone(),
+                booleanity_reference_cycle: challenges.booleanity_reference.cycle.clone(),
+                stage1_cycle_binding: stage6_stage1_cycle_binding(self.stage1)
+                    .map_err(invalid_stage_request)?
+                    .to_vec(),
+                ram_reduced_address: ram_reduced.address.to_vec(),
+                ram_reduced_cycle: ram_reduced.cycle.to_vec(),
+                instruction_r_address: instruction_read_raf.address.to_vec(),
+                instruction_r_cycle: instruction_read_raf.cycle.to_vec(),
+                inc_cycle_points: [
+                    inc_cycles.ram_read_write_cycle.to_vec(),
+                    inc_cycles.ram_val_check_cycle.to_vec(),
+                    inc_cycles.registers_read_write_cycle.to_vec(),
+                    inc_cycles.registers_val_evaluation_cycle.to_vec(),
+                ],
+                trusted_advice_layout: config.trusted_advice_layout.as_ref(),
+                untrusted_advice_layout: config.untrusted_advice_layout.as_ref(),
+                bytecode_reduction_layout: None,
+                program_image_reduction_layout: None,
+                bytecode_reduction_weights: None,
+                program_image_r_addr_rw: Vec::new(),
+            },
+            self.stage2,
+            self.stage4,
+            self.stage5,
+        )
+        .map_err(invalid_stage_request)
+    }
+
+    pub(super) fn cycle_input_claims(&self) -> Stage6BatchInputClaims<F> {
+        let mut input_claims = self.prefix.input_claims.clone();
+        input_claims.bytecode_read_raf = self.address_phase.bytecode_read_raf;
+        input_claims.booleanity = self.address_phase.booleanity;
+        input_claims
+    }
+
+    pub(super) fn materialize_relation(
+        &self,
+        instance: &Stage6BatchInstance<F>,
+    ) -> Result<Stage6RelationState<F>, ProverError> {
+        let relation = self.materialize_relation_state(instance)?;
+        let input_sum = relation.round_sum(0, F::zero())? + relation.round_sum(0, F::one())?;
+        if input_sum != instance.input_claim {
+            return Err(invalid_sumcheck_output(format!(
+                "Stage 6 instance {:?} materialized sum does not match input claim: expected {}, got {}",
+                instance.kind, instance.input_claim, input_sum
+            )));
+        }
+        Ok(relation)
+    }
+
+    fn materialize_relation_state(
+        &self,
+        instance: &Stage6BatchInstance<F>,
+    ) -> Result<Stage6RelationState<F>, ProverError> {
+        // Only the advice cycle-phase relations are materialized in-crate; every
+        // other Stage 6 relation's round polynomials are produced by jolt-backends.
+        match instance.kind {
+            Stage6InstanceKind::AdviceCyclePhase(kind) => {
+                self.materialize_advice_relation(instance, kind)
+            }
+            other => Err(invalid_stage_request(format!(
+                "Stage 6 {other:?} relation is backend-owned, not materialized in-crate"
+            ))),
+        }
+    }
+
+    fn materialize_advice_relation(
+        &self,
+        _instance: &Stage6BatchInstance<F>,
+        kind: JoltAdviceKind,
+    ) -> Result<Stage6RelationState<F>, ProverError> {
+        let layout = self.advice_layout(kind).ok_or_else(|| {
+            invalid_stage_request(format!("Stage 6 {kind:?} advice layout is missing"))
+        })?;
+        let reference = self.advice_cycle_phase_reference(kind)?.opening_point;
+        let values = materialize_advice_values(self.witness, kind)?;
+        let (advice, eq) = layout
+            .cycle_phase_polynomials(reference, values)
+            .map_err(|error| {
+                invalid_stage_request(format!(
+                    "Stage 6 {kind:?} advice cycle-phase polynomials are invalid: {error}"
+                ))
+            })?;
+        Ok(Stage6RelationState::advice(
+            AdviceCyclePhaseRelationState::new(
+                advice,
+                eq,
+                layout.cycle_phase_col_rounds(),
+                layout.cycle_phase_row_rounds(),
+            ),
+        ))
+    }
+
+    /// The per-instance expected output claims, single-sourced through the same
+    /// [`Stage6Relations`] bundle the verifier uses: each relation derives its
+    /// opening points from the 6b cycle instance point and evaluates its output
+    /// `Expr` against the produced openings — mirroring the clear verifier exactly.
+    /// The stage-6b cycle batch's expected output claims AND the produced opening
+    /// *points*, both single-sourced through the [`Stage6Relations`] bundle the
+    /// verifier uses: each relation derives its opening points once, which feed
+    /// both the output-claim check and the `Stage6ClearOutput::output_points` the
+    /// prover hands to stages 7/8. Mirrors the clear verifier exactly.
+    pub(super) fn cycle_outputs(
+        &self,
+        sumcheck_point: &[F],
+        openings: &Stage6OutputClaims<F>,
+    ) -> Result<
+        (
+            Stage6BatchExpectedOutputClaims<F>,
+            Stage6OutputClaims<Vec<F>>,
+        ),
+        ProverError,
+    > {
+        let relations = self.cycle_relations()?;
+        let algebra =
+            |error: jolt_verifier::VerifierError| invalid_sumcheck_output(error.to_string());
+
+        let bytecode_point =
+            self.instance_point(sumcheck_point, Stage6InstanceKind::BytecodeReadRaf)?;
+        let bytecode_derived = relations
+            .bytecode_read_raf
+            .derive_opening_points(&bytecode_point, &relations.bytecode_read_raf_inputs)
+            .map_err(algebra)?;
+        let bytecode_read_raf = relations
+            .bytecode_read_raf
+            .expected_output(
+                &relations.bytecode_read_raf_inputs,
+                &zip_openings(&openings.bytecode_read_raf, &bytecode_derived),
+            )
+            .map_err(algebra)?;
+
+        let booleanity_point =
+            self.instance_point(sumcheck_point, Stage6InstanceKind::Booleanity)?;
+        let booleanity_derived = relations
+            .booleanity
+            .derive_opening_points(&booleanity_point, &relations.booleanity_inputs)
+            .map_err(algebra)?;
+        let booleanity = relations
+            .booleanity
+            .expected_output(
+                &relations.booleanity_inputs,
+                &zip_openings(&openings.booleanity, &booleanity_derived),
+            )
+            .map_err(algebra)?;
+
+        let ram_hamming_point =
+            self.instance_point(sumcheck_point, Stage6InstanceKind::RamHammingBooleanity)?;
+        let ram_hamming_derived = relations
+            .ram_hamming
+            .derive_opening_points(&ram_hamming_point, &relations.ram_hamming_inputs)
+            .map_err(algebra)?;
+        let ram_hamming_booleanity = relations
+            .ram_hamming
+            .expected_output(
+                &relations.ram_hamming_inputs,
+                &zip_openings(&openings.ram_hamming_booleanity, &ram_hamming_derived),
+            )
+            .map_err(algebra)?;
+
+        let ram_ra_point =
+            self.instance_point(sumcheck_point, Stage6InstanceKind::RamRaVirtualization)?;
+        let ram_ra_derived = relations
+            .ram_ra
+            .derive_opening_points(&ram_ra_point, &relations.ram_ra_inputs)
+            .map_err(algebra)?;
+        let ram_ra_virtualization = relations
+            .ram_ra
+            .expected_output(
+                &relations.ram_ra_inputs,
+                &zip_openings(&openings.ram_ra_virtualization, &ram_ra_derived),
+            )
+            .map_err(algebra)?;
+
+        let instruction_ra_point = self.instance_point(
+            sumcheck_point,
+            Stage6InstanceKind::InstructionRaVirtualization,
+        )?;
+        let instruction_ra_derived = relations
+            .instruction_ra
+            .derive_opening_points(&instruction_ra_point, &relations.instruction_ra_inputs)
+            .map_err(algebra)?;
+        let instruction_ra_virtualization = relations
+            .instruction_ra
+            .expected_output(
+                &relations.instruction_ra_inputs,
+                &zip_openings(
+                    &openings.instruction_ra_virtualization,
+                    &instruction_ra_derived,
+                ),
+            )
+            .map_err(algebra)?;
+
+        let inc_point =
+            self.instance_point(sumcheck_point, Stage6InstanceKind::IncClaimReduction)?;
+        let inc_derived = relations
+            .inc
+            .derive_opening_points(&inc_point, &relations.inc_inputs)
+            .map_err(algebra)?;
+        let inc_claim_reduction = relations
+            .inc
+            .expected_output(
+                &relations.inc_inputs,
+                &zip_openings(&openings.inc_claim_reduction, &inc_derived),
+            )
+            .map_err(algebra)?;
+
+        // Each advice kind yields both its expected output claim and its produced
+        // opening point (for `output_points`).
+        let advice = |kind: JoltAdviceKind,
+                      relation: Option<&jolt_verifier::stages::stage6::AdviceCyclePhase<F>>|
+         -> Result<Option<(F, Vec<F>)>, ProverError> {
+            let claim = match kind {
+                JoltAdviceKind::Trusted => openings.advice_cycle_phase.trusted.as_ref(),
+                JoltAdviceKind::Untrusted => openings.advice_cycle_phase.untrusted.as_ref(),
+            };
+            match (relation, claim) {
+                (Some(relation), Some(claim)) => {
+                    let point = self.instance_point(
+                        sumcheck_point,
+                        Stage6InstanceKind::AdviceCyclePhase(kind),
+                    )?;
+                    let derived = relation
+                        .derive_opening_points(&point, &relations.advice_inputs)
+                        .map_err(algebra)?;
+                    let opening_point = match kind {
+                        JoltAdviceKind::Trusted => derived.trusted.clone(),
+                        JoltAdviceKind::Untrusted => derived.untrusted.clone(),
+                    }
+                    .ok_or_else(|| {
+                        invalid_sumcheck_output("Stage 6 advice cycle phase produced no opening")
+                    })?;
+                    let values = match kind {
+                        JoltAdviceKind::Trusted => AdviceCyclePhaseOutputClaims {
+                            trusted: Some(claim.opening_claim),
+                            untrusted: None,
+                        },
+                        JoltAdviceKind::Untrusted => AdviceCyclePhaseOutputClaims {
+                            trusted: None,
+                            untrusted: Some(claim.opening_claim),
+                        },
+                    };
+                    let expected = relation
+                        .expected_output(&relations.advice_inputs, &zip_openings(&values, &derived))
+                        .map_err(algebra)?;
+                    Ok(Some((expected, opening_point)))
+                }
+                (None, None) => Ok(None),
+                _ => Err(invalid_stage_request(format!(
+                    "Stage 6 {kind:?} advice relation/opening presence mismatch"
+                ))),
+            }
+        };
+        let trusted_advice = advice(JoltAdviceKind::Trusted, relations.trusted_advice.as_ref())?;
+        let untrusted_advice = advice(
+            JoltAdviceKind::Untrusted,
+            relations.untrusted_advice.as_ref(),
+        )?;
+
+        let reversed = |challenges: &[F]| challenges.iter().rev().copied().collect::<Vec<_>>();
+        let output_points = Stage6OutputClaims {
+            address_phase: Stage6AddressPhaseClaims {
+                bytecode_read_raf: reversed(&self.bytecode_address_challenges),
+                booleanity: reversed(&self.booleanity_address_challenges),
+                // The modular prover only supports full programs (no staged Val columns).
+                bytecode_val_stages: None,
+            },
+            bytecode_read_raf: bytecode_derived,
+            booleanity: booleanity_derived,
+            ram_hamming_booleanity: ram_hamming_derived,
+            ram_ra_virtualization: ram_ra_derived,
+            instruction_ra_virtualization: instruction_ra_derived,
+            inc_claim_reduction: inc_derived,
+            advice_cycle_phase: Stage6AdviceCyclePhaseClaims {
+                trusted: trusted_advice
+                    .as_ref()
+                    .map(|(_, point)| AdviceCyclePhaseOutputClaim {
+                        opening_claim: point.clone(),
+                    }),
+                untrusted: untrusted_advice.as_ref().map(|(_, point)| {
+                    AdviceCyclePhaseOutputClaim {
+                        opening_claim: point.clone(),
+                    }
+                }),
+            },
+            // Committed-program reductions; the modular prover is full-only.
+            bytecode_claim_reduction: None,
+            program_image_claim_reduction: None,
+        };
+        let expected = Stage6BatchExpectedOutputClaims {
+            bytecode_read_raf,
+            booleanity,
+            ram_hamming_booleanity,
+            ram_ra_virtualization,
+            instruction_ra_virtualization,
+            inc_claim_reduction,
+            trusted_advice_cycle_phase: trusted_advice.map(|(expected, _)| expected),
+            untrusted_advice_cycle_phase: untrusted_advice.map(|(expected, _)| expected),
+        };
+        Ok((expected, output_points))
+    }
+
+    /// The advice cycle-phase produced opening point for `kind` (the reversed
+    /// active-cycle challenges), used to evaluate the advice witness opening
+    /// before the output claims are assembled. Matches the `output_points` cell
+    /// `cycle_outputs` later produces.
+    pub(super) fn advice_cycle_phase_opening_point(
+        &self,
+        sumcheck_point: &[F],
+        kind: JoltAdviceKind,
+    ) -> Result<Option<Vec<F>>, ProverError> {
+        let Some(layout) = self.advice_layout(kind) else {
+            return Ok(None);
+        };
+        if self
+            .instances
+            .iter()
+            .all(|instance| instance.kind != Stage6InstanceKind::AdviceCyclePhase(kind))
+        {
+            return Ok(None);
+        }
+        let point =
+            self.instance_point(sumcheck_point, Stage6InstanceKind::AdviceCyclePhase(kind))?;
+        Ok(Some(layout.cycle_phase_opening_point(&point).map_err(
+            |error| invalid_sumcheck_output(error.to_string()),
+        )?))
+    }
+
+    pub(super) fn instance(
+        &self,
+        kind: Stage6InstanceKind,
+    ) -> Result<&Stage6BatchInstance<F>, ProverError> {
+        self.instances
+            .iter()
+            .find(|instance| instance.kind == kind)
+            .ok_or_else(|| invalid_stage_request(format!("Stage 6 instance {kind:?} is missing")))
+    }
+
+    fn instance_point(
+        &self,
+        sumcheck_point: &[F],
+        kind: Stage6InstanceKind,
+    ) -> Result<Vec<F>, ProverError> {
+        let instance = self.instance(kind)?;
+        let end = instance.offset + instance.num_vars;
+        sumcheck_point
+            .get(instance.offset..end)
+            .map(<[F]>::to_vec)
+            .ok_or_else(|| {
+                invalid_sumcheck_output(format!(
+                    "Stage 6 instance {:?} point range {}..{end} is out of range for {} variables",
+                    kind,
+                    instance.offset,
+                    sumcheck_point.len()
+                ))
+            })
+    }
+
+    fn advice_cycle_phase_reference(
+        &self,
+        kind: JoltAdviceKind,
+    ) -> Result<Stage6AdviceCyclePhaseReference<'_, F>, ProverError> {
+        stage6_advice_cycle_phase_reference(self.stage4, kind).map_err(invalid_stage_request)
+    }
+
+    pub(super) fn advice_cycle_phase_reference_opening_point(
+        &self,
+        kind: JoltAdviceKind,
+    ) -> Result<Option<&[F]>, ProverError> {
+        if self.advice_layout(kind).is_none() {
+            return Ok(None);
+        }
+        Ok(Some(self.advice_cycle_phase_reference(kind)?.opening_point))
+    }
+
+    fn advice_layout(&self, kind: JoltAdviceKind) -> Option<&AdviceClaimReductionLayout> {
+        match kind {
+            JoltAdviceKind::Trusted => self.config.trusted_advice_layout.as_ref(),
+            JoltAdviceKind::Untrusted => self.config.untrusted_advice_layout.as_ref(),
+        }
+    }
+}
+
+fn advice_cycle_phase_offset(
+    config: &Stage6ProverConfig,
+    kind: JoltAdviceKind,
+    max_num_vars: usize,
+) -> Result<usize, ProverError> {
+    let layout = match kind {
+        JoltAdviceKind::Trusted => config.trusted_advice_layout.as_ref(),
+        JoltAdviceKind::Untrusted => config.untrusted_advice_layout.as_ref(),
+    }
+    .ok_or_else(|| invalid_stage_request(format!("Stage 6 {kind:?} advice layout is missing")))?;
+    layout
+        .cycle_phase_batch_offset(max_num_vars)
+        .map_err(|error| {
+            invalid_stage_request(format!(
+                "Stage 6 {kind:?} advice cycle-phase offset is invalid: {error}"
+            ))
+        })
+}
+
+pub(super) fn evaluate_advice_cycle_phase_opening<F, W>(
+    layout: Option<&AdviceClaimReductionLayout>,
+    witness: &W,
+    kind: JoltAdviceKind,
+    reference_opening_point: Option<&[F]>,
+    opening_point: Option<&[F]>,
+) -> Result<Option<AdviceCyclePhaseOutputClaim<F>>, ProverError>
+where
+    F: Field,
+    W: WitnessProvider<F, JoltVmNamespace>,
+{
+    let Some(layout) = layout else {
+        if reference_opening_point.is_some() || opening_point.is_some() {
+            return Err(invalid_stage_request(format!(
+                "Stage 6 {kind:?} advice opening was supplied without configured advice"
+            )));
+        }
+        return Ok(None);
+    };
+    let reference_opening_point = reference_opening_point.ok_or_else(|| {
+        invalid_stage_request(format!(
+            "Stage 6 {kind:?} advice reference opening point is missing"
+        ))
+    })?;
+    let opening_point = opening_point.ok_or_else(|| {
+        invalid_stage_request(format!(
+            "Stage 6 {kind:?} advice cycle-phase opening point is missing"
+        ))
+    })?;
+    let values = materialize_advice_values(witness, kind)?;
+    let opening_claim = layout
+        .cycle_phase_opening_claim(reference_opening_point, values, opening_point)
+        .map_err(|error| {
+            invalid_stage_request(format!(
+                "Stage 6 {kind:?} advice cycle-phase opening claim is invalid: {error}"
+            ))
+        })?;
+    Ok(Some(AdviceCyclePhaseOutputClaim { opening_claim }))
+}
+
+fn materialize_advice_values<F, W>(witness: &W, kind: JoltAdviceKind) -> Result<Vec<F>, ProverError>
+where
+    F: Field,
+    W: WitnessProvider<F, JoltVmNamespace>,
+{
+    let oracle = match kind {
+        JoltAdviceKind::Trusted => OracleRef::committed(JoltCommittedPolynomial::TrustedAdvice),
+        JoltAdviceKind::Untrusted => OracleRef::committed(JoltCommittedPolynomial::UntrustedAdvice),
+    };
+    let requirement = witness
+        .view_requirements(oracle)?
+        .into_iter()
+        .next()
+        .ok_or_else(|| {
+            invalid_stage_request(format!(
+                "witness returned no view requirement for Stage 6 {kind:?} advice"
+            ))
+        })?;
+    let view = witness.oracle_view(requirement)?;
+    view.as_slice().map(<[F]>::to_vec).ok_or_else(|| {
+        invalid_stage_request(format!("Stage 6 {kind:?} advice view is not concrete"))
+    })
+}
+
+fn invalid_stage_request(error: impl std::fmt::Display) -> ProverError {
+    ProverError::InvalidStageRequest {
+        reason: error.to_string(),
+    }
+}

--- a/crates/jolt-prover/src/stages/stage6/io.rs
+++ b/crates/jolt-prover/src/stages/stage6/io.rs
@@ -1,0 +1,184 @@
+use jolt_claims::protocols::jolt::{
+    formulas::{
+        booleanity::BooleanityDimensions, bytecode::BytecodeReadRafDimensions,
+        dimensions::TraceDimensions, instruction::InstructionRaVirtualizationDimensions,
+        ram::RamRaVirtualizationDimensions,
+    },
+    AdviceClaimReductionLayout,
+};
+#[cfg(feature = "zk")]
+use jolt_crypto::VectorCommitment;
+use jolt_field::Field;
+use jolt_riscv::JoltInstructionRow;
+use jolt_sumcheck::SumcheckProof;
+#[cfg(feature = "zk")]
+use jolt_verifier::stages::stage6::outputs::Stage6PublicOutput;
+use jolt_verifier::stages::stage6::{
+    outputs::{Stage6ClearOutput, Stage6OutputClaims},
+    Stage6BatchInputClaims, Stage6TranscriptChallenges,
+};
+use jolt_verifier::stages::{
+    stage1::Stage1ClearOutput, stage2::Stage2ClearOutput, stage3::Stage3ClearOutput,
+    stage4::Stage4ClearOutput, stage5::Stage5ClearOutput,
+};
+use jolt_verifier::CheckedInputs;
+
+#[cfg(feature = "zk")]
+use crate::committed::CommittedSumcheckWitness;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Stage6BytecodeContext {
+    pub rows: Vec<JoltInstructionRow>,
+    pub entry_bytecode_index: usize,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Stage6ProverConfig {
+    pub log_t: usize,
+    pub log_k: usize,
+    pub committed_chunk_bits: usize,
+    pub bytecode_read_raf_dimensions: BytecodeReadRafDimensions,
+    pub booleanity_dimensions: BooleanityDimensions,
+    pub ram_ra_virtualization_dimensions: RamRaVirtualizationDimensions,
+    pub instruction_ra_virtualization_dimensions: InstructionRaVirtualizationDimensions,
+    pub trusted_advice_layout: Option<AdviceClaimReductionLayout>,
+    pub untrusted_advice_layout: Option<AdviceClaimReductionLayout>,
+    pub bytecode_context: Option<Stage6BytecodeContext>,
+}
+
+impl Stage6ProverConfig {
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "Stage 6 dimensions are derived by distinct protocol subsystems."
+    )]
+    pub const fn new(
+        log_t: usize,
+        log_k: usize,
+        committed_chunk_bits: usize,
+        bytecode_read_raf_dimensions: BytecodeReadRafDimensions,
+        booleanity_dimensions: BooleanityDimensions,
+        ram_ra_virtualization_dimensions: RamRaVirtualizationDimensions,
+        instruction_ra_virtualization_dimensions: InstructionRaVirtualizationDimensions,
+        trusted_advice_layout: Option<AdviceClaimReductionLayout>,
+        untrusted_advice_layout: Option<AdviceClaimReductionLayout>,
+    ) -> Self {
+        Self {
+            log_t,
+            log_k,
+            committed_chunk_bits,
+            bytecode_read_raf_dimensions,
+            booleanity_dimensions,
+            ram_ra_virtualization_dimensions,
+            instruction_ra_virtualization_dimensions,
+            trusted_advice_layout,
+            untrusted_advice_layout,
+            bytecode_context: None,
+        }
+    }
+
+    pub fn with_bytecode_context(
+        mut self,
+        rows: Vec<JoltInstructionRow>,
+        entry_bytecode_index: usize,
+    ) -> Self {
+        self.bytecode_context = Some(Stage6BytecodeContext {
+            rows,
+            entry_bytecode_index,
+        });
+        self
+    }
+
+    pub const fn trace_dimensions(&self) -> TraceDimensions {
+        TraceDimensions::new(self.log_t)
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct Stage6ProverInput<'a, F: Field, W> {
+    pub config: &'a Stage6ProverConfig,
+    pub checked: &'a CheckedInputs,
+    pub stage1: &'a Stage1ClearOutput<F>,
+    pub stage2: &'a Stage2ClearOutput<F>,
+    pub stage3: &'a Stage3ClearOutput<F>,
+    pub stage4: &'a Stage4ClearOutput<F>,
+    pub stage5: &'a Stage5ClearOutput<F>,
+    pub witness: &'a W,
+}
+
+impl<'a, F: Field, W> Stage6ProverInput<'a, F, W> {
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "Stage 6 consumes every prior clear stage output."
+    )]
+    pub const fn new(
+        config: &'a Stage6ProverConfig,
+        checked: &'a CheckedInputs,
+        stage1: &'a Stage1ClearOutput<F>,
+        stage2: &'a Stage2ClearOutput<F>,
+        stage3: &'a Stage3ClearOutput<F>,
+        stage4: &'a Stage4ClearOutput<F>,
+        stage5: &'a Stage5ClearOutput<F>,
+        witness: &'a W,
+    ) -> Self {
+        Self {
+            config,
+            checked,
+            stage1,
+            stage2,
+            stage3,
+            stage4,
+            stage5,
+            witness,
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(super) struct Stage6RegularBatchPrefixOutput<F: Field> {
+    pub(super) input_claims: Stage6BatchInputClaims<F>,
+    pub(super) challenges: Stage6TranscriptChallenges<F>,
+}
+
+impl<F: Field> Stage6RegularBatchPrefixOutput<F> {
+    pub(super) const fn new(
+        input_claims: Stage6BatchInputClaims<F>,
+        challenges: Stage6TranscriptChallenges<F>,
+    ) -> Self {
+        Self {
+            input_claims,
+            challenges,
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Stage6ProofComponent<F: Field, Proof> {
+    pub stage6a_sumcheck_proof: Proof,
+    pub stage6b_sumcheck_proof: Proof,
+    pub claims: Stage6OutputClaims<F>,
+    pub verifier_output: Stage6ClearOutput<F>,
+}
+
+#[cfg(feature = "zk")]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Stage6CommittedProofComponent<F, VC>
+where
+    F: Field,
+    VC: VectorCommitment<Field = F>,
+{
+    pub stage6a_sumcheck_proof: SumcheckProof<F, VC::Output>,
+    pub stage6b_sumcheck_proof: SumcheckProof<F, VC::Output>,
+    pub public: Stage6PublicOutput<F>,
+    pub output_claim_values: Vec<F>,
+    pub verifier_output: Stage6ClearOutput<F>,
+    /// ZK committed witness for stage 6a (address phase).
+    pub(crate) stage6a_committed_witness: CommittedSumcheckWitness<F>,
+    /// ZK committed witness for stage 6b (cycle phase).
+    pub(crate) committed_witness: CommittedSumcheckWitness<F>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(super) struct Stage6RegularBatchProofOutput<F: Field, Proof> {
+    pub(super) proof: SumcheckProof<F, Proof>,
+    pub(super) verifier_output: Stage6ClearOutput<F>,
+}

--- a/crates/jolt-prover/src/stages/stage6/mod.rs
+++ b/crates/jolt-prover/src/stages/stage6/mod.rs
@@ -1,0 +1,10 @@
+mod batch;
+mod io;
+pub(crate) mod prepare;
+pub mod prove;
+mod relation_state;
+mod verifier_output;
+
+#[cfg(feature = "zk")]
+pub use io::Stage6CommittedProofComponent;
+pub use io::{Stage6ProofComponent, Stage6ProverConfig, Stage6ProverInput};

--- a/crates/jolt-prover/src/stages/stage6/prepare.rs
+++ b/crates/jolt-prover/src/stages/stage6/prepare.rs
@@ -1,0 +1,494 @@
+use common::jolt_device::JoltDevice;
+use jolt_backends::{
+    stage6_bytecode_pc_indices, stage6_hamming_weight, stage6_inc_rows, stage6_ra_rows,
+    Stage6RegularBatchSumcheckBackend, SumcheckBooleanityStateRequest,
+    SumcheckBytecodeReadRafStateRequest, SumcheckIncClaimReductionStateRequest,
+    SumcheckInstructionRaVirtualizationStateRequest, SumcheckRamHammingBooleanityStateRequest,
+    SumcheckRamRaVirtualizationStateRequest,
+};
+use jolt_claims::protocols::jolt::{
+    formulas::{booleanity::BooleanityDimensions, bytecode},
+    AdviceClaimReductionLayout, JoltAdviceKind, JoltFormulaDimensions,
+};
+use jolt_crypto::VectorCommitment;
+use jolt_field::Field;
+use jolt_openings::CommitmentScheme;
+use jolt_transcript::Transcript;
+use jolt_verifier::stages::relations::SumcheckInstance;
+use jolt_verifier::stages::stage6::outputs::Stage6AddressPhaseClaims;
+use jolt_verifier::stages::stage6::{
+    stage6_advice_cycle_phase_reference, stage6_bytecode_cycle_points,
+    stage6_bytecode_register_points, stage6_inc_claim_reduction_cycle_points,
+    stage6_instruction_read_raf_point, stage6_post_address_transcript_challenges,
+    stage6_pre_address_transcript_challenges, stage6_stage1_cycle_binding,
+    stage6_stage5_ram_reduced_opening_point, AdviceCyclePhase, AdviceCyclePhaseInputClaims,
+    BytecodeReadRafAddressPhase, BytecodeReadRafAddressPhaseInputClaims, IncClaimReduction,
+    IncClaimReductionInputClaims, InstructionRaVirtualization,
+    InstructionRaVirtualizationInputClaims, RamHammingBooleanity, RamHammingBooleanityInputClaims,
+    RamRaVirtualization, RamRaVirtualizationInputClaims, Stage6BatchInputClaims,
+    Stage6PreAddressChallenges, Stage6TranscriptChallenges,
+};
+use jolt_verifier::stages::{
+    stage1::Stage1ClearOutput, stage2::Stage2ClearOutput, stage3::Stage3ClearOutput,
+    stage4::Stage4ClearOutput, stage5::Stage5ClearOutput,
+};
+use jolt_witness::protocols::jolt_vm::{JoltVmNamespace, JoltVmStage6Rows};
+use jolt_witness::WitnessProvider;
+
+use super::io::Stage6RegularBatchPrefixOutput;
+use super::Stage6ProverConfig;
+use crate::stages::advice::advice_layouts;
+use crate::{JoltProverPreprocessing, ProverConfig, ProverError};
+
+pub(super) const STAGE6_REGULAR_BATCH_OPT_IDS: &[&str] = &["cpu_stage6_regular_batch_sumcheck"];
+
+pub(super) struct Stage6BackendStates<B, F>
+where
+    F: Field,
+    B: Stage6RegularBatchSumcheckBackend<F>,
+{
+    pub(super) bytecode_read_raf: B::BytecodeReadRafState,
+    pub(super) booleanity: B::BooleanityState,
+    pub(super) ram_hamming_booleanity: B::RamHammingBooleanityState,
+    pub(super) ram_ra_virtualization: B::RamRaVirtualizationState,
+    pub(super) instruction_ra_virtualization: B::InstructionRaVirtualizationState,
+    pub(super) inc_claim_reduction: B::IncClaimReductionState,
+}
+
+pub(crate) fn prover_config<PCS, VC>(
+    preprocessing: &JoltProverPreprocessing<PCS, VC>,
+    public_io: &JoltDevice,
+    proof_parameters: ProverConfig,
+    formula_dimensions: JoltFormulaDimensions,
+) -> Result<Stage6ProverConfig, ProverError>
+where
+    PCS: CommitmentScheme,
+    VC: VectorCommitment<Field = PCS::Field>,
+{
+    let log_t = proof_parameters.trace_length.trailing_zeros() as usize;
+    let log_k = proof_parameters.ram_k.trailing_zeros() as usize;
+    let committed_chunk_bits = proof_parameters.one_hot_config.committed_chunk_bits();
+    let (trusted_advice_layout, untrusted_advice_layout) =
+        advice_layouts(public_io, proof_parameters, log_t, committed_chunk_bits)?;
+    let full_program = preprocessing.verifier.program.as_full().ok_or_else(|| {
+        ProverError::InvalidProverConfig {
+            reason: "Stage 6 requires full program preprocessing (committed-program mode is not supported by the prover)".to_owned(),
+        }
+    })?;
+    let entry_bytecode_index = full_program
+        .bytecode
+        .entry_bytecode_index()
+        .ok_or_else(|| ProverError::InvalidProverConfig {
+            reason: "entry address was not found in bytecode preprocessing".to_owned(),
+        })?;
+
+    Ok(Stage6ProverConfig::new(
+        log_t,
+        log_k,
+        committed_chunk_bits,
+        formula_dimensions.bytecode_read_raf,
+        BooleanityDimensions::new(formula_dimensions.ra_layout, log_t, committed_chunk_bits),
+        formula_dimensions.ram_ra_virtualization,
+        formula_dimensions.instruction_ra_virtualization,
+        trusted_advice_layout,
+        untrusted_advice_layout,
+    )
+    .with_bytecode_context(full_program.bytecode.bytecode.clone(), entry_bytecode_index))
+}
+
+pub(super) fn derive_stage6_pre_address_challenges<F, T>(
+    config: &Stage6ProverConfig,
+    stage5: &Stage5ClearOutput<F>,
+    transcript: &mut T,
+) -> Result<Stage6PreAddressChallenges<F>, ProverError>
+where
+    F: Field,
+    T: Transcript<Challenge = F>,
+{
+    let instruction_read_raf =
+        jolt_verifier::stages::stage6::stage6_instruction_read_raf_point(stage5);
+    Ok(stage6_pre_address_transcript_challenges(
+        instruction_read_raf.address,
+        instruction_read_raf.cycle,
+        config.committed_chunk_bits,
+        stage5
+            .output_claims
+            .instruction_read_raf
+            .lookup_table_flags
+            .len(),
+        transcript,
+    ))
+}
+
+/// Computes the bytecode read-RAF address-phase input claim (the stage-folding
+/// RLC).
+pub(super) fn bytecode_read_raf_address_input<F>(
+    config: &Stage6ProverConfig,
+    pre: &Stage6PreAddressChallenges<F>,
+    stage1: &Stage1ClearOutput<F>,
+    stage2: &Stage2ClearOutput<F>,
+    stage3: &Stage3ClearOutput<F>,
+    stage4: &Stage4ClearOutput<F>,
+    stage5: &Stage5ClearOutput<F>,
+) -> Result<F, ProverError>
+where
+    F: Field,
+{
+    let inputs = BytecodeReadRafAddressPhaseInputClaims::from_upstream(
+        stage1, stage2, stage3, stage4, stage5,
+    )
+    .map_err(invalid_stage_request)?;
+    // `num_val_stages` only affects produced opening points, not the input claim.
+    BytecodeReadRafAddressPhase::new(
+        config.bytecode_read_raf_dimensions,
+        pre.bytecode_gamma_powers[1],
+        [
+            pre.stage1_gammas[1],
+            pre.stage2_gammas[1],
+            pre.stage3_gammas[1],
+            pre.stage4_gammas[1],
+            pre.stage5_gammas[1],
+        ],
+        0,
+    )
+    .input_claim(&inputs)
+    .map_err(invalid_stage_request)
+}
+
+#[expect(
+    clippy::too_many_arguments,
+    reason = "Stage 6 prefix completion consumes every prior clear stage output."
+)]
+pub(super) fn complete_stage6_prefix<F, T>(
+    config: &Stage6ProverConfig,
+    pre: Stage6PreAddressChallenges<F>,
+    stage1: &Stage1ClearOutput<F>,
+    stage2: &Stage2ClearOutput<F>,
+    stage4: &Stage4ClearOutput<F>,
+    stage5: &Stage5ClearOutput<F>,
+    address_phase: &Stage6AddressPhaseClaims<F>,
+    transcript: &mut T,
+) -> Result<Stage6RegularBatchPrefixOutput<F>, ProverError>
+where
+    F: Field,
+    T: Transcript<Challenge = F>,
+{
+    let post = stage6_post_address_transcript_challenges(
+        config.instruction_ra_virtualization_dimensions,
+        transcript,
+    );
+    let transcript_challenges = Stage6TranscriptChallenges::from_address_phases(pre, post);
+    let input_claims = stage6_cycle_input_claims(
+        config,
+        &transcript_challenges,
+        address_phase,
+        stage1,
+        stage2,
+        stage4,
+        stage5,
+    )?;
+
+    Ok(Stage6RegularBatchPrefixOutput::new(
+        input_claims,
+        transcript_challenges,
+    ))
+}
+
+/// The stage-6b cycle-batch input claims, single-sourced through the same relation
+/// objects the verifier uses (`relation.input_claim`). The bytecode/booleanity
+/// cycle phases consume the stage-6a address-phase openings directly; the remaining
+/// relations evaluate their input `Expr` against the upstream openings. Input
+/// claims are point-independent, but the relations are built with their real
+/// construction points so the bundle's algebra is reproduced verbatim.
+fn stage6_cycle_input_claims<F: Field>(
+    config: &Stage6ProverConfig,
+    challenges: &Stage6TranscriptChallenges<F>,
+    address_phase: &Stage6AddressPhaseClaims<F>,
+    stage1: &Stage1ClearOutput<F>,
+    stage2: &Stage2ClearOutput<F>,
+    stage4: &Stage4ClearOutput<F>,
+    stage5: &Stage5ClearOutput<F>,
+) -> Result<Stage6BatchInputClaims<F>, ProverError> {
+    let trace_dimensions = config.trace_dimensions();
+    let committed_chunk_bits = config.committed_chunk_bits;
+
+    let ram_hamming = RamHammingBooleanity::new(
+        trace_dimensions,
+        stage6_stage1_cycle_binding(stage1)
+            .map_err(invalid_stage_request)?
+            .to_vec(),
+    );
+    let ram_hamming_booleanity = ram_hamming
+        .input_claim(&RamHammingBooleanityInputClaims::from_upstream())
+        .map_err(invalid_stage_request)?;
+
+    let ram_reduced = stage6_stage5_ram_reduced_opening_point(stage5, config.log_k, config.log_t)
+        .map_err(invalid_stage_request)?;
+    let ram_ra = RamRaVirtualization::new(
+        config.ram_ra_virtualization_dimensions,
+        ram_reduced.address.to_vec(),
+        ram_reduced.cycle.to_vec(),
+        committed_chunk_bits,
+    );
+    let ram_ra_virtualization = ram_ra
+        .input_claim(&RamRaVirtualizationInputClaims::from_upstream(stage5))
+        .map_err(invalid_stage_request)?;
+
+    let instruction_read_raf = stage6_instruction_read_raf_point(stage5);
+    let instruction_ra = InstructionRaVirtualization::new(
+        config.instruction_ra_virtualization_dimensions,
+        challenges.instruction_ra_gamma,
+        instruction_read_raf.address.to_vec(),
+        instruction_read_raf.cycle.to_vec(),
+        committed_chunk_bits,
+    );
+    let instruction_ra_virtualization = instruction_ra
+        .input_claim(&InstructionRaVirtualizationInputClaims::from_upstream(
+            stage5,
+        ))
+        .map_err(invalid_stage_request)?;
+
+    let inc_cycles = stage6_inc_claim_reduction_cycle_points(stage2, stage4, stage5, config.log_k)
+        .map_err(invalid_stage_request)?;
+    let inc = IncClaimReduction::new(
+        trace_dimensions,
+        challenges.inc_gamma,
+        inc_cycles.ram_read_write_cycle.to_vec(),
+        inc_cycles.ram_val_check_cycle.to_vec(),
+        inc_cycles.registers_read_write_cycle.to_vec(),
+        inc_cycles.registers_val_evaluation_cycle.to_vec(),
+    );
+    let inc_claim_reduction = inc
+        .input_claim(&IncClaimReductionInputClaims::from_upstream(
+            stage2, stage4, stage5,
+        ))
+        .map_err(invalid_stage_request)?;
+
+    let advice_inputs = AdviceCyclePhaseInputClaims::from_upstream(stage4);
+    let advice_input = |kind: JoltAdviceKind,
+                        layout: Option<&AdviceClaimReductionLayout>|
+     -> Result<Option<F>, ProverError> {
+        layout
+            .map(|layout| {
+                let reference = stage6_advice_cycle_phase_reference(stage4, kind)
+                    .map_err(invalid_stage_request)?;
+                AdviceCyclePhase::new(kind, layout, reference.opening_point.to_vec())
+                    .input_claim(&advice_inputs)
+                    .map_err(invalid_stage_request)
+            })
+            .transpose()
+    };
+
+    Ok(Stage6BatchInputClaims {
+        bytecode_read_raf: address_phase.bytecode_read_raf,
+        booleanity: address_phase.booleanity,
+        ram_hamming_booleanity,
+        ram_ra_virtualization,
+        instruction_ra_virtualization,
+        inc_claim_reduction,
+        trusted_advice_cycle_phase: advice_input(
+            JoltAdviceKind::Trusted,
+            config.trusted_advice_layout.as_ref(),
+        )?,
+        untrusted_advice_cycle_phase: advice_input(
+            JoltAdviceKind::Untrusted,
+            config.untrusted_advice_layout.as_ref(),
+        )?,
+    })
+}
+
+pub(super) fn bytecode_stage_values<F>(
+    config: &Stage6ProverConfig,
+    pre: &Stage6PreAddressChallenges<F>,
+    stage4: &Stage4ClearOutput<F>,
+    stage5: &Stage5ClearOutput<F>,
+) -> Result<Vec<[F; 5]>, ProverError>
+where
+    F: Field,
+{
+    let bytecode_context = config.bytecode_context.as_ref().ok_or_else(|| {
+        invalid_stage_request("Stage 6 bytecode context is required for read-RAF evaluation")
+    })?;
+    let register_points =
+        stage6_bytecode_register_points(stage4, stage5).map_err(invalid_stage_request)?;
+    let bytecode_rows = bytecode_context.rows.as_slice();
+    let stage_values = bytecode::read_raf_stage_values(bytecode::BytecodeReadRafStageValueInputs {
+        bytecode: bytecode_rows,
+        register_read_write_point: register_points.register_read_write_address,
+        register_val_evaluation_point: register_points.register_val_evaluation_address,
+        stage1_gammas: &pre.stage1_gammas,
+        stage2_gammas: &pre.stage2_gammas,
+        stage3_gammas: &pre.stage3_gammas,
+        stage4_gammas: &pre.stage4_gammas,
+        stage5_gammas: &pre.stage5_gammas,
+    });
+    Ok(stage_values)
+}
+
+#[expect(
+    clippy::too_many_arguments,
+    reason = "Stage 6 materialization consumes every prior clear stage output."
+)]
+pub(super) fn materialize_address_phase_states<F, W, B>(
+    config: &Stage6ProverConfig,
+    witness: &W,
+    stage1: &Stage1ClearOutput<F>,
+    stage2: &Stage2ClearOutput<F>,
+    stage3: &Stage3ClearOutput<F>,
+    stage4: &Stage4ClearOutput<F>,
+    stage5: &Stage5ClearOutput<F>,
+    pre: &Stage6PreAddressChallenges<F>,
+    bytecode_read_raf_input: F,
+    backend: &mut B,
+) -> Result<(B::BytecodeReadRafState, B::BooleanityState), ProverError>
+where
+    F: Field,
+    W: WitnessProvider<F, JoltVmNamespace> + JoltVmStage6Rows,
+    B: Stage6RegularBatchSumcheckBackend<F>,
+{
+    let stage6_rows = witness.stage6_rows()?;
+    let bytecode_context = config.bytecode_context.as_ref().ok_or_else(|| {
+        invalid_stage_request("Stage 6 bytecode context is required for read-RAF evaluation")
+    })?;
+
+    let bytecode_request = SumcheckBytecodeReadRafStateRequest::new(
+        "Stage 6 bytecode read-RAF",
+        bytecode_stage_values(config, pre, stage4, stage5)?,
+        stage6_bytecode_pc_indices(&stage6_rows),
+        stage6_bytecode_cycle_points(stage1, stage2, stage3, stage4, stage5)
+            .map_err(invalid_stage_request)?,
+        pre.bytecode_gamma_powers.clone(),
+        bytecode_context.entry_bytecode_index,
+        bytecode_read_raf_input,
+        config.log_t,
+        config.bytecode_read_raf_dimensions.log_k(),
+        config.committed_chunk_bits,
+    )
+    .with_optimization_ids(STAGE6_REGULAR_BATCH_OPT_IDS);
+    let bytecode_read_raf =
+        backend.materialize_sumcheck_bytecode_read_raf_state(&bytecode_request)?;
+
+    let booleanity_layout = config.booleanity_dimensions.layout;
+    let booleanity_request = SumcheckBooleanityStateRequest::new(
+        "Stage 6 booleanity",
+        stage6_ra_rows(&stage6_rows),
+        pre.booleanity_reference.address.clone(),
+        pre.booleanity_reference.cycle.clone(),
+        pre.booleanity_gamma,
+        F::zero(),
+        config.log_t,
+        config.committed_chunk_bits,
+        booleanity_layout.instruction(),
+        booleanity_layout.bytecode(),
+        booleanity_layout.ram(),
+    )
+    .with_optimization_ids(STAGE6_REGULAR_BATCH_OPT_IDS);
+    let booleanity = backend.materialize_sumcheck_booleanity_state(&booleanity_request)?;
+
+    Ok((bytecode_read_raf, booleanity))
+}
+
+#[expect(
+    clippy::too_many_arguments,
+    reason = "Stage 6 materialization consumes every prior clear stage output."
+)]
+pub(super) fn materialize_cycle_phase_states<F, W, B>(
+    config: &Stage6ProverConfig,
+    witness: &W,
+    stage1: &Stage1ClearOutput<F>,
+    stage2: &Stage2ClearOutput<F>,
+    stage4: &Stage4ClearOutput<F>,
+    stage5: &Stage5ClearOutput<F>,
+    prefix: &Stage6RegularBatchPrefixOutput<F>,
+    bytecode_read_raf: B::BytecodeReadRafState,
+    booleanity: B::BooleanityState,
+    backend: &mut B,
+) -> Result<Stage6BackendStates<B, F>, ProverError>
+where
+    F: Field,
+    W: WitnessProvider<F, JoltVmNamespace> + JoltVmStage6Rows,
+    B: Stage6RegularBatchSumcheckBackend<F>,
+{
+    let stage6_rows = witness.stage6_rows()?;
+    let (ra_rows, inc_rows) = (stage6_ra_rows(&stage6_rows), stage6_inc_rows(&stage6_rows));
+
+    let hamming_request = SumcheckRamHammingBooleanityStateRequest::new(
+        "Stage 6 RAM hamming booleanity",
+        stage6_hamming_weight(&stage6_rows),
+        stage6_stage1_cycle_binding(stage1)
+            .map_err(invalid_stage_request)?
+            .to_vec(),
+        prefix.input_claims.ram_hamming_booleanity,
+        config.log_t,
+    )
+    .with_optimization_ids(STAGE6_REGULAR_BATCH_OPT_IDS);
+    let ram_hamming_booleanity =
+        backend.materialize_sumcheck_ram_hamming_booleanity_state(&hamming_request)?;
+
+    let ram_reduced = stage6_stage5_ram_reduced_opening_point(stage5, config.log_k, config.log_t)
+        .map_err(invalid_stage_request)?;
+    let ram_ra_request = SumcheckRamRaVirtualizationStateRequest::new(
+        "Stage 6 RAM RA virtualization",
+        ra_rows.clone(),
+        ram_reduced.committed_address_chunks(config.committed_chunk_bits),
+        ram_reduced.cycle.to_vec(),
+        prefix.input_claims.ram_ra_virtualization,
+        config.log_t,
+        config.committed_chunk_bits,
+    )
+    .with_optimization_ids(STAGE6_REGULAR_BATCH_OPT_IDS);
+    let ram_ra_virtualization =
+        backend.materialize_sumcheck_ram_ra_virtualization_state(&ram_ra_request)?;
+
+    let instruction_ra_dimensions = config.instruction_ra_virtualization_dimensions;
+    let instruction_read_raf = stage6_instruction_read_raf_point(stage5);
+    let instruction_ra_request = SumcheckInstructionRaVirtualizationStateRequest::new(
+        "Stage 6 instruction RA virtualization",
+        ra_rows,
+        instruction_read_raf.committed_address_chunks(config.committed_chunk_bits),
+        instruction_read_raf.cycle.to_vec(),
+        prefix.challenges.instruction_ra_gamma_powers.clone(),
+        prefix.input_claims.instruction_ra_virtualization,
+        config.log_t,
+        config.committed_chunk_bits,
+        instruction_ra_dimensions.num_virtual_ra_polys(),
+        instruction_ra_dimensions.num_committed_per_virtual(),
+    )
+    .with_optimization_ids(STAGE6_REGULAR_BATCH_OPT_IDS);
+    let instruction_ra_virtualization = backend
+        .materialize_sumcheck_instruction_ra_virtualization_state(&instruction_ra_request)?;
+
+    let [ram_read_write_cycle, ram_val_check_cycle, registers_read_write_cycle, registers_val_evaluation_cycle] =
+        stage6_inc_claim_reduction_cycle_points(stage2, stage4, stage5, config.log_k)
+            .map_err(invalid_stage_request)?
+            .reversed_cycles();
+    let inc_request = SumcheckIncClaimReductionStateRequest::new(
+        "Stage 6 increment claim-reduction",
+        inc_rows,
+        ram_read_write_cycle,
+        ram_val_check_cycle,
+        registers_read_write_cycle,
+        registers_val_evaluation_cycle,
+        prefix.challenges.inc_gamma,
+        prefix.input_claims.inc_claim_reduction,
+        config.log_t,
+    )
+    .with_optimization_ids(STAGE6_REGULAR_BATCH_OPT_IDS);
+    let inc_claim_reduction =
+        backend.materialize_sumcheck_inc_claim_reduction_state(&inc_request)?;
+
+    Ok(Stage6BackendStates {
+        bytecode_read_raf,
+        booleanity,
+        ram_hamming_booleanity,
+        ram_ra_virtualization,
+        instruction_ra_virtualization,
+        inc_claim_reduction,
+    })
+}
+
+fn invalid_stage_request(error: impl std::fmt::Display) -> ProverError {
+    ProverError::InvalidStageRequest {
+        reason: error.to_string(),
+    }
+}

--- a/crates/jolt-prover/src/stages/stage6/prove.rs
+++ b/crates/jolt-prover/src/stages/stage6/prove.rs
@@ -1,0 +1,866 @@
+use jolt_backends::Stage6RegularBatchSumcheckBackend;
+use jolt_backends::SumcheckBackend;
+use jolt_claims::protocols::jolt::formulas::{booleanity, bytecode};
+use jolt_claims::protocols::jolt::JoltAdviceKind;
+#[cfg(feature = "zk")]
+use jolt_crypto::VectorCommitment;
+use jolt_field::Field;
+use jolt_poly::UnivariatePoly;
+use jolt_sumcheck::SumcheckProof;
+use jolt_transcript::Transcript;
+use jolt_verifier::stages::stage6::outputs::Stage6AddressPhaseClaims;
+use jolt_verifier::stages::stage6::{
+    stage6_expected_final_claim, stage6_expected_output_claim_values, stage6_input_claim_values,
+    stage6_output_claim_values, stage6_public_output, Stage6ClearOutput,
+};
+use jolt_verifier::stages::{
+    stage1::Stage1ClearOutput, stage2::Stage2ClearOutput, stage3::Stage3ClearOutput,
+    stage4::Stage4ClearOutput, stage5::Stage5ClearOutput,
+};
+
+#[cfg(feature = "zk")]
+use crate::committed::CommittedSumcheckWitness;
+use crate::stages::invalid_sumcheck_output;
+use crate::ProverError;
+
+use super::batch::{evaluate_advice_cycle_phase_opening, Stage6BatchContext, Stage6InstanceKind};
+#[cfg(feature = "zk")]
+use super::io::Stage6CommittedProofComponent;
+use super::io::{
+    Stage6ProofComponent, Stage6ProverConfig, Stage6ProverInput, Stage6RegularBatchPrefixOutput,
+    Stage6RegularBatchProofOutput,
+};
+use super::prepare::Stage6BackendStates;
+#[cfg(feature = "zk")]
+use crate::stages::recorder::CommittedSumcheckRecorder;
+use crate::stages::recorder::{ClearSumcheckRecorder, SumcheckRecorder};
+use jolt_witness::protocols::jolt_vm::JoltVmStage6Rows;
+use jolt_witness::{protocols::jolt_vm::JoltVmNamespace, WitnessProvider};
+
+/// Canonical Stage 6 prover entrypoint (transparent path).
+///
+/// Mirrors `jolt-verifier/src/stages/stage6/verify.rs` in prover order. New 09
+/// split stage 6 into stage 6a (ADDRESS phase) and stage 6b (CYCLE phase):
+///
+/// - Stage 6a is a batched sumcheck over the bytecode read-RAF + booleanity
+///   address-binding phases. Its output openings
+///   (`Stage6AddressPhaseClaims`) become the input claims of the cycle phase.
+/// - Stage 6b is the batched cycle-phase sumcheck: bytecode
+///   read-RAF + booleanity cycle phases plus the RAM-Hamming booleanity,
+///   RAM/instruction RA-virtualization, increment claim-reduction, and advice
+///   cycle-phase relations.
+///
+/// The two phases share the bytecode/booleanity backend states, which transition
+/// from their address phase to their cycle phase internally as challenges are
+/// bound. This produces `stage6a_sumcheck_proof` + `stage6b_sumcheck_proof`,
+/// `Stage6OutputClaims`, and `Stage6ClearOutput` for Stage 7.
+pub fn prove<F, W, B, T, C>(
+    input: Stage6ProverInput<'_, F, W>,
+    backend: &mut B,
+    transcript: &mut T,
+) -> Result<Stage6ProofComponent<F, SumcheckProof<F, C>>, ProverError>
+where
+    F: Field,
+    W: WitnessProvider<F, JoltVmNamespace> + JoltVmStage6Rows,
+    B: SumcheckBackend<F, JoltVmNamespace> + Stage6RegularBatchSumcheckBackend<F>,
+    T: Transcript<Challenge = F>,
+{
+    if input.checked.zk {
+        return Err(ProverError::InvalidStageRequest {
+            reason: "Stage 6 clear prover received ZK checked inputs".to_owned(),
+        });
+    }
+    if input.checked.trace_length != (1usize << input.config.log_t) {
+        return Err(ProverError::InvalidStageRequest {
+            reason: format!(
+                "Stage 6 checked trace length {} does not match log_t {}",
+                input.checked.trace_length, input.config.log_t
+            ),
+        });
+    }
+
+    let pre_challenges = super::prepare::derive_stage6_pre_address_challenges(
+        input.config,
+        input.stage5,
+        transcript,
+    )?;
+    let round_capacity = input.config.log_t + input.config.bytecode_read_raf_dimensions.log_k();
+    let run = prove_stage6_sumchecks_with_recorders(
+        input.config.clone(),
+        input.witness,
+        backend,
+        input.stage1,
+        input.stage2,
+        input.stage3,
+        input.stage4,
+        input.stage5,
+        pre_challenges,
+        transcript,
+        || Ok(ClearSumcheckRecorder::<F, C>::new(round_capacity)),
+    )?;
+    let Stage6SumcheckRunOutput {
+        stage6a_proof,
+        proof_output,
+        ..
+    } = run;
+
+    let Stage6RegularBatchProofOutput {
+        proof,
+        verifier_output,
+    } = proof_output;
+    let claims = verifier_output.output_claims.clone();
+
+    Ok(Stage6ProofComponent {
+        stage6a_sumcheck_proof: stage6a_proof,
+        stage6b_sumcheck_proof: proof,
+        claims,
+        verifier_output,
+    })
+}
+
+#[cfg(feature = "zk")]
+pub fn prove_committed_proof_component<F, W, B, T, VC>(
+    input: Stage6ProverInput<'_, F, W>,
+    backend: &mut B,
+    transcript: &mut T,
+    vc_setup: &VC::Setup,
+) -> Result<Stage6CommittedProofComponent<F, VC>, ProverError>
+where
+    F: Field,
+    W: WitnessProvider<F, JoltVmNamespace> + JoltVmStage6Rows,
+    B: SumcheckBackend<F, JoltVmNamespace> + Stage6RegularBatchSumcheckBackend<F>,
+    T: Transcript<Challenge = F>,
+    VC: VectorCommitment<Field = F>,
+{
+    if !input.checked.zk {
+        return Err(ProverError::InvalidStageRequest {
+            reason: "Stage 6 committed prover received transparent checked inputs".to_owned(),
+        });
+    }
+    if input.checked.trace_length != (1usize << input.config.log_t) {
+        return Err(ProverError::InvalidStageRequest {
+            reason: format!(
+                "Stage 6 checked trace length {} does not match log_t {}",
+                input.checked.trace_length, input.config.log_t
+            ),
+        });
+    }
+
+    let pre_challenges = super::prepare::derive_stage6_pre_address_challenges(
+        input.config,
+        input.stage5,
+        transcript,
+    )?;
+    let run = prove_stage6_sumchecks_with_recorders(
+        input.config.clone(),
+        input.witness,
+        backend,
+        input.stage1,
+        input.stage2,
+        input.stage3,
+        input.stage4,
+        input.stage5,
+        pre_challenges,
+        transcript,
+        || CommittedSumcheckRecorder::<F, VC>::new(vc_setup),
+    )?;
+    let Stage6SumcheckRunOutput {
+        stage6a_proof,
+        proof_output,
+        stage6a_committed_witness,
+        committed_witness,
+        output_claim_values,
+    } = run;
+    let Stage6RegularBatchProofOutput {
+        proof,
+        verifier_output,
+    } = proof_output;
+    Ok(Stage6CommittedProofComponent {
+        stage6a_sumcheck_proof: stage6a_proof,
+        stage6b_sumcheck_proof: proof,
+        public: verifier_output.public.clone(),
+        output_claim_values: output_claim_values.ok_or_else(|| {
+            invalid_sumcheck_output("Stage 6 committed output claim values are missing")
+        })?,
+        verifier_output,
+        stage6a_committed_witness: stage6a_committed_witness.ok_or_else(|| {
+            invalid_sumcheck_output("Stage 6a committed witness material is missing")
+        })?,
+        committed_witness: committed_witness.ok_or_else(|| {
+            invalid_sumcheck_output("Stage 6 committed witness material is missing")
+        })?,
+    })
+}
+
+struct Stage6SumcheckRunOutput<F: Field, C> {
+    stage6a_proof: SumcheckProof<F, C>,
+    proof_output: Stage6RegularBatchProofOutput<F, C>,
+    /// ZK: committed witness for the stage 6a address-phase sumcheck.
+    #[cfg(feature = "zk")]
+    stage6a_committed_witness: Option<CommittedSumcheckWitness<F>>,
+    /// ZK: committed witness for the stage 6b cycle-phase sumcheck.
+    #[cfg(feature = "zk")]
+    committed_witness: Option<CommittedSumcheckWitness<F>>,
+    #[cfg(feature = "zk")]
+    output_claim_values: Option<Vec<F>>,
+}
+
+#[derive(Clone, Copy)]
+struct Stage6AddressInstance<F: Field> {
+    kind: Stage6AddressInstanceKind,
+    input_claim: F,
+    num_vars: usize,
+    offset: usize,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Stage6AddressInstanceKind {
+    BytecodeReadRaf,
+    Booleanity,
+}
+
+impl<F: Field> Stage6AddressInstance<F> {
+    const fn is_active(&self, round: usize) -> bool {
+        round >= self.offset && round < self.offset + self.num_vars
+    }
+}
+
+/// Drives the stage 6a address-phase and stage 6b cycle-phase batched sumchecks,
+/// interleaving the transcript challenge schedule exactly as `verify()` does:
+/// `[pre-address gammas] → 6a sumcheck (+ address openings) → [post-address
+/// gammas] → 6b sumcheck`.
+#[expect(
+    clippy::too_many_arguments,
+    reason = "Stage 6 batches the address phase and six cycle relations plus optional advice instances."
+)]
+fn prove_stage6_sumchecks_with_recorders<F, W, B, T, S>(
+    config: Stage6ProverConfig,
+    witness: &W,
+    backend: &mut B,
+    stage1: &Stage1ClearOutput<F>,
+    stage2: &Stage2ClearOutput<F>,
+    stage3: &Stage3ClearOutput<F>,
+    stage4: &Stage4ClearOutput<F>,
+    stage5: &Stage5ClearOutput<F>,
+    pre_challenges: jolt_verifier::stages::stage6::Stage6PreAddressChallenges<F>,
+    transcript: &mut T,
+    mut new_recorder: impl FnMut() -> Result<S, ProverError>,
+) -> Result<Stage6SumcheckRunOutput<F, S::Commitment>, ProverError>
+where
+    F: Field,
+    W: WitnessProvider<F, JoltVmNamespace> + JoltVmStage6Rows,
+    B: SumcheckBackend<F, JoltVmNamespace> + Stage6RegularBatchSumcheckBackend<F>,
+    T: Transcript<Challenge = F>,
+    S: SumcheckRecorder<F>,
+{
+    let bytecode_read_raf_input = super::prepare::bytecode_read_raf_address_input(
+        &config,
+        &pre_challenges,
+        stage1,
+        stage2,
+        stage3,
+        stage4,
+        stage5,
+    )?;
+
+    // Materialize the bytecode/booleanity states (address phase). They host BOTH
+    // the address phase (driven by stage 6a) and the cycle phase (driven by
+    // stage 6b); they transition internally as challenges are bound, so they are
+    // shared across the two batched sumchecks.
+    let (bytecode_read_raf_state, booleanity_state) =
+        super::prepare::materialize_address_phase_states(
+            &config,
+            witness,
+            stage1,
+            stage2,
+            stage3,
+            stage4,
+            stage5,
+            &pre_challenges,
+            bytecode_read_raf_input,
+            backend,
+        )?;
+
+    let address_run = prove_stage6_address_phase(
+        &config,
+        backend,
+        bytecode_read_raf_state,
+        booleanity_state,
+        bytecode_read_raf_input,
+        transcript,
+        new_recorder()?,
+    )?;
+
+    let prefix = super::prepare::complete_stage6_prefix(
+        &config,
+        pre_challenges,
+        stage1,
+        stage2,
+        stage4,
+        stage5,
+        &address_run.address_phase,
+        transcript,
+    )?;
+
+    // Materialize the cycle-only states and combine them with the address-phase
+    // bytecode/booleanity states (now in their cycle phase).
+    let mut backend_states = super::prepare::materialize_cycle_phase_states(
+        &config,
+        witness,
+        stage1,
+        stage2,
+        stage4,
+        stage5,
+        &prefix,
+        address_run.bytecode_read_raf_state,
+        address_run.booleanity_state,
+        backend,
+    )?;
+
+    let cycle_run = prove_stage6_cycle_phase(
+        config,
+        witness,
+        backend,
+        &mut backend_states,
+        stage1,
+        stage2,
+        stage3,
+        stage4,
+        stage5,
+        &prefix,
+        &address_run.address_phase,
+        &address_run.bytecode_address_challenges,
+        &address_run.booleanity_address_challenges,
+        transcript,
+        new_recorder()?,
+    )?;
+
+    Ok(Stage6SumcheckRunOutput {
+        stage6a_proof: address_run.proof,
+        proof_output: cycle_run.proof_output,
+        #[cfg(feature = "zk")]
+        stage6a_committed_witness: address_run.committed_witness,
+        #[cfg(feature = "zk")]
+        committed_witness: cycle_run.committed_witness,
+        #[cfg(feature = "zk")]
+        output_claim_values: cycle_run.output_claim_values,
+    })
+}
+
+struct Stage6AddressRunOutput<F: Field, B, C>
+where
+    B: Stage6RegularBatchSumcheckBackend<F>,
+{
+    proof: SumcheckProof<F, C>,
+    address_phase: Stage6AddressPhaseClaims<F>,
+    /// Stage 6a sumcheck challenges restricted to the bytecode instance's active
+    /// rounds (its `log_k`-variable suffix of the address batch point).
+    bytecode_address_challenges: Vec<F>,
+    /// Stage 6a sumcheck challenges restricted to the booleanity instance's
+    /// active rounds (its `log_k_chunk`-variable suffix).
+    booleanity_address_challenges: Vec<F>,
+    /// Bytecode read-RAF state advanced into its cycle phase (address rounds
+    /// bound), handed to stage 6b.
+    bytecode_read_raf_state: B::BytecodeReadRafState,
+    /// Booleanity state advanced into its cycle phase, handed to stage 6b.
+    booleanity_state: B::BooleanityState,
+    /// ZK: committed witness material from the stage 6a address-phase sumcheck.
+    #[cfg(feature = "zk")]
+    committed_witness: Option<CommittedSumcheckWitness<F>>,
+}
+
+fn prove_stage6_address_phase<F, B, T, S>(
+    config: &Stage6ProverConfig,
+    backend: &mut B,
+    mut bytecode_read_raf_state: B::BytecodeReadRafState,
+    mut booleanity_state: B::BooleanityState,
+    bytecode_read_raf_input: F,
+    transcript: &mut T,
+    mut proof_recorder: S,
+) -> Result<Stage6AddressRunOutput<F, B, S::Commitment>, ProverError>
+where
+    F: Field,
+    B: Stage6RegularBatchSumcheckBackend<F>,
+    T: Transcript<Challenge = F>,
+    S: SumcheckRecorder<F>,
+{
+    let bytecode_claims =
+        bytecode::read_raf_address_phase::<F>(config.bytecode_read_raf_dimensions);
+    let booleanity_claims = booleanity::booleanity_address_phase::<F>(config.booleanity_dimensions);
+
+    let bytecode_vars = bytecode_claims.sumcheck.rounds;
+    let booleanity_vars = booleanity_claims.sumcheck.rounds;
+    let max_num_vars = bytecode_vars.max(booleanity_vars);
+
+    let instances = [
+        Stage6AddressInstance {
+            kind: Stage6AddressInstanceKind::BytecodeReadRaf,
+            input_claim: bytecode_read_raf_input,
+            num_vars: bytecode_vars,
+            offset: max_num_vars - bytecode_vars,
+        },
+        Stage6AddressInstance {
+            kind: Stage6AddressInstanceKind::Booleanity,
+            input_claim: F::zero(),
+            num_vars: booleanity_vars,
+            offset: max_num_vars - booleanity_vars,
+        },
+    ];
+
+    let input_claims = [instances[0].input_claim, instances[1].input_claim];
+    proof_recorder.absorb_input_claims(&input_claims, transcript);
+    let batching_coefficients = [transcript.challenge_scalar(), transcript.challenge_scalar()];
+
+    let mut individual_claims = instances
+        .iter()
+        .map(|instance| {
+            instance
+                .input_claim
+                .mul_pow_2(max_num_vars - instance.num_vars)
+        })
+        .collect::<Vec<_>>();
+    let mut running_claim = individual_claims
+        .iter()
+        .zip(&batching_coefficients)
+        .map(|(claim, coefficient)| *claim * *coefficient)
+        .sum::<F>();
+    let two_inv = F::from_u64(2).inv_or_zero();
+    let mut sumcheck_point = Vec::with_capacity(max_num_vars);
+
+    for round in 0..max_num_vars {
+        let mut individual_polys = Vec::with_capacity(instances.len());
+        for (instance, previous_claim) in instances.iter().zip(&individual_claims) {
+            if instance.is_active(round) {
+                let poly = match instance.kind {
+                    Stage6AddressInstanceKind::BytecodeReadRaf => backend
+                        .evaluate_sumcheck_bytecode_read_raf_round(
+                            &bytecode_read_raf_state,
+                            *previous_claim,
+                        )?,
+                    Stage6AddressInstanceKind::Booleanity => backend
+                        .evaluate_sumcheck_booleanity_round(&booleanity_state, *previous_claim)?,
+                };
+                let poly_sum = poly.evaluate(F::zero()) + poly.evaluate(F::one());
+                if poly_sum != *previous_claim {
+                    return Err(invalid_sumcheck_output(format!(
+                        "Stage 6a instance round {} sumcheck invariant failed: expected {}, got {}",
+                        round - instance.offset,
+                        previous_claim,
+                        poly_sum
+                    )));
+                }
+                individual_polys.push(poly);
+            } else {
+                individual_polys.push(UnivariatePoly::new(vec![*previous_claim * two_inv]));
+            }
+        }
+
+        let mut round_poly = UnivariatePoly::zero();
+        for (poly, coefficient) in individual_polys.iter().zip(&batching_coefficients) {
+            round_poly += &(poly * *coefficient);
+        }
+        let round_sum = round_poly.evaluate(F::zero()) + round_poly.evaluate(F::one());
+        if round_sum != running_claim {
+            return Err(invalid_sumcheck_output(format!(
+                "Stage 6a batch round {round} sumcheck invariant failed"
+            )));
+        }
+
+        let challenge = proof_recorder.absorb_round(&round_poly, transcript)?;
+        running_claim = round_poly.evaluate(challenge);
+        sumcheck_point.push(challenge);
+        for ((claim, poly), instance) in individual_claims
+            .iter_mut()
+            .zip(individual_polys)
+            .zip(instances.iter())
+        {
+            if instance.is_active(round) {
+                *claim = poly.evaluate(challenge);
+                match instance.kind {
+                    Stage6AddressInstanceKind::BytecodeReadRaf => backend
+                        .bind_sumcheck_bytecode_read_raf_state(
+                            &mut bytecode_read_raf_state,
+                            challenge,
+                        )?,
+                    Stage6AddressInstanceKind::Booleanity => {
+                        backend.bind_sumcheck_booleanity_state(&mut booleanity_state, challenge)?;
+                    }
+                }
+            } else {
+                *claim *= two_inv;
+            }
+        }
+    }
+
+    let bytecode_address_claim = individual_claims[0];
+    let booleanity_address_claim = individual_claims[1];
+    let expected_final_claim = batching_coefficients[0] * bytecode_address_claim
+        + batching_coefficients[1] * booleanity_address_claim;
+    if running_claim != expected_final_claim {
+        return Err(invalid_sumcheck_output(format!(
+            "Stage 6a batch final claim did not match address-phase openings: running {running_claim}, expected {expected_final_claim}"
+        )));
+    }
+
+    let address_phase = Stage6AddressPhaseClaims {
+        bytecode_read_raf: bytecode_address_claim,
+        booleanity: booleanity_address_claim,
+        // Committed-program only; the modular prover only supports full programs.
+        bytecode_val_stages: None,
+    };
+    let output_claim_values = [address_phase.bytecode_read_raf, address_phase.booleanity];
+    let recorded = proof_recorder.finish(&output_claim_values, transcript)?;
+
+    let bytecode_address_challenges = instance_challenges(&sumcheck_point, &instances[0]);
+    let booleanity_address_challenges = instance_challenges(&sumcheck_point, &instances[1]);
+
+    Ok(Stage6AddressRunOutput {
+        proof: recorded.proof,
+        address_phase,
+        bytecode_address_challenges,
+        booleanity_address_challenges,
+        bytecode_read_raf_state,
+        booleanity_state,
+        #[cfg(feature = "zk")]
+        committed_witness: recorded.committed_witness,
+    })
+}
+
+/// Returns the `num_vars`-variable suffix of the batched sumcheck point that an
+/// instance is active over (its front-loaded offset slice).
+fn instance_challenges<F: Field>(
+    sumcheck_point: &[F],
+    instance: &Stage6AddressInstance<F>,
+) -> Vec<F> {
+    sumcheck_point[instance.offset..instance.offset + instance.num_vars].to_vec()
+}
+
+struct Stage6CycleRunOutput<F: Field, C> {
+    proof_output: Stage6RegularBatchProofOutput<F, C>,
+    #[cfg(feature = "zk")]
+    committed_witness: Option<CommittedSumcheckWitness<F>>,
+    #[cfg(feature = "zk")]
+    output_claim_values: Option<Vec<F>>,
+}
+
+#[expect(
+    clippy::too_many_arguments,
+    reason = "Stage 6b batches the bytecode/booleanity cycle phases plus six base relations and optional advice."
+)]
+fn prove_stage6_cycle_phase<F, W, B, T, S>(
+    config: Stage6ProverConfig,
+    witness: &W,
+    backend: &mut B,
+    backend_states: &mut Stage6BackendStates<B, F>,
+    stage1: &Stage1ClearOutput<F>,
+    stage2: &Stage2ClearOutput<F>,
+    stage3: &Stage3ClearOutput<F>,
+    stage4: &Stage4ClearOutput<F>,
+    stage5: &Stage5ClearOutput<F>,
+    prefix: &Stage6RegularBatchPrefixOutput<F>,
+    address_phase: &Stage6AddressPhaseClaims<F>,
+    bytecode_address_challenges: &[F],
+    booleanity_address_challenges: &[F],
+    transcript: &mut T,
+    mut proof_recorder: S,
+) -> Result<Stage6CycleRunOutput<F, S::Commitment>, ProverError>
+where
+    F: Field,
+    W: WitnessProvider<F, JoltVmNamespace> + JoltVmStage6Rows,
+    B: SumcheckBackend<F, JoltVmNamespace> + Stage6RegularBatchSumcheckBackend<F>,
+    T: Transcript<Challenge = F>,
+    S: SumcheckRecorder<F>,
+{
+    let context = Stage6BatchContext::new_metadata(
+        config,
+        witness,
+        stage1,
+        stage2,
+        stage3,
+        stage4,
+        stage5,
+        prefix,
+        address_phase,
+        bytecode_address_challenges,
+        booleanity_address_challenges,
+    )?;
+
+    let mut trusted_advice_relation = if let Ok(instance) = context.instance(
+        Stage6InstanceKind::AdviceCyclePhase(JoltAdviceKind::Trusted),
+    ) {
+        Some(context.materialize_relation(instance)?)
+    } else {
+        None
+    };
+    let mut untrusted_advice_relation = if let Ok(instance) = context.instance(
+        Stage6InstanceKind::AdviceCyclePhase(JoltAdviceKind::Untrusted),
+    ) {
+        Some(context.materialize_relation(instance)?)
+    } else {
+        None
+    };
+
+    let input_claims = stage6_input_claim_values(&context.cycle_input_claims());
+    proof_recorder.absorb_input_claims(&input_claims, transcript);
+    let batching_coefficients = (0..context.instances.len())
+        .map(|_| transcript.challenge_scalar())
+        .collect::<Vec<_>>();
+
+    let mut individual_claims = context
+        .instances
+        .iter()
+        .map(|instance| {
+            instance
+                .input_claim
+                .mul_pow_2(context.max_num_vars - instance.num_vars)
+        })
+        .collect::<Vec<_>>();
+    let mut running_claim = individual_claims
+        .iter()
+        .zip(&batching_coefficients)
+        .map(|(claim, coefficient)| *claim * *coefficient)
+        .sum::<F>();
+    let two_inv = F::from_u64(2).inv_or_zero();
+    let mut sumcheck_point = Vec::with_capacity(context.max_num_vars);
+
+    for round in 0..context.max_num_vars {
+        let mut individual_polys = Vec::with_capacity(context.instances.len());
+        for (instance, previous_claim) in context.instances.iter().zip(&individual_claims) {
+            if instance.is_active(round) {
+                let local_round = round - instance.offset;
+                let poly = match instance.kind {
+                    Stage6InstanceKind::BytecodeReadRaf => backend
+                        .evaluate_sumcheck_bytecode_read_raf_round(
+                            &backend_states.bytecode_read_raf,
+                            *previous_claim,
+                        )?,
+                    Stage6InstanceKind::Booleanity => backend.evaluate_sumcheck_booleanity_round(
+                        &backend_states.booleanity,
+                        *previous_claim,
+                    )?,
+                    Stage6InstanceKind::RamHammingBooleanity => backend
+                        .evaluate_sumcheck_ram_hamming_booleanity_round(
+                            &backend_states.ram_hamming_booleanity,
+                            *previous_claim,
+                        )?,
+                    Stage6InstanceKind::RamRaVirtualization => backend
+                        .evaluate_sumcheck_ram_ra_virtualization_round(
+                            &backend_states.ram_ra_virtualization,
+                            *previous_claim,
+                        )?,
+                    Stage6InstanceKind::InstructionRaVirtualization => backend
+                        .evaluate_sumcheck_instruction_ra_virtualization_round(
+                            &backend_states.instruction_ra_virtualization,
+                            *previous_claim,
+                        )?,
+                    Stage6InstanceKind::IncClaimReduction => backend
+                        .evaluate_sumcheck_inc_claim_reduction_round(
+                            &backend_states.inc_claim_reduction,
+                            *previous_claim,
+                        )?,
+                    Stage6InstanceKind::AdviceCyclePhase(JoltAdviceKind::Trusted) => {
+                        let relation = trusted_advice_relation.as_ref().ok_or_else(|| {
+                            invalid_sumcheck_output("Stage 6 trusted advice relation is missing")
+                        })?;
+                        let degree = instance.degree;
+                        let evaluations = (0..=degree)
+                            .map(|point| relation.round_sum(local_round, F::from_u64(point as u64)))
+                            .collect::<Result<Vec<_>, _>>()?;
+                        UnivariatePoly::interpolate_over_integers(&evaluations)
+                    }
+                    Stage6InstanceKind::AdviceCyclePhase(JoltAdviceKind::Untrusted) => {
+                        let relation = untrusted_advice_relation.as_ref().ok_or_else(|| {
+                            invalid_sumcheck_output("Stage 6 untrusted advice relation is missing")
+                        })?;
+                        let degree = instance.degree;
+                        let evaluations = (0..=degree)
+                            .map(|point| relation.round_sum(local_round, F::from_u64(point as u64)))
+                            .collect::<Result<Vec<_>, _>>()?;
+                        UnivariatePoly::interpolate_over_integers(&evaluations)
+                    }
+                };
+                let poly_sum = poly.evaluate(F::zero()) + poly.evaluate(F::one());
+                if poly_sum != *previous_claim {
+                    return Err(invalid_sumcheck_output(format!(
+                        "Stage 6 instance {:?} local round {} sumcheck invariant failed: expected {}, got {}",
+                        instance.kind,
+                        round - instance.offset,
+                        previous_claim,
+                        poly_sum
+                    )));
+                }
+                individual_polys.push(poly);
+            } else {
+                individual_polys.push(UnivariatePoly::new(vec![*previous_claim * two_inv]));
+            }
+        }
+
+        let mut round_poly = UnivariatePoly::zero();
+        for (poly, coefficient) in individual_polys.iter().zip(&batching_coefficients) {
+            round_poly += &(poly * *coefficient);
+        }
+        let round_sum = round_poly.evaluate(F::zero()) + round_poly.evaluate(F::one());
+        if round_sum != running_claim {
+            return Err(invalid_sumcheck_output(format!(
+                "Stage 6 batch round {round} sumcheck invariant failed"
+            )));
+        }
+
+        let challenge = proof_recorder.absorb_round(&round_poly, transcript)?;
+        running_claim = round_poly.evaluate(challenge);
+        sumcheck_point.push(challenge);
+        for ((claim, poly), instance) in individual_claims
+            .iter_mut()
+            .zip(individual_polys)
+            .zip(&context.instances)
+        {
+            if instance.is_active(round) {
+                *claim = poly.evaluate(challenge);
+                match instance.kind {
+                    Stage6InstanceKind::BytecodeReadRaf => backend
+                        .bind_sumcheck_bytecode_read_raf_state(
+                            &mut backend_states.bytecode_read_raf,
+                            challenge,
+                        )?,
+                    Stage6InstanceKind::Booleanity => {
+                        backend.bind_sumcheck_booleanity_state(
+                            &mut backend_states.booleanity,
+                            challenge,
+                        )?;
+                    }
+                    Stage6InstanceKind::RamHammingBooleanity => backend
+                        .bind_sumcheck_ram_hamming_booleanity_state(
+                            &mut backend_states.ram_hamming_booleanity,
+                            challenge,
+                        )?,
+                    Stage6InstanceKind::RamRaVirtualization => backend
+                        .bind_sumcheck_ram_ra_virtualization_state(
+                            &mut backend_states.ram_ra_virtualization,
+                            challenge,
+                        )?,
+                    Stage6InstanceKind::InstructionRaVirtualization => backend
+                        .bind_sumcheck_instruction_ra_virtualization_state(
+                            &mut backend_states.instruction_ra_virtualization,
+                            challenge,
+                        )?,
+                    Stage6InstanceKind::IncClaimReduction => backend
+                        .bind_sumcheck_inc_claim_reduction_state(
+                            &mut backend_states.inc_claim_reduction,
+                            challenge,
+                        )?,
+                    Stage6InstanceKind::AdviceCyclePhase(JoltAdviceKind::Trusted) => {
+                        let relation = trusted_advice_relation.as_mut().ok_or_else(|| {
+                            invalid_sumcheck_output("Stage 6 trusted advice relation is missing")
+                        })?;
+                        relation.bind(round - instance.offset, challenge);
+                    }
+                    Stage6InstanceKind::AdviceCyclePhase(JoltAdviceKind::Untrusted) => {
+                        let relation = untrusted_advice_relation.as_mut().ok_or_else(|| {
+                            invalid_sumcheck_output("Stage 6 untrusted advice relation is missing")
+                        })?;
+                        relation.bind(round - instance.offset, challenge);
+                    }
+                }
+            } else {
+                *claim *= two_inv;
+            }
+        }
+    }
+
+    let trusted_advice_point =
+        context.advice_cycle_phase_opening_point(&sumcheck_point, JoltAdviceKind::Trusted)?;
+    let untrusted_advice_point =
+        context.advice_cycle_phase_opening_point(&sumcheck_point, JoltAdviceKind::Untrusted)?;
+    let trusted_advice_claim = evaluate_advice_cycle_phase_opening(
+        context.config.trusted_advice_layout.as_ref(),
+        witness,
+        JoltAdviceKind::Trusted,
+        context.advice_cycle_phase_reference_opening_point(JoltAdviceKind::Trusted)?,
+        trusted_advice_point.as_deref(),
+    )?;
+    let untrusted_advice_claim = evaluate_advice_cycle_phase_opening(
+        context.config.untrusted_advice_layout.as_ref(),
+        witness,
+        JoltAdviceKind::Untrusted,
+        context.advice_cycle_phase_reference_opening_point(JoltAdviceKind::Untrusted)?,
+        untrusted_advice_point.as_deref(),
+    )?;
+    let mut output_openings = super::verifier_output::output_claims_from_backend(
+        backend.output_sumcheck_bytecode_read_raf_state(&backend_states.bytecode_read_raf)?,
+        backend.output_sumcheck_booleanity_state(&backend_states.booleanity)?,
+        backend
+            .output_sumcheck_ram_hamming_booleanity_state(&backend_states.ram_hamming_booleanity)?,
+        backend
+            .output_sumcheck_ram_ra_virtualization_state(&backend_states.ram_ra_virtualization)?,
+        backend.output_sumcheck_instruction_ra_virtualization_state(
+            &backend_states.instruction_ra_virtualization,
+        )?,
+        backend.output_sumcheck_inc_claim_reduction_state(&backend_states.inc_claim_reduction)?,
+        trusted_advice_claim,
+        untrusted_advice_claim,
+    );
+    output_openings.address_phase = address_phase.clone();
+
+    let (expected_outputs, output_points) =
+        context.cycle_outputs(&sumcheck_point, &output_openings)?;
+    let expected_outputs_in_order = stage6_expected_output_claim_values(&expected_outputs);
+    if individual_claims.len() != expected_outputs_in_order.len() {
+        return Err(invalid_sumcheck_output(format!(
+            "Stage 6 batch has {} final instance claims for {} expected outputs",
+            individual_claims.len(),
+            expected_outputs_in_order.len()
+        )));
+    }
+    if let Some(index) = individual_claims
+        .iter()
+        .zip(&expected_outputs_in_order)
+        .position(|(actual, expected)| actual != expected)
+    {
+        return Err(invalid_sumcheck_output(format!(
+            "Stage 6 instance {:?} final claim did not match output opening: running {}, expected {}",
+            context.instances[index].kind, individual_claims[index], expected_outputs_in_order[index]
+        )));
+    }
+    let expected_final_claim =
+        stage6_expected_final_claim(&batching_coefficients, &expected_outputs)?;
+    if running_claim != expected_final_claim {
+        return Err(invalid_sumcheck_output(format!(
+            "Stage 6 batch final claim did not match output openings: running {}, expected {}",
+            running_claim, expected_final_claim
+        )));
+    }
+
+    let booleanity_opening_point = output_points
+        .booleanity_opening_point()
+        .ok_or_else(|| invalid_sumcheck_output("Stage 6 booleanity produced no opening point"))?
+        .to_vec();
+    let proof_artifacts = proof_recorder.finish(
+        &stage6_output_claim_values(
+            &output_openings,
+            &output_points.bytecode_read_raf.bytecode_ra,
+            &booleanity_opening_point,
+        ),
+        transcript,
+    )?;
+    // The batch final-claim equality was already checked above; assemble the
+    // clear output directly from the bundle-derived points (mirroring the
+    // verifier's `verify()`), rather than re-deriving them through a helper.
+    let verifier_output = Stage6ClearOutput {
+        public: stage6_public_output(&prefix.challenges, None),
+        output_claims: output_openings,
+        output_points,
+        // The modular prover is full-only, so no committed bytecode reduction.
+        bytecode_reduction_weights: None,
+    };
+
+    Ok(Stage6CycleRunOutput {
+        proof_output: Stage6RegularBatchProofOutput {
+            proof: proof_artifacts.proof,
+            verifier_output,
+        },
+        #[cfg(feature = "zk")]
+        committed_witness: proof_artifacts.committed_witness,
+        #[cfg(feature = "zk")]
+        output_claim_values: proof_artifacts.output_claim_values,
+    })
+}

--- a/crates/jolt-prover/src/stages/stage6/relation_state.rs
+++ b/crates/jolt-prover/src/stages/stage6/relation_state.rs
@@ -1,0 +1,93 @@
+use std::ops::Range;
+
+use jolt_field::Field;
+use jolt_poly::{BindingOrder, Polynomial};
+
+use crate::ProverError;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(super) struct AdviceCyclePhaseRelationState<F: Field> {
+    advice: Polynomial<F>,
+    eq: Polynomial<F>,
+    col_rounds: Range<usize>,
+    row_rounds: Range<usize>,
+    scale: F,
+}
+
+impl<F: Field> AdviceCyclePhaseRelationState<F> {
+    pub(super) fn new(
+        advice: Polynomial<F>,
+        eq: Polynomial<F>,
+        col_rounds: Range<usize>,
+        row_rounds: Range<usize>,
+    ) -> Self {
+        Self {
+            advice,
+            eq,
+            col_rounds,
+            row_rounds,
+            scale: F::one(),
+        }
+    }
+
+    fn bind(&mut self, local_round: usize, challenge: F) {
+        if self.is_active_round(local_round) {
+            self.advice
+                .bind_with_order(challenge, BindingOrder::LowToHigh);
+            self.eq.bind_with_order(challenge, BindingOrder::LowToHigh);
+        } else {
+            self.scale *= F::from_u64(2).inv_or_zero();
+        }
+    }
+
+    fn round_rows(&self, local_round: usize) -> usize {
+        if self.is_active_round(local_round) {
+            self.advice.len() / 2
+        } else {
+            self.advice.len()
+        }
+    }
+
+    fn round_eval(&self, local_round: usize, index: usize, point: F) -> F {
+        if self.is_active_round(local_round) {
+            self.scale
+                * self
+                    .advice
+                    .sumcheck_round_eval_with_order(index, point, BindingOrder::LowToHigh)
+                * self
+                    .eq
+                    .sumcheck_round_eval_with_order(index, point, BindingOrder::LowToHigh)
+        } else {
+            self.scale
+                * self.advice.evals()[index]
+                * self.eq.evals()[index]
+                * F::from_u64(2).inv_or_zero()
+        }
+    }
+
+    fn is_active_round(&self, local_round: usize) -> bool {
+        self.col_rounds.contains(&local_round) || self.row_rounds.contains(&local_round)
+    }
+}
+
+pub(super) struct Stage6RelationState<F: Field> {
+    advice: AdviceCyclePhaseRelationState<F>,
+}
+
+impl<F: Field> Stage6RelationState<F> {
+    pub(super) fn advice(advice: AdviceCyclePhaseRelationState<F>) -> Self {
+        Self { advice }
+    }
+
+    pub(super) fn round_sum(&self, local_round: usize, point: F) -> Result<F, ProverError> {
+        let mut sum = F::zero();
+        for index in 0..self.advice.round_rows(local_round) {
+            sum += self.advice.round_eval(local_round, index, point);
+        }
+        Ok(sum)
+    }
+
+    pub(super) fn bind(&mut self, local_round: usize, challenge: F) {
+        self.advice.bind(local_round, challenge);
+    }
+}

--- a/crates/jolt-prover/src/stages/stage6/verifier_output.rs
+++ b/crates/jolt-prover/src/stages/stage6/verifier_output.rs
@@ -1,0 +1,62 @@
+use jolt_backends::{
+    SumcheckBooleanityOutput, SumcheckBytecodeReadRafOutput, SumcheckIncClaimReductionOutput,
+    SumcheckInstructionRaVirtualizationOutput, SumcheckRamHammingBooleanityOutput,
+    SumcheckRamRaVirtualizationOutput,
+};
+use jolt_field::Field;
+use jolt_verifier::stages::stage6::outputs::{
+    AdviceCyclePhaseOutputClaim, BooleanityOutputClaims, BytecodeReadRafOutputClaims,
+    IncClaimReductionOutputClaims, InstructionRaVirtualizationOutputClaims,
+    RamHammingBooleanityOutputClaims, RamRaVirtualizationOutputClaims, Stage6AddressPhaseClaims,
+    Stage6AdviceCyclePhaseClaims, Stage6OutputClaims,
+};
+
+#[expect(
+    clippy::too_many_arguments,
+    reason = "Stage 6 backend output assembly mirrors the verifier output groups one-to-one."
+)]
+pub(super) fn output_claims_from_backend<F: Field>(
+    bytecode_read_raf: SumcheckBytecodeReadRafOutput<F>,
+    booleanity: SumcheckBooleanityOutput<F>,
+    ram_hamming_booleanity: SumcheckRamHammingBooleanityOutput<F>,
+    ram_ra_virtualization: SumcheckRamRaVirtualizationOutput<F>,
+    instruction_ra_virtualization: SumcheckInstructionRaVirtualizationOutput<F>,
+    inc_claim_reduction: SumcheckIncClaimReductionOutput<F>,
+    trusted_advice: Option<AdviceCyclePhaseOutputClaim<F>>,
+    untrusted_advice: Option<AdviceCyclePhaseOutputClaim<F>>,
+) -> Stage6OutputClaims<F> {
+    Stage6OutputClaims {
+        bytecode_read_raf: BytecodeReadRafOutputClaims {
+            bytecode_ra: bytecode_read_raf.bytecode_ra,
+        },
+        booleanity: BooleanityOutputClaims {
+            instruction_ra: booleanity.instruction_ra,
+            bytecode_ra: booleanity.bytecode_ra,
+            ram_ra: booleanity.ram_ra,
+        },
+        ram_hamming_booleanity: RamHammingBooleanityOutputClaims {
+            ram_hamming_weight: ram_hamming_booleanity.ram_hamming_weight,
+        },
+        ram_ra_virtualization: RamRaVirtualizationOutputClaims {
+            ram_ra: ram_ra_virtualization.ram_ra,
+        },
+        instruction_ra_virtualization: InstructionRaVirtualizationOutputClaims {
+            committed_instruction_ra: instruction_ra_virtualization.instruction_ra,
+        },
+        inc_claim_reduction: IncClaimReductionOutputClaims {
+            ram_inc: inc_claim_reduction.ram_inc,
+            rd_inc: inc_claim_reduction.rd_inc,
+        },
+        advice_cycle_phase: Stage6AdviceCyclePhaseClaims {
+            trusted: trusted_advice,
+            untrusted: untrusted_advice,
+        },
+        address_phase: Stage6AddressPhaseClaims {
+            bytecode_read_raf: F::zero(),
+            booleanity: F::zero(),
+            bytecode_val_stages: None,
+        },
+        bytecode_claim_reduction: None,
+        program_image_claim_reduction: None,
+    }
+}

--- a/crates/jolt-prover/src/stages/stage7/mod.rs
+++ b/crates/jolt-prover/src/stages/stage7/mod.rs
@@ -1,0 +1,2 @@
+pub(crate) mod prepare;
+pub mod prove;

--- a/crates/jolt-prover/src/stages/stage7/prepare.rs
+++ b/crates/jolt-prover/src/stages/stage7/prepare.rs
@@ -1,0 +1,30 @@
+use common::jolt_device::JoltDevice;
+use jolt_claims::protocols::jolt::{
+    formulas::claim_reductions::hamming_weight::HammingWeightClaimReductionDimensions,
+    JoltFormulaDimensions,
+};
+
+use super::prove::Stage7ProverConfig;
+use crate::stages::advice::advice_layouts;
+use crate::{ProverConfig, ProverError};
+
+pub(crate) fn prover_config(
+    public_io: &JoltDevice,
+    proof_parameters: ProverConfig,
+    formula_dimensions: JoltFormulaDimensions,
+) -> Result<Stage7ProverConfig, ProverError> {
+    let log_t = proof_parameters.trace_length.trailing_zeros() as usize;
+    let committed_chunk_bits = proof_parameters.one_hot_config.committed_chunk_bits();
+    let hamming_dimensions = HammingWeightClaimReductionDimensions::new(
+        formula_dimensions.ra_layout,
+        committed_chunk_bits,
+    );
+    let (trusted_advice_layout, untrusted_advice_layout) =
+        advice_layouts(public_io, proof_parameters, log_t, committed_chunk_bits)?;
+
+    Ok(Stage7ProverConfig::new(
+        hamming_dimensions,
+        trusted_advice_layout,
+        untrusted_advice_layout,
+    ))
+}

--- a/crates/jolt-prover/src/stages/stage7/prove.rs
+++ b/crates/jolt-prover/src/stages/stage7/prove.rs
@@ -1,0 +1,626 @@
+use jolt_claims::protocols::jolt::{
+    formulas::claim_reductions::hamming_weight::HammingWeightClaimReductionDimensions,
+    AdviceClaimReductionLayout, JoltAdviceKind, PrecommittedReductionLayout,
+};
+#[cfg(feature = "zk")]
+use jolt_crypto::VectorCommitment;
+use jolt_field::Field;
+use jolt_transcript::Transcript;
+use jolt_verifier::{
+    stages::{stage4::Stage4ClearOutput, stage6::Stage6ClearOutput},
+    CheckedInputs,
+};
+
+use crate::stages::invalid_sumcheck_output;
+#[cfg(feature = "zk")]
+use crate::stages::recorder::CommittedSumcheckRecorder;
+use crate::stages::recorder::{ClearSumcheckRecorder, SumcheckRecorder};
+use crate::ProverError;
+
+use jolt_backends::{
+    SumcheckBackend, SumcheckStage7AdviceAddressState, SumcheckStage7AdviceAddressStateRequest,
+    SumcheckStage7HammingState, SumcheckStage7HammingStateRequest,
+};
+use jolt_poly::UnivariatePoly;
+use jolt_sumcheck::SumcheckProof;
+#[cfg(feature = "zk")]
+use jolt_verifier::stages::stage7::outputs::Stage7PublicOutput;
+use jolt_verifier::stages::{
+    relations::SumcheckInstance,
+    stage7::{
+        advice_address_phase::AdviceAddressPhaseOutputClaims,
+        hamming_weight_claim_reduction::HammingWeightClaimReductionOutputClaims,
+        outputs::{Stage7ClearOutput, Stage7OutputClaims},
+        stage7_hamming_virtualization_address_points, Stage7InstancePoints, Stage7Layouts,
+        Stage7Relations,
+    },
+};
+use jolt_witness::{protocols::jolt_vm::JoltVmNamespace, WitnessProvider};
+
+#[cfg(feature = "zk")]
+use crate::committed::CommittedSumcheckWitness;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Stage7ProverConfig {
+    pub hamming_dimensions: HammingWeightClaimReductionDimensions,
+    pub trusted_advice_layout: Option<AdviceClaimReductionLayout>,
+    pub untrusted_advice_layout: Option<AdviceClaimReductionLayout>,
+}
+
+impl Stage7ProverConfig {
+    pub const fn new(
+        hamming_dimensions: HammingWeightClaimReductionDimensions,
+        trusted_advice_layout: Option<AdviceClaimReductionLayout>,
+        untrusted_advice_layout: Option<AdviceClaimReductionLayout>,
+    ) -> Self {
+        Self {
+            hamming_dimensions,
+            trusted_advice_layout,
+            untrusted_advice_layout,
+        }
+    }
+
+    fn layouts(&self) -> Stage7Layouts<'_> {
+        Stage7Layouts {
+            trusted_advice: self.trusted_advice_layout.as_ref(),
+            untrusted_advice: self.untrusted_advice_layout.as_ref(),
+            bytecode: None,
+            program_image: None,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct Stage7ProverInput<'a, F: Field, W> {
+    pub config: &'a Stage7ProverConfig,
+    pub checked: &'a CheckedInputs,
+    pub stage4: &'a Stage4ClearOutput<F>,
+    pub stage6: &'a Stage6ClearOutput<F>,
+    pub witness: &'a W,
+}
+
+impl<'a, F: Field, W> Stage7ProverInput<'a, F, W> {
+    pub const fn new(
+        config: &'a Stage7ProverConfig,
+        checked: &'a CheckedInputs,
+        stage4: &'a Stage4ClearOutput<F>,
+        stage6: &'a Stage6ClearOutput<F>,
+        witness: &'a W,
+    ) -> Self {
+        Self {
+            config,
+            checked,
+            stage4,
+            stage6,
+            witness,
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Stage7ProofComponent<F: Field, Proof> {
+    pub stage7_sumcheck_proof: Proof,
+    pub claims: Stage7OutputClaims<F>,
+    pub verifier_output: Stage7ClearOutput<F>,
+}
+
+#[cfg(feature = "zk")]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Stage7CommittedProofComponent<F, VC>
+where
+    F: Field,
+    VC: VectorCommitment<Field = F>,
+{
+    pub stage7_sumcheck_proof: SumcheckProof<F, VC::Output>,
+    pub public: Stage7PublicOutput<F>,
+    pub output_claim_values: Vec<F>,
+    pub verifier_output: Stage7ClearOutput<F>,
+    pub(crate) committed_witness: CommittedSumcheckWitness<F>,
+}
+
+struct Stage7PreparedBatch<F: Field> {
+    relations: Stage7Relations<F>,
+    hamming_state: SumcheckStage7HammingState<F>,
+    advice_states: Vec<Stage7AdviceAddressProverState<F>>,
+}
+
+const STAGE7_HAMMING_CHUNK_SIZE: usize = 1024;
+
+pub fn prove<F, W, B, T, C>(
+    input: Stage7ProverInput<'_, F, W>,
+    backend: &mut B,
+    transcript: &mut T,
+) -> Result<Stage7ProofComponent<F, SumcheckProof<F, C>>, ProverError>
+where
+    F: Field,
+    W: WitnessProvider<F, JoltVmNamespace>
+        + jolt_witness::RaFamilyCycleIndexSource<F, JoltVmNamespace>,
+    B: SumcheckBackend<F, JoltVmNamespace>,
+    T: Transcript<Challenge = F>,
+{
+    if input.checked.zk {
+        return Err(ProverError::InvalidStageRequest {
+            reason: "Stage 7 clear prover received ZK checked inputs".to_owned(),
+        });
+    }
+    let config = input.config;
+    let stage6 = input.stage6;
+    let Stage7PreparedBatch {
+        relations,
+        hamming_state,
+        advice_states,
+    } = prepare_stage7_regular_batch(input, backend, transcript)?;
+
+    let batch = prove_stage7_regular_batch_sumcheck_with_recorder::<F, T, B, _>(
+        &relations,
+        hamming_state,
+        advice_states,
+        transcript,
+        backend,
+        ClearSumcheckRecorder::<F, C>::new(0),
+    )?;
+    let (claims, verifier_output) =
+        stage7_claims_and_verifier_output(config, stage6, &relations, &batch)?;
+
+    Ok(Stage7ProofComponent {
+        stage7_sumcheck_proof: batch.proof,
+        claims,
+        verifier_output,
+    })
+}
+
+#[cfg(feature = "zk")]
+pub fn prove_committed_proof_component<F, W, B, T, VC>(
+    input: Stage7ProverInput<'_, F, W>,
+    backend: &mut B,
+    transcript: &mut T,
+    vc_setup: &VC::Setup,
+) -> Result<Stage7CommittedProofComponent<F, VC>, ProverError>
+where
+    F: Field,
+    W: WitnessProvider<F, JoltVmNamespace>
+        + jolt_witness::RaFamilyCycleIndexSource<F, JoltVmNamespace>,
+    B: SumcheckBackend<F, JoltVmNamespace>,
+    T: Transcript<Challenge = F>,
+    VC: VectorCommitment<Field = F>,
+{
+    if !input.checked.zk {
+        return Err(ProverError::InvalidStageRequest {
+            reason: "Stage 7 committed prover received transparent checked inputs".to_owned(),
+        });
+    }
+    let config = input.config;
+    let stage6 = input.stage6;
+    let Stage7PreparedBatch {
+        relations,
+        hamming_state,
+        advice_states,
+    } = prepare_stage7_regular_batch(input, backend, transcript)?;
+
+    let batch = prove_stage7_regular_batch_sumcheck_with_recorder::<F, T, B, _>(
+        &relations,
+        hamming_state,
+        advice_states,
+        transcript,
+        backend,
+        CommittedSumcheckRecorder::<F, VC>::new(vc_setup)?,
+    )?;
+    let (_, verifier_output) =
+        stage7_claims_and_verifier_output(config, stage6, &relations, &batch)?;
+
+    Ok(Stage7CommittedProofComponent {
+        stage7_sumcheck_proof: batch.proof,
+        public: Stage7PublicOutput {
+            hamming_gamma: relations.hamming_gamma(),
+        },
+        output_claim_values: batch.output_claim_values.ok_or_else(|| {
+            invalid_sumcheck_output("Stage 7 committed output claim values are missing".to_owned())
+        })?,
+        verifier_output,
+        committed_witness: batch.committed_witness.ok_or_else(|| {
+            invalid_sumcheck_output("Stage 7 committed witness material is missing".to_owned())
+        })?,
+    })
+}
+
+struct Stage7Batch<F: Field, C> {
+    proof: SumcheckProof<F, C>,
+    challenges: Vec<F>,
+    max_num_rounds: usize,
+    reduced_claims: Vec<F>,
+    trusted_advice: Option<F>,
+    untrusted_advice: Option<F>,
+    #[cfg(feature = "zk")]
+    committed_witness: Option<CommittedSumcheckWitness<F>>,
+    #[cfg(feature = "zk")]
+    output_claim_values: Option<Vec<F>>,
+}
+
+struct Stage7AdviceAddressProverState<F: Field> {
+    kind: JoltAdviceKind,
+    input_claim: F,
+    request: SumcheckStage7AdviceAddressStateRequest<F, JoltVmNamespace>,
+    state: SumcheckStage7AdviceAddressState<F>,
+}
+
+fn prepare_stage7_regular_batch<F, W, B, T>(
+    input: Stage7ProverInput<'_, F, W>,
+    backend: &mut B,
+    transcript: &mut T,
+) -> Result<Stage7PreparedBatch<F>, ProverError>
+where
+    F: Field,
+    W: WitnessProvider<F, JoltVmNamespace>
+        + jolt_witness::RaFamilyCycleIndexSource<F, JoltVmNamespace>,
+    B: SumcheckBackend<F, JoltVmNamespace>,
+    T: Transcript<Challenge = F>,
+{
+    let config = input.config;
+    let stage6 = input.stage6;
+    let dimensions = config.hamming_dimensions;
+
+    let hamming_gamma = transcript.challenge_scalar();
+    let relations = Stage7Relations::build(
+        dimensions,
+        hamming_gamma,
+        &config.layouts(),
+        input.stage4,
+        stage6,
+    )
+    .map_err(verifier_stage7_error)?;
+
+    let virt_points = stage7_hamming_virtualization_address_points(dimensions, stage6)
+        .map_err(verifier_stage7_error)?;
+    let booleanity_opening = stage6
+        .output_points
+        .booleanity_opening_point()
+        .ok_or_else(|| ProverError::InvalidStageRequest {
+            reason: "Stage 6 booleanity produced no opening point".to_owned(),
+        })?;
+    let (booleanity_r_address, booleanity_r_cycle) =
+        booleanity_opening.split_at(dimensions.log_k_chunk);
+    let state_request = SumcheckStage7HammingStateRequest::jolt_hamming_weight_claim_reduction(
+        dimensions,
+        booleanity_r_cycle.to_vec(),
+        booleanity_r_address.to_vec(),
+        virt_points,
+        hamming_gamma,
+        STAGE7_HAMMING_CHUNK_SIZE,
+    );
+    let hamming_state =
+        backend.materialize_sumcheck_stage7_hamming_state(&state_request, input.witness)?;
+
+    let advice_states = stage7_advice_address_states(
+        config,
+        input.stage4,
+        stage6,
+        input.witness,
+        backend,
+        &relations,
+    )?;
+
+    Ok(Stage7PreparedBatch {
+        relations,
+        hamming_state,
+        advice_states,
+    })
+}
+
+fn prove_stage7_regular_batch_sumcheck_with_recorder<F, T, B, S>(
+    relations: &Stage7Relations<F>,
+    mut hamming_state: SumcheckStage7HammingState<F>,
+    mut advice_states: Vec<Stage7AdviceAddressProverState<F>>,
+    transcript: &mut T,
+    backend: &mut B,
+    mut proof_recorder: S,
+) -> Result<Stage7Batch<F, S::Commitment>, ProverError>
+where
+    F: Field,
+    T: Transcript<Challenge = F>,
+    B: SumcheckBackend<F, JoltVmNamespace>,
+    S: SumcheckRecorder<F>,
+{
+    let hamming_rounds = hamming_state.num_rounds();
+    let max_num_rounds = advice_states.iter().fold(hamming_rounds, |rounds, advice| {
+        rounds.max(advice.request.address_phase_rounds())
+    });
+    let instance_count = 1 + advice_states.len();
+
+    let hamming_input_claim = relations
+        .hamming
+        .input_claim(&relations.hamming_inputs)
+        .map_err(verifier_stage7_error)?;
+    let input_claim_values = std::iter::once(hamming_input_claim)
+        .chain(advice_states.iter().map(|advice| advice.input_claim))
+        .collect::<Vec<_>>();
+    proof_recorder.absorb_input_claims(&input_claim_values, transcript);
+    let batching_coefficients = (0..instance_count)
+        .map(|_| transcript.challenge_scalar())
+        .collect::<Vec<_>>();
+
+    let mut individual_claims = Vec::with_capacity(instance_count);
+    individual_claims.push(hamming_input_claim.mul_pow_2(max_num_rounds - hamming_rounds));
+    individual_claims.extend(advice_states.iter().map(|advice| {
+        advice
+            .input_claim
+            .mul_pow_2(max_num_rounds - advice.request.address_phase_rounds())
+    }));
+    #[cfg(any(test, debug_assertions))]
+    let mut running_claim = individual_claims
+        .iter()
+        .zip(&batching_coefficients)
+        .map(|(claim, coefficient)| *claim * *coefficient)
+        .sum::<F>();
+
+    let hamming_offset = max_num_rounds - hamming_rounds;
+    let two_inv = F::from_u64(2)
+        .inverse()
+        .ok_or_else(|| invalid_sumcheck_output("2 is not invertible".to_owned()))?;
+    let mut challenges = Vec::with_capacity(max_num_rounds);
+    for round in 0..max_num_rounds {
+        let mut instance_polys = Vec::with_capacity(instance_count);
+        if round >= hamming_offset {
+            instance_polys.push(
+                backend
+                    .evaluate_sumcheck_stage7_hamming_round(&hamming_state, individual_claims[0])?,
+            );
+        } else {
+            instance_polys.push(UnivariatePoly::new(vec![individual_claims[0] * two_inv]));
+        }
+
+        for (index, advice) in advice_states.iter().enumerate() {
+            let claim_index = index + 1;
+            if round < advice.request.address_phase_rounds() {
+                instance_polys.push(backend.evaluate_sumcheck_stage7_advice_address_round(
+                    &advice.state,
+                    individual_claims[claim_index],
+                    max_num_rounds,
+                )?);
+            } else {
+                instance_polys.push(UnivariatePoly::new(vec![
+                    individual_claims[claim_index] * two_inv,
+                ]));
+            }
+        }
+
+        let batched_poly = instance_polys.iter().zip(&batching_coefficients).fold(
+            UnivariatePoly::zero(),
+            |mut acc, (poly, coefficient)| {
+                acc += &(poly * *coefficient);
+                acc
+            },
+        );
+        #[cfg(any(test, debug_assertions))]
+        {
+            let round_sum = batched_poly.evaluate(F::zero()) + batched_poly.evaluate(F::one());
+            if round_sum != running_claim {
+                return Err(invalid_sumcheck_output(format!(
+                    "Stage 7 regular batch round {round} sumcheck invariant failed"
+                )));
+            }
+        }
+
+        let batched_poly = trim_round_polynomial(batched_poly);
+        let challenge = proof_recorder.absorb_round(&batched_poly, transcript)?;
+        #[cfg(any(test, debug_assertions))]
+        {
+            running_claim = batched_poly.evaluate(challenge);
+        }
+        for (claim, poly) in individual_claims.iter_mut().zip(instance_polys) {
+            *claim = poly.evaluate(challenge);
+        }
+        challenges.push(challenge);
+
+        if round >= hamming_offset {
+            backend.bind_sumcheck_stage7_hamming_state(&mut hamming_state, challenge)?;
+        }
+        for advice in &mut advice_states {
+            if round < advice.request.address_phase_rounds() {
+                backend.bind_sumcheck_stage7_advice_address_state(&mut advice.state, challenge)?;
+            }
+        }
+    }
+
+    let reduced_claims = hamming_state
+        .g
+        .iter()
+        .enumerate()
+        .map(|(index, poly)| {
+            if poly.len() != 1 {
+                return Err(invalid_sumcheck_output(format!(
+                    "Stage 7 hamming G table {index} has {} rows after final bind, expected 1",
+                    poly.len()
+                )));
+            }
+            Ok(poly.evaluations()[0])
+        })
+        .collect::<Result<Vec<_>, ProverError>>()?;
+
+    let mut trusted_advice = None;
+    let mut untrusted_advice = None;
+    for advice in advice_states {
+        let opening_claim = advice
+            .state
+            .final_advice_opening()
+            .ok_or_else(|| invalid_sumcheck_output("Stage 7 advice state is not fully bound"))?;
+        match advice.kind {
+            JoltAdviceKind::Trusted => trusted_advice = Some(opening_claim),
+            JoltAdviceKind::Untrusted => untrusted_advice = Some(opening_claim),
+        }
+    }
+    let mut output_claim_values = reduced_claims.clone();
+    output_claim_values.extend(trusted_advice);
+    output_claim_values.extend(untrusted_advice);
+    let proof_artifacts = proof_recorder.finish(&output_claim_values, transcript)?;
+
+    Ok(Stage7Batch {
+        proof: proof_artifacts.proof,
+        challenges,
+        max_num_rounds,
+        reduced_claims,
+        trusted_advice,
+        untrusted_advice,
+        #[cfg(feature = "zk")]
+        committed_witness: proof_artifacts.committed_witness,
+        #[cfg(feature = "zk")]
+        output_claim_values: proof_artifacts.output_claim_values,
+    })
+}
+
+fn stage7_claims_and_verifier_output<F, C>(
+    config: &Stage7ProverConfig,
+    stage6: &Stage6ClearOutput<F>,
+    relations: &Stage7Relations<F>,
+    batch: &Stage7Batch<F, C>,
+) -> Result<(Stage7OutputClaims<F>, Stage7ClearOutput<F>), ProverError>
+where
+    F: Field,
+{
+    let layout = config.hamming_dimensions.layout;
+    if batch.reduced_claims.len() != layout.total() {
+        return Err(invalid_sumcheck_output(format!(
+            "Stage 7 hamming reduction produced {} RA claims, expected {}",
+            batch.reduced_claims.len(),
+            layout.total()
+        )));
+    }
+    let instruction_end = layout.instruction();
+    let bytecode_end = instruction_end + layout.bytecode();
+    let claims = Stage7OutputClaims {
+        hamming_weight_claim_reduction: HammingWeightClaimReductionOutputClaims {
+            instruction_ra: batch.reduced_claims[..instruction_end].to_vec(),
+            bytecode_ra: batch.reduced_claims[instruction_end..bytecode_end].to_vec(),
+            ram_ra: batch.reduced_claims[bytecode_end..].to_vec(),
+        },
+        advice_address_phase: AdviceAddressPhaseOutputClaims {
+            trusted: batch.trusted_advice,
+            untrusted: batch.untrusted_advice,
+        },
+        bytecode_address_phase: None,
+        program_image_address_phase: None,
+    };
+
+    // The hamming reduction is suffix-aligned in the batch; the advice address
+    // phases are prefix-aligned (offset 0).
+    let hamming_rounds = relations.hamming.sumcheck_relation().sumcheck.rounds;
+    let hamming_point = batch
+        .challenges
+        .get(batch.max_num_rounds - hamming_rounds..)
+        .ok_or_else(|| invalid_sumcheck_output("Stage 7 hamming sumcheck point is out of range"))?;
+    let advice_point = |relation: &Option<_>| -> Result<Option<&[F]>, ProverError> {
+        match relation {
+            Some(relation) => {
+                let rounds = SumcheckInstance::sumcheck_relation(relation)
+                    .sumcheck
+                    .rounds;
+                let point = batch.challenges.get(..rounds).ok_or_else(|| {
+                    invalid_sumcheck_output("Stage 7 advice sumcheck point is out of range")
+                })?;
+                Ok(Some(point))
+            }
+            None => Ok(None),
+        }
+    };
+    let points = Stage7InstancePoints {
+        hamming: hamming_point,
+        trusted_advice: advice_point(&relations.trusted_advice)?,
+        untrusted_advice: advice_point(&relations.untrusted_advice)?,
+        bytecode: None,
+        program_image: None,
+    };
+
+    let parts = relations
+        .clear_output(&points, &claims, stage6, &config.layouts())
+        .map_err(verifier_stage7_error)?;
+
+    Ok((claims, parts.output))
+}
+
+fn stage7_advice_address_states<F, W, B>(
+    config: &Stage7ProverConfig,
+    stage4: &Stage4ClearOutput<F>,
+    stage6: &Stage6ClearOutput<F>,
+    witness: &W,
+    backend: &mut B,
+    relations: &Stage7Relations<F>,
+) -> Result<Vec<Stage7AdviceAddressProverState<F>>, ProverError>
+where
+    F: Field,
+    W: WitnessProvider<F, JoltVmNamespace>,
+    B: SumcheckBackend<F, JoltVmNamespace>,
+{
+    let mut states = Vec::new();
+    for kind in [JoltAdviceKind::Trusted, JoltAdviceKind::Untrusted] {
+        let Some(layout) = advice_layout(config, kind) else {
+            continue;
+        };
+        if !layout.dimensions().has_address_phase() {
+            continue;
+        }
+        let relation = match kind {
+            JoltAdviceKind::Trusted => relations.trusted_advice.as_ref(),
+            JoltAdviceKind::Untrusted => relations.untrusted_advice.as_ref(),
+        }
+        .ok_or_else(|| ProverError::InvalidStageRequest {
+            reason: format!("Stage 7 {kind:?} advice address relation is missing"),
+        })?;
+        let input_claim = relation
+            .input_claim(&relations.advice_inputs)
+            .map_err(verifier_stage7_error)?;
+        let cycle_phase_variables = stage6
+            .output_points
+            .advice_cycle_phase_variables(kind)
+            .ok_or_else(|| ProverError::InvalidStageRequest {
+                reason: format!(
+                    "Stage 6 advice cycle-phase verifier output missing for {kind:?} advice"
+                ),
+            })?;
+        let contribution = stage4
+            .ram_val_check_init
+            .advice_contribution(kind)
+            .ok_or_else(|| ProverError::InvalidStageRequest {
+                reason: format!(
+                    "Stage 4 RAM value-check advice contribution missing for {kind:?} advice"
+                ),
+            })?;
+        let request = SumcheckStage7AdviceAddressStateRequest::jolt_advice_address_phase(
+            kind,
+            layout,
+            contribution.opening.point.clone(),
+            cycle_phase_variables,
+            1024,
+        );
+        let state = backend.materialize_sumcheck_stage7_advice_address_state(&request, witness)?;
+        states.push(Stage7AdviceAddressProverState {
+            kind,
+            input_claim,
+            request,
+            state,
+        });
+    }
+    Ok(states)
+}
+
+fn trim_round_polynomial<F: Field>(poly: UnivariatePoly<F>) -> UnivariatePoly<F> {
+    let mut coefficients = poly.into_coefficients();
+    while coefficients.len() > 2 && coefficients.last().is_some_and(|value| *value == F::zero()) {
+        let _ = coefficients.pop();
+    }
+    UnivariatePoly::new(coefficients)
+}
+
+fn verifier_stage7_error(error: jolt_verifier::VerifierError) -> ProverError {
+    ProverError::InvalidStageRequest {
+        reason: error.to_string(),
+    }
+}
+
+fn advice_layout(
+    config: &Stage7ProverConfig,
+    kind: JoltAdviceKind,
+) -> Option<&jolt_claims::protocols::jolt::AdviceClaimReductionLayout> {
+    match kind {
+        JoltAdviceKind::Trusted => config.trusted_advice_layout.as_ref(),
+        JoltAdviceKind::Untrusted => config.untrusted_advice_layout.as_ref(),
+    }
+}

--- a/crates/jolt-prover/src/stages/stage8/mod.rs
+++ b/crates/jolt-prover/src/stages/stage8/mod.rs
@@ -1,0 +1,2 @@
+pub(crate) mod prepare;
+pub mod prove;

--- a/crates/jolt-prover/src/stages/stage8/prepare.rs
+++ b/crates/jolt-prover/src/stages/stage8/prepare.rs
@@ -1,0 +1,26 @@
+use common::jolt_device::JoltDevice;
+use jolt_claims::protocols::jolt::JoltFormulaDimensions;
+
+use super::prove::Stage8ProverConfig;
+use crate::stages::advice::advice_layouts;
+use crate::{ProverConfig, ProverError};
+
+pub(crate) fn prover_config(
+    public_io: &JoltDevice,
+    proof_parameters: ProverConfig,
+    formula_dimensions: JoltFormulaDimensions,
+) -> Result<Stage8ProverConfig, ProverError> {
+    let log_t = proof_parameters.trace_length.trailing_zeros() as usize;
+    let committed_chunk_bits = proof_parameters.one_hot_config.committed_chunk_bits();
+    let (trusted_advice_layout, untrusted_advice_layout) =
+        advice_layouts(public_io, proof_parameters, log_t, committed_chunk_bits)?;
+
+    Ok(Stage8ProverConfig::new(
+        log_t,
+        committed_chunk_bits,
+        formula_dimensions.ra_layout,
+        proof_parameters.trace_polynomial_order,
+        trusted_advice_layout,
+        untrusted_advice_layout,
+    ))
+}

--- a/crates/jolt-prover/src/stages/stage8/prove.rs
+++ b/crates/jolt-prover/src/stages/stage8/prove.rs
@@ -1,0 +1,248 @@
+use jolt_backends::poly::{Stage8JointRlcConfig, Stage8JointRlcSource};
+use jolt_claims::protocols::jolt::{
+    formulas::dimensions::TracePolynomialOrder, formulas::ra::JoltRaPolynomialLayout,
+    AdviceClaimReductionLayout,
+};
+use jolt_crypto::HomomorphicCommitment;
+use jolt_field::Field;
+#[cfg(feature = "zk")]
+use jolt_openings::ZkOpeningScheme;
+use jolt_openings::{AdditivelyHomomorphic, CommitmentScheme};
+use jolt_transcript::Transcript;
+#[cfg(feature = "zk")]
+use jolt_verifier::stages::stage8::stage8_zk_final_opening_batch;
+#[cfg(feature = "zk")]
+use jolt_verifier::stages::stage8::Stage8FinalOpeningStructure as Stage8OpeningStructure;
+use jolt_verifier::stages::{
+    stage6::Stage6ClearOutput,
+    stage7::outputs::Stage7ClearOutput,
+    stage8::{stage8_clear_final_opening_batch, Stage8FinalOpeningBatchInput},
+};
+use jolt_witness::{
+    protocols::jolt_vm::{JoltVmNamespace, JoltVmStage6Rows},
+    WitnessProvider,
+};
+
+use crate::ProverError;
+
+/// Canonical Stage 8 prover configuration.
+///
+/// Carries the verifier-equivalent dimensions, RA layout, trace polynomial order,
+/// and advice layouts needed to build the final batched-opening order exactly as
+/// `jolt-verifier/src/stages/stage8/verify.rs` does.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Stage8ProverConfig {
+    pub log_t: usize,
+    pub committed_chunk_bits: usize,
+    pub layout: JoltRaPolynomialLayout,
+    pub trace_polynomial_order: TracePolynomialOrder,
+    pub trusted_advice_layout: Option<AdviceClaimReductionLayout>,
+    pub untrusted_advice_layout: Option<AdviceClaimReductionLayout>,
+}
+
+impl Stage8ProverConfig {
+    pub const fn new(
+        log_t: usize,
+        committed_chunk_bits: usize,
+        layout: JoltRaPolynomialLayout,
+        trace_polynomial_order: TracePolynomialOrder,
+        trusted_advice_layout: Option<AdviceClaimReductionLayout>,
+        untrusted_advice_layout: Option<AdviceClaimReductionLayout>,
+    ) -> Self {
+        Self {
+            log_t,
+            committed_chunk_bits,
+            layout,
+            trace_polynomial_order,
+            trusted_advice_layout,
+            untrusted_advice_layout,
+        }
+    }
+}
+
+/// Canonical Stage 8 prover output (clear path): the generated
+/// `joint_opening_proof` that becomes the `JoltProof` PCS artifact.
+#[derive(Clone, Debug)]
+pub(crate) struct Stage8ProofOutput<Proof> {
+    pub(crate) joint_opening_proof: Proof,
+}
+
+/// Canonical Stage 8 prover output for ZK mode: the verifier-equivalent opening
+/// structure, generated PCS proof, and prover-side opening blind retained for
+/// BlindFold.
+#[cfg(feature = "zk")]
+#[derive(Clone, Debug)]
+pub(crate) struct Stage8ZkProofOutput<F: Field, Proof, Blind> {
+    pub(crate) structure: Stage8OpeningStructure<F>,
+    pub(crate) joint_opening_proof: Proof,
+    pub(crate) hiding_evaluation_blind: Blind,
+}
+
+#[cfg(feature = "zk")]
+type Stage8ZkOutputFor<F, PCS> =
+    Stage8ZkProofOutput<F, <PCS as CommitmentScheme>::Proof, <PCS as ZkOpeningScheme>::Blind>;
+
+#[expect(
+    clippy::too_many_arguments,
+    reason = "Stage 8 needs prior-stage outputs plus the PCS commitments, retained hints, and setup, which are PCS-generic and cannot bundle into the non-generic prover input."
+)]
+pub(crate) fn prove_stage8<F, PCS, W, T>(
+    config: &Stage8ProverConfig,
+    stage6: &Stage6ClearOutput<F>,
+    stage7: &Stage7ClearOutput<F>,
+    witness: &W,
+    commitments: &[PCS::Output],
+    hints: Vec<PCS::OpeningHint>,
+    setup: &PCS::ProverSetup,
+    transcript: &mut T,
+) -> Result<Stage8ProofOutput<PCS::Proof>, ProverError>
+where
+    F: Field,
+    <F as jolt_field::WithAccumulator>::Accumulator: jolt_field::RingAccumulator<Element = F>,
+    PCS: CommitmentScheme<Field = F> + AdditivelyHomomorphic,
+    PCS::Output: HomomorphicCommitment<F>,
+    W: WitnessProvider<F, JoltVmNamespace> + JoltVmStage6Rows + Sync,
+    T: Transcript<Challenge = F>,
+{
+    let final_opening_batch = stage8_clear_final_opening_batch(
+        stage8_final_opening_batch_input(config, stage6, stage7),
+        transcript,
+    )?;
+    let structure = final_opening_batch.structure;
+    let gamma_powers = final_opening_batch.gamma_powers;
+    require_stage8_batch_size(
+        "Stage 8",
+        commitments.len(),
+        hints.len(),
+        structure.opening_ids.len(),
+    )?;
+
+    let combined_hint = PCS::combine_hints(hints, &gamma_powers);
+    let joint_polynomial = Stage8JointRlcSource::new(
+        stage8_joint_rlc_config(config),
+        witness,
+        gamma_powers.clone(),
+    )?;
+    let joint_opening_proof = PCS::open_poly(
+        &joint_polynomial,
+        structure.pcs_opening_point.as_slice(),
+        structure.joint_claim,
+        setup,
+        Some(combined_hint),
+        transcript,
+    );
+    PCS::bind_opening_inputs(
+        transcript,
+        structure.opening_point.as_slice(),
+        &structure.joint_claim,
+    );
+
+    Ok(Stage8ProofOutput {
+        joint_opening_proof,
+    })
+}
+
+#[expect(
+    clippy::too_many_arguments,
+    reason = "Stage 8 ZK opening uses the same verifier-order inputs as clear Stage 8 plus hidden PCS output material."
+)]
+#[cfg(feature = "zk")]
+pub(crate) fn prove_stage8_zk<F, PCS, W, T>(
+    config: &Stage8ProverConfig,
+    stage6: &Stage6ClearOutput<F>,
+    stage7: &Stage7ClearOutput<F>,
+    witness: &W,
+    commitments: &[PCS::Output],
+    hints: Vec<PCS::OpeningHint>,
+    setup: &PCS::ProverSetup,
+    transcript: &mut T,
+) -> Result<Stage8ZkOutputFor<F, PCS>, ProverError>
+where
+    F: Field,
+    <F as jolt_field::WithAccumulator>::Accumulator: jolt_field::RingAccumulator<Element = F>,
+    PCS: CommitmentScheme<Field = F> + AdditivelyHomomorphic + ZkOpeningScheme,
+    PCS::Output: HomomorphicCommitment<F>,
+    W: WitnessProvider<F, JoltVmNamespace> + JoltVmStage6Rows + Sync,
+    T: Transcript<Challenge = F>,
+{
+    let final_opening_batch = stage8_zk_final_opening_batch(
+        stage8_final_opening_batch_input(config, stage6, stage7),
+        transcript,
+    )?;
+    let structure = final_opening_batch.structure;
+    let gamma_powers = final_opening_batch.gamma_powers;
+    require_stage8_batch_size(
+        "Stage 8 ZK",
+        commitments.len(),
+        hints.len(),
+        structure.opening_ids.len(),
+    )?;
+
+    let combined_hint = PCS::combine_hints(hints, &gamma_powers);
+    let joint_polynomial =
+        Stage8JointRlcSource::new(stage8_joint_rlc_config(config), witness, gamma_powers)?;
+    let (joint_opening_proof, hiding_evaluation_commitment, hiding_evaluation_blind) =
+        PCS::open_zk_poly(
+            &joint_polynomial,
+            structure.pcs_opening_point.as_slice(),
+            structure.joint_claim,
+            setup,
+            combined_hint,
+            transcript,
+        );
+    PCS::bind_zk_opening_inputs(
+        transcript,
+        structure.opening_point.as_slice(),
+        &hiding_evaluation_commitment,
+    );
+
+    Ok(Stage8ZkProofOutput {
+        structure,
+        joint_opening_proof,
+        hiding_evaluation_blind,
+    })
+}
+
+fn stage8_joint_rlc_config(config: &Stage8ProverConfig) -> Stage8JointRlcConfig<'_> {
+    Stage8JointRlcConfig {
+        log_t: config.log_t,
+        committed_chunk_bits: config.committed_chunk_bits,
+        layout: config.layout,
+        trace_polynomial_order: config.trace_polynomial_order,
+        trusted_advice_layout: config.trusted_advice_layout.as_ref(),
+        untrusted_advice_layout: config.untrusted_advice_layout.as_ref(),
+    }
+}
+
+fn stage8_final_opening_batch_input<'a, F: Field>(
+    config: &'a Stage8ProverConfig,
+    stage6: &'a Stage6ClearOutput<F>,
+    stage7: &'a Stage7ClearOutput<F>,
+) -> Stage8FinalOpeningBatchInput<'a, F> {
+    Stage8FinalOpeningBatchInput {
+        log_t: config.log_t,
+        committed_chunk_bits: config.committed_chunk_bits,
+        layout: config.layout,
+        trace_polynomial_order: config.trace_polynomial_order,
+        trusted_advice_layout: config.trusted_advice_layout.as_ref(),
+        untrusted_advice_layout: config.untrusted_advice_layout.as_ref(),
+        stage6,
+        stage7,
+    }
+}
+
+fn require_stage8_batch_size(
+    label: &'static str,
+    commitments: usize,
+    hints: usize,
+    opening_ids: usize,
+) -> Result<(), ProverError> {
+    if commitments == opening_ids && hints == opening_ids {
+        return Ok(());
+    }
+    Err(ProverError::InvalidStageRequest {
+        reason: format!(
+            "{label} batch size mismatch: {commitments} commitments, {hints} hints, {opening_ids} opening ids"
+        ),
+    })
+}

--- a/crates/jolt-prover/src/zk.rs
+++ b/crates/jolt-prover/src/zk.rs
@@ -1,0 +1,981 @@
+use std::ops::Range;
+
+use common::jolt_device::JoltDevice;
+use jolt_backends::{
+    BlindFoldBackend, BlindFoldCrossTermErrorRowsRequest, BlindFoldErrorRowsRequest,
+    BlindFoldFoldErrorRowsRequest, BlindFoldFoldErrorScalarsRequest, BlindFoldFoldRowsRequest,
+    BlindFoldFoldScalarsRequest, BlindFoldRowCommitmentRequest, BlindFoldRowOpeningRequest,
+};
+use jolt_crypto::HomomorphicCommitment;
+use jolt_crypto::VectorCommitment;
+use jolt_field::Field;
+use jolt_field::FromPrimitiveInt;
+use jolt_field::RandomSampling;
+use jolt_field::{RingAccumulator, WithAccumulator};
+use jolt_openings::AdditivelyHomomorphic;
+use jolt_openings::CommitmentScheme;
+use jolt_openings::ZkOpeningScheme;
+use jolt_r1cs::constraints::jolt::{
+    SPARTAN_OUTER_UNISKIP_DOMAIN_SIZE, SPARTAN_PRODUCT_UNISKIP_DOMAIN_SIZE,
+};
+use jolt_r1cs::{ConstraintMatrices, SparseRow, Variable};
+use jolt_sumcheck::{SumcheckDomain, SumcheckDomainSpec};
+use jolt_transcript::{AppendToTranscript, Blake2bTranscript, Label, Transcript};
+use jolt_verifier::proof::JoltStageProofs;
+use jolt_verifier::proof::{JoltProof, JoltProofClaims};
+use jolt_verifier::stages::zk::{
+    blindfold,
+    inputs::BlindFoldInputs,
+    outputs::{zk_stage_outputs, BlindFoldOutput},
+};
+use jolt_verifier::JoltVerifierPreprocessing;
+
+use crate::committed::CommittedSumcheckWitness;
+use crate::stages::stage8::prove::Stage8ZkProofOutput;
+use crate::ProverError;
+use crate::{stages::stage0::CommitmentComponent, ProverConfig};
+
+pub(crate) type Stage8ZkOpeningOutput<PCS> = Stage8ZkProofOutput<
+    <PCS as CommitmentScheme>::Field,
+    <PCS as CommitmentScheme>::Proof,
+    <PCS as CommitmentScheme>::Field,
+>;
+
+pub(crate) fn build_blindfold_protocol<PCS, VC>(
+    config: &ProverConfig,
+    preprocessing: &JoltVerifierPreprocessing<PCS, VC>,
+    public_io: &JoltDevice,
+    stage0: &CommitmentComponent<PCS>,
+    stage_proofs: &JoltStageProofs<PCS::Field, VC>,
+    joint_opening_proof: &PCS::Proof,
+) -> Result<BlindFoldOutput<PCS::Field, VC::Output>, ProverError>
+where
+    PCS: CommitmentScheme
+        + AdditivelyHomomorphic
+        + ZkOpeningScheme<
+            HidingCommitment = <VC as jolt_crypto::Commitment>::Output,
+            Blind = <PCS as CommitmentScheme>::Field,
+        >,
+    PCS::Output: AppendToTranscript + HomomorphicCommitment<PCS::Field>,
+    PCS::Proof: Clone,
+    VC: VectorCommitment<Field = <PCS as CommitmentScheme>::Field>,
+    JoltStageProofs<PCS::Field, VC>: Clone,
+{
+    if !ProverConfig::features().zk {
+        return Err(ProverError::InvalidStageRequest {
+            reason: "BlindFold protocol construction requires ZK proof mode".to_owned(),
+        });
+    }
+
+    let proof = zk_proof_shell(
+        config,
+        stage0,
+        stage_proofs.clone(),
+        joint_opening_proof.clone(),
+    )?;
+    let jolt_verifier::PreStage1VerifierState {
+        checked,
+        mut transcript,
+    } = jolt_verifier::verify_until_stage1::<PCS, VC, Blake2bTranscript<PCS::Field>, ()>(
+        preprocessing,
+        public_io,
+        &proof,
+        stage0.trusted_advice_commitment.as_ref(),
+        true,
+    )?;
+
+    let formula_dimensions = jolt_verifier::stages::build_formula_dimensions(
+        &proof,
+        preprocessing,
+        &checked,
+        checked.trace_length.ilog2() as usize,
+        jolt_claims::protocols::jolt::JoltRelationId::InstructionReadRaf,
+    )?;
+
+    let stage1 = jolt_verifier::stages::stage1::verify(&checked, &proof, &mut transcript)?;
+    let stage2 = jolt_verifier::stages::stage2::verify(&checked, &proof, &mut transcript, &stage1)?;
+    let stage3 =
+        jolt_verifier::stages::stage3::verify(&checked, &proof, &mut transcript, &stage1, &stage2)?;
+    let stage4 = jolt_verifier::stages::stage4::verify(
+        &checked,
+        preprocessing,
+        &proof,
+        &mut transcript,
+        &stage2,
+        &stage3,
+    )?;
+    let stage5 = jolt_verifier::stages::stage5::verify(
+        &checked,
+        &proof,
+        &formula_dimensions,
+        &mut transcript,
+        &stage2,
+        &stage4,
+    )?;
+    let stage6 = jolt_verifier::stages::stage6::verify(
+        &checked,
+        preprocessing,
+        &proof,
+        &formula_dimensions,
+        &mut transcript,
+        &stage1,
+        &stage2,
+        &stage3,
+        &stage4,
+        &stage5,
+    )?;
+    let stage7 = jolt_verifier::stages::stage7::verify(
+        &checked,
+        &proof,
+        &formula_dimensions,
+        &mut transcript,
+        &stage4,
+        &stage6,
+    )?;
+    let stage8 = jolt_verifier::stages::stage8::verify(
+        &checked,
+        preprocessing,
+        &proof,
+        &formula_dimensions,
+        stage0.trusted_advice_commitment.as_ref(),
+        &mut transcript,
+        &stage6,
+        &stage7,
+    )?;
+
+    let zk_stages = zk_stage_outputs::<PCS, VC>(
+        &stage1, &stage2, &stage3, &stage4, &stage5, &stage6, &stage7, &stage8,
+    )?;
+    Ok(blindfold::build(BlindFoldInputs {
+        checked: &checked,
+        preprocessing,
+        proof: &proof,
+        stage1: zk_stages.stage1,
+        stage2: zk_stages.stage2,
+        stage3: zk_stages.stage3,
+        stage4: zk_stages.stage4,
+        stage5: zk_stages.stage5,
+        stage6: zk_stages.stage6,
+        stage7: zk_stages.stage7,
+        stage8: zk_stages.stage8,
+    })?)
+}
+
+fn zk_proof_shell<PCS, VC>(
+    config: &ProverConfig,
+    stage0: &CommitmentComponent<PCS>,
+    stages: JoltStageProofs<PCS::Field, VC>,
+    joint_opening_proof: PCS::Proof,
+) -> Result<JoltProof<PCS, VC, ()>, ProverError>
+where
+    PCS: CommitmentScheme,
+    PCS::Output: Clone,
+    VC: VectorCommitment<Field = PCS::Field>,
+{
+    let proof_parameters = *config;
+
+    Ok(JoltProof::<PCS, VC, ()>::new(
+        stage0.commitments.clone(),
+        stages,
+        joint_opening_proof,
+        stage0.untrusted_advice_commitment.clone(),
+        JoltProofClaims::Zk {
+            blindfold_proof: (),
+        },
+        proof_parameters.trace_length,
+        proof_parameters.ram_k,
+        proof_parameters.rw_config,
+        proof_parameters.one_hot_config,
+        proof_parameters.trace_polynomial_order,
+    ))
+}
+
+pub(crate) fn assemble_blindfold_witness<PCS, VC, R>(
+    blindfold: &BlindFoldOutput<PCS::Field, VC::Output>,
+    committed_sumchecks: &[CommittedSumcheckWitness<PCS::Field>],
+    stage8: &Stage8ZkOpeningOutput<PCS>,
+    rng: &mut R,
+) -> Result<BlindFoldProverWitness<PCS::Field>, ProverError>
+where
+    PCS: CommitmentScheme,
+    VC: VectorCommitment<Field = PCS::Field>,
+    R: rand_core::RngCore,
+{
+    let protocol = &blindfold.protocol;
+    let row_len = protocol.dimensions.witness.row_len;
+    let row_count = protocol.dimensions.witness.row_count;
+    let value_count =
+        row_len
+            .checked_mul(row_count)
+            .ok_or_else(|| ProverError::InvalidStageRequest {
+                reason: "BlindFold witness dimensions overflow".to_owned(),
+            })?;
+    if protocol.r1cs.num_vars > value_count + 1 {
+        return Err(ProverError::InvalidStageRequest {
+            reason: format!(
+                "BlindFold R1CS variable count {} exceeds padded witness capacity {}",
+                protocol.r1cs.num_vars,
+                value_count + 1
+            ),
+        });
+    }
+
+    let eval_outputs = vec![stage8.structure.joint_claim];
+    let eval_blindings = vec![stage8.hiding_evaluation_blind];
+    if protocol.eval_commitments.len() != eval_outputs.len() {
+        return Err(ProverError::InvalidStageRequest {
+            reason: format!(
+                "BlindFold final-opening count mismatch: expected {}, got {}",
+                eval_outputs.len(),
+                protocol.eval_commitments.len()
+            ),
+        });
+    }
+
+    if committed_sumchecks.len() != protocol.layout.stages.len()
+        || committed_sumchecks.len() != protocol.sumcheck_consistency.len()
+    {
+        return Err(ProverError::InvalidStageRequest {
+            reason: format!(
+                "BlindFold committed sumcheck count mismatch: witnesses {}, layouts {}, protocol {}",
+                committed_sumchecks.len(),
+                protocol.layout.stages.len(),
+                protocol.sumcheck_consistency.len()
+            ),
+        });
+    }
+
+    let mut witness_values = vec![None; value_count + 1];
+    witness_values[0] = Some(PCS::Field::from_u64(1));
+    let mut blindings = vec![PCS::Field::from_u64(0); row_count];
+
+    assign_committed_blindfold_rows(
+        &mut witness_values,
+        &mut blindings,
+        row_len,
+        protocol.dimensions.witness_rows.coefficients.clone(),
+        committed_sumchecks,
+        BlindFoldCommittedRows::Coefficients,
+    )?;
+    assign_committed_blindfold_rows(
+        &mut witness_values,
+        &mut blindings,
+        row_len,
+        protocol.dimensions.witness_rows.output_claims.clone(),
+        committed_sumchecks,
+        BlindFoldCommittedRows::OutputClaims,
+    )?;
+
+    let domains = blindfold_sumcheck_domains();
+    if domains.len() != committed_sumchecks.len() {
+        return Err(ProverError::InvalidStageRequest {
+            reason: format!(
+                "BlindFold domain count mismatch: expected {}, got {}",
+                committed_sumchecks.len(),
+                domains.len()
+            ),
+        });
+    }
+    for ((stage_layout, consistency), (witness, domain)) in protocol
+        .layout
+        .stages
+        .iter()
+        .zip(&protocol.sumcheck_consistency)
+        .zip(committed_sumchecks.iter().zip(domains))
+    {
+        assign_sumcheck_layout_witness(
+            &mut witness_values,
+            &stage_layout.sumcheck,
+            consistency,
+            witness,
+            domain,
+        )?;
+    }
+
+    let final_coordinates = protocol
+        .final_opening_witness_coordinates()
+        .map_err(|error| ProverError::InvalidStageRequest {
+            reason: format!("BlindFold final-opening coordinate derivation failed: {error}"),
+        })?;
+    if final_coordinates.len() != eval_outputs.len() {
+        return Err(ProverError::InvalidStageRequest {
+            reason: format!(
+                "BlindFold final-opening coordinate count mismatch: expected {}, got {}",
+                eval_outputs.len(),
+                final_coordinates.len()
+            ),
+        });
+    }
+    for (index, coordinates) in final_coordinates.iter().enumerate() {
+        if let Some(coordinate) = coordinates.evaluation {
+            assign_witness_cell(
+                &mut witness_values,
+                row_len,
+                coordinate.row,
+                coordinate.column,
+                eval_outputs[index],
+                "BlindFold final-opening evaluation",
+            )?;
+        }
+        if let Some(coordinate) = coordinates.blinding {
+            assign_witness_cell(
+                &mut witness_values,
+                row_len,
+                coordinate.row,
+                coordinate.column,
+                eval_blindings[index],
+                "BlindFold final-opening blinding",
+            )?;
+        }
+    }
+
+    complete_blindfold_auxiliary_witness(&protocol.r1cs, &mut witness_values)?;
+    for row in protocol.dimensions.witness_rows.auxiliary.clone() {
+        blindings[row] = PCS::Field::random(&mut *rng);
+    }
+
+    let flat_witness = witness_values
+        .into_iter()
+        .map(Option::unwrap_or_default)
+        .collect::<Vec<_>>();
+    protocol
+        .r1cs
+        .check_witness(&flat_witness)
+        .map_err(|constraint| ProverError::InvalidStageRequest {
+            reason: format!("BlindFold witness does not satisfy constraint {constraint}"),
+        })?;
+    let rows = flat_witness[1..]
+        .chunks(row_len)
+        .map(<[PCS::Field]>::to_vec)
+        .collect::<Vec<_>>();
+    if rows.len() != row_count {
+        return Err(ProverError::InvalidStageRequest {
+            reason: format!(
+                "BlindFold witness row count mismatch: expected {row_count}, got {}",
+                rows.len()
+            ),
+        });
+    }
+
+    Ok(BlindFoldProverWitness {
+        rows,
+        blindings,
+        eval_outputs,
+        eval_blindings,
+    })
+}
+
+pub(crate) struct BlindFoldProverWitness<F: Field> {
+    pub(crate) rows: Vec<Vec<F>>,
+    pub(crate) blindings: Vec<F>,
+    pub(crate) eval_outputs: Vec<F>,
+    pub(crate) eval_blindings: Vec<F>,
+}
+
+pub(crate) fn prove_blindfold<F, VC, T, R, B>(
+    setup: &VC::Setup,
+    blindfold: &BlindFoldOutput<F, VC::Output>,
+    witness: &BlindFoldProverWitness<F>,
+    transcript: &mut T,
+    rng: &mut R,
+    backend: &mut B,
+) -> Result<jolt_blindfold::BlindFoldProof<F, VC::Output>, ProverError>
+where
+    F: Field + AppendToTranscript,
+    VC: VectorCommitment<Field = F>,
+    VC::Output: HomomorphicCommitment<F>,
+    T: Transcript<Challenge = F>,
+    R: rand_core::RngCore,
+    B: BlindFoldBackend<F>,
+    <F as WithAccumulator>::Accumulator: RingAccumulator<Element = F>,
+{
+    transcript.append(&Label(b"BlindFold"));
+    let mut row_committer = BackendBlindFoldRowCommitter { backend };
+    jolt_blindfold::prove_with_row_committer::<F, VC, _, _, _>(
+        setup,
+        &blindfold.protocol,
+        transcript,
+        jolt_blindfold::BlindFoldWitness {
+            rows: &witness.rows,
+            blindings: &witness.blindings,
+            eval_outputs: &witness.eval_outputs,
+            eval_blindings: &witness.eval_blindings,
+        },
+        rng,
+        &mut row_committer,
+    )
+    .map_err(|error| ProverError::InvalidStageRequest {
+        reason: format!("BlindFold proof generation failed: {error}"),
+    })
+}
+
+struct BackendBlindFoldRowCommitter<'a, B> {
+    backend: &'a mut B,
+}
+
+impl<F, VC, B> jolt_blindfold::BlindFoldRowCommitter<F, VC> for BackendBlindFoldRowCommitter<'_, B>
+where
+    F: Field,
+    VC: VectorCommitment<Field = F>,
+    B: BlindFoldBackend<F>,
+    <F as WithAccumulator>::Accumulator: RingAccumulator<Element = F>,
+{
+    fn commit_rows(
+        &mut self,
+        setup: &VC::Setup,
+        rows: &[Vec<F>],
+        blindings: &[F],
+        name: &'static str,
+    ) -> Result<Vec<VC::Output>, jolt_blindfold::ProverError<F>> {
+        self.backend
+            .commit_blindfold_rows::<VC>(
+                BlindFoldRowCommitmentRequest::new(name, rows, blindings),
+                setup,
+            )
+            .map(|result| result.commitments)
+            .map_err(|error| jolt_blindfold::ProverError::RowCommitmentBackend {
+                name,
+                reason: error.to_string(),
+            })
+    }
+
+    fn compute_error_rows(
+        &mut self,
+        r1cs: &ConstraintMatrices<F>,
+        u: F,
+        witness: &[F],
+        row_count: usize,
+        row_len: usize,
+        name: &'static str,
+    ) -> Result<Vec<Vec<F>>, jolt_blindfold::ProverError<F>> {
+        self.backend
+            .compute_blindfold_error_rows(BlindFoldErrorRowsRequest::new(
+                name, r1cs, u, witness, row_count, row_len,
+            ))
+            .map(|result| result.rows)
+            .map_err(|error| jolt_blindfold::ProverError::BackendKernel {
+                name,
+                reason: error.to_string(),
+            })
+    }
+
+    fn compute_cross_term_error_rows(
+        &mut self,
+        r1cs: &ConstraintMatrices<F>,
+        real_u: F,
+        real_witness: &[F],
+        random_u: F,
+        random_witness: &[F],
+        row_count: usize,
+        row_len: usize,
+        name: &'static str,
+    ) -> Result<Vec<Vec<F>>, jolt_blindfold::ProverError<F>> {
+        self.backend
+            .compute_blindfold_cross_term_error_rows(BlindFoldCrossTermErrorRowsRequest::new(
+                name,
+                r1cs,
+                real_u,
+                real_witness,
+                random_u,
+                random_witness,
+                row_count,
+                row_len,
+            ))
+            .map(|result| result.rows)
+            .map_err(|error| jolt_blindfold::ProverError::BackendKernel {
+                name,
+                reason: error.to_string(),
+            })
+    }
+
+    fn fold_rows(
+        &mut self,
+        real: &[Vec<F>],
+        random: &[Vec<F>],
+        challenge: F,
+        name: &'static str,
+    ) -> Result<Vec<Vec<F>>, jolt_blindfold::ProverError<F>> {
+        self.backend
+            .fold_blindfold_rows(BlindFoldFoldRowsRequest::new(name, real, random, challenge))
+            .map(|result| result.rows)
+            .map_err(|error| jolt_blindfold::ProverError::BackendKernel {
+                name,
+                reason: error.to_string(),
+            })
+    }
+
+    fn fold_scalars(
+        &mut self,
+        real: &[F],
+        random: &[F],
+        challenge: F,
+        name: &'static str,
+    ) -> Result<Vec<F>, jolt_blindfold::ProverError<F>> {
+        self.backend
+            .fold_blindfold_scalars(BlindFoldFoldScalarsRequest::new(
+                name, real, random, challenge,
+            ))
+            .map(|result| result.scalars)
+            .map_err(|error| jolt_blindfold::ProverError::BackendKernel {
+                name,
+                reason: error.to_string(),
+            })
+    }
+
+    fn fold_error_rows(
+        &mut self,
+        real: &[Vec<F>],
+        cross: &[Vec<F>],
+        random: &[Vec<F>],
+        challenge: F,
+        name: &'static str,
+    ) -> Result<Vec<Vec<F>>, jolt_blindfold::ProverError<F>> {
+        self.backend
+            .fold_blindfold_error_rows(BlindFoldFoldErrorRowsRequest::new(
+                name, real, cross, random, challenge,
+            ))
+            .map(|result| result.rows)
+            .map_err(|error| jolt_blindfold::ProverError::BackendKernel {
+                name,
+                reason: error.to_string(),
+            })
+    }
+
+    fn fold_error_scalars(
+        &mut self,
+        real: &[F],
+        cross: &[F],
+        random: &[F],
+        challenge: F,
+        name: &'static str,
+    ) -> Result<Vec<F>, jolt_blindfold::ProverError<F>> {
+        self.backend
+            .fold_blindfold_error_scalars(BlindFoldFoldErrorScalarsRequest::new(
+                name, real, cross, random, challenge,
+            ))
+            .map(|result| result.scalars)
+            .map_err(|error| jolt_blindfold::ProverError::BackendKernel {
+                name,
+                reason: error.to_string(),
+            })
+    }
+
+    fn open_rows(
+        &mut self,
+        setup: &VC::Setup,
+        rows: &[Vec<F>],
+        blindings: &[F],
+        row_point: &[F],
+        entry_point: &[F],
+        name: &'static str,
+    ) -> Result<(jolt_crypto::VectorCommitmentOpening<F>, F), jolt_blindfold::ProverError<F>> {
+        self.backend
+            .open_blindfold_rows::<VC>(
+                BlindFoldRowOpeningRequest::new(name, rows, blindings, row_point, entry_point),
+                setup,
+            )
+            .map(|result| (result.opening, result.evaluation))
+            .map_err(|error| jolt_blindfold::ProverError::BackendKernel {
+                name,
+                reason: error.to_string(),
+            })
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum BlindFoldCommittedRows {
+    Coefficients,
+    OutputClaims,
+}
+
+fn assign_committed_blindfold_rows<F>(
+    witness_values: &mut [Option<F>],
+    blindings: &mut [F],
+    row_len: usize,
+    target_rows: Range<usize>,
+    committed_sumchecks: &[CommittedSumcheckWitness<F>],
+    row_kind: BlindFoldCommittedRows,
+) -> Result<(), ProverError>
+where
+    F: Field,
+{
+    let mut row = target_rows.start;
+    for witness in committed_sumchecks {
+        let (rows, row_blindings) = match row_kind {
+            BlindFoldCommittedRows::Coefficients => {
+                (&witness.round_coefficients, &witness.round_blindings)
+            }
+            BlindFoldCommittedRows::OutputClaims => {
+                (&witness.output_claim_rows, &witness.output_claim_blindings)
+            }
+        };
+        if rows.len() != row_blindings.len() {
+            return Err(ProverError::InvalidStageRequest {
+                reason: format!(
+                    "BlindFold {row_kind:?} row/blinding count mismatch: rows {}, blindings {}",
+                    rows.len(),
+                    row_blindings.len()
+                ),
+            });
+        }
+        for (values, &blinding) in rows.iter().zip(row_blindings) {
+            if row >= target_rows.end {
+                return Err(ProverError::InvalidStageRequest {
+                    reason: format!(
+                        "BlindFold {row_kind:?} rows exceed reserved range {:?}",
+                        target_rows
+                    ),
+                });
+            }
+            if values.len() > row_len {
+                return Err(ProverError::InvalidStageRequest {
+                    reason: format!(
+                        "BlindFold {row_kind:?} row length {} exceeds witness row length {row_len}",
+                        values.len()
+                    ),
+                });
+            }
+            for column in 0..row_len {
+                let value = values.get(column).copied().unwrap_or_else(F::zero);
+                assign_witness_cell(
+                    witness_values,
+                    row_len,
+                    row,
+                    column,
+                    value,
+                    "BlindFold committed row",
+                )?;
+            }
+            blindings[row] = blinding;
+            row += 1;
+        }
+    }
+    if row != target_rows.end {
+        return Err(ProverError::InvalidStageRequest {
+            reason: format!(
+                "BlindFold {row_kind:?} row count mismatch: expected {}, got {}",
+                target_rows.end - target_rows.start,
+                row - target_rows.start
+            ),
+        });
+    }
+    Ok(())
+}
+
+fn assign_sumcheck_layout_witness<F, C>(
+    witness_values: &mut [Option<F>],
+    layout: &jolt_sumcheck::SumcheckR1csLayout,
+    consistency: &jolt_sumcheck::CommittedSumcheckConsistency<F, C>,
+    witness: &CommittedSumcheckWitness<F>,
+    domain: SumcheckDomainSpec,
+) -> Result<(), ProverError>
+where
+    F: Field,
+{
+    let round_count = consistency.rounds.len();
+    if layout.rounds.len() != round_count
+        || witness.round_coefficients.len() != round_count
+        || witness.round_blindings.len() != round_count
+    {
+        return Err(ProverError::InvalidStageRequest {
+            reason: format!(
+                "BlindFold sumcheck round count mismatch: layout {}, consistency {}, coefficients {}, blindings {}",
+                layout.rounds.len(),
+                round_count,
+                witness.round_coefficients.len(),
+                witness.round_blindings.len()
+            ),
+        });
+    }
+
+    let Some(first_round) = witness.round_coefficients.first() else {
+        return Err(ProverError::InvalidStageRequest {
+            reason: "BlindFold sumcheck witness has no rounds".to_owned(),
+        });
+    };
+    let input_claim = round_sum_over_domain(domain, first_round)?;
+    assign_witness_variable(
+        witness_values,
+        layout.input_claim,
+        input_claim,
+        "BlindFold sumcheck input claim",
+    )?;
+
+    for ((round_layout, round), coefficients) in layout
+        .rounds
+        .iter()
+        .zip(&consistency.rounds)
+        .zip(&witness.round_coefficients)
+    {
+        if round_layout.coefficients.len() != coefficients.len() {
+            return Err(ProverError::InvalidStageRequest {
+                reason: format!(
+                    "BlindFold round coefficient count mismatch: layout {}, witness {}",
+                    round_layout.coefficients.len(),
+                    coefficients.len()
+                ),
+            });
+        }
+        for (&variable, &coefficient) in round_layout.coefficients.iter().zip(coefficients) {
+            assign_witness_variable(
+                witness_values,
+                variable,
+                coefficient,
+                "BlindFold sumcheck round coefficient",
+            )?;
+        }
+        let claim_out = evaluate_univariate_coefficients(coefficients, round.challenge);
+        assign_witness_variable(
+            witness_values,
+            round_layout.claim_out,
+            claim_out,
+            "BlindFold sumcheck output claim",
+        )?;
+    }
+    Ok(())
+}
+
+fn blindfold_sumcheck_domains() -> [SumcheckDomainSpec; 10] {
+    [
+        SumcheckDomainSpec::centered_integer(SPARTAN_OUTER_UNISKIP_DOMAIN_SIZE),
+        SumcheckDomainSpec::BooleanHypercube,
+        SumcheckDomainSpec::centered_integer(SPARTAN_PRODUCT_UNISKIP_DOMAIN_SIZE),
+        SumcheckDomainSpec::BooleanHypercube,
+        SumcheckDomainSpec::BooleanHypercube,
+        SumcheckDomainSpec::BooleanHypercube,
+        SumcheckDomainSpec::BooleanHypercube,
+        SumcheckDomainSpec::BooleanHypercube, // stage6a address phase
+        SumcheckDomainSpec::BooleanHypercube, // stage6b cycle phase
+        SumcheckDomainSpec::BooleanHypercube, // stage7
+    ]
+}
+
+fn round_sum_over_domain<F>(
+    domain: SumcheckDomainSpec,
+    coefficients: &[F],
+) -> Result<F, ProverError>
+where
+    F: Field,
+{
+    let Some(degree) = coefficients.len().checked_sub(1) else {
+        return Err(ProverError::InvalidStageRequest {
+            reason: "BlindFold round has no coefficients".to_owned(),
+        });
+    };
+    let weights =
+        <SumcheckDomainSpec as SumcheckDomain<F>>::round_sum_coefficients(&domain, degree)
+            .map_err(|error| ProverError::InvalidStageRequest {
+                reason: format!("BlindFold round-sum coefficient derivation failed: {error}"),
+            })?;
+    if weights.len() != coefficients.len() {
+        return Err(ProverError::InvalidStageRequest {
+            reason: format!(
+                "BlindFold round-sum coefficient count mismatch: expected {}, got {}",
+                coefficients.len(),
+                weights.len()
+            ),
+        });
+    }
+    Ok(coefficients
+        .iter()
+        .zip(weights)
+        .fold(F::zero(), |acc, (&coefficient, weight)| {
+            acc + coefficient * weight
+        }))
+}
+
+fn evaluate_univariate_coefficients<F>(coefficients: &[F], point: F) -> F
+where
+    F: Field,
+{
+    coefficients
+        .iter()
+        .rev()
+        .copied()
+        .fold(F::zero(), |acc, coefficient| acc * point + coefficient)
+}
+
+fn assign_witness_cell<F>(
+    witness_values: &mut [Option<F>],
+    row_len: usize,
+    row: usize,
+    column: usize,
+    value: F,
+    label: &'static str,
+) -> Result<(), ProverError>
+where
+    F: Field,
+{
+    if column >= row_len {
+        return Err(ProverError::InvalidStageRequest {
+            reason: format!(
+                "{label} column {column} exceeds BlindFold witness row length {row_len}"
+            ),
+        });
+    }
+    let index = 1 + row * row_len + column;
+    assign_witness_index(witness_values, index, value, label)
+}
+
+fn assign_witness_variable<F>(
+    witness_values: &mut [Option<F>],
+    variable: Variable,
+    value: F,
+    label: &'static str,
+) -> Result<(), ProverError>
+where
+    F: Field,
+{
+    assign_witness_index(witness_values, variable.index(), value, label)
+}
+
+fn assign_witness_index<F>(
+    witness_values: &mut [Option<F>],
+    index: usize,
+    value: F,
+    label: &'static str,
+) -> Result<(), ProverError>
+where
+    F: Field,
+{
+    let slot = witness_values
+        .get_mut(index)
+        .ok_or_else(|| ProverError::InvalidStageRequest {
+            reason: format!("{label} variable {index} is outside the BlindFold witness"),
+        })?;
+    match *slot {
+        Some(existing) if existing != value => Err(ProverError::InvalidStageRequest {
+            reason: format!("{label} variable {index} was assigned conflicting values"),
+        }),
+        Some(_) => Ok(()),
+        None => {
+            *slot = Some(value);
+            Ok(())
+        }
+    }
+}
+
+fn complete_blindfold_auxiliary_witness<F>(
+    matrices: &ConstraintMatrices<F>,
+    witness_values: &mut [Option<F>],
+) -> Result<(), ProverError>
+where
+    F: Field,
+{
+    let mut progressed = true;
+    while progressed {
+        progressed = false;
+        for constraint in 0..matrices.num_constraints {
+            let Some(a_value) = known_sparse_row_value(&matrices.a[constraint], witness_values)?
+            else {
+                continue;
+            };
+            let Some(b_value) = known_sparse_row_value(&matrices.b[constraint], witness_values)?
+            else {
+                continue;
+            };
+            let c_row = sparse_row_state(&matrices.c[constraint], witness_values)?;
+            match c_row {
+                SparseRowState::Known(c_value) => {
+                    if a_value * b_value != c_value {
+                        return Err(ProverError::InvalidStageRequest {
+                            reason: format!(
+                                "BlindFold witness violates solved constraint {constraint} of {}: A vars {:?}, B vars {:?}, C vars {:?}",
+                                matrices.num_constraints,
+                                sparse_row_variables(&matrices.a[constraint]),
+                                sparse_row_variables(&matrices.b[constraint]),
+                                sparse_row_variables(&matrices.c[constraint])
+                            ),
+                        });
+                    }
+                }
+                SparseRowState::SingleUnknown {
+                    index,
+                    coefficient,
+                    known,
+                } => {
+                    if coefficient.is_zero() {
+                        continue;
+                    }
+                    if coefficient != F::one() {
+                        return Err(ProverError::InvalidStageRequest {
+                            reason: format!(
+                                "BlindFold auxiliary constraint {constraint} has unsupported non-unit output coefficient"
+                            ),
+                        });
+                    }
+                    let value = a_value * b_value - known;
+                    assign_witness_index(
+                        witness_values,
+                        index,
+                        value,
+                        "BlindFold auxiliary witness",
+                    )?;
+                    progressed = true;
+                }
+                SparseRowState::MultipleUnknowns => {}
+            }
+        }
+    }
+    Ok(())
+}
+
+enum SparseRowState<F> {
+    Known(F),
+    SingleUnknown {
+        index: usize,
+        coefficient: F,
+        known: F,
+    },
+    MultipleUnknowns,
+}
+
+fn known_sparse_row_value<F>(
+    row: &SparseRow<F>,
+    witness_values: &[Option<F>],
+) -> Result<Option<F>, ProverError>
+where
+    F: Field,
+{
+    match sparse_row_state(row, witness_values)? {
+        SparseRowState::Known(value) => Ok(Some(value)),
+        SparseRowState::SingleUnknown { .. } | SparseRowState::MultipleUnknowns => Ok(None),
+    }
+}
+
+fn sparse_row_state<F>(
+    row: &SparseRow<F>,
+    witness_values: &[Option<F>],
+) -> Result<SparseRowState<F>, ProverError>
+where
+    F: Field,
+{
+    let mut known = F::zero();
+    let mut unknown = None;
+    for &(index, coefficient) in row {
+        let value = witness_values
+            .get(index)
+            .ok_or_else(|| ProverError::InvalidStageRequest {
+                reason: format!("BlindFold constraint references out-of-range variable {index}"),
+            })?;
+        if let Some(value) = value {
+            known += coefficient * *value;
+        } else if unknown.is_some() {
+            return Ok(SparseRowState::MultipleUnknowns);
+        } else {
+            unknown = Some((index, coefficient));
+        }
+    }
+    Ok(match unknown {
+        Some((index, coefficient)) => SparseRowState::SingleUnknown {
+            index,
+            coefficient,
+            known,
+        },
+        None => SparseRowState::Known(known),
+    })
+}
+
+fn sparse_row_variables<F>(row: &SparseRow<F>) -> Vec<usize> {
+    row.iter().map(|&(index, _)| index).collect()
+}

--- a/crates/jolt-prover/tests/e2e.rs
+++ b/crates/jolt-prover/tests/e2e.rs
@@ -1,0 +1,355 @@
+#![expect(
+    clippy::expect_used,
+    reason = "e2e proof tests should fail loudly on guest build, proving, or verification failures"
+)]
+
+use std::{
+    fmt::Debug,
+    sync::{Mutex, MutexGuard, Once},
+};
+
+use blake2::{
+    digest::{consts::U32, Digest},
+    Blake2b,
+};
+use common::{
+    constants::ONEHOT_CHUNK_THRESHOLD_LOG_T,
+    jolt_device::{JoltDevice, MemoryLayout},
+};
+use jolt_backends::cpu::CpuBackend;
+use jolt_claims::protocols::jolt::{JoltOneHotConfig, JoltReadWriteConfig, TracePolynomialOrder};
+use jolt_crypto::{Bn254G1, Pedersen};
+use jolt_dory::DoryScheme;
+use jolt_field::Fr;
+use jolt_openings::CommitmentScheme;
+use jolt_program::{
+    execution::{JoltProgram, OwnedTrace, RamAccess, TraceOutput, TraceRow},
+    preprocess::JoltProgramPreprocessing,
+};
+use jolt_prover::{JoltProverPreprocessing, ProverConfig};
+use jolt_sdk::host::Program;
+use jolt_transcript::Blake2bTranscript;
+use jolt_verifier::{
+    compat, zk_vector_commitment_capacity_requirement, JoltVerifierPreprocessing,
+    ProgramPreprocessing,
+};
+use jolt_witness::protocols::jolt_vm::{
+    JoltVmWitnessConfig, JoltVmWitnessInputs, TraceBackedJoltVmWitness,
+};
+use serde::de::DeserializeOwned;
+use tracer::TracerBackend;
+
+type Pcs = DoryScheme;
+type Vc = Pedersen<Bn254G1>;
+
+static E2E_LOCK: Mutex<()> = Mutex::new(());
+static RAYON_INIT: Once = Once::new();
+
+const TARGET_DIR: &str = "/tmp/jolt-prover-e2e-guests";
+const MULDIV_MAX_TRACE_LENGTH: usize = 65_536;
+const SHA2_CHAIN_MAX_TRACE_LENGTH: usize = 4_194_304;
+const SHA2_CHAIN_ITERS: u32 = 8;
+const E2E_STACK_SIZE: usize = 128 * 1024 * 1024;
+
+#[test]
+fn modular_muldiv_proof_verifies() {
+    let a = 12_031_293u32;
+    let b = 17u32;
+    let c = 92u32;
+    let mut input_bytes = Vec::new();
+    append_input(&mut input_bytes, &a);
+    append_input(&mut input_bytes, &b);
+    append_input(&mut input_bytes, &c);
+    let expected = a * b / c;
+
+    run_e2e(
+        "muldiv",
+        MULDIV_MAX_TRACE_LENGTH,
+        muldiv_guest::compile_muldiv,
+        input_bytes,
+        expected,
+    );
+}
+
+#[test]
+fn modular_sha2_chain_proof_verifies() {
+    let input = [5u8; 32];
+    let mut input_bytes = Vec::new();
+    append_input(&mut input_bytes, &input);
+    append_input(&mut input_bytes, &SHA2_CHAIN_ITERS);
+    let expected = sha2_chain_guest::sha2_chain(input, SHA2_CHAIN_ITERS);
+
+    run_e2e(
+        "sha2-chain",
+        SHA2_CHAIN_MAX_TRACE_LENGTH,
+        sha2_chain_guest::compile_sha2_chain,
+        input_bytes,
+        expected,
+    );
+}
+
+fn run_e2e<Output>(
+    name: &'static str,
+    max_trace_length: usize,
+    compile: fn(&str) -> Program,
+    input_bytes: Vec<u8>,
+    expected_output: Output,
+) where
+    Output: Debug + DeserializeOwned + PartialEq + Send + 'static,
+{
+    std::thread::Builder::new()
+        .name(format!("jolt-prover-e2e-{name}"))
+        .stack_size(E2E_STACK_SIZE)
+        .spawn(move || {
+            prove_and_verify(
+                name,
+                max_trace_length,
+                compile,
+                input_bytes,
+                expected_output,
+            );
+        })
+        .expect("e2e thread should spawn")
+        .join()
+        .expect("e2e thread should not panic");
+}
+
+fn prove_and_verify<Output>(
+    name: &'static str,
+    max_trace_length: usize,
+    compile: fn(&str) -> Program,
+    input_bytes: Vec<u8>,
+    expected_output: Output,
+) where
+    Output: Debug + DeserializeOwned + PartialEq,
+{
+    let _guard = e2e_guard();
+    initialize_rayon();
+    let mut host_program = compile(TARGET_DIR);
+    let program = host_program
+        .jolt_program()
+        .expect("guest should compile into a modular Jolt program");
+    let mut tracer = TracerBackend::new();
+    let trace = host_program
+        .trace_with_backend(&mut tracer, &input_bytes, &[], &[])
+        .expect("guest should execute through the tracer backend");
+    let public_io = trace.device.clone();
+    let program_preprocessing = program_preprocessing(&program, &public_io, max_trace_length);
+    let proof_parameters = proof_parameters(&program_preprocessing, &trace);
+    let preprocessing = prover_preprocessing(program_preprocessing, max_trace_length);
+    let witness = trace_witness(
+        &program,
+        preprocessing
+            .verifier
+            .program
+            .as_full()
+            .expect("prover preprocessing should retain the full program preprocessing"),
+        trace,
+        proof_parameters,
+    );
+    let mut backend = CpuBackend::default();
+    let config = proof_parameters;
+
+    let prover_output = jolt_prover::prove_with_components(
+        &preprocessing,
+        &public_io,
+        &witness,
+        config,
+        &mut backend,
+    )
+    .expect("modular prover should produce a proof");
+
+    jolt_verifier::verify::<Fr, Pcs, Vc, Blake2bTranscript>(
+        &preprocessing.verifier,
+        &public_io,
+        &prover_output.proof,
+        prover_output.trusted_advice_commitment.as_ref(),
+        cfg!(feature = "zk"),
+    )
+    .expect("modular verifier should accept the modular proof");
+
+    let actual_output: Output = decode_output(&public_io);
+    assert_eq!(actual_output, expected_output, "{name} output mismatch");
+}
+
+fn e2e_guard() -> MutexGuard<'static, ()> {
+    E2E_LOCK.lock().expect("e2e mutex should not be poisoned")
+}
+
+fn initialize_rayon() {
+    RAYON_INIT.call_once(|| {
+        rayon::ThreadPoolBuilder::new()
+            .stack_size(E2E_STACK_SIZE)
+            .build_global()
+            .expect("global rayon pool should initialize for e2e proofs");
+    });
+}
+
+fn append_input<T>(bytes: &mut Vec<u8>, value: &T)
+where
+    T: serde::Serialize + ?Sized,
+{
+    bytes.append(
+        &mut jolt_sdk::postcard::to_stdvec(value)
+            .expect("guest input should serialize with postcard"),
+    );
+}
+
+fn decode_output<Output>(public_io: &JoltDevice) -> Output
+where
+    Output: DeserializeOwned,
+{
+    let mut outputs = public_io.outputs.clone();
+    outputs.resize(public_io.memory_layout.max_output_size as usize, 0);
+    jolt_sdk::postcard::from_bytes(&outputs).expect("guest output should deserialize with postcard")
+}
+
+fn program_preprocessing(
+    program: &JoltProgram,
+    public_io: &JoltDevice,
+    max_trace_length: usize,
+) -> JoltProgramPreprocessing {
+    JoltProgramPreprocessing::new(
+        program.expanded_bytecode.clone(),
+        program.memory_init.clone(),
+        public_io.memory_layout.clone(),
+        program.entry_address,
+        max_trace_length,
+        program.profile,
+    )
+    .expect("program preprocessing should be valid")
+}
+
+fn prover_preprocessing(
+    program: JoltProgramPreprocessing,
+    max_trace_length: usize,
+) -> JoltProverPreprocessing<Pcs, Vc> {
+    let max_log_t = max_trace_length.next_power_of_two().trailing_zeros() as usize;
+    let max_log_k_chunk = if max_log_t < ONEHOT_CHUNK_THRESHOLD_LOG_T {
+        4
+    } else {
+        8
+    };
+    let (pcs_setup, _) = Pcs::setup(max_log_k_chunk + max_log_t);
+    let preprocessing_digest = preprocessing_digest(&program);
+    let verifier = JoltVerifierPreprocessing::<Pcs, Vc>::from_pcs_prover_setup(
+        ProgramPreprocessing::Full(program),
+        preprocessing_digest,
+        &pcs_setup,
+        zk_vector_commitment_capacity_requirement(),
+    );
+
+    JoltProverPreprocessing::new(verifier, pcs_setup)
+}
+
+fn preprocessing_digest(program: &JoltProgramPreprocessing) -> [u8; 32] {
+    let bytes = bincode::serde::encode_to_vec(program, bincode::config::standard())
+        .expect("program preprocessing should serialize into memory");
+    Blake2b::<U32>::digest(bytes).into()
+}
+
+fn trace_witness<'a>(
+    program: &'a JoltProgram,
+    preprocessing: &'a JoltProgramPreprocessing,
+    trace: TraceOutput<OwnedTrace>,
+    proof_parameters: ProverConfig,
+) -> TraceBackedJoltVmWitness<'a, OwnedTrace> {
+    let config = JoltVmWitnessConfig::new(
+        proof_parameters.trace_length.trailing_zeros() as usize,
+        proof_parameters.ram_k,
+        proof_parameters.one_hot_config,
+    )
+    .retain_trace_rows(true)
+    .include_trusted_advice(!trace.device.trusted_advice.is_empty())
+    .include_untrusted_advice(!trace.device.untrusted_advice.is_empty());
+
+    TraceBackedJoltVmWitness::new(
+        config,
+        JoltVmWitnessInputs::new(program, preprocessing, trace),
+    )
+}
+
+fn proof_parameters(
+    preprocessing: &JoltProgramPreprocessing,
+    trace: &TraceOutput<OwnedTrace>,
+) -> ProverConfig {
+    let trace_length = padded_trace_length(trace.trace.rows().len(), preprocessing);
+    let log_t = trace_length.trailing_zeros() as usize;
+    let ram_k = ram_k(
+        preprocessing,
+        trace.trace.rows(),
+        &trace.device.memory_layout,
+    );
+    let ram_log_k = ram_k.trailing_zeros() as usize;
+
+    let rw_config = compat::config::ReadWriteConfig::try_from((log_t, ram_log_k))
+        .expect("read-write config should be valid");
+    let one_hot_config = compat::config::OneHotConfig::from(log_t);
+
+    ProverConfig::new(
+        trace_length,
+        ram_k,
+        JoltReadWriteConfig {
+            ram_rw_phase1_num_rounds: rw_config.ram_rw_phase1_num_rounds,
+            ram_rw_phase2_num_rounds: rw_config.ram_rw_phase2_num_rounds,
+            registers_rw_phase1_num_rounds: rw_config.registers_rw_phase1_num_rounds,
+            registers_rw_phase2_num_rounds: rw_config.registers_rw_phase2_num_rounds,
+        },
+        JoltOneHotConfig {
+            log_k_chunk: one_hot_config.log_k_chunk,
+            lookups_ra_virtual_log_k_chunk: one_hot_config.lookups_ra_virtual_log_k_chunk,
+        },
+        TracePolynomialOrder::CycleMajor,
+    )
+}
+
+fn padded_trace_length(
+    unpadded_trace_length: usize,
+    preprocessing: &JoltProgramPreprocessing,
+) -> usize {
+    let trace_length = if unpadded_trace_length < 256 {
+        256
+    } else {
+        (unpadded_trace_length + 1).next_power_of_two()
+    };
+    assert!(
+        trace_length <= preprocessing.max_padded_trace_length,
+        "trace length {trace_length} exceeds max {}",
+        preprocessing.max_padded_trace_length
+    );
+    trace_length
+}
+
+fn ram_k(
+    preprocessing: &JoltProgramPreprocessing,
+    rows: &[TraceRow],
+    layout: &MemoryLayout,
+) -> usize {
+    let trace_max = rows
+        .iter()
+        .filter_map(|row| {
+            ram_access_address(row).and_then(|address| remap_address(address, layout))
+        })
+        .max()
+        .unwrap_or(0);
+    let bytecode_end = remap_address(preprocessing.ram.min_bytecode_address, layout).unwrap_or(0)
+        + preprocessing.ram.bytecode_words.len() as u64
+        + 1;
+    trace_max.max(bytecode_end).next_power_of_two() as usize
+}
+
+fn ram_access_address(row: &TraceRow) -> Option<u64> {
+    match row.ram_access {
+        RamAccess::Read(read) => Some(read.address),
+        RamAccess::Write(write) => Some(write.address),
+        RamAccess::NoOp => None,
+    }
+}
+
+fn remap_address(address: u64, layout: &MemoryLayout) -> Option<u64> {
+    if address == 0 || address < layout.get_lowest_address() {
+        None
+    } else {
+        Some((address - layout.get_lowest_address()) / 8)
+    }
+}


### PR DESCRIPTION
Part of splitting #1605 into a reviewable, individually-CI-passing stack (3/3). Top of the stack — its tree is **byte-identical** to the original #1605 head (`prover-stack/10-jolt-prover`).

**Base:** `prover-stack/10b-jolt-backends`

Adds **jolt-prover**: protocol orchestration for modular Jolt proving (prove/verify e2e over the jolt-backends CPU backend).

Also restores the full CI workflow:
- Adds the prover-e2e infra (rust-src, dory cache, ZeroOS musl toolchain, `cargo install` jolt CLI) to the `test-crates` job
- Reverts the temporary `--no-default-features` clippy exclusion from PR (2/3) — jolt-prover provides the `cpu` consumer

### Validation
- `cargo clippy --all --all-targets` in `allocative,host` / `allocative,host,zk` / `--no-default-features` (no exclusion now) — clean
- `cargo nextest run -p jolt-prover` — 17 tests (host) + 20 (zk)
- `cargo nextest run -p jolt-core muldiv` — host + host,zk pass
