### PR TITLE
Fix ZK verifier mode handling

### DIFF
--- a/examples/recursion/guest/src/lib.rs
+++ b/examples/recursion/guest/src/lib.rs
@@ -74,7 +74,7 @@ fn verify(bytes: &[u8]) -> u32 {
             jolt::VerifierPCS,
             jolt::VerifierVC,
             jolt::VerifierTranscript,
-        >(&verifier_preprocessing, &device, &proof, None, false)
+        >(&verifier_preprocessing, &device, &proof, None, proof.claims.is_zk())
         .is_ok();
         end_cycle_tracking("verification");
         all_valid = all_valid && is_valid;

--- a/examples/recursion/src/main.rs
+++ b/examples/recursion/src/main.rs
@@ -429,7 +429,7 @@ fn collect_guest_proofs(
             &io_device,
             &proof,
             None,
-            false,
+            proof.claims.is_zk(),
         )
         .is_ok();
         info!("  Verification result: {is_valid}");
@@ -608,7 +608,7 @@ fn run_recursion_proof(
                 &io_device,
                 &proof,
                 None,
-                false,
+                proof.claims.is_zk(),
             )
             .is_ok();
             let rv = postcard::from_bytes::<u32>(&output_bytes).unwrap();

--- a/jolt-eval/src/guests/mod.rs
+++ b/jolt-eval/src/guests/mod.rs
@@ -73,7 +73,7 @@ pub fn verify(
         io_device,
         &proof,
         None,
-        false,
+        proof.claims.is_zk(),
     )
 }
 
@@ -105,7 +105,7 @@ pub fn verify_with_claims(
         &io_device,
         &proof,
         None,
-        false,
+        proof.claims.is_zk(),
     )
 }
 

--- a/jolt-sdk/tests/verifier_api.rs
+++ b/jolt-sdk/tests/verifier_api.rs
@@ -41,7 +41,7 @@ mod tests {
             jolt_sdk::VerifierPCS,
             jolt_sdk::VerifierVC,
             jolt_sdk::VerifierTranscript,
-        >(&preprocessing, &device, &proof, None, false);
+        >(&preprocessing, &device, &proof, None, proof.claims.is_zk());
         let duration = start.elapsed();
         println!("Verification took: {} ms", duration.as_millis());
         assert!(result.is_ok(), "Verifier failed: {:?}", result.err());

--- a/src/build_wasm.rs
+++ b/src/build_wasm.rs
@@ -250,7 +250,7 @@ pub fn verify_{func_name}(preprocessing_data: &[u8], proof_data: &[u8], io_data:
         jolt_sdk::VerifierPCS,
         jolt_sdk::VerifierVC,
         jolt_sdk::VerifierTranscript,
-    >(&preprocessing, &program_io, &proof, None, false).is_ok()
+    >(&preprocessing, &program_io, &proof, None, proof.claims.is_zk()).is_ok()
 }}
 "#
         ));


### PR DESCRIPTION
## Summary
- Derive the modular verifier ZK mode from `proof.claims.is_zk()` in helper/example/generated verifier paths.
- Preserve standard proof behavior while allowing ZK proofs to reach the committed sumcheck and BlindFold verifier path.

## Root Cause
Some verifier call sites passed `zk = false` unconditionally after the modular verifier split. That causes valid ZK proofs to fail consistency checks as if they were clear proofs.

## Validation
- `cargo fmt -q`
- `cargo check -q -p jolt-sdk --tests --features host`
- `cargo check -q -p recursion`
- `cargo check -q -p jolt-eval`
- `cargo check -q --features host`
- `cargo clippy --all --features host -q --all-targets -- -D warnings`
- `cargo clippy --all --features host,zk -q --all-targets -- -D warnings`
- `cargo nextest run -p jolt-prover-legacy muldiv --cargo-quiet --features host`
- `cargo nextest run -p jolt-prover-legacy muldiv --cargo-quiet --features host,zk`

Posted by the assistant on behalf of Quang Dao using GPT-5.