### PR TITLE
feat(jolt-verifier): Refactor Akita verifier packing ownership and public API boundaries

### DIFF
--- a/crates/jolt-akita/src/scheme.rs
+++ b/crates/jolt-akita/src/scheme.rs
@@ -417,6 +417,71 @@ mod tests {
         .expect_err("changed direct commitment digest should reject");
     }
 
+    #[test]
+    fn sparse_native_polynomial_batch_opening_roundtrips_and_binds_commitment() {
+        let num_vars = 6;
+        let setup_params = AkitaSetupParams::new(num_vars, 1, [19; 32]);
+        let (prover_setup, verifier_setup) = AkitaScheme::setup(setup_params);
+        let unit_indices = [0, 3, 17];
+        let sparse = AkitaSparsePolynomial::from_jolt_unit_indices(num_vars, unit_indices)
+            .expect("sparse polynomial should build");
+        let (commitment, hint) =
+            AkitaScheme::commit_sparse_polynomial(&prover_setup, [23; 32], &sparse)
+                .expect("sparse commitment should build");
+        let mut dense = vec![AkitaField::zero(); 1 << num_vars];
+        for index in unit_indices {
+            dense[index] = AkitaField::one();
+        }
+        let point = (0..num_vars)
+            .map(|index| AkitaField::from_u64(index as u64 + 2))
+            .collect::<Vec<_>>();
+        let claim = Polynomial::new(dense).evaluate(&point);
+        let statement = BatchOpeningStatement {
+            logical_point: point.clone(),
+            pcs_point: point,
+            layout_digest: commitment.layout_digest,
+            claims: vec![BatchOpeningClaim {
+                id: (),
+                relation: (),
+                commitment: commitment.clone(),
+                claim,
+                view: PhysicalView::Direct,
+                scale: AkitaField::one(),
+            }],
+        };
+
+        let mut prover_transcript = RecordingTranscript::new(b"akita-sparse-native");
+        let proof = AkitaScheme::prove_sparse_batch(
+            &prover_setup,
+            &mut prover_transcript,
+            &statement,
+            &sparse,
+            hint,
+        )
+        .expect("sparse proof should prove");
+        assert_eq!(proof.commitment, commitment);
+
+        let mut verifier_transcript = RecordingTranscript::new(b"akita-sparse-native");
+        let _result = AkitaScheme::verify_batch(
+            &verifier_setup,
+            &mut verifier_transcript,
+            &statement,
+            &proof,
+        )
+        .expect("sparse proof should verify");
+
+        let mut tampered_proof = proof;
+        tampered_proof.commitment.layout_digest = [42; 32];
+        let mut verifier_transcript = RecordingTranscript::new(b"akita-sparse-native");
+        let _error = AkitaScheme::verify_batch(
+            &verifier_setup,
+            &mut verifier_transcript,
+            &statement,
+            &tampered_proof,
+        )
+        .expect_err("tampered proof commitment should reject");
+    }
+
     fn contains_subslice(haystack: &[u8], needle: &[u8]) -> bool {
         haystack
             .windows(needle.len())

--- a/crates/jolt-verifier/src/akita.rs
+++ b/crates/jolt-verifier/src/akita.rs
@@ -1,7 +1,7 @@
 //! Prover-facing helpers for assembling Akita verifier artifacts.
 
 use crate::{
-    akita_packing::AkitaPackingScheme,
+    akita_packing::{self, AkitaPackingScheme},
     akita_validation::{
         validate_akita_advice_commitment_aliases,
         validate_akita_packing_opening_proof_payload_shape,
@@ -19,10 +19,14 @@ use crate::{
     VerifierError,
 };
 use common::jolt_device::JoltDevice;
-use jolt_akita::{AkitaBatchProof, AkitaCommitment, AkitaField, AkitaProverHint};
+use jolt_akita::{
+    AkitaBatchProof, AkitaCommitment, AkitaField, AkitaProverHint, AkitaProverSetup, AkitaScheme,
+    AkitaVerifierSetup,
+};
 use jolt_field::{RingAccumulator, WithAccumulator};
 use jolt_openings::{
-    CommitmentScheme, PackingBatchProof, PackingWitnessLayout, PackingWitnessSource,
+    PackingBatch, PackingBatchProof, PackingProverSetup, PackingVerifierSetup,
+    PackingWitnessLayout, PackingWitnessSource,
 };
 use jolt_transcript::Transcript;
 
@@ -41,11 +45,14 @@ pub use crate::akita_witness::{build_akita_packing_jolt_witness, AkitaPackingJol
 
 pub type AkitaClearVectorCommitment = ClearOnlyVectorCommitment<AkitaField>;
 pub type AkitaPackingBatchProof = PackingBatchProof<AkitaBatchProof>;
-pub type AkitaPackingProverSetup = <AkitaPackingScheme as CommitmentScheme>::ProverSetup;
-pub type AkitaPackingVerifierSetup = <AkitaPackingScheme as CommitmentScheme>::VerifierSetup;
-pub type AkitaVerifierPreprocessing =
-    JoltVerifierPreprocessing<AkitaPackingScheme, AkitaClearVectorCommitment>;
-pub type AkitaJoltProof = JoltProof<AkitaPackingScheme, AkitaClearVectorCommitment>;
+pub type AkitaPackingProverSetup = PackingProverSetup<AkitaProverSetup, PackingWitnessLayout>;
+pub type AkitaPackingVerifierSetup = PackingVerifierSetup<AkitaVerifierSetup, PackingWitnessLayout>;
+pub type AkitaVerifierPreprocessing = JoltVerifierPreprocessing<
+    PackingBatch<AkitaScheme, PackingWitnessLayout>,
+    AkitaClearVectorCommitment,
+>;
+pub type AkitaJoltProof =
+    JoltProof<PackingBatch<AkitaScheme, PackingWitnessLayout>, AkitaClearVectorCommitment>;
 
 #[derive(Clone, Debug)]
 pub struct AkitaPackingWitnessArtifacts {
@@ -98,7 +105,7 @@ where
     let layout = source.layout().clone();
     validate_lattice_packed_witness_layout_config(&protocol, &layout)?;
     let (commitment, hint) =
-        AkitaPackingScheme::commit_packing_source(setup, source).map_err(|error| {
+        akita_packing::commit_packing_source(setup, source).map_err(|error| {
             VerifierError::LatticePackingCommitmentFailed {
                 reason: error.to_string(),
             }

--- a/crates/jolt-verifier/src/akita_openings.rs
+++ b/crates/jolt-verifier/src/akita_openings.rs
@@ -3,7 +3,7 @@ use crate::{
         AkitaClearVectorCommitment, AkitaJoltProof, AkitaPackingBatchProof,
         AkitaPackingProverSetup, AkitaPackingWitnessArtifacts, AkitaVerifierPreprocessing,
     },
-    akita_packing::AkitaPackingScheme,
+    akita_packing::{self, AkitaPackingScheme},
     akita_validation::validate_akita_artifacts_for_proof,
     akita_validity::{attach_akita_packing_validity_proof, prove_akita_jolt_packed_validity},
     stages::stage8::{Stage8BatchStatement, Stage8OpeningId},
@@ -67,7 +67,7 @@ where
         }
     }
 
-    AkitaPackingScheme::prove_packing_source_batch(
+    akita_packing::prove_packing_source_batch(
         setup,
         transcript,
         statement,

--- a/crates/jolt-verifier/src/akita_packing.rs
+++ b/crates/jolt-verifier/src/akita_packing.rs
@@ -1,279 +1,98 @@
 use std::collections::BTreeSet;
 
 use jolt_akita::{
-    AkitaBatchProof, AkitaCommitment, AkitaField, AkitaHidingCommitment, AkitaProverHint,
-    AkitaProverSetup, AkitaScheme, AkitaSetupParams, AkitaSparsePolynomial, AkitaVerifierSetup,
-    AKITA_D,
+    AkitaBatchProof, AkitaCommitment, AkitaField, AkitaProverHint, AkitaProverSetup, AkitaScheme,
+    AkitaSparsePolynomial, AKITA_D,
 };
-use jolt_crypto::Commitment;
 use jolt_openings::{
     has_packing_view, packing_witness_source_polynomial, prove_sparse_packing_reduction,
     validate_packing_source_dimension, validate_packing_source_layout, validate_packing_statement,
-    BatchOpeningResult, BatchOpeningScheme, BatchOpeningStatement, CommitmentScheme, OpeningsError,
-    PackingBatch, PackingBatchProof, PackingProverSetup, PackingSetupParams, PackingSource,
-    PackingVerifierSetup, PackingWitnessLayout, PackingWitnessSource, ZkBatchOpeningScheme,
-    ZkOpeningScheme,
+    BatchOpeningScheme, BatchOpeningStatement, OpeningsError, PackingBatch, PackingBatchProof,
+    PackingProverSetup, PackingSource, PackingWitnessLayout, PackingWitnessSource,
 };
-use jolt_poly::{MultilinearPoly, Polynomial};
-use jolt_transcript::{AppendToTranscript, Label, Transcript};
-use serde::{Deserialize, Serialize};
+use jolt_transcript::Transcript;
 
-type AkitaPackingAdapter = PackingBatch<AkitaScheme, PackingWitnessLayout>;
+pub(crate) type AkitaPackingScheme = PackingBatch<AkitaScheme, PackingWitnessLayout>;
+pub(crate) type AkitaPackingBatchProof = PackingBatchProof<AkitaBatchProof>;
+pub(crate) type AkitaPackingProverSetup =
+    PackingProverSetup<AkitaProverSetup, PackingWitnessLayout>;
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
-pub struct AkitaPackingScheme;
-
-impl AkitaPackingScheme {
-    pub fn commit_packing_source<S>(
-        setup: &<Self as CommitmentScheme>::ProverSetup,
-        source: &S,
-    ) -> Result<(AkitaCommitment, AkitaProverHint), OpeningsError>
-    where
-        S: PackingWitnessSource<AkitaField>,
-    {
-        validate_packing_source_dimension(setup.pcs.max_num_vars, source.layout())?;
-        if let Some(polynomial) = packed_source_sparse_polynomial(source)? {
-            return AkitaScheme::commit_sparse_polynomial(
-                &setup.pcs,
-                source.layout().digest,
-                &polynomial,
-            );
-        }
-        let polynomial = packing_witness_source_polynomial(source)?;
-        AkitaScheme::commit_group(&setup.pcs, source.layout().digest, &[polynomial])
+pub(crate) fn commit_packing_source<S>(
+    setup: &AkitaPackingProverSetup,
+    source: &S,
+) -> Result<(AkitaCommitment, AkitaProverHint), OpeningsError>
+where
+    S: PackingWitnessSource<AkitaField>,
+{
+    validate_packing_source_dimension(setup.pcs.max_num_vars, source.layout())?;
+    if let Some(polynomial) = packed_source_sparse_polynomial(source)? {
+        return AkitaScheme::commit_sparse_polynomial(
+            &setup.pcs,
+            source.layout().digest,
+            &polynomial,
+        );
     }
+    let polynomial = packing_witness_source_polynomial(source)?;
+    AkitaScheme::commit_group(&setup.pcs, source.layout().digest, &[polynomial])
+}
 
-    pub fn prove_packing_source_batch<T, OpeningId, RelationId, S>(
-        setup: &<Self as CommitmentScheme>::ProverSetup,
-        transcript: &mut T,
-        statement: &BatchOpeningStatement<AkitaField, AkitaCommitment, OpeningId, RelationId>,
-        source: &S,
-        hint: AkitaProverHint,
-    ) -> Result<PackingBatchProof<AkitaBatchProof>, OpeningsError>
-    where
-        T: Transcript<Challenge = AkitaField>,
-        S: PackingWitnessSource<AkitaField>,
-    {
-        validate_packing_source_dimension(setup.pcs.max_num_vars, source.layout())?;
-        if let Some(sparse_polynomial) = packed_source_sparse_polynomial(source)? {
-            if !has_packing_view(statement) {
-                let native = AkitaScheme::prove_sparse_batch(
-                    &setup.pcs,
-                    transcript,
-                    statement,
-                    &sparse_polynomial,
-                    hint,
-                )?;
-                return Ok(PackingBatchProof {
-                    reduction: None,
-                    native,
-                });
-            }
-
-            let shape = validate_packed_source_prover_inputs(setup, statement, source, &hint)?;
-            let source = AkitaPackingSource(source);
-            let reduction =
-                prove_sparse_packing_reduction(shape.layout, statement, &source, transcript)?;
-            let native_statement = singleton_statement(
-                shape.commitment.clone(),
-                &reduction.opening_point,
-                reduction.opening_eval,
-            );
+pub(crate) fn prove_packing_source_batch<T, OpeningId, RelationId, S>(
+    setup: &AkitaPackingProverSetup,
+    transcript: &mut T,
+    statement: &BatchOpeningStatement<AkitaField, AkitaCommitment, OpeningId, RelationId>,
+    source: &S,
+    hint: AkitaProverHint,
+) -> Result<AkitaPackingBatchProof, OpeningsError>
+where
+    T: Transcript<Challenge = AkitaField>,
+    S: PackingWitnessSource<AkitaField>,
+{
+    validate_packing_source_dimension(setup.pcs.max_num_vars, source.layout())?;
+    if let Some(sparse_polynomial) = packed_source_sparse_polynomial(source)? {
+        if !has_packing_view(statement) {
             let native = AkitaScheme::prove_sparse_batch(
                 &setup.pcs,
                 transcript,
-                &native_statement,
+                statement,
                 &sparse_polynomial,
                 hint,
             )?;
             return Ok(PackingBatchProof {
-                reduction: Some(reduction.proof),
+                reduction: None,
                 native,
             });
         }
 
-        let polynomial = packing_witness_source_polynomial(source)?;
-        <Self as BatchOpeningScheme>::prove_batch(
-            setup,
+        let shape = validate_packed_source_prover_inputs(setup, statement, source, &hint)?;
+        let source = AkitaPackingSource(source);
+        let reduction =
+            prove_sparse_packing_reduction(shape.layout, statement, &source, transcript)?;
+        let native_statement = singleton_statement(
+            shape.commitment.clone(),
+            &reduction.opening_point,
+            reduction.opening_eval,
+        );
+        let native = AkitaScheme::prove_sparse_batch(
+            &setup.pcs,
             transcript,
-            statement,
-            std::slice::from_ref(&polynomial),
-            vec![hint],
-        )
-    }
-}
-
-impl Commitment for AkitaPackingScheme {
-    type Output = AkitaCommitment;
-}
-
-impl CommitmentScheme for AkitaPackingScheme {
-    type Field = AkitaField;
-    type Proof = PackingBatchProof<AkitaBatchProof>;
-    type ProverSetup = PackingProverSetup<AkitaProverSetup, PackingWitnessLayout>;
-    type VerifierSetup = PackingVerifierSetup<AkitaVerifierSetup, PackingWitnessLayout>;
-    type Polynomial = Polynomial<AkitaField>;
-    type OpeningHint = AkitaProverHint;
-    type SetupParams = PackingSetupParams<AkitaSetupParams, PackingWitnessLayout>;
-
-    fn setup(params: Self::SetupParams) -> (Self::ProverSetup, Self::VerifierSetup) {
-        <AkitaPackingAdapter as CommitmentScheme>::setup(params)
+            &native_statement,
+            &sparse_polynomial,
+            hint,
+        )?;
+        return Ok(PackingBatchProof {
+            reduction: Some(reduction.proof),
+            native,
+        });
     }
 
-    fn verifier_setup(prover_setup: &Self::ProverSetup) -> Self::VerifierSetup {
-        <AkitaPackingAdapter as CommitmentScheme>::verifier_setup(prover_setup)
-    }
-
-    fn commit<P: MultilinearPoly<Self::Field> + ?Sized>(
-        _poly: &P,
-        _setup: &Self::ProverSetup,
-    ) -> (Self::Output, Self::OpeningHint) {
-        unsupported_dense_packed_path("commit")
-    }
-
-    fn open(
-        _poly: &Self::Polynomial,
-        _point: &[Self::Field],
-        _eval: Self::Field,
-        _setup: &Self::ProverSetup,
-        _hint: Option<Self::OpeningHint>,
-        _transcript: &mut impl Transcript<Challenge = Self::Field>,
-    ) -> Self::Proof {
-        unsupported_dense_packed_path("open")
-    }
-
-    fn verify(
-        commitment: &Self::Output,
-        point: &[Self::Field],
-        eval: Self::Field,
-        proof: &Self::Proof,
-        setup: &Self::VerifierSetup,
-        transcript: &mut impl Transcript<Challenge = Self::Field>,
-    ) -> Result<(), OpeningsError> {
-        <AkitaPackingAdapter as CommitmentScheme>::verify(
-            commitment, point, eval, proof, setup, transcript,
-        )
-    }
-
-    fn bind_opening_inputs(
-        transcript: &mut impl Transcript<Challenge = Self::Field>,
-        point: &[Self::Field],
-        eval: &Self::Field,
-    ) {
-        AkitaScheme::bind_opening_inputs(transcript, point, eval);
-    }
-}
-
-impl BatchOpeningScheme for AkitaPackingScheme {
-    fn prove_batch<T, OpeningId, RelationId>(
-        setup: &Self::ProverSetup,
-        transcript: &mut T,
-        statement: &BatchOpeningStatement<Self::Field, Self::Output, OpeningId, RelationId>,
-        polynomials: &[Self::Polynomial],
-        hints: Vec<Self::OpeningHint>,
-    ) -> Result<Self::Proof, OpeningsError>
-    where
-        T: Transcript<Challenge = Self::Field>,
-    {
-        if has_packing_view(statement) {
-            validate_packed_adapter_prover_inputs(setup, statement, polynomials, &hints)?;
-        }
-        <AkitaPackingAdapter as BatchOpeningScheme>::prove_batch(
-            setup,
-            transcript,
-            statement,
-            polynomials,
-            hints,
-        )
-    }
-
-    fn verify_batch<T, OpeningId, RelationId>(
-        setup: &Self::VerifierSetup,
-        transcript: &mut T,
-        statement: &BatchOpeningStatement<Self::Field, Self::Output, OpeningId, RelationId>,
-        proof: &Self::Proof,
-    ) -> Result<BatchOpeningResult<Self::Field, Self::Output>, OpeningsError>
-    where
-        T: Transcript<Challenge = Self::Field>,
-    {
-        if has_packing_view(statement) {
-            validate_packed_adapter_verifier_inputs(setup, statement)?;
-        }
-        <AkitaPackingAdapter as BatchOpeningScheme>::verify_batch(
-            setup, transcript, statement, proof,
-        )
-    }
-}
-
-impl ZkOpeningScheme for AkitaPackingScheme {
-    type HidingCommitment = AkitaHidingCommitment;
-    type Blind = ();
-
-    fn commit_zk<P: MultilinearPoly<Self::Field> + ?Sized>(
-        _poly: &P,
-        _setup: &Self::ProverSetup,
-    ) -> (Self::Output, Self::OpeningHint) {
-        unsupported_dense_packed_path("commit_zk")
-    }
-
-    fn open_zk(
-        _poly: &Self::Polynomial,
-        _point: &[Self::Field],
-        _eval: Self::Field,
-        _setup: &Self::ProverSetup,
-        _hint: Self::OpeningHint,
-        _transcript: &mut impl Transcript<Challenge = Self::Field>,
-    ) -> (Self::Proof, Self::HidingCommitment, Self::Blind) {
-        unsupported_dense_packed_path("open_zk")
-    }
-
-    fn verify_zk(
-        _commitment: &Self::Output,
-        _point: &[Self::Field],
-        _proof: &Self::Proof,
-        _setup: &Self::VerifierSetup,
-        _transcript: &mut impl Transcript<Challenge = Self::Field>,
-    ) -> Result<Self::HidingCommitment, OpeningsError> {
-        Err(transparent_zk_error())
-    }
-
-    fn bind_zk_opening_inputs(
-        transcript: &mut impl Transcript<Challenge = Self::Field>,
-        point: &[Self::Field],
-        hiding_commitment: &Self::HidingCommitment,
-    ) {
-        transcript.append(&Label(b"akpk_zk_inputs"));
-        append_field_slice(transcript, b"akpk_zk_point", point);
-        hiding_commitment.append_to_transcript(transcript);
-    }
-}
-
-impl ZkBatchOpeningScheme for AkitaPackingScheme {
-    fn prove_batch_zk<T, OpeningId, RelationId>(
-        _setup: &Self::ProverSetup,
-        _transcript: &mut T,
-        _statement: &BatchOpeningStatement<Self::Field, Self::Output, OpeningId, RelationId, ()>,
-        _evals: &[Self::Field],
-        _polynomials: &[Self::Polynomial],
-        _hints: Vec<Self::OpeningHint>,
-    ) -> Result<(Self::Proof, Self::HidingCommitment, Self::Blind), OpeningsError>
-    where
-        T: Transcript<Challenge = Self::Field>,
-    {
-        Err(transparent_zk_error())
-    }
-
-    fn verify_batch_zk<T, OpeningId, RelationId>(
-        _setup: &Self::VerifierSetup,
-        _transcript: &mut T,
-        _statement: &BatchOpeningStatement<Self::Field, Self::Output, OpeningId, RelationId, ()>,
-        _proof: &Self::Proof,
-    ) -> Result<BatchOpeningResult<Self::Field, Self::Output, Self::HidingCommitment>, OpeningsError>
-    where
-        T: Transcript<Challenge = Self::Field>,
-    {
-        Err(transparent_zk_error())
-    }
+    let polynomial = packing_witness_source_polynomial(source)?;
+    <AkitaPackingScheme as BatchOpeningScheme>::prove_batch(
+        setup,
+        transcript,
+        statement,
+        std::slice::from_ref(&polynomial),
+        vec![hint],
+    )
 }
 
 struct AkitaPackingSource<'a, S>(&'a S);
@@ -298,39 +117,23 @@ struct PackingBatchShape<'a> {
     commitment: AkitaCommitment,
 }
 
-fn validate_packed_adapter_prover_inputs<OpeningId, RelationId>(
-    setup: &<AkitaPackingScheme as CommitmentScheme>::ProverSetup,
+fn validate_packed_source_prover_inputs<'a, OpeningId, RelationId, S>(
+    setup: &'a AkitaPackingProverSetup,
     statement: &BatchOpeningStatement<AkitaField, AkitaCommitment, OpeningId, RelationId>,
-    polynomials: &[Polynomial<AkitaField>],
-    hints: &[AkitaProverHint],
-) -> Result<(), OpeningsError> {
+    source: &S,
+    hint: &AkitaProverHint,
+) -> Result<PackingBatchShape<'a>, OpeningsError>
+where
+    S: PackingWitnessSource<AkitaField>,
+{
     let shape = validate_packed_adapter_statement(&setup.pcs, &setup.layout, statement)?;
-    if polynomials.len() != 1 {
-        return Err(invalid_batch(format!(
-            "Akita packing proof expects one packed witness polynomial, got {}",
-            polynomials.len()
-        )));
-    }
-    if polynomials[0].num_vars() != shape.commitment.num_vars {
-        return Err(invalid_batch(format!(
-            "Akita packing witness polynomial has {} variables but commitment has {}",
-            polynomials[0].num_vars(),
-            shape.commitment.num_vars
-        )));
-    }
-    if hints.len() != 1 || !hints[0].matches_commitment(&shape.commitment) {
+    validate_packing_source_layout(shape.layout, source)?;
+    if !hint.matches_commitment(&shape.commitment) {
         return Err(invalid_batch(
             "Akita packing proof requires one hint matching the packed witness commitment",
         ));
     }
-    Ok(())
-}
-
-fn validate_packed_adapter_verifier_inputs<OpeningId, RelationId>(
-    setup: &<AkitaPackingScheme as CommitmentScheme>::VerifierSetup,
-    statement: &BatchOpeningStatement<AkitaField, AkitaCommitment, OpeningId, RelationId>,
-) -> Result<(), OpeningsError> {
-    validate_packed_adapter_statement(&setup.pcs, &setup.layout, statement).map(|_| ())
+    Ok(shape)
 }
 
 fn validate_packed_adapter_statement<'a, Setup, OpeningId, RelationId>(
@@ -351,41 +154,12 @@ where
     Ok(PackingBatchShape { layout, commitment })
 }
 
-fn validate_packed_source_prover_inputs<'a, OpeningId, RelationId, S>(
-    setup: &'a <AkitaPackingScheme as CommitmentScheme>::ProverSetup,
-    statement: &BatchOpeningStatement<AkitaField, AkitaCommitment, OpeningId, RelationId>,
-    source: &S,
-    hint: &AkitaProverHint,
-) -> Result<PackingBatchShape<'a>, OpeningsError>
-where
-    S: PackingWitnessSource<AkitaField>,
-{
-    let shape = validate_packed_adapter_statement(&setup.pcs, &setup.layout, statement)?;
-    validate_packing_source_layout(shape.layout, source)?;
-    if !hint.matches_commitment(&shape.commitment) {
-        return Err(invalid_batch(
-            "Akita packing proof requires one hint matching the packed witness commitment",
-        ));
-    }
-    Ok(shape)
-}
-
 trait AkitaPackingSetupShape {
     fn max_num_vars(&self) -> usize;
     fn default_layout_digest(&self) -> [u8; 32];
 }
 
 impl AkitaPackingSetupShape for AkitaProverSetup {
-    fn max_num_vars(&self) -> usize {
-        self.max_num_vars
-    }
-
-    fn default_layout_digest(&self) -> [u8; 32] {
-        self.default_layout_digest
-    }
-}
-
-impl AkitaPackingSetupShape for AkitaVerifierSetup {
     fn max_num_vars(&self) -> usize {
         self.max_num_vars
     }
@@ -520,30 +294,6 @@ fn singleton_statement(
     }
 }
 
-#[expect(
-    clippy::panic,
-    reason = "single-opening trait methods cannot return unsupported packed dense-path errors"
-)]
-fn unsupported_dense_packed_path(operation: &str) -> ! {
-    panic!(
-        "AkitaPackingScheme::{operation} cannot be used for dense proof-owned polynomials; use commit_packing_source/prove_packing_source_batch for W_pack or AkitaScheme direct openings for precommitted objects"
-    )
-}
-
-fn append_field_slice<T>(transcript: &mut T, label: &'static [u8], values: &[AkitaField])
-where
-    T: Transcript<Challenge = AkitaField>,
-{
-    transcript.append(&jolt_transcript::LabelWithCount(label, values.len() as u64));
-    for value in values {
-        value.append_to_transcript(transcript);
-    }
-}
-
 fn invalid_batch(reason: impl Into<String>) -> OpeningsError {
     OpeningsError::InvalidBatch(reason.into())
-}
-
-fn transparent_zk_error() -> OpeningsError {
-    invalid_batch("Akita packing batch openings do not support ZK mode yet")
 }

--- a/crates/jolt-verifier/src/akita_validation.rs
+++ b/crates/jolt-verifier/src/akita_validation.rs
@@ -412,9 +412,9 @@ mod tests {
     )]
 
     use super::*;
+    use crate::akita_packing::AkitaPackingScheme;
     use crate::{
         akita::{commit_akita_packing_witness, AkitaPackingProverSetup},
-        akita_packing::AkitaPackingScheme,
         proof::LatticeCommitmentPayload,
         stages::stage8::lattice_protocol_config_for_packed_witness_layout,
     };

--- a/crates/jolt-verifier/src/akita_validity.rs
+++ b/crates/jolt-verifier/src/akita_validity.rs
@@ -1,10 +1,10 @@
+use crate::akita_packing::AkitaPackingScheme;
 use crate::{
     akita::{
         prove_akita_packing_openings, AkitaClearVectorCommitment, AkitaJoltProof,
         AkitaPackingBatchProof, AkitaPackingProverSetup, AkitaPackingWitnessArtifacts,
         AkitaVerifierPreprocessing,
     },
-    akita_packing::AkitaPackingScheme,
     akita_validation::validate_akita_artifacts_for_proof,
     akita_validity_sumcheck::prove_combined_validity_sumcheck,
     proof::{ClearOnlyCommitment, JoltProofClaims},
@@ -750,7 +750,6 @@ mod tests {
     use super::*;
     use crate::{
         akita::{commit_akita_packing_witness_with_config, AkitaPackingVerifierSetup},
-        akita_packing::AkitaPackingScheme,
         config::{IncrementCommitmentMode, JoltProtocolConfig, PcsFamily, ProgramMode},
         proof::ClearOnlyCommitment,
         stages::{

--- a/crates/jolt-verifier/src/compat/audit.rs
+++ b/crates/jolt-verifier/src/compat/audit.rs
@@ -4,7 +4,9 @@ use common::jolt_device::JoltDevice;
 use jolt_blindfold::BlindFoldProtocol;
 use jolt_crypto::{HomomorphicCommitment, VectorCommitment};
 use jolt_field::Field;
-use jolt_openings::{BatchOpeningScheme, CommitmentScheme, ZkBatchOpeningScheme};
+use jolt_openings::{
+    BatchOpeningScheme, CommitmentLayoutDigest, CommitmentScheme, ZkBatchOpeningScheme,
+};
 use jolt_transcript::{AppendToTranscript, Transcript};
 
 use crate::{
@@ -60,7 +62,9 @@ where
     PCS: CommitmentScheme<Field = F>
         + BatchOpeningScheme
         + ZkBatchOpeningScheme<HidingCommitment = VC::Output>,
-    PCS::Output: AppendToTranscript,
+    // Stage 8 still uses shared clear/ZK statement construction; splitting a
+    // ZK-only builder would be broader than this audit helper.
+    PCS::Output: AppendToTranscript + CommitmentLayoutDigest,
     VC: VectorCommitment<Field = F>,
     VC::Output: Copy + HomomorphicCommitment<F> + AppendToTranscript,
     T: Transcript<Challenge = F>,

--- a/crates/jolt-verifier/src/lib.rs
+++ b/crates/jolt-verifier/src/lib.rs
@@ -1,7 +1,7 @@
 //! Verifier model crate for Jolt proofs.
 
 #[cfg(feature = "akita")]
-pub mod akita;
+mod akita;
 #[cfg(feature = "akita")]
 mod akita_openings;
 #[cfg(feature = "akita")]
@@ -25,16 +25,24 @@ mod verifier;
 
 #[cfg(feature = "akita")]
 pub use akita::{
-    attach_akita_packing_validity_proof, commit_akita_packing_witness,
-    commit_akita_packing_witness_with_config, prove_akita_jolt_final_openings,
-    prove_akita_jolt_final_openings_with_precommitted, prove_akita_jolt_packed_validity,
-    prove_akita_packing_openings, prove_akita_packing_validity, prove_akita_stage8_clear_openings,
-    prove_akita_stage8_clear_openings_with_precommitted, prove_and_attach_akita_opening_proofs,
-    prove_and_attach_akita_opening_proofs_with_precommitted, verify_akita_clear,
-    AkitaClearVectorCommitment, AkitaJoltProof, AkitaPackingValidityProofArtifacts,
-    AkitaPackingWitnessArtifacts, AkitaPrecommittedOpeningInput, AkitaStage8ClearOpeningProofs,
-    AkitaVerifierPreprocessing,
+    verify_akita_clear, AkitaClearVectorCommitment, AkitaJoltProof, AkitaVerifierPreprocessing,
 };
+#[cfg(feature = "akita")]
+pub mod prover_support {
+    pub use crate::akita::{
+        attach_akita_packing_validity_proof, build_akita_packing_jolt_witness,
+        commit_akita_packing_jolt_witness, commit_akita_packing_witness,
+        commit_akita_packing_witness_with_config, prove_akita_jolt_final_openings,
+        prove_akita_jolt_final_openings_with_precommitted, prove_akita_jolt_packed_validity,
+        prove_akita_packing_openings, prove_akita_packing_validity,
+        prove_akita_stage8_clear_openings, prove_akita_stage8_clear_openings_with_precommitted,
+        prove_and_attach_akita_opening_proofs,
+        prove_and_attach_akita_opening_proofs_with_precommitted, AkitaCommittedPackedJoltWitness,
+        AkitaPackingBatchProof, AkitaPackingJoltWitnessInput, AkitaPackingProverSetup,
+        AkitaPackingValidityProofArtifacts, AkitaPackingVerifierSetup,
+        AkitaPackingWitnessArtifacts, AkitaPrecommittedOpeningInput, AkitaStage8ClearOpeningProofs,
+    };
+}
 pub use config::{
     validate_proof_config, validate_protocol_config, AdviceLatticeConfig, FieldInlineLatticeConfig,
     IncrementCommitmentMode, JoltProtocolConfig, LatticeConfig, PackedWitnessConfig, PcsFamily,

--- a/crates/jolt-verifier/src/stages/stage8/verify.rs
+++ b/crates/jolt-verifier/src/stages/stage8/verify.rs
@@ -125,31 +125,14 @@ where
             if checked.zk {
                 return Err(VerifierError::ExpectedCommittedProof { field: "stage8" });
             }
-            let batch_result = PCS::verify_batch(
+            let output = verify_clear_batch_statement::<PCS, _>(
                 &preprocessing.pcs_setup,
                 transcript,
-                &batch.statement,
+                batch,
                 &proof.joint_opening_proof,
-            )
-            .map_err(|error| VerifierError::FinalOpeningVerificationFailed {
-                reason: error.to_string(),
-            })?;
-            let mut coefficients = batch_result.coefficients;
-            coefficients.extend(verify_precommitted_opening_batches::<PCS, _>(
-                &preprocessing.pcs_setup,
-                transcript,
-                &batch.precommitted_statements,
                 &proof.lattice_precommitted_opening_proofs,
-            )?);
-
-            Ok(Stage8Output::Clear(Stage8ClearOutput {
-                opening_claims: batch.opening_claims,
-                opening_ids: batch.opening_ids,
-                constraint_coefficients: coefficients,
-                pcs_opening_point: batch.pcs_opening_point,
-                joint_claim: batch_result.reduced_opening,
-                joint_commitment: batch_result.joint_commitment,
-            }))
+            )?;
+            Ok(Stage8Output::Clear(output))
         }
     }
 }
@@ -184,21 +167,48 @@ where
         return Err(VerifierError::ExpectedClearProof { field: "stage8" });
     };
 
-    let batch_result = PCS::verify_batch(
+    verify_clear_batch_statement::<PCS, _>(
         &preprocessing.pcs_setup,
         transcript,
-        &batch.statement,
+        batch,
         &proof.joint_opening_proof,
+        &proof.lattice_precommitted_opening_proofs,
     )
-    .map_err(|error| VerifierError::FinalOpeningVerificationFailed {
-        reason: error.to_string(),
-    })?;
+}
+
+fn verify_clear_batch_statement<PCS, T>(
+    setup: &PCS::VerifierSetup,
+    transcript: &mut T,
+    batch: Stage8ClearBatchStatement<PCS::Field, PCS::Output>,
+    proof: &PCS::Proof,
+    precommitted_proofs: &[PCS::Proof],
+) -> Result<Stage8ClearOutput<PCS::Field, PCS::Output>, VerifierError>
+where
+    PCS: BatchOpeningScheme,
+    T: Transcript<Challenge = PCS::Field>,
+{
+    if batch.precommitted_statements.len() != precommitted_proofs.len() {
+        return Err(VerifierError::FinalOpeningVerificationFailed {
+            reason: format!(
+                "expected {} precommitted opening proofs, got {}",
+                batch.precommitted_statements.len(),
+                precommitted_proofs.len()
+            ),
+        });
+    }
+
+    let batch_result =
+        PCS::verify_batch(setup, transcript, &batch.statement, proof).map_err(|error| {
+            VerifierError::FinalOpeningVerificationFailed {
+                reason: error.to_string(),
+            }
+        })?;
     let mut coefficients = batch_result.coefficients;
     coefficients.extend(verify_precommitted_opening_batches::<PCS, _>(
-        &preprocessing.pcs_setup,
+        setup,
         transcript,
         &batch.precommitted_statements,
-        &proof.lattice_precommitted_opening_proofs,
+        precommitted_proofs,
     )?);
 
     Ok(Stage8ClearOutput {
@@ -1032,6 +1042,173 @@ mod tests {
 
     use super::*;
     use jolt_field::{Fr, FromPrimitiveInt};
+    use jolt_openings::{BatchOpeningResult, OpeningsError};
+    use jolt_poly::{MultilinearPoly, Polynomial};
+
+    #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+    struct MainProofFailingPcs;
+
+    impl jolt_crypto::Commitment for MainProofFailingPcs {
+        type Output = u64;
+    }
+
+    impl CommitmentScheme for MainProofFailingPcs {
+        type Field = Fr;
+        type Proof = Fr;
+        type ProverSetup = ();
+        type VerifierSetup = ();
+        type Polynomial = Polynomial<Fr>;
+        type OpeningHint = ();
+        type SetupParams = ();
+
+        fn setup(_params: Self::SetupParams) -> (Self::ProverSetup, Self::VerifierSetup) {
+            ((), ())
+        }
+
+        fn verifier_setup(_prover_setup: &Self::ProverSetup) -> Self::VerifierSetup {}
+
+        fn commit<P: MultilinearPoly<Self::Field> + ?Sized>(
+            _poly: &P,
+            _setup: &Self::ProverSetup,
+        ) -> (Self::Output, Self::OpeningHint) {
+            (0, ())
+        }
+
+        fn open(
+            _poly: &Self::Polynomial,
+            _point: &[Self::Field],
+            eval: Self::Field,
+            _setup: &Self::ProverSetup,
+            _hint: Option<Self::OpeningHint>,
+            _transcript: &mut impl Transcript<Challenge = Self::Field>,
+        ) -> Self::Proof {
+            eval
+        }
+
+        fn verify(
+            _commitment: &Self::Output,
+            _point: &[Self::Field],
+            _eval: Self::Field,
+            _proof: &Self::Proof,
+            _setup: &Self::VerifierSetup,
+            _transcript: &mut impl Transcript<Challenge = Self::Field>,
+        ) -> Result<(), OpeningsError> {
+            Ok(())
+        }
+
+        fn bind_opening_inputs(
+            _transcript: &mut impl Transcript<Challenge = Self::Field>,
+            _point: &[Self::Field],
+            _eval: &Self::Field,
+        ) {
+        }
+    }
+
+    impl BatchOpeningScheme for MainProofFailingPcs {
+        fn prove_batch<T, OpeningId, RelationId>(
+            _setup: &Self::ProverSetup,
+            _transcript: &mut T,
+            statement: &BatchOpeningStatement<Self::Field, Self::Output, OpeningId, RelationId>,
+            _polynomials: &[Self::Polynomial],
+            _hints: Vec<Self::OpeningHint>,
+        ) -> Result<Self::Proof, OpeningsError>
+        where
+            T: Transcript<Challenge = Self::Field>,
+        {
+            statement
+                .claims
+                .first()
+                .map(|claim| claim.claim)
+                .ok_or(OpeningsError::VerificationFailed)
+        }
+
+        fn verify_batch<T, OpeningId, RelationId>(
+            _setup: &Self::VerifierSetup,
+            _transcript: &mut T,
+            _statement: &BatchOpeningStatement<Self::Field, Self::Output, OpeningId, RelationId>,
+            _proof: &Self::Proof,
+        ) -> Result<BatchOpeningResult<Self::Field, Self::Output>, OpeningsError>
+        where
+            T: Transcript<Challenge = Self::Field>,
+        {
+            Err(OpeningsError::InvalidBatch(
+                "main packed proof was checked first".to_string(),
+            ))
+        }
+    }
+
+    #[test]
+    fn clear_batch_rejects_precommitted_count_before_main_proof() {
+        let id = final_opening_id(JoltCommittedPolynomial::RdInc).into();
+        let point = vec![Fr::from_u64(2)];
+        let statement = BatchOpeningStatement {
+            logical_point: point.clone(),
+            pcs_point: point.clone(),
+            layout_digest: [0; 32],
+            claims: vec![BatchOpeningClaim {
+                id,
+                relation: id,
+                commitment: 7,
+                claim: Fr::from_u64(5),
+                view: PhysicalView::Direct,
+                scale: Fr::from_u64(1),
+            }],
+        };
+        let batch = Stage8ClearBatchStatement {
+            logical_manifest: Stage8LogicalManifest {
+                openings: vec![Stage8LogicalOpening {
+                    id,
+                    point: point.clone(),
+                    claim: Some(Fr::from_u64(5)),
+                    scale: Fr::from_u64(1),
+                }],
+                pcs_opening_point: Point::high_to_low(point.clone()),
+            },
+            physical_manifest: Stage8PhysicalManifest::direct(
+                &Stage8LogicalManifest {
+                    openings: Vec::new(),
+                    pcs_opening_point: Point::high_to_low(point.clone()),
+                },
+                [0; 32],
+            ),
+            opening_ids: vec![id],
+            opening_claims: Vec::new(),
+            pcs_opening_point: Point::high_to_low(point.clone()),
+            statement: statement.clone(),
+            precommitted_statements: vec![statement],
+        };
+        let mut transcript = jolt_transcript::Blake2bTranscript::new(b"stage8-count-precheck");
+
+        let error = verify_clear_batch_statement::<MainProofFailingPcs, _>(
+            &(),
+            &mut transcript,
+            batch.clone(),
+            &Fr::from_u64(99),
+            &[],
+        )
+        .expect_err("missing precommitted proof should reject before main packed proof");
+
+        assert!(matches!(
+            error,
+            VerifierError::FinalOpeningVerificationFailed { reason }
+                if reason.contains("expected 1 precommitted opening proofs, got 0")
+        ));
+
+        let error = verify_clear_batch_statement::<MainProofFailingPcs, _>(
+            &(),
+            &mut transcript,
+            batch,
+            &Fr::from_u64(99),
+            &[Fr::from_u64(1), Fr::from_u64(2)],
+        )
+        .expect_err("extra precommitted proof should reject before main packed proof");
+
+        assert!(matches!(
+            error,
+            VerifierError::FinalOpeningVerificationFailed { reason }
+                if reason.contains("expected 1 precommitted opening proofs, got 2")
+        ));
+    }
 
     #[test]
     fn committed_program_batch_entries_require_final_openings() {

--- a/crates/jolt-verifier/tests/akita_prover_support.rs
+++ b/crates/jolt-verifier/tests/akita_prover_support.rs
@@ -25,18 +25,19 @@ use jolt_riscv::{
     NormalizedOperands, StoreState,
 };
 use jolt_verifier::{
-    akita::{
+    prover_support::{
         build_akita_packing_jolt_witness, commit_akita_packing_jolt_witness,
-        commit_akita_packing_witness, commit_akita_packing_witness_with_config, verify_akita_clear,
-        AkitaJoltProof, AkitaPackingBatchProof, AkitaPackingJoltWitnessInput,
-        AkitaPackingProverSetup, AkitaPackingValidityProofArtifacts, AkitaPackingVerifierSetup,
-        AkitaPackingWitnessArtifacts, AkitaVerifierPreprocessing,
+        commit_akita_packing_witness, commit_akita_packing_witness_with_config,
+        AkitaPackingBatchProof, AkitaPackingJoltWitnessInput, AkitaPackingProverSetup,
+        AkitaPackingValidityProofArtifacts, AkitaPackingVerifierSetup,
+        AkitaPackingWitnessArtifacts,
     },
     stages::stage8::{
         lattice_protocol_config_for_packed_witness_layout,
         lattice_validity_requirements_for_packed_witness_layout,
     },
-    IncrementCommitmentMode, JoltProtocolConfig, ProgramMode, VerifierError,
+    verify_akita_clear, AkitaJoltProof, AkitaVerifierPreprocessing, IncrementCommitmentMode,
+    JoltProtocolConfig, ProgramMode, VerifierError,
 };
 
 fn physical(family: JoltPackingFamilyId) -> PackingFamilyId {
@@ -480,7 +481,7 @@ fn akita_clear_verifier_surface_is_nameable() {
         &AkitaPackingWitnessArtifacts,
         &SparsePackingWitness<AkitaField>,
     ) -> Result<AkitaPackingBatchProof, VerifierError>;
-    let _prove: ProveFn = jolt_verifier::akita::prove_akita_jolt_final_openings::<
+    let _prove: ProveFn = jolt_verifier::prover_support::prove_akita_jolt_final_openings::<
         TestTranscript,
         SparsePackingWitness<AkitaField>,
     >;
@@ -493,8 +494,9 @@ fn akita_clear_verifier_surface_is_nameable() {
         &AkitaPackingWitnessArtifacts,
         &SparsePackingWitness<AkitaField>,
     ) -> Result<AkitaPackingValidityProofArtifacts, VerifierError>;
-    let _prove_validity: ProveValidityFn = jolt_verifier::akita::prove_akita_jolt_packed_validity::<
-        TestTranscript,
-        SparsePackingWitness<AkitaField>,
-    >;
+    let _prove_validity: ProveValidityFn =
+        jolt_verifier::prover_support::prove_akita_jolt_packed_validity::<
+            TestTranscript,
+            SparsePackingWitness<AkitaField>,
+        >;
 }

--- a/crates/jolt-verifier/tests/statistical_independence/zk.rs
+++ b/crates/jolt-verifier/tests/statistical_independence/zk.rs
@@ -135,6 +135,11 @@ impl StableZkProofShape {
         let JoltProofClaims::Zk { blindfold_proof } = &case.proof.claims else {
             panic!("ZK statistical fixture must carry a BlindFold proof");
         };
+        let commitments = case
+            .proof
+            .commitments
+            .as_dory()
+            .expect("ZK statistical fixture must use Dory commitments");
 
         Self {
             public_io: case.public_io.clone(),
@@ -145,9 +150,9 @@ impl StableZkProofShape {
             one_hot_config: case.proof.one_hot_config,
             trace_polynomial_order: case.proof.trace_polynomial_order,
             commitment_shape: CommitmentShape {
-                instruction_ra: case.proof.commitments.ra.instruction.len(),
-                ram_ra: case.proof.commitments.ra.ram.len(),
-                bytecode_ra: case.proof.commitments.ra.bytecode.len(),
+                instruction_ra: commitments.ra.instruction.len(),
+                ram_ra: commitments.ra.ram.len(),
+                bytecode_ra: commitments.ra.bytecode.len(),
                 has_untrusted_advice: case.proof.untrusted_advice_commitment.is_some(),
             },
             stage_shapes: committed_stage_shapes(&case.proof.stages),
@@ -279,15 +284,16 @@ fn collect_jolt_proof_statistics(
     let JoltProofClaims::Zk { blindfold_proof } = &proof.claims else {
         panic!("ZK statistical fixture must carry a BlindFold proof");
     };
+    let commitments = proof
+        .commitments
+        .as_dory()
+        .expect("ZK statistical fixture must use Dory commitments");
 
-    tracker.record_append("pcs.commitment.rd_inc", &proof.commitments.rd_inc);
-    tracker.record_append("pcs.commitment.ram_inc", &proof.commitments.ram_inc);
-    tracker.record_append_positions(
-        "pcs.commitment.instruction_ra",
-        &proof.commitments.ra.instruction,
-    );
-    tracker.record_append_positions("pcs.commitment.ram_ra", &proof.commitments.ra.ram);
-    tracker.record_append_positions("pcs.commitment.bytecode_ra", &proof.commitments.ra.bytecode);
+    tracker.record_append("pcs.commitment.rd_inc", &commitments.rd_inc);
+    tracker.record_append("pcs.commitment.ram_inc", &commitments.ram_inc);
+    tracker.record_append_positions("pcs.commitment.instruction_ra", &commitments.ra.instruction);
+    tracker.record_append_positions("pcs.commitment.ram_ra", &commitments.ra.ram);
+    tracker.record_append_positions("pcs.commitment.bytecode_ra", &commitments.ra.bytecode);
     if let Some(commitment) = &proof.untrusted_advice_commitment {
         tracker.record_append("pcs.commitment.untrusted_advice", commitment);
     }


### PR DESCRIPTION
## Summary
- Move Akita packing adapter ownership out of public `jolt-akita` and keep `jolt-akita` native-PCS-shaped.
- Narrow `jolt-verifier` Akita prover support behind explicit `prover_support` APIs while keeping root exports verifier-facing.
- Fix Stage 8 precommitted proof-count rejection order and add ownership/regression coverage.

## Test plan
- `cargo fmt -q`
- `cargo nextest run --release -p jolt-openings --cargo-quiet`
- `cargo nextest run --release -p jolt-akita --cargo-quiet`
- `cargo nextest run --release -p jolt-verifier --cargo-quiet --features akita,core-fixtures`
- `cargo nextest run --release -p jolt-verifier --cargo-quiet --features core-fixtures,zk`
- `cargo clippy -p jolt-akita -p jolt-verifier --features akita,core-fixtures -q --all-targets -- -D warnings`
- `cargo clippy -p jolt-verifier --features core-fixtures,zk -q --all-targets -- -D warnings`