### PR TITLE
perf(akita): size setup from Jolt schedules

### DIFF
--- a/crates/jolt-akita/Cargo.toml
+++ b/crates/jolt-akita/Cargo.toml
@@ -9,12 +9,12 @@ description = "Akita batch opening adapter for the Jolt zkVM"
 workspace = true
 
 [dependencies]
-akita-config = { workspace = true, features = ["schedules-default"] }
-akita-pcs = { workspace = true, features = ["parallel", "schedules-default"] }
-akita-prover = { workspace = true, features = [
-  "parallel",
-  "schedules-default",
+akita-config = { workspace = true, features = [
+  "schedules-fp128-d64-full",
+  "schedules-fp128-d64-onehot",
 ] }
+akita-pcs = { workspace = true, features = ["parallel"] }
+akita-prover = { workspace = true, features = ["parallel"] }
 akita-challenges.workspace = true
 akita-planner.workspace = true
 akita-transcript.workspace = true

--- a/crates/jolt-akita/src/adapters.rs
+++ b/crates/jolt-akita/src/adapters.rs
@@ -11,7 +11,7 @@ use akita_types::{
 };
 use jolt_field::CanonicalBytes;
 use jolt_openings::{OpeningsError, VerifierOpeningClaim};
-use jolt_poly::{MultilinearPoly, OneHotIndexOrder, Polynomial};
+use jolt_poly::{MultilinearPoly, OneHotIndexOrder, OneHotPolynomial, Polynomial};
 use jolt_transcript::{AppendToTranscript, Label, LabelWithCount, Transcript, U64Word};
 use serde::{Deserialize, Serialize};
 use tracing::info_span;
@@ -72,7 +72,7 @@ impl AkitaSetupParams {
     }
 
     /// Setup parameters for a commitment object that only ever commits and
-    /// opens through the one-hot flavor (the packed `W_jolt` group): skips
+    /// opens through the one-hot flavor (the packed `OneHotTrace` group): skips
     /// building the full-flavor backend setup of the same shape.
     pub fn one_hot_only(
         max_num_vars: usize,
@@ -551,6 +551,19 @@ where
     AkitaBackendOneHotPoly::new(one_hot_k, AKITA_D, indices.to_vec())
         .map(Some)
         .map_err(akita_error)
+}
+
+pub(crate) fn owned_one_hot_polynomial(
+    polynomial: OneHotPolynomial,
+    one_hot_k: usize,
+) -> Result<AkitaBackendOneHotPoly, OpeningsError> {
+    if polynomial.k() != one_hot_k || polynomial.index_order() != OneHotIndexOrder::RowMajor {
+        return Err(invalid_batch(format!(
+            "Akita owned one-hot polynomial requires row-major K={one_hot_k}"
+        )));
+    }
+    let _ = validate_one_hot_k(one_hot_k)?;
+    AkitaBackendOneHotPoly::new(one_hot_k, AKITA_D, polynomial.into_indices()).map_err(akita_error)
 }
 
 pub(crate) fn validate_one_hot_k(one_hot_k: usize) -> Result<usize, OpeningsError> {

--- a/crates/jolt-akita/src/bin/gen_jolt_schedules.rs
+++ b/crates/jolt-akita/src/bin/gen_jolt_schedules.rs
@@ -1,6 +1,6 @@
 //! Offline generator for the Jolt-owned Akita schedule catalogs.
 //!
-//! Runs akita's planner DP over every `W_jolt` shape reachable from Jolt and
+//! Runs akita's planner DP over every `OneHotTrace` shape reachable from Jolt and
 //! emits the checked-in table modules under `src/schedules/` through the same
 //! `akita_planner::emit` machinery that produces akita's shipped tables.
 //!

--- a/crates/jolt-akita/src/configs.rs
+++ b/crates/jolt-akita/src/configs.rs
@@ -3,7 +3,7 @@
 //! Each config delegates every policy decision (field, ring, decomposition,
 //! SIS profile, chunking) to its upstream proof-optimized preset and
 //! overrides the schedule catalog and setup sizing hooks,
-//! so the generated schedule tables for Jolt's `W_jolt` shapes live in this
+//! so the generated schedule tables for Jolt's `OneHotTrace` shapes live in this
 //! crate (see [`crate::schedules`]) while the planner policy keeps one
 //! upstream owner. The catalog is identity-validated against the config's
 //! policy on every lookup, so a policy/table drift hard-errors instead of
@@ -79,7 +79,7 @@ fn include_scalar_root(
     include_matrix(max_setup_len, params.d_key.row_len(), d_width, "root D")
 }
 
-/// Sizes a production Wjolt setup directly from the checked-in Jolt catalog.
+/// Sizes a production OneHotTrace setup directly from the checked-in Jolt catalog.
 ///
 /// `Some` means the requested maximum shape itself is catalog-backed. Smaller
 /// catalog rows are included because setup matrices are shared prefix views
@@ -237,7 +237,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn production_wjolt_shapes_use_catalog_setup_sizing() {
+    fn production_one_hot_trace_shapes_use_catalog_setup_sizing() {
         let k16 = crate::schedules::jolt_fp128_d64_onehot_k16_table().unwrap();
         assert!(catalog_setup_envelope::<JoltD64OneHotK16>(k16, 28, 81)
             .unwrap()

--- a/crates/jolt-akita/src/configs.rs
+++ b/crates/jolt-akita/src/configs.rs
@@ -2,19 +2,137 @@
 //!
 //! Each config delegates every policy decision (field, ring, decomposition,
 //! SIS profile, chunking) to its upstream proof-optimized preset and
-//! overrides exactly one hook: [`akita_config::CommitmentConfig::schedule_catalog`],
+//! overrides the schedule catalog and setup sizing hooks,
 //! so the generated schedule tables for Jolt's `W_jolt` shapes live in this
 //! crate (see [`crate::schedules`]) while the planner policy keeps one
 //! upstream owner. The catalog is identity-validated against the config's
 //! policy on every lookup, so a policy/table drift hard-errors instead of
 //! silently planning a different schedule.
 
-use akita_config::CommitmentConfig;
+use akita_config::{setup_level_params_from_schedule, CommitmentConfig};
+use akita_pcs::AkitaError;
+use akita_planner::GeneratedScheduleTable;
+use akita_types::{AkitaScheduleLookupKey, LevelParams, SetupMatrixEnvelope, Step};
 
-/// Delegates a [`CommitmentConfig`] to an upstream preset, overriding only
-/// the schedule catalog. `get_params_for_prove` re-derives the single-group
-/// lookup key through the public layout API; multi-group layouts (never
-/// produced by Jolt's shapes) fall back to the base preset's DP planning.
+fn include_matrix(
+    max_setup_len: &mut usize,
+    rows: usize,
+    columns: usize,
+    role: &str,
+) -> Result<(), AkitaError> {
+    let len = rows
+        .checked_mul(columns)
+        .ok_or_else(|| AkitaError::InvalidSetup(format!("{role} setup envelope overflow")))?;
+    *max_setup_len = (*max_setup_len).max(len);
+    Ok(())
+}
+
+fn include_level(params: &LevelParams, max_setup_len: &mut usize) -> Result<(), AkitaError> {
+    if !params.precommitted_groups.is_empty() || params.setup_prefix.is_some() {
+        return Err(AkitaError::InvalidSetup(
+            "Jolt's scalar schedule catalog contains multi-group setup metadata".to_string(),
+        ));
+    }
+    include_matrix(
+        max_setup_len,
+        params.a_key.row_len(),
+        params.inner_width(),
+        "A",
+    )?;
+    include_matrix(
+        max_setup_len,
+        params.b_key.row_len(),
+        params.outer_width(),
+        "B",
+    )?;
+    include_matrix(
+        max_setup_len,
+        params.d_key.row_len(),
+        params.d_matrix_width(),
+        "D",
+    )
+}
+
+fn include_scalar_root(
+    params: &LevelParams,
+    num_polynomials: usize,
+    max_setup_len: &mut usize,
+) -> Result<(), AkitaError> {
+    let d_width = num_polynomials
+        .checked_mul(params.num_blocks)
+        .and_then(|width| width.checked_mul(params.num_digits_open))
+        .ok_or_else(|| AkitaError::InvalidSetup("root D setup width overflow".to_string()))?;
+    let b_width = params
+        .a_key
+        .row_len()
+        .checked_mul(params.num_digits_open)
+        .and_then(|width| width.checked_mul(params.num_blocks))
+        .and_then(|width| width.checked_mul(num_polynomials))
+        .ok_or_else(|| AkitaError::InvalidSetup("root B setup width overflow".to_string()))?;
+    include_matrix(
+        max_setup_len,
+        params.a_key.row_len(),
+        params.inner_width(),
+        "root A",
+    )?;
+    include_matrix(max_setup_len, params.b_key.row_len(), b_width, "root B")?;
+    include_matrix(max_setup_len, params.d_key.row_len(), d_width, "root D")
+}
+
+/// Sizes a production Wjolt setup directly from the checked-in Jolt catalog.
+///
+/// `Some` means the requested maximum shape itself is catalog-backed. Smaller
+/// catalog rows are included because setup matrices are shared prefix views
+/// and planned footprints are not monotone in either layout dimension.
+fn catalog_setup_envelope<Cfg: CommitmentConfig>(
+    table: GeneratedScheduleTable,
+    max_num_vars: usize,
+    max_num_batched_polys: usize,
+) -> Result<Option<SetupMatrixEnvelope>, AkitaError> {
+    let requested_shape_is_catalogued = table.entries.iter().any(|entry| {
+        entry.precommitteds.is_empty()
+            && entry.final_group.num_vars() == max_num_vars
+            && entry.final_group.num_polynomials() == max_num_batched_polys
+    });
+    if !requested_shape_is_catalogued {
+        return Ok(None);
+    }
+
+    let mut envelope = SetupMatrixEnvelope { max_setup_len: 1 };
+    for entry in table.entries.iter().filter(|entry| {
+        entry.precommitteds.is_empty()
+            && entry.final_group.num_vars() <= max_num_vars
+            && entry.final_group.num_polynomials() <= max_num_batched_polys
+    }) {
+        let schedule = Cfg::runtime_schedule(AkitaScheduleLookupKey::single(entry.final_group))?;
+        for params in setup_level_params_from_schedule(&schedule) {
+            include_level(&params, &mut envelope.max_setup_len)?;
+        }
+        let root_params = match schedule.steps.first() {
+            Some(Step::Fold(step)) => Some(&step.params),
+            Some(Step::Direct(step)) => step.params.as_ref(),
+            None => {
+                return Err(AkitaError::InvalidSetup(
+                    "Jolt catalog schedule has no steps".to_string(),
+                ));
+            }
+        };
+        if let Some(params) = root_params {
+            include_scalar_root(
+                params,
+                entry.final_group.num_polynomials(),
+                &mut envelope.max_setup_len,
+            )?;
+        }
+    }
+    Ok(Some(envelope))
+}
+
+/// Delegates a [`CommitmentConfig`] to an upstream preset, overriding its
+/// schedule catalog and catalog-backed setup sizing. `get_params_for_prove`
+/// re-derives the single-group lookup key through the public layout API;
+/// multi-group layouts (never produced by Jolt's shapes) fall back to the base
+/// preset's DP planning.
 macro_rules! delegate_preset {
     ($(#[$doc:meta])* $name:ident, $base:ty, $catalog:expr) => {
         $(#[$doc])*
@@ -51,6 +169,20 @@ macro_rules! delegate_preset {
                 max_num_vars: usize,
                 max_num_batched_polys: usize,
             ) -> Result<akita_types::SetupMatrixEnvelope, akita_pcs::AkitaError> {
+                if max_num_batched_polys == 0 {
+                    return Err(akita_pcs::AkitaError::InvalidSetup(
+                        "max_num_batched_polys must be at least 1".to_string(),
+                    ));
+                }
+                if let Some(table) = $catalog {
+                    if let Some(envelope) = catalog_setup_envelope::<Self>(
+                        table,
+                        max_num_vars,
+                        max_num_batched_polys,
+                    )? {
+                        return Ok(envelope);
+                    }
+                }
                 <$base>::max_setup_matrix_size(max_num_vars, max_num_batched_polys)
             }
 
@@ -95,3 +227,25 @@ delegate_preset!(
     akita_config::proof_optimized::fp128::D64OneHot,
     crate::schedules::jolt_fp128_d64_onehot_k256_table()
 );
+
+#[cfg(test)]
+#[expect(
+    clippy::unwrap_used,
+    reason = "catalog setup tests should fail loudly on malformed schedules"
+)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn production_wjolt_shapes_use_catalog_setup_sizing() {
+        let k16 = crate::schedules::jolt_fp128_d64_onehot_k16_table().unwrap();
+        assert!(catalog_setup_envelope::<JoltD64OneHotK16>(k16, 28, 81)
+            .unwrap()
+            .is_some());
+
+        let k256 = crate::schedules::jolt_fp128_d64_onehot_k256_table().unwrap();
+        assert!(catalog_setup_envelope::<JoltD64OneHotK256>(k256, 38, 41)
+            .unwrap()
+            .is_some());
+    }
+}

--- a/crates/jolt-akita/src/schedules/mod.rs
+++ b/crates/jolt-akita/src/schedules/mod.rs
@@ -2,10 +2,10 @@
 //!
 //! Tables are emitted offline by the `gen_jolt_schedules` binary (this
 //! crate) through `akita_planner::emit` — the same emitter and DP that
-//! produce akita's own shipped tables — over the `W_jolt` shapes reachable
-//! from Jolt: every member width the RA layout, unsigned-inc chunking, and
-//! MSB can produce, across the trace sizes of each K regime. Checked-in
-//! tables are source; regenerate with:
+//! produce akita's own shipped tables — over the `OneHotTrace` shapes reachable
+//! from Jolt: every native group width produced by the RA layout and
+//! unsigned-increment chunking across each K regime. Checked-in tables are
+//! source; regenerate with:
 //!
 //! ```text
 //! cargo run --release -p jolt-akita --bin gen_jolt_schedules -- crates/jolt-akita/src/schedules
@@ -38,7 +38,7 @@ mod jolt_fp128_d64_onehot_k16;
 )]
 mod jolt_fp128_d64_onehot_k256;
 
-/// The K=16 `W_jolt` catalog.
+/// The K=16 `OneHotTrace` catalog.
 pub fn jolt_fp128_d64_onehot_k16_table() -> Option<GeneratedScheduleTable> {
     Some(GeneratedScheduleTable {
         entries: jolt_fp128_d64_onehot_k16::JOLT_FP128_D64_ONEHOT_K16_SCHEDULES,
@@ -46,7 +46,7 @@ pub fn jolt_fp128_d64_onehot_k16_table() -> Option<GeneratedScheduleTable> {
     })
 }
 
-/// The K=256 large-trace `W_jolt` catalog.
+/// The K=256 large-trace `OneHotTrace` catalog.
 pub fn jolt_fp128_d64_onehot_k256_table() -> Option<GeneratedScheduleTable> {
     Some(GeneratedScheduleTable {
         entries: jolt_fp128_d64_onehot_k256::JOLT_FP128_D64_ONEHOT_K256_SCHEDULES,
@@ -56,7 +56,7 @@ pub fn jolt_fp128_d64_onehot_k256_table() -> Option<GeneratedScheduleTable> {
 
 /// Emit-spec construction shared by the `gen_jolt_schedules` binary and the
 /// drift test: one family per config, scalar single-group keys over the
-/// reachable `W_jolt` grid.
+/// reachable `OneHotTrace` grid.
 pub mod emit {
     use akita_config::{policy_of, CommitmentConfig};
     use akita_pcs::AkitaError;
@@ -67,24 +67,24 @@ pub mod emit {
 
     use crate::configs::{JoltD64OneHotK16, JoltD64OneHotK256};
 
-    /// `W_jolt` member widths at K=16 (`log_k_chunk = 4`): 49 fixed members
-    /// (32 instruction-address chunks, 16 fused-increment chunks, the
-    /// increment MSB) plus up to 16 bytecode and 16 RAM chunks; width 1
-    /// covers singleton one-hot opens.
+    /// `OneHotTrace` widths at K=16: 49 fixed columns (32 instruction-address
+    /// chunks, 16 unsigned-increment chunks, and the increment MSB), plus up
+    /// to 16 bytecode and 16 RAM chunks. Width one covers singleton one-hot
+    /// objects.
     pub const K16_NUM_POLYS: &[usize] = &[
         1, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70,
         71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81,
     ];
-    /// Member arity is `4 + log_T`; `log_T < 25` in the K=16 regime.
+    /// Column arity is `4 + log_T`; `log_T < 25` in the K=16 regime.
     pub const K16_NUM_VARS: (usize, usize) = (1, 28);
 
-    /// `W_jolt` member widths at K=256 (`log_k_chunk = 8`): 25 fixed members
-    /// (16 instruction chunks, 8 fused-increment chunks, the MSB) plus up to
-    /// 8 bytecode and 8 RAM chunks.
+    /// `OneHotTrace` widths at K=256: 25 fixed columns (16 instruction
+    /// chunks, eight unsigned-increment chunks, and the MSB), plus up to eight
+    /// bytecode and eight RAM chunks.
     pub const K256_NUM_POLYS: &[usize] = &[
         1, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41,
     ];
-    /// Member arity is `8 + log_T`; the K=256 regime starts at `log_T = 25`.
+    /// Column arity is `8 + log_T`; the K=256 regime starts at `log_T = 25`.
     pub const K256_NUM_VARS: (usize, usize) = (33, 38);
 
     fn regen<Cfg: CommitmentConfig>(key: PolynomialGroupLayout) -> Result<Schedule, AkitaError> {

--- a/crates/jolt-akita/src/scheme.rs
+++ b/crates/jolt-akita/src/scheme.rs
@@ -11,12 +11,12 @@ use serde::{Deserialize, Serialize};
 
 use crate::adapters::{
     akita_error, akita_ordered_evaluations, backend_stack, commit_failed, dense_polynomials,
-    domain_size, invalid_batch, one_hot_polynomial, serialize_akita, sparse_unit_polynomial,
-    transparent_zk_error, validate_one_hot_k, AkitaBackendCommitment, AkitaBackendDensePoly,
-    AkitaBackendHint, AkitaBackendScheme, AkitaBatchProof, AkitaCommitment, AkitaField,
-    AkitaHidingCommitment, AkitaHintPolynomials, AkitaLayoutDigest, AkitaOneHotK16BackendScheme,
-    AkitaOneHotK256BackendScheme, AkitaProverHint, AkitaProverSetup, AkitaSetupParams,
-    AkitaVerifierSetup, AKITA_D, AKITA_ONE_HOT_K16, AKITA_ONE_HOT_K256,
+    domain_size, invalid_batch, one_hot_polynomial, owned_one_hot_polynomial, serialize_akita,
+    sparse_unit_polynomial, transparent_zk_error, validate_one_hot_k, AkitaBackendCommitment,
+    AkitaBackendDensePoly, AkitaBackendHint, AkitaBackendScheme, AkitaBatchProof, AkitaCommitment,
+    AkitaField, AkitaHidingCommitment, AkitaHintPolynomials, AkitaLayoutDigest,
+    AkitaOneHotK16BackendScheme, AkitaOneHotK256BackendScheme, AkitaProverHint, AkitaProverSetup,
+    AkitaSetupParams, AkitaVerifierSetup, AKITA_D, AKITA_ONE_HOT_K16, AKITA_ONE_HOT_K256,
 };
 use crate::native_batching::{AkitaNativeBatchPolynomials, AkitaNativeBatching};
 
@@ -109,6 +109,91 @@ impl AkitaScheme {
         )
     }
 
+    /// Commits owned one-hot columns without cloning their hot-index buffers
+    /// at the Jolt/Akita boundary. The opening hint retains the backend
+    /// representations needed by the prover.
+    pub fn commit_one_hot_group_owned(
+        setup: &AkitaProverSetup,
+        layout_digest: [u8; 32],
+        polynomials: Vec<OneHotPolynomial>,
+    ) -> Result<(AkitaCommitment, AkitaProverHint), OpeningsError> {
+        let first = polynomials
+            .first()
+            .ok_or_else(|| invalid_batch("Akita commitment group must contain a polynomial"))?;
+        let num_vars = first.num_vars();
+        Self::validate_commit_shape(setup, num_vars, polynomials.len())?;
+        let backend_polynomials = polynomials
+            .into_iter()
+            .map(|polynomial| {
+                if polynomial.num_vars() != num_vars {
+                    return Err(invalid_batch(format!(
+                        "Akita commitment group mixes {}-variable and {num_vars}-variable polynomials",
+                        polynomial.num_vars()
+                    )));
+                }
+                owned_one_hot_polynomial(polynomial, setup.one_hot_k())
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        let (backend_prover_setup, prepared_backend_setup) = setup.one_hot_backend()?;
+        let stack = backend_stack(backend_prover_setup, prepared_backend_setup)?;
+        let (backend_commitment, backend_hint) = match setup.one_hot_k() {
+            AKITA_ONE_HOT_K16 => AkitaOneHotK16BackendScheme::commit(
+                backend_prover_setup,
+                &backend_polynomials,
+                &stack,
+            ),
+            AKITA_ONE_HOT_K256 => AkitaOneHotK256BackendScheme::commit(
+                backend_prover_setup,
+                &backend_polynomials,
+                &stack,
+            ),
+            _ => unreachable!("one-hot K is validated during setup"),
+        }
+        .map_err(commit_failed)?;
+        Self::package_commitment(
+            layout_digest,
+            num_vars,
+            backend_commitment,
+            backend_hint,
+            AkitaHintPolynomials::OneHot(backend_polynomials.into()),
+        )
+    }
+
+    /// Opens committed one-hot columns directly from their hint. The hint
+    /// owns the witnesses after [`Self::commit_one_hot_group_owned`], so no
+    /// second Jolt-side allocation is required.
+    pub fn open_one_hot_group_from_hint(
+        point: &[AkitaField],
+        evaluations: &[AkitaField],
+        setup: &AkitaProverSetup,
+        hint: AkitaProverHint,
+        transcript: &mut impl Transcript<Challenge = AkitaField>,
+    ) -> Result<AkitaBatchProof, OpeningsError> {
+        let statement = evaluations
+            .iter()
+            .map(|evaluation| VerifierOpeningClaim {
+                commitment: hint.commitment.clone(),
+                evaluation: EvaluationClaim::new(point.to_vec(), *evaluation),
+            })
+            .collect();
+        let shapes = (0..evaluations.len())
+            .map(|_| CommittedOneHotShape {
+                num_vars: point.len(),
+            })
+            .collect::<Vec<_>>();
+        let polynomials: AkitaNativeBatchPolynomials<'_> = shapes
+            .iter()
+            .map(|shape| shape as &dyn MultilinearPoly<AkitaField>)
+            .collect();
+        <AkitaNativeBatching as BatchOpeningScheme>::prove_batch(
+            setup,
+            statement,
+            polynomials,
+            hint,
+            transcript,
+        )
+    }
+
     /// Validates the commitment shape before handing values to Akita.
     fn validate_commit_shape(
         setup: &AkitaProverSetup,
@@ -184,6 +269,28 @@ impl AkitaScheme {
             backend_hint,
             AkitaHintPolynomials::Dense(dense.into()),
         )
+    }
+}
+
+struct CommittedOneHotShape {
+    num_vars: usize,
+}
+
+impl MultilinearPoly<AkitaField> for CommittedOneHotShape {
+    fn num_vars(&self) -> usize {
+        self.num_vars
+    }
+
+    fn evaluate(&self, _point: &[AkitaField]) -> AkitaField {
+        unreachable!("hint-owned one-hot witness is evaluated by the Akita backend")
+    }
+
+    fn for_each_row(&self, _sigma: usize, _f: &mut dyn FnMut(usize, &[AkitaField])) {
+        unreachable!("hint-owned one-hot witness is streamed by the Akita backend")
+    }
+
+    fn is_one_hot(&self) -> bool {
+        true
     }
 }
 
@@ -717,7 +824,7 @@ mod tests {
     }
 }
 
-/// Timed comparison of the two W_jolt commitment formats at production shape:
+/// Timed comparison of the two OneHotTrace commitment formats at production shape:
 /// one sparse-unit union polynomial (`slots` slots × `2^(8+log_t)` cells)
 /// versus one batched one-hot group (`slots` polynomials of `8+log_t`
 /// variables each) — commit + batched open + verify for both.

--- a/crates/jolt-akita/tests/packing.rs
+++ b/crates/jolt-akita/tests/packing.rs
@@ -347,7 +347,7 @@ fn akita_prefix_packed_batch_rejects_wrong_witness_dimension() {
 
 /// Two Akita commitment objects of different widths discharged through one
 /// joint reduction sumcheck — the shape of Jolt's packed final opening
-/// (`W_jolt` plus a smaller advice/program object).
+/// (`OneHotTrace` plus a smaller advice/program object).
 #[test]
 fn akita_joint_packed_openings_roundtrip_across_two_objects() {
     let wide_polynomials = packed_polynomials();

--- a/crates/jolt-akita/tests/schedules.rs
+++ b/crates/jolt-akita/tests/schedules.rs
@@ -12,10 +12,10 @@ use jolt_akita::schedules::{jolt_fp128_d64_onehot_k16_table, jolt_fp128_d64_oneh
 
 /// Every key of a family grid resolves from its checked-in table (binary
 /// lookup over sorted entries) — no planner-DP fallback for reachable
-/// `W_jolt` shapes. Identity validity is exercised by every akita e2e (an
+/// `OneHotTrace` shapes. Identity validity is exercised by every akita e2e (an
 /// identity mismatch hard-errors instead of falling back).
 #[test]
-fn catalogs_cover_every_reachable_wjolt_shape() {
+fn catalogs_cover_every_reachable_one_hot_trace_shape() {
     for (table, num_polys, num_vars) in [
         (
             jolt_fp128_d64_onehot_k16_table().expect("K16 catalog is checked in"),

--- a/crates/jolt-claims/src/protocols/jolt/lattice/mod.rs
+++ b/crates/jolt-claims/src/protocols/jolt/lattice/mod.rs
@@ -2,7 +2,7 @@
 //! Jolt PIOP over a packed one-hot witness committed with a
 //! non-homomorphic PCS. Design: `specs/lattice-claims.md`.
 //!
-//! This module names facts only — the canonical native Wjolt member set,
+//! This module names facts only — the canonical native OneHotTrace column set,
 //! auxiliary `jolt-openings::PrefixPacking` registrations, extra relations,
 //! and final-opening map. Witness materialization, transcripts, and stage
 //! orchestration live in the verifier/prover crates.
@@ -24,7 +24,7 @@
 //!   bits are always the logical point's suffix.
 //! - **final claim** — claims flow through the relation DAG until, per
 //!   polynomial, one claim remains that no relation consumes. In base mode
-//!   the stage-8 RLC batch settles it; in lattice mode Wjolt members are opened
+//!   the stage-8 RLC batch settles it; in lattice mode OneHotTrace columns are opened
 //!   natively at one point while auxiliary columns use one packed-slot claim.
 
 pub mod geometry;
@@ -36,6 +36,9 @@ pub use geometry::{
 };
 pub mod strategy;
 pub use packing::{
-    advice_bytes_packing, precommitted_packing, wjolt_members, PrecommittedPackingShape, WJoltShape,
+    advice_bytes_packing, one_hot_trace_columns, precommitted_packing, OneHotTraceShape,
+    PrecommittedPackingShape,
 };
-pub use strategy::{WJoltLayout, WJoltLayoutPlan, WJoltSetupShape, W_JOLT_LAYOUT};
+pub use strategy::{
+    OneHotTraceLayout, OneHotTraceLayoutPlan, OneHotTraceSetupShape, ONE_HOT_TRACE_LAYOUT,
+};

--- a/crates/jolt-claims/src/protocols/jolt/lattice/packing.rs
+++ b/crates/jolt-claims/src/protocols/jolt/lattice/packing.rs
@@ -1,9 +1,8 @@
-//! Canonical auxiliary-object packings and the native Wjolt member registry.
+//! Canonical auxiliary-object packings and the native `OneHotTrace` column registry.
 //!
 //! `jolt-openings::PrefixPacking` is the single source of truth for slot
-//! assignment within auxiliary advice and committed-program objects. Wjolt is
-//! not prefix-packed: [`wjolt_members`] returns the exact ordered members of
-//! its native same-point one-hot commitment group.
+//! assignment within auxiliary advice and committed-program objects. `OneHotTrace`
+//! is not prefix-packed: [`one_hot_trace_columns`] returns its exact ordered columns.
 
 use jolt_lookup_tables::{LookupTableKind, XLEN};
 use jolt_openings::PrefixPacking;
@@ -17,13 +16,13 @@ use super::geometry::{
     byte_num_vars, word_byte_num_vars, LatticeGeometryError, UnsignedIncChunking,
 };
 
-/// Shape of the per-proof native commitment group (`W_jolt`): the canonical
-/// committed Jolt data — `Ra` families, unsigned-inc chunks, and MSB — as
-/// uniform one-hot members opened together at one point.
+/// Shape of the per-proof `OneHotTrace`: the canonical committed Jolt data —
+/// `Ra` families, unsigned-inc chunks, and MSB — as semantic columns of one
+/// packed one-hot polynomial.
 /// Advice byte columns are their own commitment objects
 /// ([`advice_bytes_packing`]).
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub struct WJoltShape {
+pub struct OneHotTraceShape {
     pub ra_layout: JoltRaPolynomialLayout,
     pub log_t: usize,
     /// Shared one-hot chunk size: the address bits of each `Ra` family and
@@ -32,7 +31,7 @@ pub struct WJoltShape {
     pub log_k_chunk: usize,
 }
 
-/// Shape of the preprocessing-time packed commitment (`W_prog`,
+/// Shape of the preprocessing-time packed commitment (`ProgramOneHot`,
 /// committed-program mode): the per-lane bytecode decompositions and program
 /// image bytes. All public or verifier-trusted, so their one-hot structure
 /// is checked offline rather than by in-protocol relations.
@@ -46,9 +45,9 @@ pub struct PrecommittedPackingShape {
     pub program_image_log_words: Option<usize>,
 }
 
-/// Returns the canonical ordered native one-hot members of Wjolt.
-pub fn wjolt_members(
-    shape: &WJoltShape,
+/// Returns the canonical ordered one-hot columns of `OneHotTrace`.
+pub fn one_hot_trace_columns(
+    shape: &OneHotTraceShape,
 ) -> Result<Vec<JoltCommittedPolynomial>, LatticeGeometryError> {
     let chunking = UnsignedIncChunking::new(shape.log_k_chunk)?;
     let mut polynomials = shape.ra_layout.committed_polynomials().collect::<Vec<_>>();
@@ -135,8 +134,8 @@ fn precommitted_polynomials(
 mod tests {
     use super::*;
 
-    fn wjolt_shape() -> WJoltShape {
-        WJoltShape {
+    fn one_hot_trace_shape() -> OneHotTraceShape {
+        OneHotTraceShape {
             ra_layout: JoltRaPolynomialLayout::new(2, 1, 1).unwrap(),
             log_t: 5,
             log_k_chunk: 8,
@@ -153,15 +152,15 @@ mod tests {
     }
 
     #[test]
-    fn wjolt_members_cover_every_committed_lattice_polynomial() {
-        let members = wjolt_members(&wjolt_shape()).unwrap();
+    fn one_hot_trace_columns_cover_every_committed_lattice_polynomial() {
+        let columns = one_hot_trace_columns(&one_hot_trace_shape()).unwrap();
 
         // 4 Ra polynomials + 8 inc chunks + msb.
-        assert_eq!(members.len(), 4 + 8 + 1);
-        assert_eq!(members[0], JoltCommittedPolynomial::InstructionRa(0));
-        assert!(members.contains(&JoltCommittedPolynomial::UnsignedIncChunk(7)));
+        assert_eq!(columns.len(), 4 + 8 + 1);
+        assert_eq!(columns[0], JoltCommittedPolynomial::InstructionRa(0));
+        assert!(columns.contains(&JoltCommittedPolynomial::UnsignedIncChunk(7)));
         assert_eq!(
-            members.last(),
+            columns.last(),
             Some(&JoltCommittedPolynomial::UnsignedIncMsb)
         );
     }
@@ -180,13 +179,13 @@ mod tests {
     }
 
     #[test]
-    fn wjolt_members_reject_invalid_chunk_widths() {
-        let shape = WJoltShape {
+    fn one_hot_trace_columns_reject_invalid_chunk_widths() {
+        let shape = OneHotTraceShape {
             log_k_chunk: 7,
-            ..wjolt_shape()
+            ..one_hot_trace_shape()
         };
         assert_eq!(
-            wjolt_members(&shape),
+            one_hot_trace_columns(&shape),
             Err(LatticeGeometryError::ChunkWidthMisaligned { chunk_width: 7 })
         );
     }

--- a/crates/jolt-claims/src/protocols/jolt/lattice/relations/hamming_weight.rs
+++ b/crates/jolt-claims/src/protocols/jolt/lattice/relations/hamming_weight.rs
@@ -62,7 +62,7 @@ pub struct LatticeHammingWeightClaimReductionInputClaims<C> {
     #[opening(committed = RamRa, from = RamRaVirtualization)]
     pub ram_virtualization: Vec<C>,
     #[opening(committed = UnsignedIncChunk, from = Booleanity)]
-    pub unsigned_inc_booleanity: Vec<C>,
+    pub unsigned_inc_chunk_booleanity: Vec<C>,
     #[opening(committed = UnsignedIncMsb, from = Booleanity)]
     pub unsigned_inc_msb_booleanity: C,
     #[opening(FusedInc, from = FusedIncClaimReduction)]

--- a/crates/jolt-claims/src/protocols/jolt/lattice/strategy.rs
+++ b/crates/jolt-claims/src/protocols/jolt/lattice/strategy.rs
@@ -1,74 +1,77 @@
-//! The canonical native-Akita `W_jolt` commitment layout. Every committed
-//! member is a strict `K x T` one-hot polynomial, in the order returned by
-//! [`wjolt_members`](super::packing::wjolt_members), and all members open at
-//! one common `(cycle || address)` point.
+//! The canonical native-Akita `OneHotTrace` commitment layout. Every semantic
+//! column returned by
+//! [`one_hot_trace_columns`](super::packing::one_hot_trace_columns) is a
+//! strict `K x T` one-hot polynomial, and the columns open together at one
+//! common `(cycle || address)` point.
 
 use blake2::{digest::consts::U32, Blake2b, Digest};
 use jolt_field::Field;
 use jolt_openings::OpeningsError;
 
 use super::super::JoltCommittedPolynomial;
-use super::packing::{wjolt_members, WJoltShape};
+use super::packing::{one_hot_trace_columns, OneHotTraceShape};
 
-/// Wjolt is always committed as one native Akita group of strict one-hot
-/// members.
-pub const W_JOLT_LAYOUT: WJoltLayout = WJoltLayout;
+/// `OneHotTrace` is committed as one native Akita group of one-hot columns.
+pub const ONE_HOT_TRACE_LAYOUT: OneHotTraceLayout = OneHotTraceLayout;
 
-/// The one protocol layout for the per-proof `W_jolt` commitment.
+/// The one protocol layout for the per-proof `OneHotTrace` commitment.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub struct WJoltLayout;
+pub struct OneHotTraceLayout;
 
-/// The canonical member order and uniform arity for one proof shape.
-pub struct WJoltLayoutPlan {
-    pub members: Vec<JoltCommittedPolynomial>,
-    pub member_arity: usize,
+/// The canonical column order and uniform arity for one proof.
+pub struct OneHotTraceLayoutPlan {
+    pub columns: Vec<JoltCommittedPolynomial>,
+    pub column_arity: usize,
 }
 
 /// The commitment-object setup shape the layout requires.
-pub struct WJoltSetupShape {
+pub struct OneHotTraceSetupShape {
     pub num_vars: usize,
     pub num_polys: usize,
 }
 
-impl WJoltLayout {
+impl OneHotTraceLayout {
     /// The canonical object layout for `shape`.
-    pub fn plan(&self, shape: &WJoltShape) -> Result<WJoltLayoutPlan, OpeningsError> {
-        let members =
-            wjolt_members(shape).map_err(|error| OpeningsError::InvalidBatch(error.to_string()))?;
-        Ok(WJoltLayoutPlan {
-            members,
-            member_arity: shape.log_k_chunk + shape.log_t,
+    pub fn plan(&self, shape: &OneHotTraceShape) -> Result<OneHotTraceLayoutPlan, OpeningsError> {
+        let columns = one_hot_trace_columns(shape)
+            .map_err(|error| OpeningsError::InvalidBatch(error.to_string()))?;
+        Ok(OneHotTraceLayoutPlan {
+            columns,
+            column_arity: shape.log_k_chunk + shape.log_t,
         })
     }
 
     /// The commitment-object setup shape.
-    pub fn setup_shape(&self, shape: &WJoltShape) -> Result<WJoltSetupShape, OpeningsError> {
+    pub fn setup_shape(
+        &self,
+        shape: &OneHotTraceShape,
+    ) -> Result<OneHotTraceSetupShape, OpeningsError> {
         let plan = self.plan(shape)?;
-        Ok(WJoltSetupShape {
-            num_vars: plan.member_arity,
-            num_polys: plan.members.len(),
+        Ok(OneHotTraceSetupShape {
+            num_vars: plan.column_arity,
+            num_polys: plan.columns.len(),
         })
     }
 
     /// A protocol-owned digest of the exact native batch layout. This binds
-    /// the commitment and verifier setup to the ordered member identities,
+    /// the commitment and verifier setup to the ordered column identities,
     /// dimensions, and layout version; it is never supplied by the proof.
-    pub fn layout_digest(&self, shape: &WJoltShape) -> Result<[u8; 32], OpeningsError> {
-        let WJoltLayoutPlan {
-            members,
-            member_arity,
+    pub fn layout_digest(&self, shape: &OneHotTraceShape) -> Result<[u8; 32], OpeningsError> {
+        let OneHotTraceLayoutPlan {
+            columns,
+            column_arity,
         } = self.plan(shape)?;
         let mut hasher = Blake2b::<U32>::new();
-        hasher.update(b"jolt/akita/w_jolt/native-one-hot/v1");
-        append_usize(&mut hasher, member_arity);
-        append_usize(&mut hasher, members.len());
+        hasher.update(b"jolt/akita/one_hot_trace/native-one-hot-columns/v2");
+        append_usize(&mut hasher, column_arity);
+        append_usize(&mut hasher, columns.len());
         append_usize(&mut hasher, shape.log_t);
         append_usize(&mut hasher, shape.log_k_chunk);
         append_usize(&mut hasher, shape.ra_layout.instruction());
         append_usize(&mut hasher, shape.ra_layout.bytecode());
         append_usize(&mut hasher, shape.ra_layout.ram());
-        for member in members {
-            match member {
+        for column in columns {
+            match column {
                 JoltCommittedPolynomial::InstructionRa(index) => {
                     hasher.update([0]);
                     append_usize(&mut hasher, index);
@@ -88,7 +91,7 @@ impl WJoltLayout {
                 JoltCommittedPolynomial::UnsignedIncMsb => hasher.update([4]),
                 other => {
                     return Err(OpeningsError::InvalidBatch(format!(
-                        "non-Wjolt polynomial {other:?} in native one-hot layout"
+                        "non-OneHotTrace polynomial {other:?} in native one-hot layout"
                     )));
                 }
             }
@@ -96,43 +99,39 @@ impl WJoltLayout {
         Ok(hasher.finalize().into())
     }
 
-    /// Maps a column's leaf-claim point (its `(address || cycle)` cell order,
-    /// high-to-low) onto the committed variable order.
-    ///
-    /// Members are row-major (`cycle || address`), while relation leaves use
-    /// (`address || cycle`), so this moves the address block behind the cycle
-    /// block. The MSB is treated identically: it is a full `K x T` one-hot
-    /// member whose hot address is either zero or one.
-    pub fn member_point<F: Field>(
+    /// Maps a column's leaf-claim point from `(address || cycle)` to the
+    /// row-major committed order `(cycle || address)`.
+    pub fn column_point<F: Field>(
         &self,
         polynomial: JoltCommittedPolynomial,
         chunk_width: usize,
         leaf_point: &[F],
     ) -> Result<Vec<F>, OpeningsError> {
         let invalid = |message: String| OpeningsError::InvalidBatch(message);
-        match polynomial {
+        if !matches!(
+            polynomial,
             JoltCommittedPolynomial::InstructionRa(_)
-            | JoltCommittedPolynomial::BytecodeRa(_)
-            | JoltCommittedPolynomial::RamRa(_)
-            | JoltCommittedPolynomial::UnsignedIncChunk(_)
-            | JoltCommittedPolynomial::UnsignedIncMsb => {
-                if leaf_point.len() < chunk_width {
-                    return Err(invalid(format!(
-                        "{polynomial:?} leaf point has {} variables, below its \
-                         {chunk_width}-variable address block",
-                        leaf_point.len()
-                    )));
-                }
-                let (address, cycle) = leaf_point.split_at(chunk_width);
-                let mut point = Vec::with_capacity(leaf_point.len());
-                point.extend_from_slice(cycle);
-                point.extend_from_slice(address);
-                Ok(point)
-            }
-            other => Err(invalid(format!(
-                "polynomial {other:?} is not a per-proof packed column"
-            ))),
+                | JoltCommittedPolynomial::BytecodeRa(_)
+                | JoltCommittedPolynomial::RamRa(_)
+                | JoltCommittedPolynomial::UnsignedIncChunk(_)
+                | JoltCommittedPolynomial::UnsignedIncMsb
+        ) {
+            return Err(invalid(format!(
+                "polynomial {polynomial:?} is not a OneHotTrace column"
+            )));
         }
+        if leaf_point.len() < chunk_width {
+            return Err(invalid(format!(
+                "OneHotTrace leaf point has {} variables, below its \
+                 {chunk_width}-variable address block",
+                leaf_point.len()
+            )));
+        }
+        let (address, cycle) = leaf_point.split_at(chunk_width);
+        let mut point = Vec::with_capacity(leaf_point.len());
+        point.extend_from_slice(cycle);
+        point.extend_from_slice(address);
+        Ok(point)
     }
 }
 
@@ -147,8 +146,8 @@ mod tests {
     use crate::protocols::jolt::geometry::ra::JoltRaPolynomialLayout;
     use jolt_field::{Fr, FromPrimitiveInt};
 
-    fn shape(log_t: usize) -> WJoltShape {
-        WJoltShape {
+    fn shape(log_t: usize) -> OneHotTraceShape {
+        OneHotTraceShape {
             ra_layout: JoltRaPolynomialLayout::new(2, 1, 1).unwrap(),
             log_t,
             log_k_chunk: 8,
@@ -157,23 +156,26 @@ mod tests {
 
     #[test]
     fn native_layout_is_uniform_and_digest_bound() {
-        let WJoltLayoutPlan {
-            members,
-            member_arity,
-        } = W_JOLT_LAYOUT.plan(&shape(5)).unwrap();
-        assert_eq!(member_arity, 13);
+        let OneHotTraceLayoutPlan {
+            columns,
+            column_arity,
+        } = ONE_HOT_TRACE_LAYOUT.plan(&shape(5)).unwrap();
+        assert_eq!(column_arity, 13);
         assert_eq!(
-            members.last(),
+            columns.last(),
             Some(&JoltCommittedPolynomial::UnsignedIncMsb)
         );
 
-        let digest = W_JOLT_LAYOUT.layout_digest(&shape(5)).unwrap();
+        let digest = ONE_HOT_TRACE_LAYOUT.layout_digest(&shape(5)).unwrap();
         assert_ne!(digest, [0; 32]);
-        assert_ne!(digest, W_JOLT_LAYOUT.layout_digest(&shape(6)).unwrap());
+        assert_ne!(
+            digest,
+            ONE_HOT_TRACE_LAYOUT.layout_digest(&shape(6)).unwrap()
+        );
     }
 
     #[test]
-    fn every_member_uses_the_same_point_permutation() {
+    fn every_column_uses_the_same_point_permutation() {
         let leaf = (0..5).map(Fr::from_u64).collect::<Vec<_>>();
         let expected = [2, 3, 4, 0, 1]
             .into_iter()
@@ -187,7 +189,9 @@ mod tests {
             JoltCommittedPolynomial::UnsignedIncMsb,
         ] {
             assert_eq!(
-                W_JOLT_LAYOUT.member_point(polynomial, 2, &leaf).unwrap(),
+                ONE_HOT_TRACE_LAYOUT
+                    .column_point(polynomial, 2, &leaf)
+                    .unwrap(),
                 expected
             );
         }

--- a/crates/jolt-claims/tests/lattice_semantics.rs
+++ b/crates/jolt-claims/tests/lattice_semantics.rs
@@ -1,5 +1,5 @@
 //! Semantic integration tests for the lattice module: build concrete one-hot
-//! witness data and check the identities the relations claim — native Wjolt
+//! witness data and check the identities the relations claim — native OneHotTrace
 //! member shape, fused-inc chunk reconstruction, and auxiliary
 //! advice/bytecode/program-image decodes — against real multilinear evaluations.
 
@@ -9,7 +9,9 @@ use jolt_claims::protocols::jolt::geometry::claim_reductions::bytecode::{
 use jolt_claims::protocols::jolt::geometry::dimensions::REGISTER_ADDRESS_BITS;
 use jolt_claims::protocols::jolt::geometry::ra::JoltRaPolynomialLayout;
 use jolt_claims::protocols::jolt::lattice::geometry::{byte_decode_weight, selector_block_weight};
-use jolt_claims::protocols::jolt::lattice::{wjolt_members, UnsignedIncChunking, WJoltShape};
+use jolt_claims::protocols::jolt::lattice::{
+    one_hot_trace_columns, OneHotTraceShape, UnsignedIncChunking,
+};
 use jolt_claims::protocols::jolt::{BytecodeRegisterLane, JoltCommittedPolynomial};
 use jolt_field::{Fr, FromPrimitiveInt, RingCore};
 use jolt_lookup_tables::{LookupTableKind, XLEN};
@@ -76,19 +78,19 @@ fn byte_decode_sum(partials: &[Fr], place_bits: usize) -> Fr {
     sum
 }
 
-/// Every Wjolt member is a full `K x T` one-hot polynomial in the canonical
+/// Every OneHotTrace column is a full `K x T` one-hot polynomial in the canonical
 /// native-batch order, including the MSB member at address zero or one.
 #[test]
 #[expect(clippy::unwrap_used)]
-fn wjolt_members_are_uniform_native_one_hot_polynomials() {
+fn one_hot_trace_columns_are_uniform_native_one_hot_polynomials() {
     let log_t = 3;
     let log_k_chunk = 4;
-    let shape = WJoltShape {
+    let shape = OneHotTraceShape {
         ra_layout: JoltRaPolynomialLayout::new(1, 1, 1).unwrap(),
         log_t,
         log_k_chunk,
     };
-    let members = wjolt_members(&shape).unwrap();
+    let members = one_hot_trace_columns(&shape).unwrap();
 
     // Size accounting: 3 Ra + 16 chunk polynomials + the MSB polynomial,
     // all represented as 4-address-bit one-hot matrices over 3 cycle bits.

--- a/crates/jolt-poly/src/one_hot.rs
+++ b/crates/jolt-poly/src/one_hot.rs
@@ -87,6 +87,12 @@ impl OneHotPolynomial {
         &self.indices
     }
 
+    /// Consumes the polynomial and returns its row-wise hot indices.
+    #[inline]
+    pub fn into_indices(self) -> Vec<Option<u8>> {
+        self.indices
+    }
+
     #[inline]
     pub fn num_rows(&self) -> usize {
         self.indices.len()

--- a/crates/jolt-prover-legacy/src/subprotocols/booleanity.rs
+++ b/crates/jolt-prover-legacy/src/subprotocols/booleanity.rs
@@ -643,7 +643,7 @@ pub fn lattice_booleanity_params<F: JoltField>(
 /// Per-cycle lattice increment one-hot columns consumed by Booleanity and the
 /// Stage 7 hamming-weight reduction.
 #[cfg(all(feature = "prover", feature = "akita"))]
-pub struct LatticeIncColumns {
+pub struct FusedIncColumns {
     /// `hot_lanes[i][j]` is chunk `i`'s hot address at cycle `j`.
     pub hot_lanes: Vec<Vec<u8>>,
     /// The MSB column's hot address (zero or one) at each cycle.

--- a/crates/jolt-prover-legacy/src/zkvm/claim_reductions/advice_bytes.rs
+++ b/crates/jolt-prover-legacy/src/zkvm/claim_reductions/advice_bytes.rs
@@ -12,7 +12,7 @@
 //! The reference point `r_ref` is drawn fresh over the cell domain before
 //! the instance gamma; the word kernel binds the completed advice claim's
 //! own point. The column opening produced here is the leaf claim the packed
-//! stage-8 `A_unt` statement consumes.
+//! stage-8 `UntrustedAdviceOneHot` statement consumes.
 
 use allocative::Allocative;
 #[cfg(feature = "allocative")]

--- a/crates/jolt-prover-legacy/src/zkvm/claim_reductions/bytecode_reconstruction.rs
+++ b/crates/jolt-prover-legacy/src/zkvm/claim_reductions/bytecode_reconstruction.rs
@@ -2,7 +2,7 @@
 //!
 //! Settles the base `BytecodeClaimReduction`'s per-chunk claims (all chunks
 //! at one shared `(lane ‖ row)` point) against the precommitted per-lane
-//! sub-columns of `W_prog` in ONE γ-batched sumcheck — the chunk polynomials
+//! sub-columns of `ProgramOneHot` in ONE γ-batched sumcheck — the chunk polynomials
 //! are never PCS-opened.
 //!
 //! Leg embedding contract (shared with the verifier): the batch binds the

--- a/crates/jolt-prover-legacy/src/zkvm/claim_reductions/inc_virtualization.rs
+++ b/crates/jolt-prover-legacy/src/zkvm/claim_reductions/inc_virtualization.rs
@@ -50,7 +50,7 @@ use crate::transcripts::Transcript;
 use crate::utils::math::Math;
 use crate::zkvm::instruction::CircuitFlags;
 #[cfg(feature = "prover")]
-use crate::zkvm::packed_witness::FusedIncCycle;
+use crate::zkvm::packed_witness::FusedIncValue;
 use crate::zkvm::witness::{CommittedPolynomial, VirtualPolynomial};
 
 const DEGREE_BOUND: usize = 3;
@@ -205,7 +205,7 @@ impl<F: JoltField> IncVirtualizationSumcheckProver<F> {
             .map(|cycle| {
                 // One predicate read for both columns — the selector is the
                 // same Store flag `from_cycle_with_store` keys the delta off.
-                let (fused, store) = FusedIncCycle::from_cycle_with_store(cycle);
+                let (fused, store) = FusedIncValue::from_cycle_with_store(cycle);
                 (fused.delta, u8::from(store))
             })
             .unzip();

--- a/crates/jolt-prover-legacy/src/zkvm/claim_reductions/program_image_reconstruction.rs
+++ b/crates/jolt-prover-legacy/src/zkvm/claim_reductions/program_image_reconstruction.rs
@@ -2,7 +2,7 @@
 //!
 //! The trusted-advice decode shape over the program image byte column:
 //! settles the completed `ProgramImageInit` claim against the precommitted
-//! `ProgramImageBytes` one-hot column of `W_prog`. Only the `(byte ‖ place)`
+//! `ProgramImageBytes` one-hot column of `ProgramOneHot`. Only the `(byte ‖ place)`
 //! variables bind (the word point stays fixed by the incoming claim); the
 //! single decode leg `byte · 256^place` is degree 2, and the produced byte
 //! opening lands at `(bound ‖ r_word)` — the column's own packed-slot point.

--- a/crates/jolt-prover-legacy/src/zkvm/instruction/test.rs
+++ b/crates/jolt-prover-legacy/src/zkvm/instruction/test.rs
@@ -116,7 +116,7 @@ mod flags {
     /// cycle's declared RAM-write access — stores are the only provable
     /// instruction shape that writes RAM; every read-modify-write
     /// instruction lowers into a sequence whose RAM-writing step is a plain
-    /// store. `FusedIncCycle::from_cycle_with_store` debug-asserts the same
+    /// store. `FusedIncValue::from_cycle_with_store` debug-asserts the same
     /// per cycle at witness-generation time.
     #[test]
     fn store_flag_matches_ram_write_access() {

--- a/crates/jolt-prover-legacy/src/zkvm/packed.rs
+++ b/crates/jolt-prover-legacy/src/zkvm/packed.rs
@@ -2204,8 +2204,13 @@ mod committed_tests {
             .expect("packed prover should produce a verifier-native proof");
         eprintln!("akita prove: {:.2?}", prove_start.elapsed());
 
+        let verifier_preprocessing_start = Instant::now();
         let verifier_preprocessing =
             akita_verifier_preprocessing(&prover_preprocessing, verifier_setup, None);
+        eprintln!(
+            "akita verifier preprocessing: {:.2?}",
+            verifier_preprocessing_start.elapsed()
+        );
         let verify_start = Instant::now();
         jolt_verifier::verify::<AkitaField, AkitaScheme, AkitaVc, AkitaTranscript>(
             &verifier_preprocessing,

--- a/crates/jolt-prover-legacy/src/zkvm/packed.rs
+++ b/crates/jolt-prover-legacy/src/zkvm/packed.rs
@@ -1,14 +1,14 @@
 //! The packed (Akita/lattice) prove path.
 //!
 //! Mirrors [`super::prover::JoltCpuProver::prove_parts`] with the lattice
-//! stage swaps: one native Akita commitment group `W_jolt` replaces the
+//! stage swaps: one native Akita commitment group `OneHotTrace` replaces the
 //! per-polynomial streaming Dory commits, the `IncVirtualization` phase runs
 //! strictly between stage 5 and the stage-6 address phase, the six-stage
 //! bytecode read-raf and the lattice booleanity carry the fused-inc columns,
 //! stage 6b gains `FusedIncClaimReduction`, stage 7 folds the increment
 //! one-hot claims into `HammingWeightClaimReduction`, the reconstruction phase
 //! settles auxiliary advice/bytecode/image columns, and stage 8 uses one native
-//! same-point Akita opening for Wjolt plus packed openings for auxiliaries.
+//! same-point Akita opening for OneHotTrace plus packed openings for auxiliaries.
 //!
 //! The prover runs over the `AkitaFp128` newtype (the legacy `JoltField`
 //! impl of the same underlying fp128 element the verifier stack uses), so
@@ -26,15 +26,15 @@ use ark_serialize::{CanonicalDeserialize, CanonicalSerialize, Compress, Validate
 use jolt_claims::protocols::jolt::geometry::ra::JoltRaPolynomialLayout;
 use jolt_claims::protocols::jolt::lattice::geometry::{word_byte_num_vars, WORD_BYTES};
 use jolt_claims::protocols::jolt::lattice::{
-    advice_bytes_packing, precommitted_packing, PrecommittedPackingShape, UnsignedIncChunking,
-    WJoltLayoutPlan, WJoltShape, W_JOLT_LAYOUT,
+    advice_bytes_packing, precommitted_packing, OneHotTraceLayoutPlan, OneHotTraceShape,
+    PrecommittedPackingShape, ONE_HOT_TRACE_LAYOUT,
 };
 use jolt_claims::protocols::jolt::{BytecodeRegisterLane, JoltAdviceKind, JoltCommittedPolynomial};
 use jolt_openings::{
     prove_packed_openings, CommitmentScheme as VerifierCommitmentScheme, EvaluationClaim,
     PackedProverGroup, PackedProverObject, PrefixPackedStatement, PrefixPacking,
 };
-use jolt_poly::{MultilinearPoly, OneHotPolynomial};
+use jolt_poly::OneHotPolynomial;
 use jolt_transcript::append_length_prefixed;
 use jolt_verifier::config::{CommitmentConfig, JoltProtocolConfig, ZkConfig};
 use jolt_verifier::preprocessing::JoltVerifierPreprocessing;
@@ -50,8 +50,8 @@ use crate::poly::commitment::dory::{DoryGlobals, DoryLayout};
 use crate::poly::multilinear_polynomial::MultilinearPolynomial;
 use crate::poly::opening_proof::{OpeningAccumulator, SumcheckId};
 use crate::subprotocols::booleanity::{
-    lattice_booleanity_params, LatticeBooleanityAddressSumcheckProver,
-    LatticeBooleanityCycleSumcheckProver, LatticeIncColumns,
+    lattice_booleanity_params, FusedIncColumns, LatticeBooleanityAddressSumcheckProver,
+    LatticeBooleanityCycleSumcheckProver,
 };
 use crate::transcripts::Transcript as LegacyTranscript;
 use crate::utils::math::Math;
@@ -73,9 +73,7 @@ use crate::zkvm::fiat_shamir_preamble;
 use crate::zkvm::instruction_lookups::ra_virtual::{
     InstructionRaSumcheckParams, InstructionRaSumcheckProver as LookupsRaSumcheckProver,
 };
-use crate::zkvm::packed_witness::{
-    assemble_one_hot_members, FusedIncCycle, SparseUnitPolynomial, UNSIGNED_INC_BITS,
-};
+use crate::zkvm::packed_witness::{FusedIncValue, SparseUnitPolynomial, UNSIGNED_INC_BITS};
 use crate::zkvm::prover::JoltCpuProver;
 use crate::zkvm::ram::hamming_booleanity::{
     HammingBooleanitySumcheckParams, HammingBooleanitySumcheckProver,
@@ -251,14 +249,14 @@ impl JoltCurve for AkitaNoCurve {
 }
 
 /// A zero-sized stand-in for the legacy per-polynomial commitment machinery:
-/// the Akita path commits Wjolt as one native one-hot member group, so none of
+/// the Akita path commits OneHotTrace as one native one-hot member group, so none of
 /// these entry points is ever reached.
 #[derive(Clone, Debug, Default, PartialEq, CanonicalSerialize, CanonicalDeserialize)]
 pub struct AkitaPackedScheme;
 
 macro_rules! no_per_polynomial_commitment {
     () => {
-        panic!("the Akita path commits one native Wjolt member group; legacy per-polynomial commitment entry points are unreachable")
+        panic!("the Akita path commits one native OneHotTrace column group; legacy per-polynomial commitment entry points are unreachable")
     };
 }
 
@@ -386,7 +384,7 @@ impl crate::zkvm::proof::ProofCurve<AkitaFp128> for AkitaNoCurve {
 }
 
 /// The transparent setup of a singleton commitment object (advice byte
-/// columns, `W_prog`): one polynomial at `num_vars`, fixed zero seed — the
+/// columns, `ProgramOneHot`): one polynomial at `num_vars`, fixed zero seed — the
 /// convention `akita_verifier_preprocessing` re-derives on the verifier
 /// side, so the two must stay a single definition.
 fn transparent_object_setup(
@@ -403,10 +401,10 @@ fn transparent_object_setup(
     ))
 }
 
-/// A packed advice commitment object (`A_unt` per proof, `A_tru`
+/// A packed advice commitment object (`UntrustedAdviceOneHot` per proof, `TrustedAdviceOneHot`
 /// precommitted): the word polynomial the base advice reductions run over,
 /// the byte one-hot column, and its commitment data.
-pub struct PackedAdviceObject {
+pub struct AdviceOneHot {
     pub words: Vec<u64>,
     pub byte_column: SparseUnitPolynomial<AkitaField>,
     pub commitment: <AkitaScheme as jolt_crypto::Commitment>::Output,
@@ -419,10 +417,10 @@ pub struct PackedAdviceObject {
 /// past the actual advice length — the same zero padding the base word
 /// polynomial carries. The setup is derived from the public advice shape
 /// with the same fixed seed on both sides (the Akita setup is transparent).
-pub fn packed_advice_byte_object(
+pub fn commit_advice_one_hot(
     advice_bytes: &[u8],
     max_advice_bytes: usize,
-) -> Result<PackedAdviceObject, VerifierError> {
+) -> Result<AdviceOneHot, VerifierError> {
     let commit_failed = |reason: String| VerifierError::FinalOpeningVerificationFailed { reason };
 
     let mut words = vec![0u64; max_advice_bytes / 8];
@@ -446,7 +444,7 @@ pub fn packed_advice_byte_object(
     let (commitment, hint) =
         <AkitaScheme as VerifierCommitmentScheme>::commit(&byte_column, &setup)
             .map_err(|error| commit_failed(error.to_string()))?;
-    Ok(PackedAdviceObject {
+    Ok(AdviceOneHot {
         words,
         byte_column,
         commitment,
@@ -455,21 +453,21 @@ pub fn packed_advice_byte_object(
     })
 }
 
-/// Precommits the trusted-advice byte one-hot column (`A_tru`) out of band.
+/// Precommits the trusted-advice byte one-hot column (`TrustedAdviceOneHot`) out of band.
 /// The caller passes the returned object to the packed prove and its
 /// commitment to the verifier.
-pub fn commit_trusted_advice_packed(
+pub fn commit_trusted_advice_one_hot(
     trusted_advice_bytes: &[u8],
     max_trusted_advice_bytes: usize,
-) -> Result<PackedAdviceObject, VerifierError> {
-    packed_advice_byte_object(trusted_advice_bytes, max_trusted_advice_bytes)
+) -> Result<AdviceOneHot, VerifierError> {
+    commit_advice_one_hot(trusted_advice_bytes, max_trusted_advice_bytes)
 }
 
-/// The precommitted `W_prog` commitment object (committed-program mode):
+/// The precommitted `ProgramOneHot` commitment object (committed-program mode):
 /// the packed sub-column witness (bytecode lanes + program image), its
 /// Akita commitment/hint, the shape-exact setup, and the packing shape —
 /// assembled and committed once at preprocessing time.
-pub struct PackedProgramObject {
+pub struct ProgramOneHot {
     pub shape: PrecommittedPackingShape,
     pub witness: SparseUnitPolynomial<AkitaField>,
     pub commitment: <AkitaScheme as jolt_crypto::Commitment>::Output,
@@ -477,17 +475,17 @@ pub struct PackedProgramObject {
     pub setup: <AkitaScheme as VerifierCommitmentScheme>::ProverSetup,
 }
 
-/// Assembles and commits `W_prog` from the full (public) program: every
+/// Assembles and commits `ProgramOneHot` from the full (public) program: every
 /// bytecode sub-column plus the program image, packed per the canonical
 /// `precommitted_packing`. The setup is derived from the public program
 /// shape with the same fixed seed on both sides (the Akita setup is
 /// transparent). The imm lane uses the field's canonical byte width, so
 /// negative immediates (`p − |imm|`) reconstruct exactly.
-pub fn commit_program_packed(
+pub fn commit_program_one_hot(
     program: &crate::zkvm::program::FullProgramPreprocessing,
     memory_layout: &common::jolt_device::MemoryLayout,
     bytecode_chunk_count: usize,
-) -> Result<PackedProgramObject, VerifierError> {
+) -> Result<ProgramOneHot, VerifierError> {
     let commit_failed = |reason: String| VerifierError::FinalOpeningVerificationFailed { reason };
     let imm_byte_width = <AkitaFp128 as crate::field::JoltField>::NUM_BYTES;
     let bytecode_len = program.bytecode_len();
@@ -519,7 +517,7 @@ pub fn commit_program_packed(
         .map_err(|error| commit_failed(error.to_string()))?;
     let (commitment, hint) = <AkitaScheme as VerifierCommitmentScheme>::commit(&witness, &setup)
         .map_err(|error| commit_failed(error.to_string()))?;
-    Ok(PackedProgramObject {
+    Ok(ProgramOneHot {
         shape,
         witness,
         commitment,
@@ -529,13 +527,13 @@ pub fn commit_program_packed(
 }
 
 /// The packed sibling of `JoltSharedPreprocessing::new_committed`: marks the
-/// program committed (metadata + digest) and assembles/commits `W_prog`
-/// through [`commit_program_packed`] instead of per-polynomial commitments.
+/// program committed (metadata + digest) and assembles/commits `ProgramOneHot`
+/// through [`commit_program_one_hot`] instead of per-polynomial commitments.
 /// The placeholder per-polynomial structs carry unit commitments and zeroed
-/// shape fields — the packed path never reads them; the real `W_prog`
+/// shape fields — the packed path never reads them; the real `ProgramOneHot`
 /// commitment binds via explicit transcript absorption in canonical object
 /// order, exactly like the base committed chunk commitments.
-pub fn shared_preprocessing_committed_packed(
+pub fn shared_preprocessing_with_program_one_hot(
     program: crate::zkvm::program::ProgramPreprocessing<AkitaPackedScheme>,
     memory_layout: common::jolt_device::MemoryLayout,
     max_padded_trace_length: usize,
@@ -544,7 +542,7 @@ pub fn shared_preprocessing_committed_packed(
     (
         crate::zkvm::preprocessing::JoltSharedPreprocessing<AkitaPackedScheme>,
         crate::zkvm::program::CommittedProgramProverData<AkitaPackedScheme>,
-        PackedProgramObject,
+        ProgramOneHot,
     ),
     VerifierError,
 > {
@@ -553,7 +551,7 @@ pub fn shared_preprocessing_committed_packed(
             reason: "packed committed preprocessing starts from a full program".to_string(),
         });
     };
-    let w_prog = commit_program_packed(&full, &memory_layout, bytecode_chunk_count)?;
+    let program_one_hot = commit_program_one_hot(&full, &memory_layout, bytecode_chunk_count)?;
     let meta = full.meta();
     let meta_for_shared = meta.clone();
     let bytecode_len = full.bytecode_len();
@@ -588,7 +586,7 @@ pub fn shared_preprocessing_committed_packed(
             program_image_hint: AkitaPackedScheme,
         },
     };
-    Ok((shared, prover_data, w_prog))
+    Ok((shared, prover_data, program_one_hot))
 }
 
 /// The packed prover pinned to the Akita stack.
@@ -596,16 +594,16 @@ pub type AkitaPackedProver<'a> =
     JoltCpuProver<'a, AkitaFp128, AkitaNoCurve, AkitaPackedScheme, AkitaTranscript>;
 
 impl AkitaPackedProver<'_> {
-    /// Akita setup parameters sized to Wjolt: one commitment
-    /// group of per-column one-hot members over the shared cell dimension.
-    pub fn wjolt_setup_params(&self) -> jolt_akita::AkitaSetupParams {
-        let wjolt_shape = self.wjolt_shape();
-        let shape = W_JOLT_LAYOUT
-            .setup_shape(&wjolt_shape)
-            .expect("canonical Wjolt layout must exist");
-        let layout_digest = W_JOLT_LAYOUT
-            .layout_digest(&wjolt_shape)
-            .expect("canonical Wjolt layout digest must exist");
+    /// Akita setup parameters sized to the native `OneHotTrace` group of
+    /// uniform one-hot columns.
+    pub fn one_hot_trace_setup_params(&self) -> jolt_akita::AkitaSetupParams {
+        let one_hot_trace_shape = self.one_hot_trace_shape();
+        let shape = ONE_HOT_TRACE_LAYOUT
+            .setup_shape(&one_hot_trace_shape)
+            .expect("canonical OneHotTrace layout must exist");
+        let layout_digest = ONE_HOT_TRACE_LAYOUT
+            .layout_digest(&one_hot_trace_shape)
+            .expect("canonical OneHotTrace layout digest must exist");
         jolt_akita::AkitaSetupParams::one_hot_only(
             shape.num_vars,
             shape.num_polys,
@@ -614,8 +612,8 @@ impl AkitaPackedProver<'_> {
         )
     }
 
-    fn wjolt_shape(&self) -> WJoltShape {
-        WJoltShape {
+    fn one_hot_trace_shape(&self) -> OneHotTraceShape {
+        OneHotTraceShape {
             ra_layout: self.ra_layout(),
             log_t: self.trace.len().log_2(),
             log_k_chunk: self.one_hot_params.log_k_chunk,
@@ -631,60 +629,79 @@ impl AkitaPackedProver<'_> {
         .expect("Jolt always commits at least one RA polynomial")
     }
 
-    /// Per-cycle hot addresses of a committed `Ra` polynomial, mirroring
-    /// `CommittedPolynomial::generate_witness`'s one-hot index computation.
-    fn packed_ra_indices(&self, polynomial: JoltCommittedPolynomial) -> Option<Vec<Option<usize>>> {
+    /// Builds the native `OneHotTrace` columns from compact per-cycle source
+    /// data. Each returned index buffer is handed to Akita by ownership, so
+    /// there is no witness clone at the PCS boundary.
+    #[tracing::instrument(skip_all, name = "assemble_one_hot_trace")]
+    fn assemble_one_hot_trace(
+        &self,
+        plan: &OneHotTraceLayoutPlan,
+        fused_inc: &[FusedIncValue],
+    ) -> Vec<OneHotPolynomial> {
         use crate::zkvm::instruction::LookupQuery;
         use crate::zkvm::ram::remap_address;
         use common::constants::XLEN;
         use rayon::prelude::*;
 
         let params = &self.one_hot_params;
-        let indices = match polynomial {
-            JoltCommittedPolynomial::InstructionRa(index) => self
-                .trace
-                .par_iter()
-                .map(|cycle| {
-                    let lookup_index = LookupQuery::<XLEN>::to_lookup_index(cycle);
-                    Some(params.lookup_index_chunk(lookup_index, index) as usize)
-                })
-                .collect(),
-            JoltCommittedPolynomial::BytecodeRa(index) => self
-                .trace
-                .par_iter()
-                .map(|cycle| {
-                    let pc = self.preprocessing.materialized_program().get_pc(cycle);
-                    Some(params.bytecode_pc_chunk(pc, index) as usize)
-                })
-                .collect(),
-            JoltCommittedPolynomial::RamRa(index) => self
-                .trace
-                .par_iter()
-                .map(|cycle| {
-                    remap_address(
-                        cycle.ram_access().address() as u64,
-                        &self.preprocessing.shared.memory_layout,
-                    )
-                    .map(|address| params.ram_address_chunk(address, index) as usize)
-                })
-                .collect(),
-            _ => return None,
-        };
-        Some(indices)
+        let trace = &self.trace;
+        let program = self.preprocessing.materialized_program();
+        let memory_layout = &self.preprocessing.shared.memory_layout;
+        let cycle_data = trace
+            .par_iter()
+            .map(|cycle| {
+                (
+                    LookupQuery::<XLEN>::to_lookup_index(cycle),
+                    program.get_pc(cycle),
+                    remap_address(cycle.ram_access().address() as u64, memory_layout),
+                )
+            })
+            .collect::<Vec<_>>();
+        let k = 1usize << params.log_k_chunk;
+        plan.columns
+            .par_iter()
+            .map(|polynomial| {
+                let indices = cycle_data
+                    .iter()
+                    .zip(fused_inc)
+                    .map(|((lookup_index, pc, ram_address), inc)| {
+                        let hot = match polynomial {
+                            JoltCommittedPolynomial::InstructionRa(index) => {
+                                Some(params.lookup_index_chunk(*lookup_index, *index) as usize)
+                            }
+                            JoltCommittedPolynomial::BytecodeRa(index) => {
+                                Some(params.bytecode_pc_chunk(*pc, *index) as usize)
+                            }
+                            JoltCommittedPolynomial::RamRa(index) => (*ram_address)
+                                .map(|address| params.ram_address_chunk(address, *index) as usize),
+                            JoltCommittedPolynomial::UnsignedIncChunk(index) => {
+                                Some(inc.chunk_hot_lane_bits(params.log_k_chunk, *index))
+                            }
+                            JoltCommittedPolynomial::UnsignedIncMsb => Some(usize::from(inc.msb())),
+                            _ => unreachable!("OneHotTrace plan contains only canonical columns"),
+                        };
+                        hot.map(|hot| {
+                            u8::try_from(hot).expect("OneHotTrace K is at most the u8 lane domain")
+                        })
+                    })
+                    .collect();
+                OneHotPolynomial::new(k, indices)
+            })
+            .collect()
     }
 
     /// The per-cycle fused increments, shared by the inc-column witness
-    /// build and Wjolt assembly.
-    fn fused_inc_cycles(&self) -> Vec<FusedIncCycle> {
+    /// build and OneHotTrace assembly.
+    fn fused_inc_values(&self) -> Vec<FusedIncValue> {
         use rayon::prelude::*;
 
         self.trace
             .par_iter()
-            .map(FusedIncCycle::from_cycle)
+            .map(FusedIncValue::from_cycle)
             .collect()
     }
 
-    fn lattice_inc_columns(&self, fused_cycles: &[FusedIncCycle]) -> LatticeIncColumns {
+    fn fused_inc_columns(&self, fused_cycles: &[FusedIncValue]) -> FusedIncColumns {
         use rayon::prelude::*;
 
         let chunk_count = UNSIGNED_INC_BITS / self.one_hot_params.log_k_chunk;
@@ -702,24 +719,24 @@ impl AkitaPackedProver<'_> {
             .map(|cycle| u8::from(cycle.msb()))
             .collect();
         let fused: Vec<i128> = fused_cycles.par_iter().map(|cycle| cycle.delta).collect();
-        LatticeIncColumns {
+        FusedIncColumns {
             hot_lanes,
             msb_hot_lanes,
             fused,
         }
     }
 
-    /// Builds and commits the untrusted-advice byte one-hot column (`A_unt`).
+    /// Builds and commits the untrusted-advice byte one-hot column (`UntrustedAdviceOneHot`).
     /// Also materializes the base advice *word* polynomial on `self.advice`
     /// so the shared stage-4/6b/7 advice reduction machinery runs unchanged.
     #[tracing::instrument(skip_all, name = "generate_and_commit_untrusted_advice_packed")]
     fn generate_and_commit_untrusted_advice_packed(
         &mut self,
-    ) -> Result<Option<PackedAdviceObject>, VerifierError> {
+    ) -> Result<Option<AdviceOneHot>, VerifierError> {
         if self.program_io.untrusted_advice.is_empty() {
             return Ok(None);
         }
-        let object = packed_advice_byte_object(
+        let object = commit_advice_one_hot(
             &self.program_io.untrusted_advice,
             self.program_io.memory_layout.max_untrusted_advice_size as usize,
         )?;
@@ -731,26 +748,6 @@ impl AkitaPackedProver<'_> {
         self.advice.untrusted_advice_polynomial =
             Some(MultilinearPolynomial::from(object.words.clone()));
         Ok(Some(object))
-    }
-
-    /// Builds the strict one-hot member polynomials of `W_jolt` in the
-    /// canonical native-batch member order.
-    #[tracing::instrument(skip_all, name = "assemble_witness")]
-    fn assemble_witness(
-        &self,
-        members: &[JoltCommittedPolynomial],
-        fused_inc: &[FusedIncCycle],
-    ) -> Vec<OneHotPolynomial> {
-        let chunking = UnsignedIncChunking::new(self.one_hot_params.log_k_chunk)
-            .expect("log_k_chunk divides the 64 unsigned-inc bits");
-        assemble_one_hot_members(
-            members,
-            chunking,
-            self.trace.len().log_2(),
-            &|polynomial| self.packed_ra_indices(polynomial),
-            fused_inc,
-        )
-        .expect("Wjolt assembly must cover every native member")
     }
 
     /// The `IncVirtualization` phase: a single-instance batched sumcheck
@@ -775,7 +772,7 @@ impl AkitaPackedProver<'_> {
     #[tracing::instrument(skip_all, name = "prove_stage6a_lattice")]
     fn prove_stage6a_lattice(
         &mut self,
-        columns: &LatticeIncColumns,
+        columns: &FusedIncColumns,
     ) -> (
         crate::subprotocols::sumcheck::SumcheckInstanceProof<
             AkitaFp128,
@@ -1022,7 +1019,7 @@ impl AkitaPackedProver<'_> {
     #[tracing::instrument(skip_all, name = "prove_stage7_lattice")]
     fn prove_stage7_lattice(
         &mut self,
-        columns: LatticeIncColumns,
+        columns: FusedIncColumns,
     ) -> crate::subprotocols::sumcheck::SumcheckInstanceProof<
         AkitaFp128,
         AkitaNoCurve,
@@ -1126,8 +1123,8 @@ impl AkitaPackedProver<'_> {
     #[tracing::instrument(skip_all, name = "prove_reconstruction_phase")]
     fn prove_reconstruction_phase(
         &mut self,
-        untrusted: Option<&PackedAdviceObject>,
-        trusted: Option<&PackedAdviceObject>,
+        untrusted: Option<&AdviceOneHot>,
+        trusted: Option<&AdviceOneHot>,
     ) -> Option<
         crate::subprotocols::sumcheck::SumcheckInstanceProof<
             AkitaFp128,
@@ -1140,8 +1137,7 @@ impl AkitaPackedProver<'_> {
             return None;
         }
 
-        let word_vars =
-            |object: &PackedAdviceObject| object.words.len().next_power_of_two().log_2();
+        let word_vars = |object: &AdviceOneHot| object.words.len().next_power_of_two().log_2();
         let mut untrusted_prover = untrusted.map(|object| {
             let params = UntrustedAdviceReconstructionSumcheckParams::new(
                 word_vars(object),
@@ -1206,11 +1202,9 @@ impl AkitaPackedProver<'_> {
         Some(proof)
     }
 
-    /// The legacy `(polynomial, sumcheck)` pair holding a `W_jolt` packed
-    /// column's final claim on the accumulator.
-    /// The legacy `(polynomial, relation)` pair holding a packed column's
-    /// final claim on the accumulator — `W_jolt` members and `W_prog`
-    /// sub-columns alike (their variant sets are disjoint).
+    /// The `(polynomial, relation)` pair holding a semantic column's final
+    /// claim on the accumulator. This covers `OneHotTrace` columns and
+    /// `ProgramOneHot` sub-columns (their variant sets are disjoint).
     fn leaf_source(
         polynomial: JoltCommittedPolynomial,
     ) -> Result<(CommittedPolynomial, SumcheckId), VerifierError> {
@@ -1304,7 +1298,7 @@ impl AkitaPackedProver<'_> {
     fn packed_advice_statement(
         &self,
         kind: JoltAdviceKind,
-        object: &PackedAdviceObject,
+        object: &AdviceOneHot,
     ) -> Result<(PrefixPacking<JoltCommittedPolynomial>, AkitaPackedStatement), VerifierError> {
         let batch_failed = |reason: String| VerifierError::FinalOpeningBatchFailed { reason };
         let word_vars = object.words.len().next_power_of_two().log_2();
@@ -1337,12 +1331,12 @@ impl AkitaPackedProver<'_> {
         Ok((packing, statement))
     }
 
-    /// The `W_prog` statement: one final claim per precommitted sub-column,
+    /// The `ProgramOneHot` statement: one final claim per precommitted sub-column,
     /// pulled from the accumulator at the reconstruction phase's produced
     /// ids.
     fn packed_program_statement(
         &self,
-        object: &PackedProgramObject,
+        object: &ProgramOneHot,
     ) -> Result<(PrefixPacking<JoltCommittedPolynomial>, AkitaPackedStatement), VerifierError> {
         let batch_failed = |reason: String| VerifierError::FinalOpeningBatchFailed { reason };
         let packing =
@@ -1373,15 +1367,15 @@ impl AkitaPackedProver<'_> {
     }
 
     /// The Akita prove pipeline. `object_setup` is the Akita prover setup
-    /// sized to Wjolt ([`Self::wjolt_setup_params`]);
-    /// `trusted_advice` is the precommitted `A_tru` object, passed exactly
+    /// sized to OneHotTrace ([`Self::one_hot_trace_setup_params`]);
+    /// `trusted_advice` is the precommitted `TrustedAdviceOneHot` object, passed exactly
     /// when trusted advice exists.
     #[tracing::instrument(skip_all, name = "prove_packed")]
     pub fn prove_packed(
         mut self,
         object_setup: &<AkitaScheme as VerifierCommitmentScheme>::ProverSetup,
-        trusted_advice: Option<PackedAdviceObject>,
-        program: Option<PackedProgramObject>,
+        trusted_advice: Option<AdviceOneHot>,
+        program: Option<ProgramOneHot>,
     ) -> Result<AkitaJoltProof, VerifierError> {
         assert!(
             !cfg!(feature = "zk"),
@@ -1390,12 +1384,12 @@ impl AkitaPackedProver<'_> {
         assert_eq!(
             program.is_some(),
             self.preprocessing.is_committed_mode(),
-            "committed-program mode and the W_prog object must agree"
+            "committed-program mode and the ProgramOneHot object must agree"
         );
         assert_eq!(
             trusted_advice.is_some(),
             !self.program_io.trusted_advice.is_empty(),
-            "the precommitted A_tru object must be passed exactly when trusted advice exists"
+            "the precommitted TrustedAdviceOneHot object must be passed exactly when trusted advice exists"
         );
 
         let preprocessing_digest = self.preprocessing.shared.digest();
@@ -1421,17 +1415,16 @@ impl AkitaPackedProver<'_> {
             Some(DoryLayout::CycleMajor),
         );
 
-        let fused_cycles = self.fused_inc_cycles();
-        let columns = self.lattice_inc_columns(&fused_cycles);
-        let plan = W_JOLT_LAYOUT
-            .plan(&self.wjolt_shape())
-            .expect("canonical Wjolt layout must exist");
-        let WJoltLayoutPlan { members, .. } = &plan;
-        let w_jolt_witness = self.assemble_witness(members, &fused_cycles);
-        let (commitment, hint) = AkitaScheme::commit_one_hot_group(
+        let fused_cycles = self.fused_inc_values();
+        let fused_inc_columns = self.fused_inc_columns(&fused_cycles);
+        let plan = ONE_HOT_TRACE_LAYOUT
+            .plan(&self.one_hot_trace_shape())
+            .expect("canonical OneHotTrace layout must exist");
+        let one_hot_trace_witness = self.assemble_one_hot_trace(&plan, &fused_cycles);
+        let (commitment, hint) = AkitaScheme::commit_one_hot_group_owned(
             object_setup,
             object_setup.default_layout_digest(),
-            &w_jolt_witness,
+            one_hot_trace_witness,
         )
         .map_err(|error| VerifierError::FinalOpeningVerificationFailed {
             reason: error.to_string(),
@@ -1449,7 +1442,7 @@ impl AkitaPackedProver<'_> {
         if let Some(program) = program.as_ref() {
             append_length_prefixed(
                 &mut self.transcript,
-                b"w_prog_commitment",
+                b"program_one_hot_commitment",
                 &program.commitment,
             );
         }
@@ -1463,24 +1456,24 @@ impl AkitaPackedProver<'_> {
         let (stage5_sumcheck_proof, _r_stage5) = self.prove_stage5();
         let inc_virtualization_proof = self.prove_inc_virtualization_phase();
         let (stage6a_sumcheck_proof, bytecode_read_raf_params, booleanity_cycle_input) =
-            self.prove_stage6a_lattice(&columns);
+            self.prove_stage6a_lattice(&fused_inc_columns);
         let stage6b_sumcheck_proof = self.prove_stage6b_lattice(
             bytecode_read_raf_params,
             booleanity_cycle_input,
-            columns.fused.clone(),
+            fused_inc_columns.fused.clone(),
         );
-        let stage7_sumcheck_proof = self.prove_stage7_lattice(columns);
+        let stage7_sumcheck_proof = self.prove_stage7_lattice(fused_inc_columns);
         let reconstruction_proof =
             self.prove_reconstruction_phase(advice_object.as_ref(), trusted_advice.as_ref());
 
-        // Stage 8: Wjolt opens directly as one native same-point batch. Advice
-        // and Wprog, when present, remain auxiliary packed objects.
+        // Stage 8: OneHotTrace opens as one native same-point batch. Advice
+        // and ProgramOneHot remain auxiliary packed objects.
         let mut common_point: Option<Vec<AkitaField>> = None;
-        let mut w_jolt_evaluations = Vec::with_capacity(members.len());
-        for polynomial in members {
+        let mut evaluations = Vec::with_capacity(plan.columns.len());
+        for polynomial in &plan.columns {
             let (leaf_point, value) = self.resolve_leaf_claim(*polynomial)?;
-            let point = W_JOLT_LAYOUT
-                .member_point(*polynomial, self.one_hot_params.log_k_chunk, &leaf_point)
+            let point = ONE_HOT_TRACE_LAYOUT
+                .column_point(*polynomial, self.one_hot_params.log_k_chunk, &leaf_point)
                 .map_err(|error| VerifierError::FinalOpeningBatchFailed {
                     reason: error.to_string(),
                 })?;
@@ -1488,26 +1481,21 @@ impl AkitaPackedProver<'_> {
                 if expected != &point {
                     return Err(VerifierError::FinalOpeningBatchFailed {
                         reason: format!(
-                            "Wjolt member {polynomial:?} does not share the canonical opening point"
+                            "OneHotTrace column {polynomial:?} does not share the canonical opening point"
                         ),
                     });
                 }
             } else {
                 common_point = Some(point);
             }
-            w_jolt_evaluations.push(value);
+            evaluations.push(value);
         }
         let common_point = common_point.ok_or_else(|| VerifierError::FinalOpeningBatchFailed {
-            reason: "Wjolt has no members".to_string(),
+            reason: "OneHotTrace has no columns".to_string(),
         })?;
-        let w_jolt_polys: Vec<&dyn MultilinearPoly<AkitaField>> = w_jolt_witness
-            .iter()
-            .map(|member| member as &dyn MultilinearPoly<AkitaField>)
-            .collect();
-        let w_jolt_opening = <AkitaScheme as VerifierCommitmentScheme>::open_batch(
-            &w_jolt_polys,
+        let one_hot_trace_opening = AkitaScheme::open_one_hot_group_from_hint(
             &common_point,
-            &w_jolt_evaluations,
+            &evaluations,
             object_setup,
             hint,
             &mut self.transcript,
@@ -1579,7 +1567,7 @@ impl AkitaPackedProver<'_> {
             )
         };
         let joint_opening_proof = jolt_verifier::proof::AkitaJointOpeningProof {
-            w_jolt: w_jolt_opening,
+            one_hot_trace: one_hot_trace_opening,
             auxiliary,
         };
 
@@ -1638,7 +1626,7 @@ impl AkitaPackedProver<'_> {
 }
 
 /// The verifier preprocessing for a packed proof: the program preprocessing
-/// (full-program mode), the digest, the `W_jolt` setup, and the per-object
+/// (full-program mode), the digest, the `OneHotTrace` setup, and the per-object
 /// setups derived from the public shapes (transparent setup, fixed seed —
 /// the same derivation the prover's object builders use).
 pub fn akita_verifier_preprocessing(
@@ -1648,7 +1636,7 @@ pub fn akita_verifier_preprocessing(
         AkitaPackedScheme,
     >,
     akita_verifier_setup: <AkitaScheme as VerifierCommitmentScheme>::VerifierSetup,
-    w_prog_commitment: Option<<AkitaScheme as jolt_crypto::Commitment>::Output>,
+    program_one_hot_commitment: Option<<AkitaScheme as jolt_crypto::Commitment>::Output>,
 ) -> JoltVerifierPreprocessing<AkitaScheme, AkitaVc> {
     let program = match &preprocessing.shared.program {
         crate::zkvm::program::ProgramPreprocessing::Full(full) => {
@@ -1673,8 +1661,8 @@ pub fn akita_verifier_preprocessing(
                     },
                     memory_layout: preprocessing.shared.memory_layout.clone(),
                     max_padded_trace_length: preprocessing.shared.max_padded_trace_length,
-                    w_prog_commitment: w_prog_commitment
-                        .expect("committed-program mode requires the W_prog commitment"),
+                    program_one_hot_commitment: program_one_hot_commitment
+                        .expect("committed-program mode requires the ProgramOneHot commitment"),
                     bytecode_chunk_count: preprocessing.shared.bytecode_chunk_count,
                 },
             )
@@ -1703,8 +1691,8 @@ pub fn akita_verifier_preprocessing(
         advice_setup(layout.max_untrusted_advice_size as usize);
     verifier_preprocessing.trusted_advice_setup =
         advice_setup(layout.max_trusted_advice_size as usize);
-    // The W_prog setup is derived from the public program shape (transparent
-    // setup, fixed seed) — the same shape `commit_program_packed` committed
+    // The ProgramOneHot setup is derived from the public program shape (transparent
+    // setup, fixed seed) — the same shape `commit_program_one_hot` committed
     // at.
     if committed_mode {
         let imm_byte_width = <AkitaFp128 as crate::field::JoltField>::NUM_BYTES;
@@ -1726,7 +1714,7 @@ pub fn akita_verifier_preprocessing(
             precommitted_packing(&shape).expect("the canonical precommitted packing must exist");
         let (_, program_verifier_setup) = transparent_object_setup(packing.packed_num_vars)
             .expect("the transparent program-shape setup must derive");
-        verifier_preprocessing.w_prog_setup = Some(program_verifier_setup);
+        verifier_preprocessing.program_one_hot_setup = Some(program_verifier_setup);
     }
     verifier_preprocessing
 }
@@ -1742,7 +1730,7 @@ mod tests {
     use serial_test::serial;
 
     /// Proves and verifies muldiv end to end over the packed (Akita) stack:
-    /// the full-program packed pipeline, one `W_jolt` commitment object, and
+    /// the full-program packed pipeline, one `OneHotTrace` commitment object, and
     /// the joint packed opening.
     #[test]
     #[serial]
@@ -1771,7 +1759,7 @@ mod tests {
             None,
         );
         let io_device = prover.program_io.clone();
-        let setup_params = prover.wjolt_setup_params();
+        let setup_params = prover.one_hot_trace_setup_params();
         assert_eq!(setup_params.one_hot_k(), 16);
         let (object_setup, verifier_setup) =
             <AkitaScheme as VerifierCommitmentScheme>::setup(setup_params).unwrap();
@@ -1873,7 +1861,8 @@ mod tests {
         );
         let io_device = prover.program_io.clone();
         let (object_setup, verifier_setup) =
-            <AkitaScheme as VerifierCommitmentScheme>::setup(prover.wjolt_setup_params()).unwrap();
+            <AkitaScheme as VerifierCommitmentScheme>::setup(prover.one_hot_trace_setup_params())
+                .unwrap();
         let proof = prover
             .prove_packed(&object_setup, None, None)
             .expect("packed prover should produce a verifier-native proof");
@@ -1905,7 +1894,7 @@ mod advice_tests {
     use serial_test::serial;
 
     /// The packed advice e2e: a guest consuming both advice kinds, proved
-    /// over three commitment objects (`W_jolt`, `A_unt`, `A_tru`), with
+    /// over three commitment objects (`OneHotTrace`, `UntrustedAdviceOneHot`, `TrustedAdviceOneHot`), with
     /// per-object tamper rejection.
     #[test]
     #[serial]
@@ -1930,7 +1919,7 @@ mod advice_tests {
         let prover_preprocessing = JoltProverPreprocessing::new(shared);
         let elf_contents = program.get_elf_contents().expect("elf contents is None");
 
-        let trusted_object = commit_trusted_advice_packed(
+        let trusted_object = commit_trusted_advice_one_hot(
             &trusted_advice,
             io_device.memory_layout.max_trusted_advice_size as usize,
         )
@@ -1949,7 +1938,7 @@ mod advice_tests {
         let io_device = prover.program_io.clone();
 
         let (object_setup, verifier_setup) =
-            <AkitaScheme as VerifierCommitmentScheme>::setup(prover.wjolt_setup_params())
+            <AkitaScheme as VerifierCommitmentScheme>::setup(prover.one_hot_trace_setup_params())
                 .expect("the transparent packed setup must derive");
         let trusted_commitment = trusted_object.commitment.clone();
         let proof = prover
@@ -1957,7 +1946,7 @@ mod advice_tests {
             .expect("packed prover should produce a verifier-native proof");
         assert!(proof.untrusted_advice_commitment.is_some());
         assert!(proof.stages.reconstruction_sumcheck_proof.is_some());
-        // Wjolt is discharged by its native same-point batch. The two advice
+        // OneHotTrace is discharged by its native same-point batch. The two advice
         // commitment objects remain in the auxiliary packed opening.
         let auxiliary = proof
             .joint_opening_proof
@@ -2021,7 +2010,7 @@ mod committed_tests {
     use crate::zkvm::prover::JoltProverPreprocessing;
     use serial_test::serial;
 
-    /// The committed-program packed e2e: `W_prog` joins as the second
+    /// The committed-program packed e2e: `ProgramOneHot` joins as the second
     /// commitment object (muldiv carries no advice), with tamper rejection
     /// on its claimed evaluation and a reconstruction wire.
     fn committed_e2e(bytecode_chunk_count: usize) {
@@ -2033,7 +2022,7 @@ mod committed_tests {
 
         let program_data = ProgramPreprocessing::preprocess(bytecode, init_memory_state, e_entry)
             .expect("program preprocessing");
-        let (shared, prover_data, w_prog) = shared_preprocessing_committed_packed(
+        let (shared, prover_data, program_one_hot) = shared_preprocessing_with_program_one_hot(
             program_data,
             io_device.memory_layout.clone(),
             1 << 16,
@@ -2057,14 +2046,14 @@ mod committed_tests {
         let io_device = prover.program_io.clone();
 
         let (object_setup, verifier_setup) =
-            <AkitaScheme as VerifierCommitmentScheme>::setup(prover.wjolt_setup_params())
+            <AkitaScheme as VerifierCommitmentScheme>::setup(prover.one_hot_trace_setup_params())
                 .expect("the transparent packed setup must derive");
-        let w_prog_commitment = w_prog.commitment.clone();
+        let program_one_hot_commitment = program_one_hot.commitment.clone();
         let proof = prover
-            .prove_packed(&object_setup, None, Some(w_prog))
+            .prove_packed(&object_setup, None, Some(program_one_hot))
             .expect("packed prover should produce a verifier-native proof");
         assert!(proof.stages.reconstruction_sumcheck_proof.is_some());
-        // Wjolt is discharged by its native same-point batch; Wprog is the
+        // OneHotTrace is discharged by its native same-point batch; ProgramOneHot is the
         // only auxiliary packed object.
         let auxiliary = proof
             .joint_opening_proof
@@ -2077,7 +2066,7 @@ mod committed_tests {
         let verifier_preprocessing = akita_verifier_preprocessing(
             &prover_preprocessing,
             verifier_setup,
-            Some(w_prog_commitment),
+            Some(program_one_hot_commitment),
         );
         let verify = |proof: &AkitaJoltProof| {
             jolt_verifier::verify::<AkitaField, AkitaScheme, AkitaVc, AkitaTranscript>(
@@ -2089,7 +2078,7 @@ mod committed_tests {
         };
         verify(&proof).expect("packed verifier should accept the committed packed proof");
 
-        // Tampers: the W_prog claimed evaluation (last object) breaks its
+        // Tampers: the ProgramOneHot claimed evaluation (last object) breaks its
         // native opening; a mutated reconstruction wire breaks the batched
         // output check.
         let mut tampered = proof.clone();
@@ -2101,7 +2090,7 @@ mod committed_tests {
             .evaluations[0] += AkitaField::from_u64(1);
         assert!(
             verify(&tampered).is_err(),
-            "tampered W_prog evaluation must be rejected"
+            "tampered ProgramOneHot evaluation must be rejected"
         );
         let mut tampered = proof.clone();
         let jolt_verifier::proof::JoltProofClaims::Clear(claims) = &mut tampered.claims else {
@@ -2191,8 +2180,8 @@ mod committed_tests {
         );
         let io_device = prover.program_io.clone();
         eprintln!("trace length: {}", prover.trace.len());
-        let setup_params = prover.wjolt_setup_params();
-        eprintln!("Wjolt one-hot K: {}", setup_params.one_hot_k());
+        let setup_params = prover.one_hot_trace_setup_params();
+        eprintln!("OneHotTrace one-hot K: {}", setup_params.one_hot_k());
         let setup_start = Instant::now();
         let (object_setup, verifier_setup) =
             <AkitaScheme as VerifierCommitmentScheme>::setup(setup_params).unwrap();

--- a/crates/jolt-prover-legacy/src/zkvm/packed_witness.rs
+++ b/crates/jolt-prover-legacy/src/zkvm/packed_witness.rs
@@ -1,5 +1,5 @@
-//! Prover-side Akita witness assembly. Wjolt is a native commitment group of
-//! uniform row-major one-hot members; auxiliary program/advice objects retain
+//! Prover-side Akita witness assembly. `OneHotTrace` contains the uniform
+//! row-major one-hot columns derived from the execution trace; auxiliary program/advice objects retain
 //! sparse prefix-packed representations.
 
 use jolt_claims::protocols::jolt::lattice::geometry::WORD_BYTES;
@@ -113,11 +113,11 @@ impl<F: jolt_field::Field> jolt_poly::MultilinearPoly<F> for SparseUnitPolynomia
 /// The per-cycle fused increment stream: the RAM delta on store cycles, the
 /// rd delta otherwise. Padding cycles carry `delta = 0`.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub struct FusedIncCycle {
+pub struct FusedIncValue {
     pub delta: i128,
 }
 
-impl FusedIncCycle {
+impl FusedIncValue {
     /// The per-cycle fused delta: the RAM write delta on store cycles, the
     /// rd write delta otherwise.
     pub fn from_cycle(cycle: &tracer::instruction::Cycle) -> Self {
@@ -130,7 +130,7 @@ impl FusedIncCycle {
     /// selector opens.
     pub fn from_cycle_with_store(cycle: &tracer::instruction::Cycle) -> (Self, bool) {
         let store = JoltTraceCycle::try_new(cycle)
-            .expect("Wjolt cycles must be final Jolt instruction rows")
+            .expect("OneHotTrace cycles must be final Jolt instruction rows")
             .circuit_flags()[CircuitFlags::Store];
         let ram_delta = match cycle.ram_access() {
             tracer::instruction::RAMAccess::Write(write) => {
@@ -158,9 +158,9 @@ impl FusedIncCycle {
         (Self { delta }, store)
     }
 
-    /// The shifted unsigned encoding `2^64 + delta`: the msb bit and the
-    /// low-64-bit chunk hot_lanes. Padding (`delta = 0`) encodes as msb hot
-    /// with every chunk at hot_lane 0 (the jolt-claims padding invariant).
+    /// The shifted unsigned encoding `2^64 + delta`: the MSB and low-64-bit
+    /// chunks. Padding (`delta = 0`) encodes as MSB hot with every chunk at
+    /// hot lane zero.
     fn shifted(self) -> u128 {
         debug_assert!(self.delta.unsigned_abs() < 1u128 << UNSIGNED_INC_BITS);
         (self.delta + (1i128 << UNSIGNED_INC_BITS)) as u128
@@ -174,7 +174,7 @@ impl FusedIncCycle {
         self.chunk_hot_lane_bits(chunking.chunk_width(), index)
     }
 
-    /// Chunk hot_lane from a plain bit width (the shared-final-point invariant
+    /// Chunk hot lane from a plain bit width (the shared-final-point invariant
     /// fixes `width == log_k_chunk`).
     pub fn chunk_hot_lane_bits(self, width: usize, index: usize) -> usize {
         let low = self.shifted() & ((1u128 << UNSIGNED_INC_BITS) - 1);
@@ -186,25 +186,25 @@ impl FusedIncCycle {
 enum ColumnCells {
     /// Per-cycle hot address (`None` on padding cycles — no access).
     Ra(Vec<Option<usize>>),
-    /// The fused-inc chunk column at this index.
+    /// The unsigned fused-increment chunk at this index.
     Chunk(usize),
-    /// The fused-inc msb column.
+    /// The unsigned fused-increment MSB.
     Msb,
 }
 
-/// Builds the strict one-hot Wjolt members in canonical order for the native
-/// one-hot commitment format: `K = 2^chunk_width` lanes over `2^log_t`
+/// Builds the strict one-hot `OneHotTrace` columns in canonical order:
+/// `K = 2^chunk_width` lanes over `2^log_t`
 /// row-major rows (`cycle · K + lane`).
 ///
-/// `Ra` members take their per-cycle hot address, `UnsignedIncChunk(i)` its
-/// per-cycle chunk address, and the MSB member encodes its bit as hot address
+/// `Ra` columns take their per-cycle hot address, `UnsignedIncChunk(i)` its
+/// per-cycle chunk address, and the MSB column encodes its bit as hot address
 /// zero or one.
-pub fn assemble_one_hot_members(
-    members: &[JoltCommittedPolynomial],
+pub fn assemble_one_hot_trace_columns(
+    column_ids: &[JoltCommittedPolynomial],
     chunking: UnsignedIncChunking,
     log_t: usize,
     ra_indices: &dyn Fn(JoltCommittedPolynomial) -> Option<Vec<Option<usize>>>,
-    fused_inc: &[FusedIncCycle],
+    fused_inc: &[FusedIncValue],
 ) -> Result<Vec<OneHotPolynomial>, String> {
     debug_assert!(fused_inc.len() <= 1 << log_t);
     let k = 1usize
@@ -212,14 +212,14 @@ pub fn assemble_one_hot_members(
         .filter(|k| *k <= u8::MAX as usize + 1)
         .ok_or_else(|| {
             format!(
-                "one-hot member lanes need chunk width <= 8, got {}",
+                "one-hot trace lanes need chunk width <= 8, got {}",
                 chunking.chunk_width()
             )
         })?;
     let rows = 1usize << log_t;
 
     let mut columns = Vec::new();
-    for polynomial in members {
+    for polynomial in column_ids {
         let cells = match polynomial {
             JoltCommittedPolynomial::InstructionRa(_)
             | JoltCommittedPolynomial::BytecodeRa(_)
@@ -230,7 +230,7 @@ pub fn assemble_one_hot_members(
             JoltCommittedPolynomial::UnsignedIncChunk(index) => ColumnCells::Chunk(*index),
             JoltCommittedPolynomial::UnsignedIncMsb => ColumnCells::Msb,
             other => {
-                return Err(format!("polynomial {other:?} is not a native Wjolt member"));
+                return Err(format!("polynomial {other:?} is not an OneHotTrace column"));
             }
         };
         columns.push((*polynomial, cells));
@@ -265,7 +265,7 @@ pub fn assemble_one_hot_members(
         .collect()
 }
 
-/// Scatters the precommitted `W_prog` sub-columns (per-chunk bytecode lanes
+/// Scatters the precommitted `ProgramOneHot` sub-columns (per-chunk bytecode lanes
 /// and the program image) into one-positions of the packed precommitted
 /// witness, per the canonical `precommitted_packing` slots. Row domain per
 /// chunk is `2^log_bytecode_rows` (bytecode rows, zero-padded); byte
@@ -384,7 +384,7 @@ pub fn assemble_precommitted_witness<F: JoltField>(
             }
             JoltCommittedPolynomial::ProgramImageBytes => {
                 let words = program_image_words
-                    .ok_or_else(|| "program image words missing for W_prog".to_string())?;
+                    .ok_or_else(|| "program image words missing for ProgramOneHot".to_string())?;
                 let word_vars = slot.num_vars - 8 - WORD_BYTES.log_2();
                 let limb_bits = WORD_BYTES.log_2();
                 debug_assert!(words.len() <= 1 << word_vars);
@@ -423,14 +423,14 @@ mod tests {
         UnsignedIncChunking::new(LOG_K_CHUNK).unwrap()
     }
 
-    fn fused_trace() -> Vec<FusedIncCycle> {
+    fn fused_trace() -> Vec<FusedIncValue> {
         [7i128, -3, 0, (1 << 40) + 5, -(1 << 63), 1, -1, 0]
             .into_iter()
-            .map(|delta| FusedIncCycle { delta })
+            .map(|delta| FusedIncValue { delta })
             .collect()
     }
 
-    fn members() -> Vec<(JoltCommittedPolynomial, OneHotPolynomial)> {
+    fn columns() -> Vec<(JoltCommittedPolynomial, OneHotPolynomial)> {
         let ra = |polynomial: JoltCommittedPolynomial| {
             let base = match polynomial {
                 JoltCommittedPolynomial::InstructionRa(_) => 3usize,
@@ -452,35 +452,35 @@ mod tests {
         ids.extend((0..chunking().chunk_count()).map(JoltCommittedPolynomial::UnsignedIncChunk));
         ids.push(JoltCommittedPolynomial::UnsignedIncMsb);
         let polynomials =
-            assemble_one_hot_members(&ids, chunking(), LOG_T, &ra, &fused_trace()).unwrap();
+            assemble_one_hot_trace_columns(&ids, chunking(), LOG_T, &ra, &fused_trace()).unwrap();
         ids.into_iter().zip(polynomials).collect()
     }
 
     #[test]
-    fn every_wjolt_member_has_the_uniform_native_shape() {
-        for (_, member) in members() {
-            assert_eq!(member.num_vars(), LOG_K_CHUNK + LOG_T);
-            assert_eq!(member.k(), 1 << LOG_K_CHUNK);
-            assert_eq!(member.indices().len(), 1 << LOG_T);
+    fn every_one_hot_trace_column_has_the_uniform_native_shape() {
+        for (_, column) in columns() {
+            assert_eq!(column.num_vars(), LOG_K_CHUNK + LOG_T);
+            assert_eq!(column.k(), 1 << LOG_K_CHUNK);
+            assert_eq!(column.indices().len(), 1 << LOG_T);
         }
     }
 
     #[test]
     fn chunk_columns_reconstruct_the_shifted_fused_increment() {
-        let chunking = chunking();
+        let encoding = chunking();
         let trace = fused_trace();
-        let members = members();
+        let columns = columns();
         for (cycle, inc) in trace.iter().enumerate() {
             let mut reconstructed = 0u128;
-            for index in 0..chunking.chunk_count() {
-                let (_, member) = members
+            for index in 0..encoding.chunk_count() {
+                let (_, column) = columns
                     .iter()
                     .find(|(id, _)| *id == JoltCommittedPolynomial::UnsignedIncChunk(index))
                     .unwrap();
-                let hot = member.indices()[cycle].unwrap() as usize;
-                reconstructed |= (hot as u128) << (chunking.chunk_width() * index);
+                let hot = column.indices()[cycle].unwrap() as usize;
+                reconstructed |= (hot as u128) << (encoding.chunk_width() * index);
             }
-            let (_, msb) = members
+            let (_, msb) = columns
                 .iter()
                 .find(|(id, _)| *id == JoltCommittedPolynomial::UnsignedIncMsb)
                 .unwrap();
@@ -495,7 +495,7 @@ mod tests {
 
     #[test]
     fn msb_is_one_hot_at_address_zero_or_one() {
-        let (_, msb) = members()
+        let (_, msb) = columns()
             .into_iter()
             .find(|(id, _)| *id == JoltCommittedPolynomial::UnsignedIncMsb)
             .unwrap();
@@ -505,8 +505,8 @@ mod tests {
     }
 
     #[test]
-    fn padding_cycles_encode_msb_hot_chunks_at_zero() {
-        let padding = FusedIncCycle { delta: 0 };
+    fn padding_cycles_encode_msb_hot_and_zero_digits() {
+        let padding = FusedIncValue { delta: 0 };
         assert!(padding.msb());
         for index in 0..chunking().chunk_count() {
             assert_eq!(padding.chunk_hot_lane(chunking(), index), 0);
@@ -514,8 +514,8 @@ mod tests {
     }
 
     #[test]
-    fn ra_member_retains_absent_rows() {
-        let (_, instruction) = members()
+    fn ra_column_retains_absent_rows() {
+        let (_, instruction) = columns()
             .into_iter()
             .find(|(id, _)| *id == JoltCommittedPolynomial::InstructionRa(0))
             .unwrap();
@@ -559,7 +559,7 @@ mod precommitted_tests {
         }
     }
 
-    /// Per-cell reconstruction weight of a `W_prog` sub-column: the value the
+    /// Per-cell reconstruction weight of a `ProgramOneHot` sub-column: the value the
     /// bytecode chunk reconstruction attributes to that cell against the
     /// chunk's lane-eq table (register/lookup selectors and flags are plain
     /// lane weights; pc/imm bytes carry the `byte · 256^place` decode).

--- a/crates/jolt-prover-legacy/src/zkvm/proof.rs
+++ b/crates/jolt-prover-legacy/src/zkvm/proof.rs
@@ -237,7 +237,7 @@ where
                 ),
             })
         }
-        // The packed committed-program preprocessing (one W_prog commitment
+        // The packed committed-program preprocessing (one ProgramOneHot commitment
         // plus its chunk count) is assembled by the akita prove path.
         #[cfg(feature = "akita")]
         ProverProgramPreprocessing::Committed(_) => {

--- a/crates/jolt-prover-legacy/src/zkvm/prover.rs
+++ b/crates/jolt-prover-legacy/src/zkvm/prover.rs
@@ -3364,7 +3364,22 @@ mod tests {
             max_trace,
         )
         .unwrap();
+        let setup_start = Instant::now();
         let prover_preprocessing = JoltProverPreprocessing::new(shared_preprocessing);
+        eprintln!("dory prover preprocessing: {:.2?}", setup_start.elapsed());
+        // `DoryCommitmentScheme::setup_prover` initializes this in production,
+        // but deliberately skips it in test binaries because unrelated tests
+        // construct differently-sized setups in one process. This isolated
+        // release harness must mirror the production verifier configuration.
+        let pairing_cache_start = Instant::now();
+        DoryGlobals::init_prepared_cache(
+            &prover_preprocessing.generators.g1_vec,
+            &prover_preprocessing.generators.g2_vec,
+        );
+        eprintln!(
+            "dory prepared-pairing cache: {:.2?}",
+            pairing_cache_start.elapsed()
+        );
         let elf_contents_opt = program.get_elf_contents();
         let elf_contents = elf_contents_opt.as_deref().expect("elf contents is None");
         let prover = RV64IMACProver::gen_from_elf(
@@ -3386,8 +3401,20 @@ mod tests {
         let prove_start = Instant::now();
         let (proof, _) = prover.prove().expect("dory prover should produce a proof");
         eprintln!("dory prove: {:.2?}", prove_start.elapsed());
+        let verifier_preprocessing_start = Instant::now();
+        let verifier_preprocessing = verifier_preprocessing_from_prover(&prover_preprocessing);
+        eprintln!(
+            "dory verifier preprocessing: {:.2?}",
+            verifier_preprocessing_start.elapsed()
+        );
         let verify_start = Instant::now();
-        verify_verifier_proof(&prover_preprocessing, proof, io_device, None);
+        jolt_verifier::verify::<
+            jolt_field::Fr,
+            jolt_dory::DoryScheme,
+            jolt_crypto::Pedersen<jolt_crypto::Bn254G1>,
+            jolt_transcript::LegacyBlake2bTranscript<jolt_field::Fr>,
+        >(&verifier_preprocessing, &io_device, &proof, None)
+        .expect("canonical verifier rejected prover-native proof");
         eprintln!("dory verify: {:.2?}", verify_start.elapsed());
     }
 

--- a/crates/jolt-prover-legacy/src/zkvm/witness.rs
+++ b/crates/jolt-prover-legacy/src/zkvm/witness.rs
@@ -53,29 +53,29 @@ pub enum CommittedPolynomial {
     /// (lattice/packed mode only; a slot of the packed witness `W`).
     UnsignedIncMsb,
     /// One-hot register selector `(chunk, lane)` of the precommitted
-    /// bytecode decomposition (lattice/packed mode; a `W_prog` slot). Lane
+    /// bytecode decomposition (lattice/packed mode; a `ProgramOneHot` slot). Lane
     /// order is rs1, rs2, rd.
     BytecodeRegisterSelector(usize, usize),
     /// Boolean circuit-flag column `(chunk, flag)` of the precommitted
-    /// bytecode decomposition (lattice/packed mode; a `W_prog` slot).
+    /// bytecode decomposition (lattice/packed mode; a `ProgramOneHot` slot).
     BytecodeCircuitFlag(usize, usize),
     /// Boolean instruction-flag column `(chunk, flag)` of the precommitted
-    /// bytecode decomposition (lattice/packed mode; a `W_prog` slot).
+    /// bytecode decomposition (lattice/packed mode; a `ProgramOneHot` slot).
     BytecodeInstructionFlag(usize, usize),
     /// One-hot lookup-table selector of a precommitted bytecode chunk
-    /// (lattice/packed mode; a `W_prog` slot).
+    /// (lattice/packed mode; a `ProgramOneHot` slot).
     BytecodeLookupSelector(usize),
     /// Boolean RAF flag column of a precommitted bytecode chunk
-    /// (lattice/packed mode; a `W_prog` slot).
+    /// (lattice/packed mode; a `ProgramOneHot` slot).
     BytecodeRafFlag(usize),
     /// Byte one-hot decomposition of a chunk's unexpanded PCs
-    /// (lattice/packed mode; a `W_prog` slot).
+    /// (lattice/packed mode; a `ProgramOneHot` slot).
     BytecodeUnexpandedPcBytes(usize),
     /// Byte one-hot decomposition of a chunk's canonical immediate field
-    /// bytes (lattice/packed mode; a `W_prog` slot).
+    /// bytes (lattice/packed mode; a `ProgramOneHot` slot).
     BytecodeImmBytes(usize),
     /// Byte one-hot decomposition of the program image words
-    /// (lattice/packed mode; a `W_prog` slot).
+    /// (lattice/packed mode; a `ProgramOneHot` slot).
     ProgramImageBytes,
 }
 
@@ -273,7 +273,7 @@ impl CommittedPolynomial {
                     .par_iter()
                     .map(|cycle| {
                         Some(
-                            crate::zkvm::packed_witness::FusedIncCycle::from_cycle(cycle)
+                            crate::zkvm::packed_witness::FusedIncValue::from_cycle(cycle)
                                 .chunk_hot_lane_bits(width, *i) as u8,
                         )
                     })
@@ -289,7 +289,7 @@ impl CommittedPolynomial {
                     .par_iter()
                     .map(|cycle| {
                         u8::from(
-                            crate::zkvm::packed_witness::FusedIncCycle::from_cycle(cycle).msb(),
+                            crate::zkvm::packed_witness::FusedIncValue::from_cycle(cycle).msb(),
                         )
                     })
                     .collect();
@@ -310,7 +310,7 @@ impl CommittedPolynomial {
             | CommittedPolynomial::BytecodeUnexpandedPcBytes(_)
             | CommittedPolynomial::BytecodeImmBytes(_)
             | CommittedPolynomial::ProgramImageBytes => {
-                panic!("W_prog sub-columns commit through the packed precommitted witness, not generate_witness")
+                panic!("ProgramOneHot sub-columns commit through the packed precommitted witness, not generate_witness")
             }
             #[cfg(not(feature = "prover"))]
             CommittedPolynomial::BytecodeRegisterSelector(..)

--- a/crates/jolt-verifier/src/preprocessing.rs
+++ b/crates/jolt-verifier/src/preprocessing.rs
@@ -23,11 +23,11 @@ pub struct CommittedProgramPreprocessing<PCS: CommitmentScheme> {
     pub bytecode_chunk_commitments: Vec<PCS::Output>,
     #[cfg(not(feature = "akita"))]
     pub program_image_commitment: PCS::Output,
-    /// The one packed `W_prog` commitment covering every bytecode lane
+    /// The one packed `ProgramOneHot` commitment covering every bytecode lane
     /// sub-column and the program image bytes (the per-chunk/image commitment
     /// pair does not exist on the packed path).
     #[cfg(feature = "akita")]
-    pub w_prog_commitment: PCS::Output,
+    pub program_one_hot_commitment: PCS::Output,
     #[cfg(feature = "akita")]
     pub bytecode_chunk_count: usize,
 }
@@ -137,7 +137,7 @@ where
     pub program: ProgramPreprocessing<PCS>,
     pub preprocessing_digest: [u8; 32],
     /// The main PCS setup: every per-polynomial opening on the homomorphic
-    /// build, the `W_jolt` object on the `akita` build (whose remaining
+    /// build, the `OneHotTrace` object on the `akita` build (whose remaining
     /// objects carry their own shape-exact setups below).
     pub pcs_setup: PCS::VerifierSetup,
     pub vc_setup: Option<VC::Setup>,
@@ -145,9 +145,9 @@ where
     pub untrusted_advice_setup: Option<PCS::VerifierSetup>,
     #[cfg(feature = "akita")]
     pub trusted_advice_setup: Option<PCS::VerifierSetup>,
-    /// Committed-program mode: the `W_prog` object setup.
+    /// Committed-program mode: the `ProgramOneHot` object setup.
     #[cfg(feature = "akita")]
-    pub w_prog_setup: Option<PCS::VerifierSetup>,
+    pub program_one_hot_setup: Option<PCS::VerifierSetup>,
 }
 
 impl<PCS, VC> JoltVerifierPreprocessing<PCS, VC>
@@ -171,7 +171,7 @@ where
             #[cfg(feature = "akita")]
             trusted_advice_setup: None,
             #[cfg(feature = "akita")]
-            w_prog_setup: None,
+            program_one_hot_setup: None,
         }
     }
 }

--- a/crates/jolt-verifier/src/proof.rs
+++ b/crates/jolt-verifier/src/proof.rs
@@ -20,7 +20,7 @@ use crate::{
 #[cfg(not(feature = "akita"))]
 pub type ProofCommitments<PCS> = JoltCommitments<<PCS as Commitment>::Output>;
 /// The proof-carried polynomial commitments on the `akita` build: the single
-/// packed `W_jolt` commitment carrying every per-proof column.
+/// packed `OneHotTrace` commitment carrying every per-proof column.
 #[cfg(feature = "akita")]
 pub type ProofCommitments<PCS> = <PCS as Commitment>::Output;
 
@@ -28,12 +28,12 @@ pub type ProofCommitments<PCS> = <PCS as Commitment>::Output;
 /// opening proof at the unified point.
 #[cfg(not(feature = "akita"))]
 pub type JointOpeningProof<PCS> = <PCS as CommitmentScheme>::Proof;
-/// The Akita Wjolt opening is native and same-point. Only auxiliary packed
+/// The Akita OneHotTrace opening is native and same-point. Only auxiliary packed
 /// objects retain the generic reduction proof.
 #[cfg(feature = "akita")]
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct AkitaJointOpeningProof<F, P> {
-    pub w_jolt: P,
+    pub one_hot_trace: P,
     pub auxiliary: Option<jolt_openings::PackedOpeningProof<F, P>>,
 }
 

--- a/crates/jolt-verifier/src/stages/stage7/hamming_weight_claim_reduction.rs
+++ b/crates/jolt-verifier/src/stages/stage7/hamming_weight_claim_reduction.rs
@@ -55,7 +55,7 @@ pub fn hamming_weight_input_values_from_upstream<F: Field>(
         bytecode_virtualization: cycle_phase.bytecode_read_raf.bytecode_ra.clone(),
         ram_virtualization: cycle_phase.ram_ra_virtualization.ram_ra.clone(),
         #[cfg(feature = "akita")]
-        unsigned_inc_booleanity: cycle_phase.booleanity.unsigned_inc_chunks.clone(),
+        unsigned_inc_chunk_booleanity: cycle_phase.booleanity.unsigned_inc_chunks.clone(),
         #[cfg(feature = "akita")]
         unsigned_inc_msb_booleanity: cycle_phase.booleanity.unsigned_inc_msb,
         #[cfg(feature = "akita")]

--- a/crates/jolt-verifier/src/stages/stage7/outputs.rs
+++ b/crates/jolt-verifier/src/stages/stage7/outputs.rs
@@ -309,7 +309,7 @@ mod tests {
     /// old hand count to the Expr-derived sums.
     #[test]
     #[expect(clippy::unwrap_used)]
-    fn output_shape_member_counts_match_hand_derived_openings() {
+    fn output_shape_column_counts_match_hand_derived_openings() {
         use jolt_claims::protocols::jolt::geometry::claim_reductions::hamming_weight::{
             claim_reduction_output_openings, HammingWeightClaimReductionDimensions,
         };

--- a/crates/jolt-verifier/src/stages/stage8/mod.rs
+++ b/crates/jolt-verifier/src/stages/stage8/mod.rs
@@ -27,9 +27,10 @@ pub use verify::verify;
 pub use verify::{batch_entries, Stage8BatchEntry};
 
 /// The commitment/setup metadata Stage 8 enforces before dispatching a
-/// native Wjolt opening — the generic [`jolt_openings`] traits, applied here
-/// to the W_jolt group (impls live beside the concrete PCS types).
+/// native OneHotTrace opening — the generic [`jolt_openings`] traits, applied here
+/// to the OneHotTrace group (impls live beside the concrete PCS types).
 #[cfg(feature = "akita")]
 pub use jolt_openings::{
-    GroupCommitmentMetadata as WJoltCommitmentMetadata, GroupSetupMetadata as WJoltSetupMetadata,
+    GroupCommitmentMetadata as OneHotTraceCommitmentMetadata,
+    GroupSetupMetadata as OneHotTraceSetupMetadata,
 };

--- a/crates/jolt-verifier/src/stages/stage8/outputs.rs
+++ b/crates/jolt-verifier/src/stages/stage8/outputs.rs
@@ -29,7 +29,7 @@ pub enum Stage8Output<F: Field, C, H> {
     #[cfg(not(feature = "akita"))]
     Clear(Stage8ClearOutput<F, C>),
     /// The akita build's clear stage 8 verifies to completion inside
-    /// [`super::verify`] (native W_jolt batch + auxiliary packed openings),
+    /// [`super::verify`] (native OneHotTrace batch + auxiliary packed openings),
     /// so no per-opening payload survives it.
     #[cfg(feature = "akita")]
     Clear,

--- a/crates/jolt-verifier/src/stages/stage8/packed.rs
+++ b/crates/jolt-verifier/src/stages/stage8/packed.rs
@@ -1,8 +1,8 @@
 //! The Akita final opening.
 //!
-//! Wjolt is a native group of uniform one-hot members, all opened directly at
-//! one canonical point. Optional advice and committed-program objects have
-//! distinct domains and are discharged separately through
+//! `OneHotTrace` is one native group of uniform one-hot columns, all opened
+//! directly at one canonical point. Optional advice and committed-program
+//! objects have distinct domains and are discharged separately through
 //! [`jolt_openings::verify_packed_openings`].
 
 use std::collections::BTreeMap;
@@ -10,9 +10,11 @@ use std::collections::BTreeMap;
 use jolt_claims::protocols::jolt::geometry::dimensions::JoltFormulaDimensions;
 use jolt_claims::protocols::jolt::lattice::geometry::word_byte_num_vars;
 use jolt_claims::protocols::jolt::lattice::packing::{
-    advice_bytes_packing, precommitted_packing, PrecommittedPackingShape, WJoltShape,
+    advice_bytes_packing, precommitted_packing, OneHotTraceShape, PrecommittedPackingShape,
 };
-use jolt_claims::protocols::jolt::lattice::strategy::{WJoltLayoutPlan, W_JOLT_LAYOUT};
+use jolt_claims::protocols::jolt::lattice::strategy::{
+    OneHotTraceLayoutPlan, ONE_HOT_TRACE_LAYOUT,
+};
 use jolt_claims::protocols::jolt::{
     JoltAdviceKind, JoltCommittedPolynomial, JoltOneHotConfig, JoltOpeningId, JoltPolynomialId,
 };
@@ -26,7 +28,7 @@ use jolt_transcript::{AppendToTranscript, Transcript};
 
 use super::reconstruction::ReconstructionClearOutput;
 use crate::stages::stage7::outputs::Stage7ClearOutput;
-use crate::stages::stage8::{WJoltCommitmentMetadata, WJoltSetupMetadata};
+use crate::stages::stage8::{OneHotTraceCommitmentMetadata, OneHotTraceSetupMetadata};
 use crate::VerifierError;
 
 fn batch_failed(reason: impl ToString) -> VerifierError {
@@ -41,48 +43,48 @@ fn opening_failed(reason: impl ToString) -> VerifierError {
     }
 }
 
-fn validate_wjolt_metadata<C, S>(
+fn validate_one_hot_trace_metadata<C, S>(
     commitment: &C,
     setup: &S,
     canonical_digest: [u8; 32],
-    member_arity: usize,
-    member_count: usize,
+    column_arity: usize,
+    column_count: usize,
     one_hot_k: usize,
 ) -> Result<(), VerifierError>
 where
-    C: WJoltCommitmentMetadata,
-    S: WJoltSetupMetadata,
+    C: OneHotTraceCommitmentMetadata,
+    S: OneHotTraceSetupMetadata,
 {
     if !commitment.is_one_hot_backend() {
         return Err(batch_failed(
-            "Wjolt commitment must use Akita's one-hot backend",
+            "OneHotTrace commitment must use Akita's one-hot backend",
         ));
     }
     if commitment.one_hot_k() != one_hot_k || setup.one_hot_k() != one_hot_k {
         return Err(batch_failed(format!(
-            "Wjolt commitment/setup one-hot chunk size must equal canonical K={one_hot_k}"
+            "OneHotTrace commitment/setup one-hot chunk size must equal canonical K={one_hot_k}"
         )));
     }
     if commitment.layout_digest() != canonical_digest {
         return Err(batch_failed(
-            "Wjolt commitment has a noncanonical layout digest",
+            "OneHotTrace commitment has a noncanonical layout digest",
         ));
     }
-    if commitment.num_vars() != member_arity || setup.max_num_vars() != member_arity {
+    if commitment.num_vars() != column_arity || setup.max_num_vars() != column_arity {
         return Err(batch_failed(format!(
-            "Wjolt commitment/setup arity must equal canonical arity {member_arity}"
+            "OneHotTrace commitment/setup arity must equal canonical arity {column_arity}"
         )));
     }
-    if commitment.poly_count() != member_count
-        || setup.max_num_polys_per_commitment_group() != member_count
+    if commitment.poly_count() != column_count
+        || setup.max_num_polys_per_commitment_group() != column_count
     {
         return Err(batch_failed(format!(
-            "Wjolt commitment/setup member count must equal canonical count {member_count}"
+            "OneHotTrace commitment/setup column count must equal canonical count {column_count}"
         )));
     }
     if setup.default_layout_digest() != canonical_digest {
         return Err(batch_failed(
-            "Wjolt verifier setup has a noncanonical layout digest",
+            "OneHotTrace verifier setup has a noncanonical layout digest",
         ));
     }
     Ok(())
@@ -143,7 +145,7 @@ pub fn verify<PCS, VC, T>(
     formula_dimensions: &JoltFormulaDimensions,
     one_hot_config: JoltOneHotConfig,
     preprocessing: &crate::preprocessing::JoltVerifierPreprocessing<PCS, VC>,
-    w_jolt_commitment: &PCS::Output,
+    one_hot_trace_commitment: &PCS::Output,
     untrusted_advice_commitment: Option<&PCS::Output>,
     trusted_advice_commitment: Option<&PCS::Output>,
     proof: &crate::proof::AkitaJointOpeningProof<PCS::Field, PCS::Proof>,
@@ -153,53 +155,57 @@ pub fn verify<PCS, VC, T>(
 ) -> Result<(), VerifierError>
 where
     PCS: CommitmentScheme,
-    PCS::Output: Clone + AppendToTranscript + WJoltCommitmentMetadata,
-    PCS::VerifierSetup: WJoltSetupMetadata,
+    PCS::Output: Clone + AppendToTranscript + OneHotTraceCommitmentMetadata,
+    PCS::VerifierSetup: OneHotTraceSetupMetadata,
     VC: jolt_crypto::VectorCommitment<Field = PCS::Field>,
     T: Transcript<Challenge = PCS::Field>,
 {
     // Per-object packings, commitments, and setups in canonical object order:
-    // `W_jolt` is one native group of uniform one-hot members, followed by the
-    // optional auxiliary commitment objects. The shared layout is the same
-    // one the prover committed under.
+    // `OneHotTrace` is one native group of uniform one-hot columns, followed
+    // by the optional auxiliary commitment objects. The shared layout is the
+    // same one the prover committed under.
     // Optional objects join exactly when their reconstruction outputs exist;
     // presence must agree with the proof/preprocessing commitment slots.
     let chunk_width = one_hot_config.committed_chunk_bits();
-    let wjolt_shape = WJoltShape {
+    let one_hot_trace_shape = OneHotTraceShape {
         ra_layout: formula_dimensions.ra_layout,
         log_t: formula_dimensions.trace.log_t(),
         log_k_chunk: chunk_width,
     };
-    let plan = W_JOLT_LAYOUT.plan(&wjolt_shape).map_err(batch_failed)?;
-    let canonical_digest = W_JOLT_LAYOUT
-        .layout_digest(&wjolt_shape)
+    let plan = ONE_HOT_TRACE_LAYOUT
+        .plan(&one_hot_trace_shape)
         .map_err(batch_failed)?;
-    let WJoltLayoutPlan {
-        members,
-        member_arity,
+    let canonical_digest = ONE_HOT_TRACE_LAYOUT
+        .layout_digest(&one_hot_trace_shape)
+        .map_err(batch_failed)?;
+    let OneHotTraceLayoutPlan {
+        columns,
+        column_arity,
     } = &plan;
-    validate_wjolt_metadata(
-        w_jolt_commitment,
+    validate_one_hot_trace_metadata(
+        one_hot_trace_commitment,
         &preprocessing.pcs_setup,
         canonical_digest,
-        *member_arity,
-        members.len(),
+        *column_arity,
+        columns.len(),
         1 << chunk_width,
     )?;
     let leaves = leaf_claims(stage7, reconstruction);
     let mut common_point: Option<Vec<PCS::Field>> = None;
-    let mut evaluations = Vec::with_capacity(members.len());
-    for polynomial in members {
-        let claim = leaves
-            .get(polynomial)
-            .ok_or_else(|| batch_failed(format!("missing final Wjolt claim for {polynomial:?}")))?;
-        let point = W_JOLT_LAYOUT
-            .member_point(*polynomial, chunk_width, claim.point.as_slice())
+    let mut evaluations = Vec::with_capacity(columns.len());
+    for polynomial in columns {
+        let claim = leaves.get(polynomial).ok_or_else(|| {
+            batch_failed(format!(
+                "missing final OneHotTrace claim for {polynomial:?}"
+            ))
+        })?;
+        let point = ONE_HOT_TRACE_LAYOUT
+            .column_point(*polynomial, chunk_width, claim.point.as_slice())
             .map_err(batch_failed)?;
         if let Some(expected) = &common_point {
             if expected != &point {
                 return Err(batch_failed(format!(
-                    "Wjolt member {polynomial:?} does not share the canonical opening point"
+                    "OneHotTrace column {polynomial:?} does not share the canonical opening point"
                 )));
             }
         } else {
@@ -207,12 +213,12 @@ where
         }
         evaluations.push(claim.value);
     }
-    let common_point = common_point.ok_or_else(|| batch_failed("Wjolt has no members"))?;
+    let common_point = common_point.ok_or_else(|| batch_failed("OneHotTrace has no columns"))?;
     PCS::verify_batch(
-        w_jolt_commitment,
+        one_hot_trace_commitment,
         &common_point,
         &evaluations,
-        &proof.w_jolt,
+        &proof.one_hot_trace,
         &preprocessing.pcs_setup,
         transcript,
     )
@@ -258,10 +264,15 @@ where
         preprocessing.program.committed(),
     ) {
         (Some(bytecode_points), Some(committed)) => {
-            let setup = preprocessing.w_prog_setup.as_ref().ok_or_else(|| {
-                batch_failed("committed-program object without a verifier setup in preprocessing")
-            })?;
-            // The `W_prog` shape is claim-derived: the packing must match the
+            let setup = preprocessing
+                .program_one_hot_setup
+                .as_ref()
+                .ok_or_else(|| {
+                    batch_failed(
+                        "committed-program object without a verifier setup in preprocessing",
+                    )
+                })?;
+            // The `ProgramOneHot` shape is claim-derived: the packing must match the
             // committed witness or its PCS opening fails, so the lane/image
             // point arities are an honest source for the row/word counts.
             let log_bytecode_rows = bytecode_points
@@ -286,18 +297,18 @@ where
                 })
                 .map_err(batch_failed)?,
             );
-            commitments.push(&committed.w_prog_commitment);
+            commitments.push(&committed.program_one_hot_commitment);
             setups.push(setup);
         }
         (None, None) => {}
         (Some(_), None) => {
             return Err(batch_failed(
-                "program reconstruction leaves without a W_prog commitment",
+                "program reconstruction leaves without a ProgramOneHot commitment",
             ));
         }
         (None, Some(_)) => {
             return Err(batch_failed(
-                "W_prog commitment supplied without program reconstruction leaves",
+                "ProgramOneHot commitment supplied without program reconstruction leaves",
             ));
         }
     }
@@ -526,7 +537,7 @@ mod tests {
         one_hot_k: usize,
     }
 
-    impl WJoltCommitmentMetadata for CommitmentMetadata {
+    impl OneHotTraceCommitmentMetadata for CommitmentMetadata {
         fn is_one_hot_backend(&self) -> bool {
             self.one_hot
         }
@@ -556,7 +567,7 @@ mod tests {
         one_hot_k: usize,
     }
 
-    impl WJoltSetupMetadata for SetupMetadata {
+    impl OneHotTraceSetupMetadata for SetupMetadata {
         fn max_num_vars(&self) -> usize {
             self.num_vars
         }
@@ -579,7 +590,7 @@ mod tests {
     }
 
     #[test]
-    fn wjolt_metadata_is_enforced_before_pcs_verification() {
+    fn one_hot_trace_metadata_is_enforced_before_pcs_verification() {
         let digest = [7; 32];
         let commitment = CommitmentMetadata {
             one_hot: true,
@@ -594,7 +605,7 @@ mod tests {
             poly_count: 17,
             one_hot_k: 256,
         };
-        assert!(validate_wjolt_metadata(&commitment, &setup, digest, 12, 17, 256).is_ok());
+        assert!(validate_one_hot_trace_metadata(&commitment, &setup, digest, 12, 17, 256).is_ok());
 
         for invalid in [
             CommitmentMetadata {
@@ -618,7 +629,9 @@ mod tests {
                 ..commitment
             },
         ] {
-            assert!(validate_wjolt_metadata(&invalid, &setup, digest, 12, 17, 256).is_err());
+            assert!(
+                validate_one_hot_trace_metadata(&invalid, &setup, digest, 12, 17, 256).is_err()
+            );
         }
         for invalid in [
             SetupMetadata {
@@ -638,7 +651,10 @@ mod tests {
                 ..setup
             },
         ] {
-            assert!(validate_wjolt_metadata(&commitment, &invalid, digest, 12, 17, 256).is_err());
+            assert!(
+                validate_one_hot_trace_metadata(&commitment, &invalid, digest, 12, 17, 256)
+                    .is_err()
+            );
         }
     }
 

--- a/crates/jolt-verifier/src/stages/stage8/reconstruction.rs
+++ b/crates/jolt-verifier/src/stages/stage8/reconstruction.rs
@@ -1,7 +1,7 @@
 //! The packed reconstruction phase, strictly after stage 7: one batched
 //! sumcheck settling every virtualized word/chunk claim against its committed
 //! one-hot decomposition, producing the packed final claims for the advice
-//! byte columns and the `W_prog` lane columns. Members in canonical
+//! byte columns and the `ProgramOneHot` lane columns. Members in canonical
 //! commitment-object order: untrusted advice, trusted advice, bytecode
 //! chunks, program image. The phase is entirely absent (zero transcript
 //! interaction) when no advice is present and the program is full.

--- a/crates/jolt-verifier/src/stages/stage8/verify.rs
+++ b/crates/jolt-verifier/src/stages/stage8/verify.rs
@@ -449,8 +449,8 @@ pub fn verify<F, PCS, VC, T, ZkProof>(
 where
     F: Field,
     PCS: CommitmentScheme<Field = F>,
-    PCS::Output: Clone + AppendToTranscript + super::WJoltCommitmentMetadata,
-    PCS::VerifierSetup: super::WJoltSetupMetadata,
+    PCS::Output: Clone + AppendToTranscript + super::OneHotTraceCommitmentMetadata,
+    PCS::VerifierSetup: super::OneHotTraceSetupMetadata,
     VC: VectorCommitment<Field = F>,
     T: Transcript<Challenge = F>,
 {
@@ -465,7 +465,7 @@ where
         stage7.clear()?,
     )?;
 
-    // Wjolt then opens natively at its shared point; reconstruction leaves are
+    // OneHotTrace then opens natively at its shared point; reconstruction leaves are
     // discharged by separate auxiliary packed openings.
     super::packed::verify(
         formula_dimensions,

--- a/crates/jolt-verifier/src/verifier.rs
+++ b/crates/jolt-verifier/src/verifier.rs
@@ -167,7 +167,7 @@ where
 
 /// The Akita verification path: the same stage spine, with the
 /// inc-virtualization phase opening the stage-6 region, the reconstruction
-/// phase producing auxiliary leaves, a native same-point Wjolt opening, and
+/// phase producing auxiliary leaves, a native same-point OneHotTrace opening, and
 /// separate packed openings for auxiliary objects in place of the homomorphic
 /// RLC batch. No homomorphism bounds and no ZK tail.
 #[cfg(feature = "akita")]
@@ -180,8 +180,8 @@ pub fn verify<F, PCS, VC, T>(
 where
     F: Field + AppendToTranscript,
     PCS: CommitmentScheme<Field = F>,
-    PCS::Output: Clone + AppendToTranscript + stage8::WJoltCommitmentMetadata,
-    PCS::VerifierSetup: stage8::WJoltSetupMetadata,
+    PCS::Output: Clone + AppendToTranscript + stage8::OneHotTraceCommitmentMetadata,
+    PCS::VerifierSetup: stage8::OneHotTraceSetupMetadata,
     VC: VectorCommitment<Field = F>,
     VC::Output: Copy + AppendToTranscript,
     T: Transcript<Challenge = F>,
@@ -645,8 +645,8 @@ pub(crate) fn absorb_preamble<PCS, VC, ZkProof, T>(
 /// polynomial commitments, the optional advice commitments, then the committed
 /// program's preprocessing-held commitments. WARNING: the prover must absorb
 /// identically or the transcripts diverge. On the `akita` build the order is
-/// the canonical commitment-object order: `W_jolt`, untrusted advice, trusted
-/// advice, `W_prog`.
+/// the canonical commitment-object order: `OneHotTrace`, untrusted advice, trusted
+/// advice, `ProgramOneHot`.
 pub(crate) fn absorb_commitments<PCS, VC, ZkProof, T>(
     preprocessing: &JoltVerifierPreprocessing<PCS, VC>,
     proof: &JoltProof<PCS, VC, ZkProof>,
@@ -684,8 +684,8 @@ pub(crate) fn absorb_commitments<PCS, VC, ZkProof, T>(
             append_length_prefixed(transcript, b"trusted_advice", commitment);
         }
         if let Some(committed) = preprocessing.program.committed() {
-            let commitment = &committed.w_prog_commitment;
-            append_length_prefixed(transcript, b"w_prog_commitment", commitment);
+            let commitment = &committed.program_one_hot_commitment;
+            append_length_prefixed(transcript, b"program_one_hot_commitment", commitment);
         }
     }
 }
@@ -1325,7 +1325,7 @@ mod tests {
             joint_opening_proof: (),
             #[cfg(feature = "akita")]
             joint_opening_proof: crate::proof::AkitaJointOpeningProof {
-                w_jolt: (),
+                one_hot_trace: (),
                 auxiliary: None,
             },
             untrusted_advice_commitment: None,

--- a/crates/jolt-verifier/tests/soundness/tampering/akita.rs
+++ b/crates/jolt-verifier/tests/soundness/tampering/akita.rs
@@ -8,7 +8,7 @@
 //!   ([`for_each_scalar_mut`]) fully destructures every aggregate, so a future
 //!   claim wire cannot be added without failing to compile until it is covered.
 //! - A byte-level commitment sweep ([`every_commitment_wire_rejects_perturbation`]):
-//!   every serde leaf of the `W_jolt` (and untrusted-advice) commitment objects
+//!   every serde leaf of the `OneHotTrace` (and untrusted-advice) commitment objects
 //!   — layout digest, declared dimensions, backend flavor, backend bytes — is
 //!   perturbed; a deserialization failure or a verifier rejection both count.
 //! - Proof-shape tampers ([`akita_proof_shape_tampers_reject`],
@@ -89,7 +89,7 @@ use crate::support::akita_fixtures::{
 };
 use crate::support::assert_rejects;
 
-/// The single packed `W_jolt` commitment object type (also the advice object
+/// The single packed `OneHotTrace` commitment object type (also the advice object
 /// type): the concrete `Commitment::Output` of the akita scheme.
 type AkitaCommitment = <AkitaScheme as jolt_crypto::Commitment>::Output;
 
@@ -714,7 +714,7 @@ fn sweep_commitment(
     }
 }
 
-/// Every commitment-object wire — the `W_jolt` layout digest, declared
+/// Every commitment-object wire — the `OneHotTrace` layout digest, declared
 /// dimensions, backend flavor, and backend bytes, plus the untrusted-advice
 /// object when present — rejects a leaf-level perturbation.
 #[test]

--- a/crates/jolt-verifier/tests/support/akita_fixtures.rs
+++ b/crates/jolt-verifier/tests/support/akita_fixtures.rs
@@ -19,8 +19,8 @@ use jolt_verifier::{verify, JoltVerifierPreprocessing, VerifierError};
 use jolt_openings::CommitmentScheme as VerifierCommitmentScheme;
 use jolt_prover_legacy::host;
 use jolt_prover_legacy::zkvm::packed::{
-    akita_verifier_preprocessing, commit_trusted_advice_packed,
-    shared_preprocessing_committed_packed, AkitaField, AkitaJoltProof, AkitaPackedProver,
+    akita_verifier_preprocessing, commit_trusted_advice_one_hot,
+    shared_preprocessing_with_program_one_hot, AkitaField, AkitaJoltProof, AkitaPackedProver,
     AkitaPackedScheme, AkitaScheme, AkitaTranscript, AkitaVc,
 };
 use jolt_prover_legacy::zkvm::preprocessing::JoltSharedPreprocessing;
@@ -51,20 +51,20 @@ impl AkitaFixtureCase {
     }
 }
 
-/// The muldiv case: one `W_jolt` commitment object, no auxiliary objects.
+/// The muldiv case: one `OneHotTrace` commitment object, no auxiliary objects.
 pub fn akita_muldiv_case() -> &'static AkitaFixtureCase {
     static CASE: OnceLock<AkitaFixtureCase> = OnceLock::new();
     CASE.get_or_init(generate_muldiv)
 }
 
 /// The advice case: both advice kinds, three commitment objects
-/// (`W_jolt`, `A_unt`, `A_tru`) and an auxiliary joint opening.
+/// (`OneHotTrace`, `UntrustedAdviceOneHot`, `TrustedAdviceOneHot`) and an auxiliary joint opening.
 pub fn akita_advice_case() -> &'static AkitaFixtureCase {
     static CASE: OnceLock<AkitaFixtureCase> = OnceLock::new();
     CASE.get_or_init(generate_advice)
 }
 
-/// The committed-program case: `W_prog` as the auxiliary packed object.
+/// The committed-program case: `ProgramOneHot` as the auxiliary packed object.
 pub fn akita_committed_muldiv_case() -> &'static AkitaFixtureCase {
     static CASE: OnceLock<AkitaFixtureCase> = OnceLock::new();
     CASE.get_or_init(generate_committed_muldiv)
@@ -94,7 +94,7 @@ fn generate_muldiv() -> AkitaFixtureCase {
     );
     let public_io = prover.program_io.clone();
     let (object_setup, verifier_setup) =
-        <AkitaScheme as VerifierCommitmentScheme>::setup(prover.wjolt_setup_params())
+        <AkitaScheme as VerifierCommitmentScheme>::setup(prover.one_hot_trace_setup_params())
             .expect("transparent packed setup");
     let proof = prover
         .prove_packed(&object_setup, None, None)
@@ -125,7 +125,7 @@ fn generate_advice() -> AkitaFixtureCase {
         JoltSharedPreprocessing::new(program_data, io_device.memory_layout.clone(), 1 << 16);
     let prover_preprocessing = JoltProverPreprocessing::new(shared);
     let elf_contents = program.get_elf_contents().expect("elf contents");
-    let trusted_object = commit_trusted_advice_packed(
+    let trusted_object = commit_trusted_advice_one_hot(
         &trusted_advice,
         io_device.memory_layout.max_trusted_advice_size as usize,
     )
@@ -142,7 +142,7 @@ fn generate_advice() -> AkitaFixtureCase {
     );
     let public_io = prover.program_io.clone();
     let (object_setup, verifier_setup) =
-        <AkitaScheme as VerifierCommitmentScheme>::setup(prover.wjolt_setup_params())
+        <AkitaScheme as VerifierCommitmentScheme>::setup(prover.one_hot_trace_setup_params())
             .expect("transparent packed setup");
     let trusted_commitment = trusted_object.commitment.clone();
     let proof = prover
@@ -165,7 +165,7 @@ fn generate_committed_muldiv() -> AkitaFixtureCase {
 
     let program_data = ProgramPreprocessing::preprocess(bytecode, init_memory_state, e_entry)
         .expect("program preprocessing");
-    let (shared, prover_data, w_prog) = shared_preprocessing_committed_packed(
+    let (shared, prover_data, program_one_hot) = shared_preprocessing_with_program_one_hot(
         program_data,
         io_device.memory_layout.clone(),
         1 << 16,
@@ -187,16 +187,16 @@ fn generate_committed_muldiv() -> AkitaFixtureCase {
     );
     let public_io = prover.program_io.clone();
     let (object_setup, verifier_setup) =
-        <AkitaScheme as VerifierCommitmentScheme>::setup(prover.wjolt_setup_params())
+        <AkitaScheme as VerifierCommitmentScheme>::setup(prover.one_hot_trace_setup_params())
             .expect("transparent packed setup");
-    let w_prog_commitment = w_prog.commitment.clone();
+    let program_one_hot_commitment = program_one_hot.commitment.clone();
     let proof = prover
-        .prove_packed(&object_setup, None, Some(w_prog))
+        .prove_packed(&object_setup, None, Some(program_one_hot))
         .expect("packed prover");
     let preprocessing = akita_verifier_preprocessing(
         &prover_preprocessing,
         verifier_setup,
-        Some(w_prog_commitment),
+        Some(program_one_hot_commitment),
     );
     AkitaFixtureCase {
         preprocessing,

--- a/specs/akita-optimal-committed-data.md
+++ b/specs/akita-optimal-committed-data.md
@@ -1,7 +1,7 @@
 # Optimal committed-data form for the packed (Akita) path
 
 > **Status 2026-07-16**: superseded in part by the #1683 distillation
-> (`specs/akita-1683-distillation.md`): W_jolt now commits as the native
+> (`specs/akita-1683-distillation.md`): OneHotTrace now commits as the native
 > one-hot group and opens at one common point (no packed union, no
 > reduction sumcheck), K=16 below 2^25 with jolt-owned schedule catalogs.
 > Measured 2^20 sha2-chain: akita 8.19s vs dory 13.64s (0.60×). The
@@ -11,7 +11,7 @@
 > protocol work.
 
 
-Working note for co-designing the W_jolt commitment format with the akita
+Working note for co-designing the OneHotTrace commitment format with the akita
 backend (local checkout at `../akita`, baseline upstream `33169b8d`). The
 question: what is the cheapest sound way to commit and open Jolt's packed
 one-hot witness data? This is the canonical record of the investigation —
@@ -51,7 +51,7 @@ select" over `T = 2^20` cycles:
 |---|---|
 | information content | `T` one-byte symbols ≈ 1 MB / member |
 | PIOP object (one-hot multilinear extension) | `K·T = 2^28` cells, ≤ `2^20` ones |
-| whole `W_jolt` (~29 members at 2^20) | ~29 MB of data → ~2^32.9 committed cells, ~3.0·10^7 ones |
+| whole `OneHotTrace` (~29 members at 2^20) | ~29 MB of data → ~2^32.9 committed cells, ~3.0·10^7 ones |
 
 The PIOP's sumchecks emit evaluation claims on the **28-variable one-hot
 extension**, not on the symbol vector — so whatever we commit must support
@@ -136,7 +136,7 @@ Two corrections this table forced on our intuitions:
 | K=2^16 fusion (`log_k_chunk = 16`) | ~4.5 s | ones ×0.52, `n_a`→7 | chunk-65536 preset + regenerated schedules; u16 indices exist upstream |
 | ~~sparse-unit union on de-tiered backend~~ | ~~1–2 s?~~ | small-`num_vars` kernel constant | **measured DEAD below: 72 s commit / 112 s open at 33v** |
 | **committed-symbols mode (the optimal path)** | **~2.8 s stock, ~1 s with a bit-aware backend preset/kernel** | commit the bit-planes (2^23 cells, m ≈ 2^17) via the dense path: per symbol `n_a·D` mults/8 ≈ 144 add-eq vs one-hot's 384 (2.7× stock); unit-norm sizing + narrow-CRT accumulation close the rest | opening gains a degree-9 one-hot-evaluation sumcheck leg + bit-booleanity |
-| multi-group merge of advice/W_prog (orthogonal) | −0.5–1 s of opens | upstream #275 | protocol plumbing only |
+| multi-group merge of advice/ProgramOneHot (orthogonal) | −0.5–1 s of opens | upstream #275 | protocol plumbing only |
 
 ### The committed-symbols co-design, in one paragraph
 
@@ -193,7 +193,7 @@ floor against the measured breakdown (commit 7.5 + open 4.7 + reduction 1.9
 | one-hot accumulate vectorization (NEON, accumulator batching, narrow-CRT) | akita, kernel-only | commit → 2–3.5 s | medium-high (6× over arithmetic floor is measured) |
 | `n_a` sizing at 28v (6 → 5?) under the 138-bit tables | akita, config | ×0.83 on commit, partial on open | unknown — estimator question |
 | open-phase parallelization (~1.5× utilization today) | akita, same proof bytes | open → 1.5–2.5 s | medium |
-| multi-group merge of advice/W_prog (#275) | jolt plumbing | −0.5–1 s | high |
+| multi-group merge of advice/ProgramOneHot (#275) | jolt plumbing | −0.5–1 s | high |
 | ~~reduction sweep-halving (paired rounds)~~ | jolt | **measured neutral** — the sweep is bound by split-eq table accesses (4/position paired vs 2×2 single), not arithmetic; object-parallel rounds also measured neutral earlier. The reduction window (~1.9 s) is access-bound from every angle | — |
 | PIOP stage polish | jolt | −0.3–0.5 s | medium |
 
@@ -252,7 +252,7 @@ the lattice booleanity / hamming-weight-1 machinery becomes partially
 redundant (~1–2 s candidate), but it reshapes the claim flow feeding the
 leaves — its own iteration.
 
-**Phase 4 — multi-group merge (orthogonal).** Advice/W_prog into the same
+**Phase 4 — multi-group merge (orthogonal).** Advice/ProgramOneHot into the same
 commitment via upstream #275 (~0.5–1 s of singleton opens).
 
 **Backend co-dev track (parallel, `../akita`):** audited schedule entries
@@ -278,23 +278,29 @@ remain akita-side fallback tracks.
 
 ## Current state and code map (for the cleanup phase)
 
-The pipeline today: `W_jolt` = one commitment object of ~29 row-major
-K=256 `OneHotPolynomial` members (one per committed column), committed by
-`AkitaScheme::commit_one_hot_group` and opened by one native batched proof;
-`W_prog` and the advice byte columns remain singleton objects. The packed
-reduction settles every leaf claim (one per member, plus the singletons')
-in a single sumcheck, after which groups open natively.
+The pipeline today: `OneHotTrace` is one native Akita commitment group of
+uniform row-major `K x T` one-hot columns. Every column opens at the same
+`(cycle || address)` point in one backend batch proof. `ProgramOneHot` and the
+advice byte columns remain separate singleton objects.
+
+The single-polynomial layout experiment was rejected. Packing the semantic
+columns into a new Boolean column axis required power-of-two zero padding and
+raised the polynomial arity by six or seven variables. At `T = 2^20`, the
+result took 47.52 s to prove versus the earlier 6.97 s grouped baseline, while
+verification remained 23.59 ms. The extra arity, not padding alone, destroys
+the native one-hot schedule economics. There is therefore no column-axis fold
+and no additional sumcheck.
 
 | piece | where |
 |---|---|
-| member assembly (`assemble_one_hot_members`) | `jolt-prover-legacy/src/zkvm/packed_witness.rs` |
-| prove pipeline (`prove_packed`, member statements, groups) | `jolt-prover-legacy/src/zkvm/packed.rs` |
-| leaf-point mapping (`one_hot_member_point`, symbol‖cycle → cycle‖lane; msb as lanes {0,1}) | `jolt-claims/src/protocols/jolt/lattice/packing.rs` |
+| compact-source column assembly (`assemble_one_hot_trace`) | `jolt-prover-legacy/src/zkvm/packed.rs` |
+| prove pipeline (one native grouped opening) | `jolt-prover-legacy/src/zkvm/packed.rs` |
+| layout and point mapping (`address‖cycle` → `cycle‖address`) | `jolt-claims/src/protocols/jolt/lattice/strategy.rs` |
 | reduction sumcheck + grouped native tail (`prove/verify_packed_openings`, `PackedObjectGroup`, `open_batch`) | `jolt-openings/src/packing.rs` |
-| backend adapter (`commit_one_hot_group`, `open_batch`/`verify_batch`, one-hot-only setups) | `jolt-akita/src/{scheme,native_batching,adapters}.rs` |
+| owned backend adapter (`commit_one_hot_group_owned`, `open_one_hot_group_from_hint`) | `jolt-akita/src/{scheme,adapters}.rs` |
 | verifier mirror | `jolt-verifier/src/stages/stage8/packed.rs` |
 | flavor/measurement bench (`flavor_bench`, `BENCH_*` env knobs) | `jolt-akita/src/scheme.rs` |
-| packed config (`log_k_chunk = 8` forced under `cfg(feature = "akita")`) | `jolt-prover-legacy/src/zkvm/config.rs`, `preprocessing.rs` |
+| packed config (`K=16` or `K=256`, selected like Dory) | `jolt-prover-legacy/src/zkvm/config.rs`, `preprocessing.rs` |
 
 The `akita-*` deps build from the local `../akita` clone (committed on this
 branch for co-design; pin a fork rev before the branch travels). (This spec

--- a/specs/akita-perf-plan.md
+++ b/specs/akita-perf-plan.md
@@ -93,7 +93,7 @@ Repeat without pausing between iterations until target or hard-blocked:
 
 > Status 2026-07-16 (post-#1683 distillation, slices A–E of
 > `specs/akita-1683-distillation.md`): the fused-inc pipeline + native
-> W_jolt opening + K16 toggle + jolt-owned schedule catalogs are landed.
+> OneHotTrace opening + K16 toggle + jolt-owned schedule catalogs are landed.
 > Measured at 2^20 sha2-chain, same machine back-to-back:
 > **akita prove 8.19s vs dory 13.64s = 0.60×** (verify 36.8ms vs 610ms;
 > the dory harness lacks the prepared-pairing-cache init, so the verify
@@ -102,7 +102,7 @@ Repeat without pausing between iterations until target or hard-blocked:
 > removal, column-derivation reuse, Hachi-style layout experiment,
 > prepared-setup cache). CAUTION: akita upstream #302 (quantum SIS
 > cutover) made one-hot setup construction ~400× slower (83s at the
-> 2^20 W_jolt shape vs 0.2s pre-#302) — per-shape and cacheable, but the
+> 2^20 OneHotTrace shape vs 0.2s pre-#302) — per-shape and cacheable, but the
 > setup cache (lever 5) is now urgent, and prove-side #302 impact vs
 > machine variance is unattributed (quang's pre-#302 prove was
 > 5.5–6.1s on his machine). Older analysis below and in
@@ -115,7 +115,7 @@ From the original branch's trace analysis. Treat as hypotheses to RE-VALIDATE
 against your own fresh traces, not as a work plan. Ranked by expected size:
 
 1. **STRUCTURAL/FORMAT (the big one** — kernel wins alone were measured
-   insufficient): commit W_jolt as GROUPED strict one-hot columns through the
+   insufficient): commit OneHotTrace as GROUPED strict one-hot columns through the
    akita backend's one-hot flavor + grouped commitment protocol instead of
    today's sparse-unit UNION object. The backend's own flavor bench measured
    one-hot commit+open ≈5.4× cheaper than sparse-unit at equal domain/ones.

--- a/specs/lattice-claims.md
+++ b/specs/lattice-claims.md
@@ -13,13 +13,13 @@ Akita is a lattice PCS: it commits to small-norm coefficient vectors and has no
 commitment homomorphism. Two consequences for Jolt:
 
 1. **No RLC of commitments.** The stage-8 final-opening step over homomorphic
-   commitments cannot be reused. The per-proof `W_jolt` commitment is therefore
+   commitments cannot be reused. The per-proof `OneHotTrace` commitment is therefore
    one native Akita commitment group: every member is a strict `K x T` one-hot
    polynomial, all members open at one canonical point, and one native Akita
    batch proof settles the group. Advice and committed-program objects have
    different domains and remain auxiliary `PrefixPacking` reductions.
 2. **0/1 cells, for efficiency.** Committing 0/1 vectors is where Akita is
-   fast, so Wjolt and the auxiliary objects stay one-hot/boolean throughout — this is a
+   fast, so OneHotTrace and the auxiliary objects stay one-hot/boolean throughout — this is a
    performance choice, not a norm-bound requirement. Every committed column
    that is not already one-hot gets a one-hot encoding: the dense signed
    `RdInc`/`RamInc` columns become a **fused, shifted, one-hot chunk
@@ -45,7 +45,7 @@ rejected here.
 V1 scope (full prototype parity):
 
 ```text
-canonical native one-hot Wjolt layout plus auxiliary prefix-packed objects
+canonical native one-hot OneHotTrace layout plus auxiliary prefix-packed objects
 inc fusion (RamInc/RdInc -> one Inc stream selected by the bytecode Store flag)
 base-2^b one-hot chunk decomposition + full one-hot msb column
 standalone IncVirtualization after stage 5, retaining the Store claim needed by
@@ -61,7 +61,7 @@ bytecode sub-column decomposition (register selectors, circuit/instruction
     BytecodeChunkReconstruction relation rebuilding chunk lane values
 program-image byte decomposition + its reconstruction relation
 decode-weight point algebra (the relations' derived semantics)
-final-opening map (native Wjolt claim | auxiliary packed claim | virtualized)
+final-opening map (native OneHotTrace claim | auxiliary packed claim | virtualized)
 ```
 
 Out of scope (deferred):
@@ -88,13 +88,13 @@ encoding is not re-proven in-protocol.
 
 | Crate | Owns | Must NOT contain |
 |-------|------|------------------|
-| `jolt-claims` | ids, arities, symbolic relations, final-opening map, canonical Wjolt member order and layout digest | transcripts, witnesses, PCS |
+| `jolt-claims` | ids, arities, symbolic relations, final-opening map, canonical OneHotTrace column order and layout digest | transcripts, witnesses, PCS |
 | `jolt-openings` | `PrefixPacking` slot assignment, suffix-compat check, eq-prefix reduction, transcript binding | Jolt-specific ids or protocol semantics |
-| `jolt-verifier` | `ConcreteSumcheck` impls, stage schedule, native Wjolt opening and auxiliary packed openings | relation algebra (sourced from `jolt-claims`) |
+| `jolt-verifier` | `ConcreteSumcheck` impls, stage schedule, native OneHotTrace opening and auxiliary packed openings | relation algebra (sourced from `jolt-claims`) |
 | `jolt-witness`/prover | one-hot witness materialization and matching stage schedule | — |
 | `jolt-akita` | PCS transport | — |
 
-`jolt-claims` owns the ordered Wjolt member list and hashes the order, member
+`jolt-claims` owns the ordered OneHotTrace column list and hashes the order, member
 identities, and dimensions into a nonzero setup digest. The proof never chooses
 this digest. `jolt-openings::PrefixPacking` remains the source of truth only for
 the auxiliary advice and committed-program objects.
@@ -112,9 +112,9 @@ crates/jolt-claims/src/protocols/jolt/lattice/
 │                   definitions of the reconstruction relations' deriveds,
 │                   composed from jolt-poly's IdentityPolynomial /
 │                   eq_index_msb primitives); pure functions
-├── packing.rs      wjolt_members(..) -> canonical native member order;
+├── packing.rs      one_hot_trace_columns(..) -> canonical native member order;
 │                   auxiliary precommitted/advice PrefixPacking registration
-├── strategy.rs     the one native Wjolt layout, common-point permutation,
+├── strategy.rs     the one native OneHotTrace layout, common-point permutation,
 │                   setup shape, and canonical nonzero layout digest
 └── relations/
     ├── inc_virtualization.rs
@@ -154,7 +154,7 @@ ProgramImageReconstruction,      // word-decode leg only
 BytecodeChunkReconstruction,     // chunk -> lane sub-column decode
 
 // JoltCommittedPolynomial — appended variants (committed only in lattice mode,
-// as native Wjolt members or auxiliary packed columns; base mode never
+// as native OneHotTrace columns or auxiliary packed columns; base mode never
 // constructs them)
 UnsignedIncChunk(usize),   // one-hot column j of the fused unsigned inc
 UnsignedIncMsb,            // full K x T one-hot column, hot address 0 or 1
@@ -180,8 +180,8 @@ FusedInc,                  // gamma-batched RamInc/RdInc stream; its selector
 ```
 
 WARNING: enum `Ord` is protocol data for auxiliary objects — `PrefixPacking`
-assigns slots by `(num_vars, Id)` order. Wjolt does not use this ordering: its
-member order is constructed explicitly by `wjolt_members` and hashed into its
+assigns slots by `(num_vars, Id)` order. OneHotTrace does not use this ordering: its
+member order is constructed explicitly by `one_hot_trace_columns` and hashed into its
 canonical layout digest.
 
 Per-relation challenge/public sub-enums live in `protocols/jolt/ids.rs` next to every other
@@ -203,17 +203,17 @@ allowed the same id to denote claims at two different points.
 
 ## Commitment Layout
 
-Every native Wjolt member and every auxiliary packed column is identified by
+Every native OneHotTrace column and every auxiliary packed column is identified by
 `JoltCommittedPolynomial`. The earlier draft's separate `LatticeColumn` id
-family is gone. Wjolt has one relation-produced claim per member at a shared
+family is gone. OneHotTrace has one relation-produced claim per column at a shared
 point; auxiliary columns have one claim per prefix-packed slot.
 
-Wjolt is one native Akita group; the helper below supplies its canonical
+OneHotTrace is one native Akita group; the helper below supplies its canonical
 ordered member list. Auxiliary objects use separate prefix packings:
 
 ```rust
-/// Canonical per-proof Wjolt member order.
-pub fn wjolt_members(shape) -> Vec<JoltCommittedPolynomial>;
+/// Canonical per-proof OneHotTrace column order.
+pub fn one_hot_trace_columns(shape) -> Vec<JoltCommittedPolynomial>;
 // InstructionRa(0..I), BytecodeRa(0..B), RamRa(0..R)   log_k_chunk + log_T each
 // UnsignedIncChunk(0..N)                               log_k_chunk + log_T each
 //                       (chunk width b = log_k_chunk, N = 64 / b)
@@ -250,7 +250,7 @@ logical polynomial / slot / prefix, plus each family's own dimension names —
   dummy place cells are zero by convention (checked offline with the rest of
   the precommitted validity).
 
-Every Wjolt member has the same arity. Relation leaves use
+Every OneHotTrace column has the same arity. Relation leaves use
 `(address || cycle)` order; the native Akita members use row-major
 `(cycle || address)` order. Stage 8 applies this one permutation to every
 member and rejects unless all mapped points are identical. A protocol-owned,
@@ -450,7 +450,7 @@ would emit.
 
 ## Packed-Claim Invariants and Final Openings
 
-Wjolt's native batch requires one evaluation per committed member at exactly
+OneHotTrace's native batch requires one evaluation per committed column at exactly
 one point. Stage 7 therefore lands all RA, increment chunk, and MSB claims at
 the same `(address || cycle)` point, after which Stage 8 applies the common
 row-major permutation. Any missing member, arity mismatch, or point mismatch
@@ -472,7 +472,7 @@ row, `γ` for the advice column).
 `lattice/packing.rs` is the single source of truth for the endgame:
 
 A polynomial's **final claim** is the one claim left when the relation DAG
-bottoms out. Wjolt final claims feed the native batch; auxiliary claims feed
+bottoms out. OneHotTrace final claims feed the native batch; auxiliary claims feed
 their packed reductions. `Virtualized` polynomials have none.
 
 ```rust
@@ -514,7 +514,7 @@ base stage-8 RLC order for lattice mode.
   `FusedIncClaimReduction` member.
 - Stage 7 extends `HammingWeightClaimReduction` with hamming, Booleanity, and
   shifted-decode terms for all increment one-hot columns.
-- Stage 8 opens Wjolt directly with one native same-point Akita batch and runs
+- Stage 8 opens OneHotTrace directly with one native same-point Akita batch and runs
   the generic packed-opening reduction only for auxiliary objects.
 - The Dory build instantiates the original Booleanity, increment claim
   reduction, HammingWeightClaimReduction, and homomorphic final opening.
@@ -529,11 +529,11 @@ base stage-8 RLC order for lattice mode.
   `Σ 2^(b*j)·address(chunk_j) + 2^64·address(msb) − 2^64`
   round-trips the value.
 - Semantic integration tests (`tests/lattice_semantics.rs`) over concrete
-  witness data: every Wjolt member is a uniform `K x T` one-hot polynomial;
+  witness data: every OneHotTrace column is a uniform `K x T` one-hot polynomial;
   the chunk/MSB decomposition reconstructs signed increments including
   padding; auxiliary lane/advice reconstruction terms reproduce the committed
   evaluations.
-- Determinism: `wjolt_members`/`precommitted_packing` are pure functions of
+- Determinism: `one_hot_trace_columns`/`precommitted_packing` are pure functions of
   shape (golden test), and every packed proof column has a claim source.
 
 ## Dropped From the Prototype (jolt-claims-ref) and Why
@@ -545,7 +545,7 @@ base stage-8 RLC order for lattice mode.
 | `JoltOpeningId::Lattice { relation, index }` | deleted | untyped; hid polynomial identity and point identity |
 | `PackingValidityRequirement`/`PackingValidityKind` + digest | deleted | validity is not metadata; it is the validity **relations** (prover-supplied columns) or an **offline preprocessing check** (public precommitted columns) |
 | `PackingViewFormula`/`PackingViewTerm` | deleted | briefly survived as `ReconstructionTerm` lists, then replaced outright by the reconstruction *relations* (5–8) + the decode-weight point algebra; provenness follows from the column's validity story |
-| two-entry one-hot boolean-flag encoding | replaced for auxiliary public bytecode flags | plain 0/1 columns of `log_rows` variables; `1 − flag` is expression algebra, and the auxiliary commitment stays 0/1. The increment MSB is not such a flag: it is a full `K x T` Wjolt one-hot member. |
+| two-entry one-hot boolean-flag encoding | replaced for auxiliary public bytecode flags | plain 0/1 columns of `log_rows` variables; `1 − flag` is expression algebra, and the auxiliary commitment stays 0/1. The increment MSB is not such a flag: it is a full `K x T` OneHotTrace one-hot column. |
 | bytecode store-rd-disjoint, canonical imm bytes, sub-column one-hot validity | moved offline | public precommitted data; the verifier checks structure at preprocessing instead of spending relations |
 | Public→Challenge enum migration (EqCycle etc.) | not ported | orthogonal to lattice; main's Derived model already covers it |
 | eq-polynomial / coefficient materialization helpers | not ported | belongs to verifier/witness crates per the boundary contract |


### PR DESCRIPTION
## Summary

- size production Wjolt one-hot setup envelopes directly from the checked-in Jolt K=16/K=256 schedule catalogs
- account for every catalogued sub-shape plus exact root A/B/D footprints, with checked overflow and scalar-layout guards
- retain the upstream planner fallback for non-Wjolt development and test shapes
- enable only the fp128 D64 full and one-hot Akita schedule families instead of the broad default bundle

This is stacked on #1676.

## Performance scope

The catalog envelope calculation for both maximum production grids completes in about 28 ms in the focused test. This removes planner-DP scans from production Wjolt setup sizing. It does not remove first-time quantum-SIS public-matrix expansion; that remains a separate setup-materialization and caching optimization.

## Validation

- cargo nextest run -p jolt-akita production_wjolt_shapes_use_catalog_setup_sizing catalogs_cover_every_reachable_wjolt_shape --cargo-quiet
- cargo nextest run -p jolt-prover-legacy --features host,akita -E test(e2e_akita) --cargo-quiet
- cargo nextest run -p jolt-prover-legacy muldiv --cargo-quiet --features host
- cargo nextest run -p jolt-prover-legacy muldiv --cargo-quiet --features host,zk
- cargo clippy -p jolt-akita --all-targets -- -D warnings
- cargo clippy -p jolt-prover-legacy --features host,akita --all-targets -- -D warnings
- cargo clippy --all --features host -q --all-targets -- -D warnings
- cargo clippy --all --features host,zk -q --all-targets -- -D warnings
- cargo fmt --all -- --check