### PR TITLE
chore(deps): bump dory-pcs to 0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -583,7 +583,7 @@ dependencies = [
  "alloy-rlp",
  "alloy-serde",
  "alloy-sol-types",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "serde",
  "serde_json",
  "serde_with",
@@ -2205,9 +2205,9 @@ dependencies = [
 
 [[package]]
 name = "dory-pcs"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8c58baea9f0ed973489cd1981b0e6a8c91aafddb05e3903b1dd54175ddcb52d"
+checksum = "5c6a5b6aa708db35ced06eeef3d2b4408004c76279091e0bc387f8fd42796555"
 dependencies = [
  "ark-bn254 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ark-ec 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5037,7 +5037,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.118",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -267,7 +267,7 @@ spongefish = { git = "https://github.com/arkworks-rs/spongefish", rev = "d2d190b
   "sha3",
 ] }
 jolt-optimizations = { git = "https://github.com/a16z/arkworks-algebra", branch = "dev/twist-shout" }
-dory = { package = "dory-pcs", version = "0.3.0", features = [
+dory = { package = "dory-pcs", version = "0.4.0", features = [
   "backends",
   "cache",
   "disk-persistence",

--- a/crates/jolt-prover-legacy/src/poly/commitment/dory/wrappers.rs
+++ b/crates/jolt-prover-legacy/src/poly/commitment/dory/wrappers.rs
@@ -7,6 +7,7 @@ use crate::{
         multilinear_polynomial::{MultilinearPolynomial, PolynomialEvaluation},
     },
     transcripts::Transcript,
+    utils::math::Math,
 };
 use ark_bn254::Fr;
 use ark_ec::CurveGroup;
@@ -49,7 +50,19 @@ impl DoryPolynomial<ArkFr> for MultilinearPolynomial<Fr> {
     fn evaluate(&self, point: &[ArkFr]) -> ArkFr {
         // Dory uses little-endian variable order; reverse to match Jolt's big-endian order.
         // Use Fr directly (not Challenge type) to avoid type mismatch issues.
-        let native_point: Vec<Fr> = point.iter().rev().map(ark_to_jolt).collect();
+        let mut native_point: Vec<Fr> = point.iter().rev().map(ark_to_jolt).collect();
+        // In AddressMajor layout the (big-endian) Dory opening point is
+        // [cycle vars || address vars], but OneHotPolynomial::evaluate expects
+        // [address vars || cycle vars]. dory calls this to derive the ZK evaluation
+        // commitment, so the result must match the committed matrix relation.
+        // (The RLC arm of PolynomialEvaluation::evaluate consumes the Dory matrix
+        // order directly and needs no reorder.)
+        if matches!(self, MultilinearPolynomial::OneHot(_))
+            && DoryGlobals::get_layout() == DoryLayout::AddressMajor
+        {
+            let log_T = DoryGlobals::get_T().log_2();
+            native_point.rotate_left(log_T);
+        }
         let result = PolynomialEvaluation::evaluate(self, native_point.as_slice());
         jolt_to_ark(&result)
     }

--- a/crates/jolt-prover-legacy/src/zkvm/proof.rs
+++ b/crates/jolt-prover-legacy/src/zkvm/proof.rs
@@ -617,12 +617,12 @@ where
 }
 
 fn prover_dory_commitment_into_verifier(commitment: &ProverDoryCommitment) -> Bn254GT {
-    // `ArkGT` (prover Dory) and `Bn254GT` (modular `jolt-dory`) both wrap the same
-    // patched `ark_bn254::Fq12`, so convert through the shared inner element. This
-    // is equivalent to the previous `transmute_copy` but layout-independent: a
-    // future change to either wrapper becomes a type error here instead of silent
-    // memory corruption on the soundness-critical commitment path.
-    Bn254GT::from(commitment.0)
+    // `ArkGT` (prover Dory, via `PairingOutput<Bn254>`) and `Bn254GT` (modular
+    // `jolt-dory`) both wrap the same patched `ark_bn254::Fq12`, so convert
+    // through the shared inner element rather than transmuting: a future change
+    // to either wrapper becomes a type error here instead of silent memory
+    // corruption on the soundness-critical commitment path.
+    Bn254GT::from(commitment.0 .0)
 }
 
 #[cfg(feature = "zk")]

--- a/crates/jolt-verifier/tests/statistical_independence/zk.rs
+++ b/crates/jolt-verifier/tests/statistical_independence/zk.rs
@@ -400,8 +400,12 @@ fn collect_dory_opening_statistics(proof: &jolt_dory::DoryProof, tracker: &mut B
         tracker.record_canonical(format!("{prefix}.e2_plus"), &message.e2_plus);
         tracker.record_canonical(format!("{prefix}.e2_minus"), &message.e2_minus);
     }
-    tracker.record_canonical("dory.final.e1", &proof.final_message.e1);
-    tracker.record_canonical("dory.final.e2", &proof.final_message.e2);
+    // A ZK proof carries no clear final message (it would reveal the folded
+    // witness); the hiding scalar-product Σ-proof recorded below replaces it.
+    assert!(
+        proof.final_message.is_none(),
+        "ZK proof must not carry a clear final message"
+    );
 
     if let Some(sigma1) = &proof.sigma1_proof {
         tracker.record_canonical("dory.sigma1.a1", &sigma1.a1);

--- a/crates/jolt-verifier/tests/support/verifier_fixtures.rs
+++ b/crates/jolt-verifier/tests/support/verifier_fixtures.rs
@@ -1,6 +1,5 @@
 #![expect(
     clippy::expect_used,
-    clippy::panic,
     reason = "fixture generation should fail loudly when verifier object construction or serialization breaks"
 )]
 
@@ -456,34 +455,34 @@ fn write_fixture_file(path: &PathBuf, fixture: &GeneratedVerifierFixture) {
     fs::write(path, bytes).expect("write verifier fixture file");
 }
 
+/// Returns `None` on any decode failure, not just a magic mismatch: cached
+/// fixtures embed proof types whose serialized layout can change under a
+/// dependency bump, and a stale cache must count as a miss so
+/// `load_or_generate_fixture` regenerates it.
 fn read_fixture_file(path: &PathBuf) -> Option<GeneratedVerifierFixture> {
     let bytes = fs::read(path).expect("read verifier fixture file");
     let mut cursor = Cursor::new(bytes.as_slice());
     let mut magic = [0; FIXTURE_MAGIC.len()];
-    cursor
-        .read_exact(&mut magic)
-        .expect("read verifier fixture magic");
+    cursor.read_exact(&mut magic).ok()?;
     if &magic != FIXTURE_MAGIC {
         return None;
     }
 
-    let preprocessing = read_section(&mut cursor);
-    let public_io = read_section(&mut cursor);
-    let proof = read_section(&mut cursor);
+    let preprocessing = read_section(&mut cursor)?;
+    let public_io = read_section(&mut cursor)?;
+    let proof = read_section(&mut cursor)?;
     let mut has_trusted_advice_commitment = [0];
-    cursor
-        .read_exact(&mut has_trusted_advice_commitment)
-        .expect("read trusted advice commitment marker");
+    cursor.read_exact(&mut has_trusted_advice_commitment).ok()?;
     let trusted_advice_commitment = match has_trusted_advice_commitment[0] {
         0 => None,
-        1 => Some(deserialize_verifier_object(&read_section(&mut cursor))),
-        marker => panic!("invalid trusted advice commitment marker {marker}"),
+        1 => Some(deserialize_verifier_object(&read_section(&mut cursor)?)?),
+        _ => return None,
     };
 
     Some(GeneratedVerifierFixture {
-        preprocessing: deserialize_verifier_object(&preprocessing),
-        public_io: deserialize_verifier_object(&public_io),
-        proof: deserialize_verifier_object(&proof),
+        preprocessing: deserialize_verifier_object(&preprocessing)?,
+        public_io: deserialize_verifier_object(&public_io)?,
+        proof: deserialize_verifier_object(&proof)?,
         trusted_advice_commitment,
     })
 }
@@ -493,16 +492,17 @@ fn write_section(out: &mut Vec<u8>, section: &[u8]) {
     out.extend_from_slice(section);
 }
 
-fn read_section(cursor: &mut Cursor<&[u8]>) -> Vec<u8> {
+fn read_section(cursor: &mut Cursor<&[u8]>) -> Option<Vec<u8>> {
     let mut len = [0; 8];
-    cursor
-        .read_exact(&mut len)
-        .expect("read verifier fixture section length");
-    let mut section = vec![0; u64::from_le_bytes(len) as usize];
-    cursor
-        .read_exact(&mut section)
-        .expect("read verifier fixture section");
-    section
+    cursor.read_exact(&mut len).ok()?;
+    let len = usize::try_from(u64::from_le_bytes(len)).ok()?;
+    let remaining = (cursor.get_ref().len() as u64).saturating_sub(cursor.position());
+    if len as u64 > remaining {
+        return None;
+    }
+    let mut section = vec![0; len];
+    cursor.read_exact(&mut section).ok()?;
+    Some(section)
 }
 
 fn serialize_verifier_object<T: serde::Serialize>(item: &T) -> Vec<u8> {
@@ -510,11 +510,10 @@ fn serialize_verifier_object<T: serde::Serialize>(item: &T) -> Vec<u8> {
         .expect("serialize verifier object")
 }
 
-fn deserialize_verifier_object<T: serde::de::DeserializeOwned>(bytes: &[u8]) -> T {
-    let (value, consumed) = bincode::serde::decode_from_slice(bytes, bincode::config::standard())
-        .expect("deserialize verifier object");
-    assert_eq!(consumed, bytes.len(), "trailing bytes in verifier object");
-    value
+fn deserialize_verifier_object<T: serde::de::DeserializeOwned>(bytes: &[u8]) -> Option<T> {
+    let (value, consumed) =
+        bincode::serde::decode_from_slice(bytes, bincode::config::standard()).ok()?;
+    (consumed == bytes.len()).then_some(value)
 }
 
 fn assert_verifier_accepts(


### PR DESCRIPTION
Bumps dory-pcs 0.3.0 → 0.4.0, whose headline change is a fix for a critical ZK soundness bug

API adaptations: `ArkGT` now wraps `PairingOutput<Bn254>`; ZK proofs carry `final_message: None`

Two jolt-side bugs surfaced:

1. **Layout-unaware `DoryPolynomial::evaluate`** (`wrappers.rs`): for OneHot polynomials under AddressMajor the opening point is `[cycle || address]` but was evaluated as `[address || cycle]`, so the ZK `y_com` committed to the wrong evaluation. dory 0.3 accepted this due to its unbound-point bug; 0.4 correctly rejects it (`test_dory_one_hot_address_major` under `host,zk`). Fixed by reordering the point.
2. **Stale fixture cache panic** (`verifier_fixtures.rs`): cached ZK fixtures serialized under the 0.3 proof schema panicked on deserialize. Decode failures now count as a cache miss and regenerate.