### PR TITLE
ci: fix cache eviction thrash and cut redundant compilation

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -18,6 +18,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref || github.run_id }}
   cancel-in-progress: true
 
+# Caching strategy: jobs with near-identical dependency footprints share one
+# rust-cache entry (shared-key), and only the job with the largest footprint
+# saves it. Per-job caches previously totaled >10 GB, blowing the repository
+# cache quota so every run started cold.
 jobs:
   fmt:
     runs-on: ubuntu-latest
@@ -26,6 +30,7 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           components: rustfmt
+          cache: false
       - name: cargo fmt
         run: cargo fmt --all --check
 
@@ -47,6 +52,10 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           components: clippy
+          cache: false
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: clippy
       - name: cargo clippy --features allocative,host
         run: cargo clippy --all --all-targets --features allocative,host
       - name: cargo clippy --features allocative,host,zk
@@ -114,6 +123,11 @@ jobs:
     steps:
       - uses: actions/checkout@v7.0.1
       - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          cache: false
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: wasm
       - name: Install wasm32 target
         run: rustup target add wasm32-unknown-unknown
       - name: Build Wasm
@@ -128,6 +142,11 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           components: rust-src
+          cache: false
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: release-tests
+          save-if: false
           cache-directories: ~/.cache/dory
       - name: Cache ZeroOS musl toolchain
         id: cache-zeroos-musl
@@ -141,12 +160,14 @@ jobs:
           curl -fsSL https://github.com/LayerZero-Labs/ZeroOS/releases/download/musl-toolchain-musl-1.2.3-gcc-9.4.0/zeroos-musl-toolchain-musl-1.2.3-gcc-9.4.0-Linux-x86_64.tar.gz -o /tmp/zeroos-musl.tar.gz
           mkdir -p ~/.zeroos
           tar -xzf /tmp/zeroos-musl.tar.gz -C ~/.zeroos
+      # --target-dir target shares dependency artifacts with the test build
+      # below (cargo install otherwise compiles everything in a temp dir).
       - name: Build and install jolt CLI
-        run: cargo install --path . --locked --force
+        run: cargo install --path . --locked --force --profile ci --target-dir target
       - name: Install nextest
         uses: taiki-e/install-action@nextest
       - name: Run jolt-prover-legacy tests
-        run: cargo nextest run --release -p jolt-prover-legacy
+        run: cargo nextest run --cargo-profile ci -p jolt-prover-legacy
 
   test-prover-zk:
     runs-on: ubuntu-latest
@@ -156,6 +177,11 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           components: rust-src
+          cache: false
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: release-tests
+          save-if: false
           cache-directories: ~/.cache/dory
       - name: Cache ZeroOS musl toolchain
         id: cache-zeroos-musl
@@ -170,11 +196,11 @@ jobs:
           mkdir -p ~/.zeroos
           tar -xzf /tmp/zeroos-musl.tar.gz -C ~/.zeroos
       - name: Build and install jolt CLI
-        run: cargo install --path . --locked --force
+        run: cargo install --path . --locked --force --profile ci --target-dir target
       - name: Install nextest
         uses: taiki-e/install-action@nextest
       - name: Run jolt-prover-legacy tests with zk feature
-        run: cargo nextest run --release -p jolt-prover-legacy --features zk
+        run: cargo nextest run --cargo-profile ci -p jolt-prover-legacy --features zk
 
   test-prover-akita:
     runs-on: ubuntu-latest
@@ -184,6 +210,12 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           components: rust-src
+          cache: false
+      # Sole saver for the release-tests shared cache — largest dependency
+      # footprint of the group (host + akita at release).
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: release-tests
           cache-directories: ~/.cache/dory
       - name: Cache ZeroOS musl toolchain
         id: cache-zeroos-musl
@@ -198,14 +230,14 @@ jobs:
           mkdir -p ~/.zeroos
           tar -xzf /tmp/zeroos-musl.tar.gz -C ~/.zeroos
       - name: Build and install jolt CLI
-        run: cargo install --path . --locked --force
+        run: cargo install --path . --locked --force --profile ci --target-dir target
       - name: Install nextest
         uses: taiki-e/install-action@nextest
       # The packed-prover e2e suite: muldiv, forced K=256, trusted/untrusted
       # advice, and committed-program, each proving and verifying over the
       # Akita lattice PCS (the release-only perf harness stays ignored).
       - name: Run jolt-prover-legacy tests with akita feature
-        run: cargo nextest run --release -p jolt-prover-legacy --features akita
+        run: cargo nextest run --cargo-profile ci -p jolt-prover-legacy --features akita
 
   test-verifier-akita-fixtures:
     runs-on: ubuntu-latest
