### PR TITLE
refactor(jolt-claims): dedup opening-id constructors, collapse aliases (cleanup phase 1)

### DIFF
--- a/crates/jolt-claims/src/protocols/jolt/geometry/bytecode.rs
+++ b/crates/jolt-claims/src/protocols/jolt/geometry/bytecode.rs
@@ -15,6 +15,11 @@ use super::super::{
 use super::claim_reductions::bytecode::NUM_BYTECODE_VAL_STAGES;
 use super::dimensions::JoltFormulaPointError;
 use super::error::require_len;
+use super::instruction::{imm, instruction_raf_flag, lookup_table_flag, unexpanded_pc};
+use super::registers::{
+    rd_wa_read_write, rd_wa_val_evaluation, rs1_ra_read_write, rs2_ra_read_write,
+};
+use super::spartan::unexpanded_pc_shift;
 
 /// Per-stage (1..=5) gamma-power vector lengths for the bytecode read-RAF stage
 /// folds — the arities of the prover's `challenge_scalar_powers` draws. The
@@ -261,12 +266,12 @@ pub struct BytecodeReadRafStageValueInputs<'a, F> {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct BytecodeReadRafRegisterEqEvals<F> {
+struct BytecodeReadRafRegisterEqEvals<F> {
     pub read_write: Vec<F>,
     pub val_evaluation: Vec<F>,
 }
 
-pub fn read_raf_register_eq_evals<F>(
+fn read_raf_register_eq_evals<F>(
     register_read_write_point: &[F],
     register_val_evaluation_point: &[F],
 ) -> BytecodeReadRafRegisterEqEvals<F>
@@ -371,7 +376,7 @@ where
     clippy::too_many_arguments,
     reason = "Each gamma slice corresponds to one protocol subexpression."
 )]
