### PR TITLE
fix(inlines): reject zero-hash ECDSA inputs

### DIFF
--- a/jolt-inlines/p256/src/sdk.rs
+++ b/jolt-inlines/p256/src/sdk.rs
@@ -148,11 +148,12 @@ fn bytes_to_limbs(bytes: &[u8; 32]) -> [u64; 4] {
 /// Error types for P-256 operations.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 pub enum P256Error {
-    InvalidFqElement,        // input array does not correspond to a valid Fq element
-    InvalidFrElement,        // input array does not correspond to a valid Fr element
-    NotOnCurve,              // point is not on the P-256 curve
-    QAtInfinity,             // public key is point at infinity
-    ROrSZero,                // one of the signature components is zero
+    InvalidFqElement, // input array does not correspond to a valid Fq element
+    InvalidFrElement, // input array does not correspond to a valid Fr element
+    NotOnCurve,       // point is not on the P-256 curve
+    QAtInfinity,      // public key is point at infinity
+    ROrSZero,         // one of the signature components is zero
+    ZeroMessageHash,
     RxMismatch,              // computed R.x does not match r
     InvalidGlvSignWord(u64), // GLV sign word is not 0 or 1
 }
@@ -830,9 +831,11 @@ pub fn ecdsa_verify(z: P256Fr, r: P256Fr, s: P256Fr, q: P256Point) -> Result<(),
     if q.is_infinity() {
         return Err(P256Error::QAtInfinity);
     }
-    // Check that r, s, and z are non-zero
-    if r.is_zero() || s.is_zero() || z.is_zero() {
+    if r.is_zero() || s.is_zero() {
         return Err(P256Error::ROrSZero);
+    }
+    if z.is_zero() {
+        return Err(P256Error::ZeroMessageHash);
     }
 
     // Step 1: Compute u1 = z/s, u2 = r/s

--- a/jolt-inlines/p256/src/tests.rs
+++ b/jolt-inlines/p256/src/tests.rs
@@ -1115,7 +1115,7 @@ mod p256_tests {
         let r = P256Fr::from_u64_arr(&[1, 0, 0, 0]).unwrap();
         let s = P256Fr::from_u64_arr(&[1, 0, 0, 0]).unwrap();
         let result = ecdsa_verify(zero, r, s, g);
-        assert!(matches!(result, Err(P256Error::ROrSZero)));
+        assert!(matches!(result, Err(P256Error::ZeroMessageHash)));
     }
 
     /// Verify that a cross-cancellation attack with correlated forged advice is

--- a/jolt-inlines/secp256k1/src/sdk.rs
+++ b/jolt-inlines/secp256k1/src/sdk.rs
@@ -52,7 +52,8 @@ pub enum Secp256k1Error {
     NotOnCurve,       // point is not on the secp256k1 curve
     QAtInfinity,      // public key is point at infinity
     ROrSZero,         // one of the signature components is zero
-    RxMismatch,       // computed R.x does not match r
+    ZeroMessageHash,
+    RxMismatch, // computed R.x does not match r
     InvalidGlvSignWord(u64),
 }
 
@@ -892,9 +893,11 @@ pub fn ecdsa_verify(
     if q.is_infinity() {
         return Err(Secp256k1Error::QAtInfinity);
     }
-    // Check that r and s are non-zero
     if r.is_zero() || s.is_zero() {
         return Err(Secp256k1Error::ROrSZero);
+    }
+    if z.is_zero() {
+        return Err(Secp256k1Error::ZeroMessageHash);
     }
     // step 2: compute u1 = z / s (mod r) and u2 = r / s (mod r)
     let u1 = z.div_assume_nonzero(&s);

--- a/jolt-inlines/secp256k1/src/tests.rs
+++ b/jolt-inlines/secp256k1/src/tests.rs
@@ -495,6 +495,20 @@ mod sequence_tests {
         assert!(matches!(result, Err(Secp256k1Error::NotOnCurve)));
     }
 
+    #[test]
+    fn test_ecdsa_verify_rejects_zero_hash_forgery() {
+        use crate::sdk::{ecdsa_verify, Secp256k1Error};
+
+        let q = Secp256k1Point::generator();
+        let z = Secp256k1Fr::from_u64_arr(&[0; 4]).unwrap();
+        let r = Secp256k1Fr::from_u64_arr(&q.x().e()).unwrap();
+        let s = r.clone();
+
+        // With z=0 and r=s=x(Q), the verification equation collapses to R=Q.
+        let result = ecdsa_verify(z, r, s, q);
+        assert!(matches!(result, Err(Secp256k1Error::ZeroMessageHash)));
+    }
+
     /// Verify assumptions about Fq and Fr modulus limb structure used in
     /// `is_fq_non_canonical` and `is_fr_non_canonical`.
     #[test]


### PR DESCRIPTION
## Summary

Reject zero message hashes in secp256k1 ECDSA verification. Without this guard, a prover can choose `z = 0` and construct `r = s = x(Q)`, collapsing verification to `R = Q` without knowing the private key.

## Changes

- Reject `z = 0` in `jolt_inlines::secp256k1::ecdsa_verify`.
- Add `ZeroMessageHash` to both secp256k1 and P-256 error enums.
- Keep `ROrSZero` specific to zero signature components.
- Add a secp256k1 regression test encoding the forgery construction.
- Update the existing P-256 zero-hash regression to assert the precise error.

## Testing

- [x] Ran tests for modified crates
  - `cargo nextest run -p jolt-inlines-secp256k1 --cargo-quiet --features host`
  - `cargo nextest run -p jolt-inlines-p256 --cargo-quiet --features host`
- [x] `cargo clippy` and `cargo fmt` pass
  - Host and guest clippy for both modified crates
  - Workspace pre-commit clippy and formatting checks

## Security Considerations

This closes a signature-verification bypass when `z` is prover supplied. The check executes inside the guest verification path, so a malicious witness cannot bypass it. P-256 already rejected zero message hashes; its behavior is unchanged apart from the more precise error variant. No proof-format changes.

## Breaking Changes

Adds `ZeroMessageHash` to the public secp256k1 and P-256 error enums. Exhaustive matches must handle the new variant.