@@ -215,6 +247,11 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           components: rust-src
+          cache: false
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: release-tests
+          save-if: false
           cache-directories: ~/.cache/dory
       - name: Cache ZeroOS musl toolchain
         id: cache-zeroos-musl
@@ -229,7 +266,7 @@ jobs:
           mkdir -p ~/.zeroos
           tar -xzf /tmp/zeroos-musl.tar.gz -C ~/.zeroos
       - name: Build and install jolt CLI
-        run: cargo install --path . --locked --force
+        run: cargo install --path . --locked --force --profile ci --target-dir target
       - name: Install nextest
         uses: taiki-e/install-action@nextest
       # The fixture-driven akita suites: valid-fixture acceptance
@@ -237,7 +274,7 @@ jobs:
       # proof-shape, and presence tamper sweeps (tampering/akita.rs), backed
       # by fixtures the real packed prover generates at test time.
       - name: Run jolt-verifier akita fixture and tamper suites
-        run: cargo nextest run --release -p jolt-verifier --features akita,prover-fixtures
+        run: cargo nextest run --cargo-profile ci -p jolt-verifier --features akita,prover-fixtures
 
   typos:
     runs-on: ubuntu-latest
@@ -254,9 +291,14 @@ jobs:
       - uses: actions/checkout@v7.0.1
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
+          cache: false
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: release-tests
+          save-if: false
           cache-directories: ~/.cache/dory
       - name: Build and install jolt CLI
-        run: cargo install --path . --locked --force
+        run: cargo install --path . --locked --force --profile ci --target-dir target
 
       - name: Use the `jolt` binary to generate code
         run: jolt new sample_project
@@ -284,12 +326,17 @@ jobs:
       - uses: actions/checkout@v7.0.1
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
+          cache: false
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: release-tests
+          save-if: false
           cache-directories: ~/.cache/dory
       - uses: actions/setup-node@v7
         with:
           node-version: '22'
       - name: Build and install jolt CLI
-        run: cargo install --path . --locked --force
+        run: cargo install --path . --locked --force --profile ci --target-dir target
 
       - name: Cache wasm-pack
         id: cache-wasm-pack
@@ -335,6 +382,11 @@ jobs:
     steps:
       - uses: actions/checkout@v7.0.1
       - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          cache: false
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: dev-tests
       - name: Install nextest
         uses: taiki-e/install-action@nextest
       - name: Discover modular crates
@@ -377,6 +429,13 @@ jobs:
     steps:
       - uses: actions/checkout@v7.0.1
       - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          cache: false
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: release-tests
+          save-if: false
+          cache-directories: ~/.cache/dory
       - name: Install nextest
         uses: taiki-e/install-action@nextest
       # Regenerates every checked-in schedule through the planner DP and
@@ -384,7 +443,7 @@ jobs:
       # planner drift. Ignored by default (minutes of DP solves), so it needs
       # its own lane.
       - name: Regenerate schedule catalogs through the planner
-        run: cargo nextest run --release -p jolt-akita --run-ignored all -E 'test(catalogs_match_planner_regeneration)' --cargo-quiet
+        run: cargo nextest run --cargo-profile ci -p jolt-akita --run-ignored all -E 'test(catalogs_match_planner_regeneration)' --cargo-quiet
 
   test-inlines:
     name: Test inlines
@@ -392,6 +451,12 @@ jobs:
     steps:
       - uses: actions/checkout@v7.0.1
       - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          cache: false
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: dev-tests
+          save-if: false
       - name: Install nextest
         uses: taiki-e/install-action@nextest
       - name: Discover inline crates
@@ -420,15 +485,20 @@ jobs:
       - uses: actions/checkout@v7.0.1
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
+          cache: false
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: release-tests
+          save-if: false
           cache-directories: ~/.cache/dory
       - name: Build and install jolt CLI
-        run: cargo install --path . --locked --force
+        run: cargo install --path . --locked --force --profile ci --target-dir target
       - name: Install nextest
         uses: taiki-e/install-action@nextest
       - name: Generate test fixtures
         run: bash jolt-sdk/tests/gen-fixtures.sh
       - name: Run SDK verifier tests
-        run: cargo nextest run --release -p jolt-sdk --features host
+        run: cargo nextest run --cargo-profile ci -p jolt-sdk --features host
 
   test-tracer:
     runs-on: ubuntu-latest
@@ -436,14 +506,21 @@ jobs:
     steps:
       - uses: actions/checkout@v7.0.1
       - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          cache: false
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: release-tests
+          save-if: false
+          cache-directories: ~/.cache/dory
       - name: Build and install jolt CLI
-        run: cargo install --path . --locked --force
+        run: cargo install --path . --locked --force --profile ci --target-dir target
       - name: Install nextest
         uses: taiki-e/install-action@nextest
       - name: Run tracer tests
