### PR TITLE
ci: enforce conventional commit PR titles

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,38 @@
+name: PR Title
+
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize]
+
+permissions: {}
+
+jobs:
+  conventional-title:
+    name: Conventional Commits
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate PR title
+        env:
+          TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          types='feat|fix|chore|docs|refactor|perf|test|build|ci|style|revert|spec'
+          re="^($types)(\([a-z0-9 ,._/-]+\))?!?: .+"
+
+          if [[ "$TITLE" =~ ^Revert\  ]]; then
+            echo "Revert PR, skipping"
+            exit 0
+          fi
+
+          if [[ "$TITLE" =~ $re ]]; then
+            echo "PR title OK: $TITLE"
+            exit 0
+          fi
+
+          echo "::error::PR title does not follow Conventional Commits: \"$TITLE\""
+          echo "Expected: <type>[optional scope][optional !]: <description>"
+          echo "Types: ${types//|/ }"
+          echo "Examples:"
+          echo "  feat(dory): batch tier-2 openings"
+          echo "  fix: handle empty trace in preprocessing"
+          echo "  refactor(claims,verifier)!: split relation claims"
+          exit 1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,6 +90,18 @@ cargo nextest run -p jolt-prover-legacy muldiv --cargo-quiet --features host
 cargo nextest run -p jolt-prover-legacy muldiv --cargo-quiet --features host,zk
 ```
 
+## PR Titles and Commit Messages
+
+PR titles must follow [Conventional Commits](https://www.conventionalcommits.org/) — CI enforces this (`.github/workflows/pr-title.yml`):
+
+```
+<type>[optional scope][optional !]: <description>
+```
+
+Allowed types: `feat` `fix` `chore` `docs` `refactor` `perf` `test` `build` `ci` `style` `revert` `spec`
+
+Since PRs are squash-merged, only the PR title is checked — individual commit messages are not.
+
 ## Code Style
 
 - `cargo fmt` + `cargo clippy` with zero warnings


### PR DESCRIPTION
Adds a PR title check enforcing Conventional Commits.

## What

**`.github/workflows/pr-title.yml`** — validates the PR title on opened/edited/reopened/synchronize. Inline bash regex, no third-party action, `permissions: {}`, no checkout.

## Rules

```
<type>[optional scope][optional !]: <description>
```

Types are taken from actual repo usage (last ~300 commits on main), not a stock list: `feat` `fix` `chore` `docs` `refactor` `perf` `test` `build` `ci` `style` `revert` `spec`. Scope charset allows the forms already in history (`claims,verifier`, `bigint inline`, `deps`). `Revert "..."` titles are exempt.

Titles only — we squash-merge, so the PR title is what lands on main. Individual commit messages are not checked.

## Won't break existing flow

Tested against the last 100 merged PR titles: **91/100 pass** (45/50 on the last 50). All 9 failures are titles that genuinely aren't conventional (`Refactor jolt-witness`, `Fix ZK verifier mode handling`, ...) — the exact cases this check exists to catch. Every dependabot title passes.

Workflow passes actionlint.