-pub fn read_raf_row_values<F>(
+fn read_raf_row_values<F>(
     instruction: &JoltInstructionRow,
     register_read_write_eq: &[F],
     register_val_evaluation_eq: &[F],
@@ -468,10 +473,7 @@ pub fn read_raf_output_openings(
 }
 
 pub fn read_raf_consistency_openings() -> [(JoltOpeningId, JoltOpeningId); 1] {
-    [(
-        unexpanded_pc_spartan_shift(),
-        unexpanded_pc_instruction_input(),
-    )]
+    [(unexpanded_pc_shift(), unexpanded_pc())]
 }
 
 pub(crate) fn stage1_claim<F>() -> JoltExpr<F>
@@ -507,8 +509,8 @@ where
 {
     let beta = challenge(BytecodeReadRafChallenge::Stage3Gamma);
 
-    opening(imm_instruction_input())
-        + beta.clone() * opening(unexpanded_pc_spartan_shift())
+    opening(imm())
+        + beta.clone() * opening(unexpanded_pc_shift())
         + beta.clone().pow(2)
             * opening(instruction_flag_input(
                 InstructionFlags::LeftOperandIsRs1Value,
@@ -593,27 +595,6 @@ pub(crate) fn instruction_flag_product(flag: InstructionFlags) -> JoltOpeningId 
     )
 }
 
-pub(crate) fn imm_instruction_input() -> JoltOpeningId {
-    JoltOpeningId::virtual_polynomial(
-        JoltVirtualPolynomial::Imm,
-        JoltRelationId::InstructionInputVirtualization,
-    )
-}
-
-fn unexpanded_pc_instruction_input() -> JoltOpeningId {
-    JoltOpeningId::virtual_polynomial(
-        JoltVirtualPolynomial::UnexpandedPC,
-        JoltRelationId::InstructionInputVirtualization,
-    )
-}
-
-pub(crate) fn unexpanded_pc_spartan_shift() -> JoltOpeningId {
-    JoltOpeningId::virtual_polynomial(
-        JoltVirtualPolynomial::UnexpandedPC,
-        JoltRelationId::SpartanShift,
-    )
-}
-
 pub(crate) fn instruction_flag_input(flag: InstructionFlags) -> JoltOpeningId {
     JoltOpeningId::virtual_polynomial(
         JoltVirtualPolynomial::InstructionFlags(flag),
@@ -635,54 +616,8 @@ pub(crate) fn op_flag_shift(flag: CircuitFlags) -> JoltOpeningId {
     )
 }
 
-pub(crate) fn rd_wa_read_write() -> JoltOpeningId {
-    JoltOpeningId::virtual_polynomial(
-        JoltVirtualPolynomial::RdWa,
-        JoltRelationId::RegistersReadWriteChecking,
-    )
-}
-
-pub(crate) fn rs1_ra_read_write() -> JoltOpeningId {
-    JoltOpeningId::virtual_polynomial(
-        JoltVirtualPolynomial::Rs1Ra,
-        JoltRelationId::RegistersReadWriteChecking,
-    )
-}
-
-pub(crate) fn rs2_ra_read_write() -> JoltOpeningId {
-    JoltOpeningId::virtual_polynomial(
-        JoltVirtualPolynomial::Rs2Ra,
-        JoltRelationId::RegistersReadWriteChecking,
-    )
-}
-
-pub(crate) fn rd_wa_val_evaluation() -> JoltOpeningId {
-    JoltOpeningId::virtual_polynomial(
-        JoltVirtualPolynomial::RdWa,
-        JoltRelationId::RegistersValEvaluation,
-    )
-}
-
-pub(crate) fn instruction_raf_flag() -> JoltOpeningId {
-    JoltOpeningId::virtual_polynomial(
-        JoltVirtualPolynomial::InstructionRafFlag,
-        JoltRelationId::InstructionReadRaf,
-    )
-}
-
-fn lookup_table_flag(table: LookupTableKind<XLEN>) -> JoltOpeningId {
-    JoltOpeningId::virtual_polynomial(
-        JoltVirtualPolynomial::LookupTableFlag(table.index()),
-        JoltRelationId::InstructionReadRaf,
-    )
-}
-
 pub(crate) fn pc_spartan_outer() -> JoltOpeningId {
     JoltOpeningId::virtual_polynomial(JoltVirtualPolynomial::PC, JoltRelationId::SpartanOuter)
-}
-
-pub(crate) fn pc_spartan_shift() -> JoltOpeningId {
-    JoltOpeningId::virtual_polynomial(JoltVirtualPolynomial::PC, JoltRelationId::SpartanShift)
 }
 
 pub(crate) fn bytecode_ra(index: usize) -> JoltOpeningId {

--- a/crates/jolt-claims/src/protocols/jolt/geometry/claim_reductions/bytecode.rs
+++ b/crates/jolt-claims/src/protocols/jolt/geometry/claim_reductions/bytecode.rs
@@ -48,11 +48,6 @@ pub const fn total_lanes() -> usize {
 /// Fixed lane capacity for committed bytecode rows.
 pub const COMMITTED_BYTECODE_LANE_CAPACITY: usize = total_lanes().next_power_of_two();
 
-#[inline(always)]
-pub const fn committed_lanes() -> usize {
-    COMMITTED_BYTECODE_LANE_CAPACITY
-}
-
 pub const fn committed_lane_vars() -> usize {
     COMMITTED_BYTECODE_LANE_CAPACITY.trailing_zeros() as usize
 }
@@ -307,9 +302,9 @@ impl BytecodeClaimReductionLayout {
                 got: inputs.r_bc.len(),
             });
         }
-        if inputs.lane_weights.len() != committed_lanes() {
+        if inputs.lane_weights.len() != COMMITTED_BYTECODE_LANE_CAPACITY {
             return Err(JoltFormulaPointError::EvaluationDomainLengthMismatch {
-                expected: committed_lanes(),
+                expected: COMMITTED_BYTECODE_LANE_CAPACITY,
                 got: inputs.lane_weights.len(),
             });
         }
@@ -421,7 +416,7 @@ pub fn lane_weights<F: Field>(
         None,
     );
 
-    let mut weights = vec![F::zero(); committed_lanes()];
+    let mut weights = vec![F::zero(); COMMITTED_BYTECODE_LANE_CAPACITY];
 
     {
         let coeff = eta_powers[0];
@@ -660,10 +655,10 @@ mod tests {
         );
         assert_eq!(layout.raf_flag_idx + 1, total_lanes());
 
-        assert!(committed_lanes().is_power_of_two());
-        assert!(committed_lanes() >= total_lanes());
-        assert!(committed_lanes() < 2 * total_lanes());
-        assert_eq!(1 << committed_lane_vars(), committed_lanes());
+        assert!(COMMITTED_BYTECODE_LANE_CAPACITY.is_power_of_two());
+        assert!(COMMITTED_BYTECODE_LANE_CAPACITY >= total_lanes());
+        assert!(COMMITTED_BYTECODE_LANE_CAPACITY < 2 * total_lanes());
+        assert_eq!(1 << committed_lane_vars(), COMMITTED_BYTECODE_LANE_CAPACITY);
     }
 
     #[test]
@@ -856,20 +851,21 @@ mod tests {
                 .unwrap_or_else(|error| panic!("opening point should assemble: {error}"));
 
             let r_bc = [fr(23)];
-            let mut lane_weight_values = vec![Fr::from_u64(0); committed_lanes()];
+            let mut lane_weight_values = vec![Fr::from_u64(0); COMMITTED_BYTECODE_LANE_CAPACITY];
             for (lane, weight) in lane_weight_values.iter_mut().enumerate() {
                 *weight = fr(3 + lane as u64);
             }
 
             let chunk_cycle_len = 2usize;
             let eq_rbc = EqPolynomial::<Fr>::evals(&r_bc, None);
-            let mut grid = vec![Fr::from_u64(0); committed_lanes() * chunk_cycle_len];
+            let mut grid =
+                vec![Fr::from_u64(0); COMMITTED_BYTECODE_LANE_CAPACITY * chunk_cycle_len];
             for (lane, lane_weight) in lane_weight_values.iter().enumerate() {
                 for (cycle, eq_cycle) in eq_rbc.iter().enumerate() {
                     let index = trace_order.address_cycle_to_index(
                         lane,
                         cycle,
-                        committed_lanes(),
+                        COMMITTED_BYTECODE_LANE_CAPACITY,
                         chunk_cycle_len,
                     );
                     grid[index] = *lane_weight * *eq_cycle;

--- a/crates/jolt-claims/src/protocols/jolt/geometry/claim_reductions/hamming_weight.rs
+++ b/crates/jolt-claims/src/protocols/jolt/geometry/claim_reductions/hamming_weight.rs
@@ -2,9 +2,10 @@ use jolt_field::{Field, RingCore};
 
 use crate::opening;
 
-use super::super::super::{JoltExpr, JoltOpeningId, JoltRelationId, JoltVirtualPolynomial};
+use super::super::super::{JoltExpr, JoltOpeningId, JoltRelationId};
 use super::super::dimensions::JoltFormulaPointError;
 use super::super::ra::{JoltRaPolynomial, JoltRaPolynomialLayout};
+use super::super::ram::ram_hamming_weight;
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct HammingWeightClaimReductionDimensions {
@@ -109,13 +110,6 @@ pub(crate) fn virtualization_claim(polynomial: JoltRaPolynomial) -> JoltOpeningI
 
 pub(crate) fn reduced_claim(polynomial: JoltRaPolynomial) -> JoltOpeningId {
     polynomial.opening(JoltRelationId::HammingWeightClaimReduction)
-}
-
-pub(crate) fn ram_hamming_weight() -> JoltOpeningId {
-    JoltOpeningId::virtual_polynomial(
-        JoltVirtualPolynomial::RamHammingWeight,
-        JoltRelationId::RamHammingBooleanity,
-    )
 }
 
 #[cfg(test)]

--- a/crates/jolt-claims/src/protocols/jolt/geometry/claim_reductions/increments.rs
+++ b/crates/jolt-claims/src/protocols/jolt/geometry/claim_reductions/increments.rs
@@ -1,6 +1,8 @@
 use jolt_field::RingCore;
 
 use super::super::super::{JoltCommittedPolynomial, JoltExpr, JoltOpeningId, JoltRelationId};
+use super::super::ram::{ram_inc, ram_inc_val_check};
+use super::super::registers::{rd_inc_read_write, rd_inc_val_evaluation};
 use crate::opening;
 
 /// The γ-batched consumption of the four inc consumer claims. Shared by the
@@ -10,35 +12,10 @@ pub(crate) fn inc_consumers_input<F>(gamma: JoltExpr<F>) -> JoltExpr<F>
 where
     F: RingCore,
 {
-    opening(ram_inc_read_write())
+    opening(ram_inc())
         + gamma.clone() * opening(ram_inc_val_check())
         + gamma.clone().pow(2) * opening(rd_inc_read_write())
         + gamma.pow(3) * opening(rd_inc_val_evaluation())
-}
-
-pub(crate) fn ram_inc_read_write() -> JoltOpeningId {
-    JoltOpeningId::committed(
-        JoltCommittedPolynomial::RamInc,
-        JoltRelationId::RamReadWriteChecking,
-    )
-}
-
-pub(crate) fn ram_inc_val_check() -> JoltOpeningId {
-    JoltOpeningId::committed(JoltCommittedPolynomial::RamInc, JoltRelationId::RamValCheck)
-}
-
-pub(crate) fn rd_inc_read_write() -> JoltOpeningId {
-    JoltOpeningId::committed(
-        JoltCommittedPolynomial::RdInc,
-        JoltRelationId::RegistersReadWriteChecking,
-    )
-}
-
-pub(crate) fn rd_inc_val_evaluation() -> JoltOpeningId {
-    JoltOpeningId::committed(
-        JoltCommittedPolynomial::RdInc,
-        JoltRelationId::RegistersValEvaluation,
-    )
 }
 
 pub fn ram_inc_reduced() -> JoltOpeningId {

--- a/crates/jolt-claims/src/protocols/jolt/geometry/claim_reductions/program_image.rs
+++ b/crates/jolt-claims/src/protocols/jolt/geometry/claim_reductions/program_image.rs
@@ -24,7 +24,7 @@ use super::precommitted::{
 
 /// Committed length of the program-image polynomial: the initial RAM
 /// bytecode-word slice padded to a power of two (at least two words).
-pub fn padded_program_image_len_words(program_image_len_words: usize) -> usize {
+fn padded_program_image_len_words(program_image_len_words: usize) -> usize {
     program_image_len_words.next_power_of_two().max(2)
 }
 

--- a/crates/jolt-claims/src/protocols/jolt/geometry/committed_openings.rs
+++ b/crates/jolt-claims/src/protocols/jolt/geometry/committed_openings.rs
@@ -50,23 +50,6 @@ pub fn final_opening_polynomial_order(
     polynomials
 }
 
-pub fn final_opening_ids(
-    layout: JoltRaPolynomialLayout,
-    include_trusted_advice: bool,
-    include_untrusted_advice: bool,
-    committed_program_chunks: Option<usize>,
-) -> Vec<JoltOpeningId> {
-    final_opening_polynomial_order(
-        layout,
-        include_trusted_advice,
-        include_untrusted_advice,
-        committed_program_chunks,
-    )
-    .into_iter()
-    .map(final_opening_id)
-    .collect()
-}
-
 pub fn final_opening_id(polynomial: JoltCommittedPolynomial) -> JoltOpeningId {
     match polynomial {
         JoltCommittedPolynomial::TrustedAdvice => {
@@ -79,7 +62,7 @@ pub fn final_opening_id(polynomial: JoltCommittedPolynomial) -> JoltOpeningId {
     }
 }
 
-pub fn final_opening_relation(polynomial: JoltCommittedPolynomial) -> JoltRelationId {
+fn final_opening_relation(polynomial: JoltCommittedPolynomial) -> JoltRelationId {
     match polynomial {
         JoltCommittedPolynomial::RdInc | JoltCommittedPolynomial::RamInc => {
             JoltRelationId::IncClaimReduction
@@ -267,8 +250,12 @@ mod tests {
 
     #[test]
     fn final_opening_ids_use_sumcheck_sources() {
+        let ids = final_opening_polynomial_order(layout(), true, false, None)
+            .into_iter()
+            .map(final_opening_id)
+            .collect::<Vec<_>>();
         assert_eq!(
-            final_opening_ids(layout(), true, false, None),
+            ids,
             vec![
                 JoltOpeningId::committed(
                     JoltCommittedPolynomial::RamInc,

--- a/crates/jolt-claims/src/protocols/jolt/geometry/dimensions.rs
+++ b/crates/jolt-claims/src/protocols/jolt/geometry/dimensions.rs
@@ -16,10 +16,6 @@ pub const OUTER_UNISKIP_FIRST_ROUND_DEGREE: usize = 27;
 pub const PRODUCT_UNISKIP_DOMAIN_SIZE: usize = 3;
 pub const PRODUCT_UNISKIP_FIRST_ROUND_DEGREE: usize = 6;
 
-// The sumcheck domain is a protocol-agnostic crate-root type; this alias keeps
-// the `Jolt*` spelling that the rest of the codebase uses.
-pub use crate::SumcheckDomain as JoltSumcheckDomain;
-
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub enum TracePolynomialOrder {
     #[default]

--- a/crates/jolt-claims/src/protocols/jolt/geometry/instruction.rs
+++ b/crates/jolt-claims/src/protocols/jolt/geometry/instruction.rs
@@ -10,7 +10,13 @@ use super::super::{
     InstructionReadRafPublic, JoltCommittedPolynomial, JoltExpr, JoltOpeningId, JoltRelationId,
     JoltVirtualPolynomial,
 };
+use super::claim_reductions::instruction::{
+    left_instruction_input_reduced, lookup_output_reduced, right_instruction_input_reduced,
+};
 use super::dimensions::{JoltFormulaDimensionsError, JoltFormulaPointError};
+use super::spartan::{
+    left_instruction_input_product, lookup_output_product, right_instruction_input_product,
+};
 
 pub(crate) const INPUT_VIRTUALIZATION_DEGREE: usize = 3;
 pub(crate) const READ_RAF_BASE_DEGREE: usize = 2;
@@ -207,29 +213,17 @@ pub fn read_raf_output_openings(
 ) -> InstructionReadRafOutputOpenings {
     InstructionReadRafOutputOpenings {
         lookup_table_flags: LookupTableKind::<XLEN>::iter()
-            .map(read_raf_lookup_table_flag_opening)
+            .map(lookup_table_flag)
             .collect(),
         instruction_ra: (0..dimensions.num_virtual_ra_polys())
-            .map(read_raf_instruction_ra_opening)
+            .map(instruction_ra)
             .collect(),
-        instruction_raf_flag: read_raf_instruction_raf_flag_opening(),
+        instruction_raf_flag: instruction_raf_flag(),
     }
 }
 
 pub fn read_raf_consistency_openings() -> [(JoltOpeningId, JoltOpeningId); 1] {
     [(lookup_output_reduced(), lookup_output_product())]
-}
-
-pub fn read_raf_lookup_table_flag_opening(table: LookupTableKind<XLEN>) -> JoltOpeningId {
-    lookup_table_flag(table)
-}
-
-pub fn read_raf_instruction_ra_opening(index: usize) -> JoltOpeningId {
-    instruction_ra(index)
-}
-
-pub fn read_raf_instruction_raf_flag_opening() -> JoltOpeningId {
-    instruction_raf_flag()
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -254,7 +248,7 @@ pub fn ra_virtualization_output_openings(
         .map(|virtual_index| {
             let start = virtual_index * dimensions.num_committed_per_virtual();
             (start..start + dimensions.num_committed_per_virtual())
-                .map(ra_virtualization_committed_instruction_ra_opening)
+                .map(committed_instruction_ra)
                 .collect()
         })
         .collect();
@@ -262,10 +256,6 @@ pub fn ra_virtualization_output_openings(
     InstructionRaVirtualizationOutputOpenings {
         committed_instruction_ra_by_virtual,
     }
-}
-
-pub fn ra_virtualization_committed_instruction_ra_opening(index: usize) -> JoltOpeningId {
-    committed_instruction_ra(index)
 }
 
 pub(crate) fn eq_table_value(table: LookupTableKind<XLEN>) -> InstructionReadRafPublic {
@@ -312,84 +302,28 @@ where
     product
 }
 
-pub(crate) fn left_instruction_input_product() -> JoltOpeningId {
-    JoltOpeningId::virtual_polynomial(
-        JoltVirtualPolynomial::LeftInstructionInput,
-        JoltRelationId::SpartanProductVirtualization,
-    )
-}
-
-pub(crate) fn right_instruction_input_product() -> JoltOpeningId {
-    JoltOpeningId::virtual_polynomial(
-        JoltVirtualPolynomial::RightInstructionInput,
-        JoltRelationId::SpartanProductVirtualization,
-    )
-}
-
-fn left_instruction_input_reduced() -> JoltOpeningId {
-    JoltOpeningId::virtual_polynomial(
-        JoltVirtualPolynomial::LeftInstructionInput,
-        JoltRelationId::InstructionClaimReduction,
-    )
-}
-
-fn right_instruction_input_reduced() -> JoltOpeningId {
-    JoltOpeningId::virtual_polynomial(
-        JoltVirtualPolynomial::RightInstructionInput,
-        JoltRelationId::InstructionClaimReduction,
-    )
-}
-
-fn lookup_output_product() -> JoltOpeningId {
-    JoltOpeningId::virtual_polynomial(
-        JoltVirtualPolynomial::LookupOutput,
-        JoltRelationId::SpartanProductVirtualization,
-    )
-}
-
-pub(crate) fn lookup_output_reduced() -> JoltOpeningId {
-    JoltOpeningId::virtual_polynomial(
-        JoltVirtualPolynomial::LookupOutput,
-        JoltRelationId::InstructionClaimReduction,
-    )
-}
-
-pub(crate) fn left_lookup_operand_reduced() -> JoltOpeningId {
-    JoltOpeningId::virtual_polynomial(
-        JoltVirtualPolynomial::LeftLookupOperand,
-        JoltRelationId::InstructionClaimReduction,
-    )
-}
-
-pub(crate) fn right_lookup_operand_reduced() -> JoltOpeningId {
-    JoltOpeningId::virtual_polynomial(
-        JoltVirtualPolynomial::RightLookupOperand,
-        JoltRelationId::InstructionClaimReduction,
-    )
-}
-
-pub(crate) fn instruction_ra(index: usize) -> JoltOpeningId {
+pub fn instruction_ra(index: usize) -> JoltOpeningId {
     JoltOpeningId::virtual_polynomial(
         JoltVirtualPolynomial::InstructionRa(index),
         JoltRelationId::InstructionReadRaf,
     )
 }
 
-fn committed_instruction_ra(index: usize) -> JoltOpeningId {
+pub fn committed_instruction_ra(index: usize) -> JoltOpeningId {
     JoltOpeningId::committed(
         JoltCommittedPolynomial::InstructionRa(index),
         JoltRelationId::InstructionRaVirtualization,
     )
 }
 
-pub(crate) fn lookup_table_flag(table: LookupTableKind<XLEN>) -> JoltOpeningId {
+pub fn lookup_table_flag(table: LookupTableKind<XLEN>) -> JoltOpeningId {
     JoltOpeningId::virtual_polynomial(
         JoltVirtualPolynomial::LookupTableFlag(table.index()),
         JoltRelationId::InstructionReadRaf,
     )
 }
 
-pub(crate) fn instruction_raf_flag() -> JoltOpeningId {
+pub fn instruction_raf_flag() -> JoltOpeningId {
     JoltOpeningId::virtual_polynomial(
         JoltVirtualPolynomial::InstructionRafFlag,
         JoltRelationId::InstructionReadRaf,

--- a/crates/jolt-claims/src/protocols/jolt/geometry/ram.rs
+++ b/crates/jolt-claims/src/protocols/jolt/geometry/ram.rs
@@ -160,10 +160,6 @@ impl<F: Field> RamRaClaimReductionPublicValues<F> {
     }
 }
 
-pub fn ra_virtualization_committed_ram_ra_opening(index: usize) -> JoltOpeningId {
-    committed_ram_ra(index)
-}
-
 pub(crate) fn committed_ram_ra_product<F>(dimensions: RamRaVirtualizationDimensions) -> JoltExpr<F>
 where
     F: RingCore,
@@ -246,7 +242,7 @@ pub fn ram_ra_claim_reduction() -> JoltOpeningId {
     )
 }
 
-pub(crate) fn committed_ram_ra(index: usize) -> JoltOpeningId {
+pub fn committed_ram_ra(index: usize) -> JoltOpeningId {
     JoltOpeningId::committed(
         JoltCommittedPolynomial::RamRa(index),
         JoltRelationId::RamRaVirtualization,

--- a/crates/jolt-claims/src/protocols/jolt/lattice/relations/inc_virtualization.rs
+++ b/crates/jolt-claims/src/protocols/jolt/lattice/relations/inc_virtualization.rs
@@ -122,9 +122,8 @@ pub fn fused_inc_store_opening() -> JoltOpeningId {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::protocols::jolt::geometry::claim_reductions::increments::{
-        ram_inc_read_write, ram_inc_val_check, rd_inc_read_write, rd_inc_val_evaluation,
-    };
+    use crate::protocols::jolt::geometry::ram::{ram_inc, ram_inc_val_check};
+    use crate::protocols::jolt::geometry::registers::{rd_inc_read_write, rd_inc_val_evaluation};
     use crate::protocols::jolt::{JoltChallengeId, JoltDerivedId};
     use jolt_field::{Fr, FromPrimitiveInt};
 
@@ -147,7 +146,7 @@ mod tests {
 
         let input = relation.input_expression::<Fr>().evaluate(
             |id| match *id {
-                id if id == ram_inc_read_write() => ram_rw,
+                id if id == ram_inc() => ram_rw,
                 id if id == ram_inc_val_check() => ram_val,
                 id if id == rd_inc_read_write() => rd_rw,
                 id if id == rd_inc_val_evaluation() => rd_val,

--- a/crates/jolt-claims/src/protocols/jolt/mod.rs
+++ b/crates/jolt-claims/src/protocols/jolt/mod.rs
@@ -14,8 +14,7 @@ pub use geometry::{
     claim_reductions::program_image::ProgramImageClaimReductionLayout,
     dimensions::{
         CommitmentMatrixShape, JoltFormulaDimensions, JoltOneHotConfig, JoltOneHotDimensions,
-        JoltReadWriteConfig, JoltSumcheckDomain, ReadWriteDimensions, TraceDimensions,
-        TracePolynomialOrder,
+        JoltReadWriteConfig, ReadWriteDimensions, TraceDimensions, TracePolynomialOrder,
     },
     error::{JoltFormulaDimensionsError, JoltFormulaPointError},
 };

--- a/crates/jolt-claims/src/protocols/jolt/relations/bytecode/read_raf.rs
+++ b/crates/jolt-claims/src/protocols/jolt/relations/bytecode/read_raf.rs
@@ -3,9 +3,10 @@
 use jolt_field::RingCore;
 
 use crate::protocols::jolt::geometry::bytecode::{
-    pc_spartan_outer, pc_spartan_shift, read_raf_cycle_output, stage1_claim, stage2_claim,
-    stage3_claim, stage4_claim, stage5_claim, BytecodeReadRafDimensions,
+    pc_spartan_outer, read_raf_cycle_output, stage1_claim, stage2_claim, stage3_claim,
+    stage4_claim, stage5_claim, BytecodeReadRafDimensions,
 };
+use crate::protocols::jolt::geometry::spartan::pc_shift;
 use crate::protocols::jolt::{
     BytecodeReadRafChallenge, JoltChallengeId, JoltDerivedId, JoltExpr, JoltOpeningId,
     JoltRelationId,
@@ -72,7 +73,7 @@ impl SymbolicSumcheck for ReadRaf {
             + gamma.clone().pow(3) * stage4_claim()
             + gamma.clone().pow(4) * stage5_claim::<F>()
             + gamma.clone().pow(5) * opening(pc_spartan_outer())
-            + gamma.pow(6) * opening(pc_spartan_shift())
+            + gamma.pow(6) * opening(pc_shift())
     }
 
     fn output_expression<F: RingCore>(&self) -> JoltExpr<F> {
@@ -84,11 +85,14 @@ impl SymbolicSumcheck for ReadRaf {
 mod tests {
     use super::*;
     use crate::protocols::jolt::geometry::bytecode::{
-        bytecode_ra, imm_instruction_input, imm_spartan_outer, instruction_flag_input,
-        instruction_flag_product, instruction_flag_shift, instruction_raf_flag, op_flag_product,
-        op_flag_shift, rd_wa_read_write, rd_wa_val_evaluation, rs1_ra_read_write,
-        rs2_ra_read_write, unexpanded_pc_spartan_outer, unexpanded_pc_spartan_shift,
+        bytecode_ra, imm_spartan_outer, instruction_flag_input, instruction_flag_product,
+        instruction_flag_shift, op_flag_product, op_flag_shift, unexpanded_pc_spartan_outer,
     };
+    use crate::protocols::jolt::geometry::instruction::{imm, instruction_raf_flag};
+    use crate::protocols::jolt::geometry::registers::{
+        rd_wa_read_write, rd_wa_val_evaluation, rs1_ra_read_write, rs2_ra_read_write,
+    };
+    use crate::protocols::jolt::geometry::spartan::unexpanded_pc_shift;
     use crate::protocols::jolt::{BytecodeReadRafPublic, JoltPolynomialId, JoltVirtualPolynomial};
     use jolt_field::{Fr, FromPrimitiveInt};
     use jolt_lookup_tables::{LookupTableKind, XLEN};
@@ -140,8 +144,8 @@ mod tests {
                     Fr::from_u64(37)
                 }
                 id if id == op_flag_product(CircuitFlags::VirtualInstruction) => Fr::from_u64(41),
-                id if id == imm_instruction_input() => Fr::from_u64(43),
-                id if id == unexpanded_pc_spartan_shift() => Fr::from_u64(47),
+                id if id == imm() => Fr::from_u64(43),
+                id if id == unexpanded_pc_shift() => Fr::from_u64(47),
                 id if id == instruction_flag_input(InstructionFlags::LeftOperandIsRs1Value) => {
                     Fr::from_u64(53)
                 }
@@ -163,7 +167,7 @@ mod tests {
                 id if id == rd_wa_val_evaluation() => Fr::from_u64(101),
                 id if id == instruction_raf_flag() => Fr::from_u64(103),
                 id if id == pc_spartan_outer() => Fr::from_u64(107),
-                id if id == pc_spartan_shift() => Fr::from_u64(109),
+                id if id == pc_shift() => Fr::from_u64(109),
                 JoltOpeningId::Polynomial {
                     polynomial: JoltPolynomialId::Virtual(JoltVirtualPolynomial::OpFlags(flag)),
                     relation: JoltRelationId::SpartanOuter,

--- a/crates/jolt-claims/src/protocols/jolt/relations/bytecode/read_raf_address_phase.rs
+++ b/crates/jolt-claims/src/protocols/jolt/relations/bytecode/read_raf_address_phase.rs
@@ -5,10 +5,11 @@ use jolt_riscv::{CircuitFlags, InstructionFlags};
 use serde::{Deserialize, Serialize};
 
 use crate::protocols::jolt::geometry::bytecode::{
-    bytecode_read_raf_address_phase_opening, pc_spartan_outer, pc_spartan_shift, stage1_claim,
-    stage2_claim, stage3_claim, stage4_claim, stage5_claim, BytecodeReadRafDimensions,
+    bytecode_read_raf_address_phase_opening, pc_spartan_outer, stage1_claim, stage2_claim,
+    stage3_claim, stage4_claim, stage5_claim, BytecodeReadRafDimensions,
     BYTECODE_STAGE_GAMMA_COUNTS,
 };
+use crate::protocols::jolt::geometry::spartan::pc_shift;
 use crate::protocols::jolt::{
     BytecodeReadRafChallenge, JoltChallengeId, JoltDerivedId, JoltExpr, JoltOpeningId,
     JoltRelationId,
@@ -200,7 +201,7 @@ impl SymbolicSumcheck for ReadRafAddressPhase {
             + gamma.clone().pow(3) * stage4_claim()
             + gamma.clone().pow(4) * stage5_claim::<F>()
             + gamma.clone().pow(5) * opening(pc_spartan_outer())
-            + gamma.pow(6) * opening(pc_spartan_shift())
+            + gamma.pow(6) * opening(pc_shift())
     }
 
     fn output_expression<F: RingCore>(&self) -> JoltExpr<F> {

--- a/crates/jolt-claims/src/protocols/jolt/relations/claim_reductions/hamming_weight.rs
+++ b/crates/jolt-claims/src/protocols/jolt/relations/claim_reductions/hamming_weight.rs
@@ -130,9 +130,9 @@ impl SymbolicSumcheck for ClaimReduction {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::protocols::jolt::geometry::claim_reductions::hamming_weight::ram_hamming_weight;
     use crate::protocols::jolt::geometry::dimensions::JoltFormulaDimensionsError;
     use crate::protocols::jolt::geometry::ra::{JoltRaPolynomial, JoltRaPolynomialLayout};
+    use crate::protocols::jolt::geometry::ram::ram_hamming_weight;
     use jolt_field::{Fr, FromPrimitiveInt};
 
     fn layout(

--- a/crates/jolt-claims/src/protocols/jolt/relations/claim_reductions/increments.rs
+++ b/crates/jolt-claims/src/protocols/jolt/relations/claim_reductions/increments.rs
@@ -100,9 +100,8 @@ impl SymbolicSumcheck for ClaimReduction {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::protocols::jolt::geometry::claim_reductions::increments::{
-        ram_inc_read_write, ram_inc_val_check, rd_inc_read_write, rd_inc_val_evaluation,
-    };
+    use crate::protocols::jolt::geometry::ram::{ram_inc, ram_inc_val_check};
+    use crate::protocols::jolt::geometry::registers::{rd_inc_read_write, rd_inc_val_evaluation};
     use jolt_field::{Fr, FromPrimitiveInt};
 
     fn dimensions() -> TraceDimensions {
@@ -128,7 +127,7 @@ mod tests {
 
         let input = relation.input_expression::<Fr>().evaluate(
             |id| match *id {
-                id if id == ram_inc_read_write() => ram_rw,
+                id if id == ram_inc() => ram_rw,
                 id if id == ram_inc_val_check() => ram_val,
                 id if id == rd_inc_read_write() => rd_rw,
                 id if id == rd_inc_val_evaluation() => rd_val,

--- a/crates/jolt-claims/src/protocols/jolt/relations/instruction/input_virtualization.rs
+++ b/crates/jolt-claims/src/protocols/jolt/relations/instruction/input_virtualization.rs
@@ -4,9 +4,11 @@ use jolt_riscv::InstructionFlags;
 use serde::{Deserialize, Serialize};
 
 use crate::protocols::jolt::geometry::instruction::{
-    imm, left_instruction_input_product, left_operand_is_pc, left_operand_is_rs1,
-    right_instruction_input_product, right_operand_is_imm, right_operand_is_rs2, rs1_value,
-    rs2_value, unexpanded_pc, INPUT_VIRTUALIZATION_DEGREE,
+    imm, left_operand_is_pc, left_operand_is_rs1, right_operand_is_imm, right_operand_is_rs2,
+    rs1_value, rs2_value, unexpanded_pc, INPUT_VIRTUALIZATION_DEGREE,
+};
+use crate::protocols::jolt::geometry::spartan::{
+    left_instruction_input_product, right_instruction_input_product,
 };
 use crate::protocols::jolt::{
     InstructionInputChallenge, InstructionInputPublic, JoltExpr, JoltRelationId, TraceDimensions,

--- a/crates/jolt-claims/src/protocols/jolt/relations/instruction/read_raf.rs
+++ b/crates/jolt-claims/src/protocols/jolt/relations/instruction/read_raf.rs
@@ -4,9 +4,11 @@ use jolt_field::RingCore;
 use jolt_lookup_tables::{LookupTableKind, XLEN};
 use serde::{Deserialize, Serialize};
 
+use crate::protocols::jolt::geometry::claim_reductions::instruction::{
+    left_lookup_operand_reduced, lookup_output_reduced, right_lookup_operand_reduced,
+};
 use crate::protocols::jolt::geometry::instruction::{
-    eq_table_value, instruction_ra_product, instruction_raf_flag, left_lookup_operand_reduced,
-    lookup_output_reduced, lookup_table_flag, right_lookup_operand_reduced,
+    eq_table_value, instruction_ra_product, instruction_raf_flag, lookup_table_flag,
     InstructionReadRafDimensions, READ_RAF_BASE_DEGREE,
 };
 use crate::protocols::jolt::{

--- a/crates/jolt-claims/src/protocols/jolt/relations/spartan/outer_uniskip.rs
+++ b/crates/jolt-claims/src/protocols/jolt/relations/spartan/outer_uniskip.rs
@@ -10,7 +10,7 @@ use crate::protocols::jolt::geometry::dimensions::{
 };
 use crate::protocols::jolt::geometry::spartan::{outer_uniskip_opening, SpartanOuterDimensions};
 use crate::protocols::jolt::{
-    JoltChallengeId, JoltDerivedId, JoltExpr, JoltOpeningId, JoltRelationId, JoltSumcheckDomain,
+    JoltChallengeId, JoltDerivedId, JoltExpr, JoltOpeningId, JoltRelationId,
 };
 use crate::{opening, InputClaims, OutputClaims, SumcheckDomain, SymbolicSumcheck};
 
@@ -76,7 +76,7 @@ impl SymbolicSumcheck for OuterUniskip {
     }
 
     fn domain(&self) -> SumcheckDomain {
-        JoltSumcheckDomain::centered_integer(OUTER_UNISKIP_DOMAIN_SIZE)
+        SumcheckDomain::centered_integer(OUTER_UNISKIP_DOMAIN_SIZE)
     }
 
     fn rounds(&self) -> usize {

--- a/crates/jolt-claims/src/protocols/jolt/relations/spartan/product_uniskip.rs
+++ b/crates/jolt-claims/src/protocols/jolt/relations/spartan/product_uniskip.rs
@@ -11,9 +11,9 @@ use crate::protocols::jolt::geometry::spartan::{
     product_uniskip_opening, product_uniskip_weight, SpartanProductDimensions,
 };
 use crate::protocols::jolt::{
-    JoltChallengeId, JoltDerivedId, JoltExpr, JoltOpeningId, JoltRelationId, JoltSumcheckDomain,
+    JoltChallengeId, JoltDerivedId, JoltExpr, JoltOpeningId, JoltRelationId,
 };
-use crate::{opening, InputClaims, OutputClaims, SymbolicSumcheck};
+use crate::{opening, InputClaims, OutputClaims, SumcheckDomain, SymbolicSumcheck};
 
 /// Consumed product uni-skip inputs: the three Spartan-outer openings the first
 /// round reduces (`product`, `should_branch`, `should_jump`), each reweighted by a
@@ -66,8 +66,8 @@ impl SymbolicSumcheck for ProductUniskip {
         JoltRelationId::SpartanProductVirtualization
     }
 
-    fn domain(&self) -> JoltSumcheckDomain {
-        JoltSumcheckDomain::centered_integer(PRODUCT_UNISKIP_DOMAIN_SIZE)
+    fn domain(&self) -> SumcheckDomain {
+        SumcheckDomain::centered_integer(PRODUCT_UNISKIP_DOMAIN_SIZE)
     }
 
     fn rounds(&self) -> usize {

--- a/crates/jolt-claims/tests/lattice_semantics.rs
+++ b/crates/jolt-claims/tests/lattice_semantics.rs
@@ -5,7 +5,7 @@
 //! relations — against real multilinear evaluations.
 
 use jolt_claims::protocols::jolt::geometry::claim_reductions::bytecode::{
-    committed_lane_vars, committed_lanes, BYTECODE_LANE_LAYOUT,
+    committed_lane_vars, BYTECODE_LANE_LAYOUT, COMMITTED_BYTECODE_LANE_CAPACITY,
 };
 use jolt_claims::protocols::jolt::geometry::dimensions::REGISTER_ADDRESS_BITS;
 use jolt_claims::protocols::jolt::geometry::ra::JoltRaPolynomialLayout;
@@ -283,7 +283,7 @@ fn bytecode_lane_decode_matches_committed_chunk() {
     let instruction_flag = |row: usize, flag: usize| (row + flag).is_multiple_of(4);
 
     // The committed chunk polynomial: value[(lane << log_rows) | row].
-    let mut chunk_data = vec![fr(0); committed_lanes() << log_rows];
+    let mut chunk_data = vec![fr(0); COMMITTED_BYTECODE_LANE_CAPACITY << log_rows];
     let mut lane = |lane: usize, row: usize, value: Fr| {
         chunk_data[(lane << log_rows) | row] = value;
     };

--- a/crates/jolt-prover-legacy/src/zkvm/clear_claims.rs
+++ b/crates/jolt-prover-legacy/src/zkvm/clear_claims.rs
@@ -252,27 +252,25 @@ fn stage5_claims_from_openings<F: Field>(
     claims: &OpeningClaimMap<F>,
 ) -> Result<Stage5OutputClaims<F>, VerifierError> {
     let lookup_table_flags = LookupTableKind::<RISCV_XLEN>::iter()
-        .map(|table| claims.require(instruction::read_raf_lookup_table_flag_opening(table)))
+        .map(|table| claims.require(instruction::lookup_table_flag(table)))
         .collect::<Result<Vec<_>, _>>()?;
     let mut instruction_ra = Vec::new();
     for index in 0.. {
-        let Some(opening_claim) = claims.get(instruction::read_raf_instruction_ra_opening(index))
-        else {
+        let Some(opening_claim) = claims.get(instruction::instruction_ra(index)) else {
             break;
         };
         instruction_ra.push(opening_claim);
     }
     if instruction_ra.is_empty() {
         return Err(VerifierError::MissingOpeningClaim {
-            id: instruction::read_raf_instruction_ra_opening(0),
+            id: instruction::instruction_ra(0),
         });
     }
     Ok(Stage5OutputClaims {
         instruction_read_raf: InstructionReadRafOutputClaims {
             lookup_table_flags,
             instruction_ra,
-            instruction_raf_flag: claims
-                .require(instruction::read_raf_instruction_raf_flag_opening())?,
+            instruction_raf_flag: claims.require(instruction::instruction_raf_flag())?,
         },
         ram_ra_claim_reduction: RamRaClaimReductionOutputClaims {
             ram_ra: claims.require(ram::ram_ra_claim_reduction())?,
@@ -375,7 +373,7 @@ fn stage6b_claims_from_openings<F: Field>(
 
     let mut ram_ra = Vec::new();
     for index in 0.. {
-        let id = ram::ra_virtualization_committed_ram_ra_opening(index);
+        let id = ram::committed_ram_ra(index);
         let Some(opening_claim) = claims.get(id) else {
             break;
         };
@@ -384,7 +382,7 @@ fn stage6b_claims_from_openings<F: Field>(
 
     let mut committed_instruction_ra = Vec::new();
     for index in 0.. {
-        let id = instruction::ra_virtualization_committed_instruction_ra_opening(index);
+        let id = instruction::committed_instruction_ra(index);
         let Some(opening_claim) = claims.get(id) else {
             break;
         };
@@ -392,7 +390,7 @@ fn stage6b_claims_from_openings<F: Field>(
     }
     if committed_instruction_ra.is_empty() {
         return Err(VerifierError::MissingOpeningClaim {
-            id: instruction::ra_virtualization_committed_instruction_ra_opening(0),
+            id: instruction::committed_instruction_ra(0),
         });
     }
 

--- a/crates/jolt-verifier/src/stages/zk/blindfold/mod.rs
+++ b/crates/jolt-verifier/src/stages/zk/blindfold/mod.rs
@@ -56,6 +56,7 @@
 //! a committed output-claim row or in the final hiding evaluation commitment.
 use jolt_blindfold::{BlindFoldProtocol, BlindFoldProtocolBuilder, OpeningAlias};
 use jolt_claims::protocols::jolt::relations;
+use jolt_claims::SumcheckDomain;
 use jolt_claims::{
     derived, opening,
     protocols::jolt::{
@@ -88,7 +89,7 @@ use jolt_claims::{
         InstructionRaVirtualizationChallenge, InstructionRaVirtualizationPublic,
         InstructionReadRafChallenge, InstructionReadRafPublic, JoltAdviceKind, JoltChallengeId,
         JoltCommittedPolynomial, JoltDerivedId, JoltExpr, JoltOpeningId, JoltPolynomialId,
-        JoltRelationId, JoltSumcheckDomain, JoltVirtualPolynomial, PrecommittedReductionLayout,
+        JoltRelationId, JoltVirtualPolynomial, PrecommittedReductionLayout,
         ProgramImageClaimReductionLayout, ProgramImageClaimReductionPublic,
         RamHammingBooleanityPublic, RamOutputCheckPublic, RamRaClaimReductionChallenge,
         RamRaClaimReductionPublic, RamRaVirtualizationPublic, RamRafEvaluationPublic,
@@ -207,7 +208,7 @@ where
 fn add_batched_stage<F, C>(
     builder: Builder<F, C>,
     name: &'static str,
-    batch_domain: JoltSumcheckDomain,
+    batch_domain: SumcheckDomain,
     claims: &[(usize, VerifierExpr<F>, VerifierExpr<F>)],
     consistency: &BatchedCommittedSumcheckConsistency<F, C>,
     output_claims: &CommittedOutputClaimOutput<C>,
@@ -376,10 +377,10 @@ fn require_expr_sources<F: Field>(
     Ok(())
 }
 
-fn domain_spec(domain: JoltSumcheckDomain) -> SumcheckDomainSpec {
+fn domain_spec(domain: SumcheckDomain) -> SumcheckDomainSpec {
     match domain {
-        JoltSumcheckDomain::BooleanHypercube => SumcheckDomainSpec::BooleanHypercube,
-        JoltSumcheckDomain::CenteredInteger { domain_size } => {
+        SumcheckDomain::BooleanHypercube => SumcheckDomainSpec::BooleanHypercube,
+        SumcheckDomain::CenteredInteger { domain_size } => {
             SumcheckDomainSpec::CenteredInteger { domain_size }
         }
     }

--- a/crates/jolt-verifier/src/stages/zk/blindfold/stage1.rs
+++ b/crates/jolt-verifier/src/stages/zk/blindfold/stage1.rs
@@ -14,7 +14,7 @@ where
     let dimensions = SpartanOuterDimensions::rv64(log_t);
     let uniskip_rounds = 1;
     let uniskip_degree = SPARTAN_OUTER_UNISKIP_FIRST_ROUND_DEGREE;
-    let uniskip_domain = JoltSumcheckDomain::centered_integer(SPARTAN_OUTER_UNISKIP_DOMAIN_SIZE);
+    let uniskip_domain = SumcheckDomain::centered_integer(SPARTAN_OUTER_UNISKIP_DOMAIN_SIZE);
     builder = add_stage(
         builder,
         "stage1.outer_uniskip",
@@ -48,7 +48,7 @@ where
     }
 
     let remainder_rounds = 1 + log_t;
-    let remainder_domain = JoltSumcheckDomain::BooleanHypercube;
+    let remainder_domain = SumcheckDomain::BooleanHypercube;
     let [remainder_batching_coefficient] = input
         .stage1
         .remainder_consistency

--- a/crates/jolt-verifier/src/stages/zk/blindfold/stage2.rs
+++ b/crates/jolt-verifier/src/stages/zk/blindfold/stage2.rs
@@ -30,7 +30,7 @@ where
     let product_uniskip_rounds = 1;
     let product_uniskip_degree = SPARTAN_PRODUCT_UNISKIP_FIRST_ROUND_DEGREE;
     let product_uniskip_domain =
-        JoltSumcheckDomain::centered_integer(SPARTAN_PRODUCT_UNISKIP_DOMAIN_SIZE);
+        SumcheckDomain::centered_integer(SPARTAN_PRODUCT_UNISKIP_DOMAIN_SIZE);
     let product_weights = centered_lagrange_evals(
         SPARTAN_PRODUCT_UNISKIP_DOMAIN_SIZE,
         input.stage2.product_tau_high,

--- a/crates/jolt-verifier/tests/soundness/tampering/openings.rs
+++ b/crates/jolt-verifier/tests/soundness/tampering/openings.rs
@@ -12,7 +12,10 @@ use crate::support::proof_claims::offset_opening_claim;
 use crate::support::{tamper_manifest, verifier_fixtures};
 #[cfg(all(feature = "prover-fixtures", not(feature = "zk")))]
 use jolt_claims::protocols::jolt::{
-    geometry::{committed_openings::final_opening_ids, dimensions::JoltFormulaDimensions},
+    geometry::{
+        committed_openings::{final_opening_id, final_opening_polynomial_order},
+        dimensions::JoltFormulaDimensions,
+    },
     JoltOpeningId,
 };
 #[cfg(all(feature = "prover-fixtures", not(feature = "zk")))]
@@ -53,7 +56,7 @@ fn stage8_final_opening_ids(base: &verifier_fixtures::VerifierFixtureCase) -> Ve
         base.proof.ram_K,
     ))
     .expect("verifier fixture has invalid final opening dimensions");
-    final_opening_ids(
+    final_opening_polynomial_order(
         dimensions.ra_layout,
         base.trusted_advice_commitment.is_some(),
         base.proof.untrusted_advice_commitment.is_some(),
@@ -62,6 +65,9 @@ fn stage8_final_opening_ids(base: &verifier_fixtures::VerifierFixtureCase) -> Ve
             .committed()
             .map(|committed| committed.bytecode_chunk_count()),
     )
+    .into_iter()
+    .map(final_opening_id)
+    .collect()
 }
 
 #[test]

--- a/crates/jolt-verifier/tests/soundness/tampering/sumcheck.rs
+++ b/crates/jolt-verifier/tests/soundness/tampering/sumcheck.rs
@@ -899,11 +899,11 @@ fn stage5_formula_output_openings(
     openings.extend(LookupTableKind::<RISCV_XLEN>::iter().map(|table| {
         (
             "stage5.claims.instruction_read_raf.lookup_table_flags",
-            instruction::read_raf_lookup_table_flag_opening(table),
+            instruction::lookup_table_flag(table),
         )
     }));
     for index in 0.. {
-        let id = instruction::read_raf_instruction_ra_opening(index);
+        let id = instruction::instruction_ra(index);
         if opening_claim(&base.proof, id).is_none() {
             break;
         }
@@ -911,7 +911,7 @@ fn stage5_formula_output_openings(
     }
     openings.push((
         "stage5.claims.instruction_read_raf.instruction_raf_flag",
-        instruction::read_raf_instruction_raf_flag_opening(),
+        instruction::instruction_raf_flag(),
     ));
     openings.extend(
         [ram::ram_ra_claim_reduction()]

--- a/crates/jolt-verifier/tests/support/proof_claims.rs
+++ b/crates/jolt-verifier/tests/support/proof_claims.rs
@@ -343,7 +343,7 @@ fn claim_mut_from_stage5_outputs<F: Field>(
     id: native::JoltOpeningId,
 ) -> Option<&mut F> {
     for table in LookupTableKind::<RISCV_XLEN>::iter() {
-        if id == instruction::read_raf_lookup_table_flag_opening(table) {
+        if id == instruction::lookup_table_flag(table) {
             return claims
                 .instruction_read_raf
                 .lookup_table_flags
@@ -356,7 +356,7 @@ fn claim_mut_from_stage5_outputs<F: Field>(
         .iter_mut()
         .enumerate()
     {
-        if id == instruction::read_raf_instruction_ra_opening(index) {
+        if id == instruction::instruction_ra(index) {
             return Some(opening_claim);
         }
     }
@@ -367,7 +367,7 @@ fn claim_mut_from_stage5_outputs<F: Field>(
         registers::rd_wa_val_evaluation(),
     ];
     match id {
-        id if id == instruction::read_raf_instruction_raf_flag_opening() => {
+        id if id == instruction::instruction_raf_flag() => {
             Some(&mut claims.instruction_read_raf.instruction_raf_flag)
         }
         id if id == ram_ra => Some(&mut claims.ram_ra_claim_reduction.ram_ra),
@@ -427,7 +427,7 @@ fn claim_mut_from_stage6_outputs<'a, F: Field>(
         return Some(&mut stage6b.ram_hamming_booleanity.ram_hamming_weight);
     }
     for (index, opening_claim) in stage6b.ram_ra_virtualization.ram_ra.iter_mut().enumerate() {
-        if id == ram::ra_virtualization_committed_ram_ra_opening(index) {
+        if id == ram::committed_ram_ra(index) {
             return Some(opening_claim);
         }
     }
@@ -437,7 +437,7 @@ fn claim_mut_from_stage6_outputs<'a, F: Field>(
         .iter_mut()
         .enumerate()
     {
-        if id == instruction::ra_virtualization_committed_instruction_ra_opening(index) {
+        if id == instruction::committed_instruction_ra(index) {
             return Some(opening_claim);
         }
     }


### PR DESCRIPTION
Phase 1 of the jolt-claims `geometry/` cleanup ([plan context]: dedup + deletions only, no directory restructure — that's phase 2, held for akita-stack coordination).

## What

Every `JoltOpeningId` now has exactly one constructor. **28 duplicate/alias constructor fns deleted** (net −174 lines across 27 files):

- **18 same-name duplicate definitions** deleted; the surviving definition lives in the module matching the id's relation area (e.g. `rd_wa_read_write` keeps its `geometry/registers.rs` home, the `geometry/bytecode.rs` copy is gone).
- **5 renamed duplicates** collapsed onto their canonical pub twins: `imm_instruction_input`→`imm`, `unexpanded_pc_instruction_input`→`unexpanded_pc`, `pc_spartan_shift`→`pc_shift`, `unexpanded_pc_spartan_shift`→`unexpanded_pc_shift`, `ram_inc_read_write`→`ram_inc`.
- **5 pure delegation wrappers** (`read_raf_*_opening`, `ra_virtualization_committed_*_opening`) deleted; their inner canonical constructors are now `pub` and prover-legacy/verifier-test callers call them directly.
- `JoltSumcheckDomain` re-export alias collapsed (bare `SumcheckDomain` everywhere); jolt-claims' `committed_lanes()` const-wrapper deleted (prover-legacy's distinct same-name fn untouched).
- `final_opening_ids` (test-only) inlined into its single consumer (verifier tampering test); the final-opening **order-pinning test stays in jolt-claims** via `final_opening_polynomial_order`.
- Internal-only helpers demoted out of the pub API: `read_raf_row_values`, `read_raf_register_eq_evals` (+ struct), `final_opening_relation`, `padded_program_image_len_words`.

## Why

`geometry/` accumulated ~130 five-line opening-id constructors with heavy duplication — the same `(polynomial, relation)` id constructed in two files, sometimes under two names. Duplicate definitions are how prover/verifier claim-id drift starts; after this PR each id has a single owner.

## No behavioral change

Every surviving constructor builds the byte-identical `(polynomial, relation)` id as the deleted duplicate it replaces (independently audited per deleted fn). Verification:

- clippy `-D warnings`: `host`, `host,zk`, `allocative,host`, `allocative,host,zk`, `--no-default-features`, `-p jolt-verifier --features prover-fixtures[,zk]`
- nextest: modular crates (418 passed), field-inline (247 passed)
- `muldiv` e2e: **both** `host` and `host,zk` modes

Based on `main` (rebased from `refactor/sumcheck-batch-macro`; the changed lines are byte-identical and all gates were re-run on the main base).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