-        run: cargo nextest run --release -p tracer --features test-utils --cargo-quiet
+        run: cargo nextest run --cargo-profile ci -p tracer --features test-utils --cargo-quiet
       - name: Run tracer tests with field-inline
-        run: cargo nextest run --release -p tracer --features test-utils,field-inline --cargo-quiet
+        run: cargo nextest run --cargo-profile ci -p tracer --features test-utils,field-inline --cargo-quiet
 
   zklean-extractor-tests:
     name: ZkLean extractor tests

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -376,9 +376,17 @@ jobs:
         working-directory: ./sample_project
         run: node verify.mjs
 
-  test-crates:
-    name: Test modular crates
+  # Sharded 3-way: the sequential per-crate loop was the CI critical path
+  # (~18 min). Crates are assigned to shards by discovery index; each crate
+  # keeps its own nextest invocation so per-crate feature resolution is
+  # unchanged.
+  test-crates-shard:
+    name: Test modular crates (shard ${{ matrix.shard }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [0, 1, 2]
     steps:
       - uses: actions/checkout@v7.0.1
       - uses: actions-rust-lang/setup-rust-toolchain@v1
@@ -386,7 +394,7 @@ jobs:
           cache: false
       - uses: Swatinem/rust-cache@v2
         with:
-          shared-key: dev-tests
+          shared-key: dev-tests-${{ matrix.shard }}
       - name: Install nextest
         uses: taiki-e/install-action@nextest
       - name: Discover modular crates
@@ -403,25 +411,47 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          i=0
           for pkg in ${{ steps.discover.outputs.pkgs }}; do
-            features=()
-            if cargo metadata --format-version=1 --no-deps \
-                 | jq -e --arg pkg "$pkg" '.packages[] | select(.name == $pkg) | .features | has("test-utils")' >/dev/null; then
-              features=(--features test-utils)
+            if (( i % 3 == ${{ matrix.shard }} )); then
+              features=()
+              if cargo metadata --format-version=1 --no-deps \
+                   | jq -e --arg pkg "$pkg" '.packages[] | select(.name == $pkg) | .features | has("test-utils")' >/dev/null; then
+                features=(--features test-utils)
+              fi
+              cargo nextest run -p "$pkg" "${features[@]}" --no-tests=pass
             fi
-            cargo nextest run -p "$pkg" "${features[@]}" --no-tests=pass
+            i=$((i + 1))
           done
       - name: Test lookup table prover ABI
+        if: matrix.shard == 1
         run: cargo nextest run -p jolt-lookup-tables --features prover-abi-tests --test prover_lookup_table_abi --cargo-quiet
       - name: Test jolt-verifier with akita feature
+        if: matrix.shard == 1
         run: cargo nextest run -p jolt-verifier --features akita --no-tests=pass --cargo-quiet
       - name: Test crates with field-inline
+        if: matrix.shard == 1
         shell: bash
         run: |
           set -euo pipefail
           cargo nextest run -p jolt-claims -p jolt-r1cs \
             -p jolt-program -p jolt-riscv -p jolt-lookup-tables \
             --features field-inline --no-tests=pass --cargo-quiet
+
+  # Join gate so the check name "Test modular crates" is stable regardless of
+  # shard count.
+  test-crates:
+    name: Test modular crates
+    runs-on: ubuntu-latest
+    needs: test-crates-shard
+    if: always()
+    steps:
+      - name: Check shard results
+        run: |
+          if [ "${{ needs.test-crates-shard.result }}" != "success" ]; then
+            echo "Shard result: ${{ needs.test-crates-shard.result }}"
+            exit 1
+          fi
 
   test-akita-schedules:
     name: Akita schedule catalog drift
@@ -455,8 +485,7 @@ jobs:
           cache: false
       - uses: Swatinem/rust-cache@v2
         with:
-          shared-key: dev-tests
-          save-if: false
+          shared-key: dev-inlines
       - name: Install nextest
         uses: taiki-e/install-action@nextest
       - name: Discover inline crates

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -163,6 +163,14 @@ debug = 0
 debug = 1
 lto = "fat"
 
+# CI test builds: release-grade codegen without fat LTO and debuginfo, which
+# dominate CI compile time. Guest builds keep using --release, so guest
+# artifacts are identical to production.
+[profile.ci]
+inherits = "release"
+debug = 0
+lto = "off"
+
 [profile.build-fast]
 inherits = "release"
 incremental = true


### PR DESCRIPTION
CI wall clock on main is ~23 min. Almost all of it is redundant compilation, not tests. This PR takes steady-state wall clock to ~11.5 min without touching any gate.

## Where the minutes went (baseline: [run 30114078600](https://github.com/a16z/jolt/actions/runs/30114078600), main @ 6ba6490)

Three root causes:

1. **Every rust-cache missed, every run.** The 16 per-job caches totaled ~7.4 GB per Cargo.lock hash; with the other workflows the repo sat at 10.9 GB against the 10 GB quota, so GitHub evicted everything between runs — the baseline logs show `No cache found` in every job, including the immutable ZeroOS musl toolchain key.
2. **`profile.release` has `lto = "fat"` + `debug = 1`**, so every test job paid a fat-LTO link of the full dep graph for its test binaries. The akita job spent 592 s compiling for 75 s of tests.
3. **`cargo install --path .` built the entire dep tree a second time** in a temp target dir (~170 s in each of 8 jobs), then the test step rebuilt the same deps in `target/`.

Plus one structural issue: the modular-crates job runs 23 crates sequentially on one runner (~18 min loop; jolt-akita alone compiles for ~6 min), making it the critical path.

## Changes

- **Shared cache keys sized to fit the quota.** Jobs with near-identical dependency footprints share one rust-cache entry (`release-tests`, `dev-tests-{0,1,2}`, `dev-inlines`, `clippy`, `wasm`); in the release group only the largest job (akita) saves, so a fast subset job can't poison the key. Steady-state usage for this workflow drops from ~7.4 GB to ~2.7 GB, so caches survive. The fmt job stops saving a 255 MB cache for a job that compiles nothing.
- **`[profile.ci]`** (`inherits = "release"`, `lto = "off"`, `debug = 0`) for host-side test binaries and the jolt CLI. Same opt-level 3, same test sets. Guest builds still go through `--release` internally, so guest artifacts are bit-identical to before. Fat-LTO release compilation stays covered by the CI Benchmarks workflow on main; `gen-fixtures.sh` keeps `build-fast`.
- **`cargo install --profile ci --target-dir target`** so the CLI build and the test build in the same job share dependency artifacts instead of compiling them twice.
- **Shard the modular-crate loop 3 ways** by discovery index. Each crate keeps its own nextest invocation, so per-crate feature resolution is untouched. A join job keeps the `Test modular crates` check name stable for branch protection.

## Gates: unchanged

Same clippy invocations with `-D warnings`, same nextest test sets, machete/fmt/taplo/typos untouched, wasm build still `--release`, zklean jobs untouched. Verified against this PR's runs: prover suites run 441 / 477 (zk) / 442 (akita) / 84 (verifier fixtures) tests — identical to baseline; sharded modular-crate jobs run 2282 tests total, exactly matching the unsharded job.

## Before / after

Baseline = [30114078600](https://github.com/a16z/jolt/actions/runs/30114078600) (main). Cold = [30119375278](https://github.com/a16z/jolt/actions/runs/30119375278/attempts/1) (this PR, empty caches). Warm = [30120832008](https://github.com/a16z/jolt/actions/runs/30120832008) attempt 2 (steady state).

| Job | Baseline | Warm |
|---|---|---|
| **Wall clock** | **23m21s** | **11m37s** |
| Test modular crates | 23m18s | 8m36s (slowest of 3 shards: 4m43/8m00/8m36) |
| Test jolt-prover-legacy (akita) | 14m44s | 7m45s |
| WASM Verifier E2E | 13m59s | 11m31s |
| Test jolt-verifier (akita fixtures) | 12m42s | 6m47s |
| jolt binary check | 12m27s | 10m15s |
| Akita schedule catalog drift | 11m41s | 6m24s |
| Test jolt-prover-legacy (zk) | 11m30s | 7m20s |
| Test jolt-prover-legacy | 9m25s | 5m45s |
| Jolt SDK Verifier Tests | 7m51s | 5m25s |
| clippy | 6m8s | 5m16s |
| Test tracer | 5m11s | 2m39s |
| Test inlines | 5m0s | 3m16s |
| Build Wasm | 3m38s | 2m18s |

Fully cold (fresh Cargo.lock, empty caches) the PR still finishes in 22m09s — no regression even in the worst case, because the profile.ci and install-dedupe wins don't depend on the cache.

The new floor is the WASM E2E / jolt binary check pair (~10–11.5 min): both build a freshly generated sample project pinned to the current commit, which by construction can't cache.

## Evaluated and rejected

- **sccache**: workspace crates change every commit so per-unit caching adds infra for little gain over rust-cache once deps hit.
- **nextest partition sharding for the prover suites**: pointless while compile dominates — the akita suite runs 75 s of actual tests.
- **Caching the sample-project builds (jolt binary check / WASM E2E)**: keyed on the current commit by design (`rev =` pin), so a cache can never hit; dep resolution floats to latest semver so cross-run reuse is luck-based.