### PR TITLE
chore(claude): rightsize CLAUDE.md and skills for Claude 5 context rules

### DIFF
--- a/.claude/skills/analyze-spec/SKILL.md
+++ b/.claude/skills/analyze-spec/SKILL.md
@@ -68,140 +68,12 @@ For each dimension below 0.9, generate a targeted question that would improve it
 
 ## Phase 3: Output (mode-dependent)
 
-### Remote Mode — Single-Pass
-
-Post a **single PR comment** with all findings:
-
-```
-**Spec Analysis: {spec title}**
-
-| Dimension | Score | Gap |
-|-----------|-------|-----|
-| Goal | {s} | {gap or "Clear"} |
-| Constraints | {s} | {gap or "Clear"} |
-| Success Criteria | {s} | {gap or "Clear"} |
-| Context | {s} | {gap or "Clear"} |
-| **Ambiguity** | | **{score}%** |
-
-{If ambiguity ≤ 20%:}
-**Status: Approved** — The spec is clear enough for one-shot implementation.
-
-**Summary:**
-- {what will be built}
-- {key invariants}
-- {critical evaluation criteria}
-
-**Next step:** Run `/implement-spec` to implement this spec:
-- [Open in Claude Code (cloud)](https://claude.ai/code) — run `/implement-spec` on this branch
-- Or run `/implement-spec` locally in Claude Code
-
-{If ambiguity > 20%:}
-**Status: Questions remain** — {n} ambiguities to resolve before implementation.
-
-**Questions:**
-
-**1. [{dimension}]** {question}
-
-**2. [{dimension}]** {question}
-
-...
-
-> After addressing these questions, update the spec and re-add the `claude-spec-review-request` label.
-```
-
-If approved, add the label: `gh pr edit --add-label claude-spec-approved`
-
-If NOT approved, do NOT add the label.
-
-### Local Mode — Interactive Socratic Interview
-
-Full iterative loop, one question at a time:
-
-**Each round:**
-1. Identify the dimension with the LOWEST clarity score
-2. State why this dimension is the bottleneck
-3. Ask ONE targeted question
-4. Wait for the author's response
-5. Re-score all dimensions
-6. Report progress:
-
-```
-Round {n} complete.
-
-| Dimension | Score | Weight | Weighted | Gap |
-|-----------|-------|--------|----------|-----|
-| Goal | {s} | 0.35 | {s*w} | {gap or "Clear"} |
-| Constraints | {s} | 0.20 | {s*w} | {gap or "Clear"} |
-| Success Criteria | {s} | 0.30 | {s*w} | {gap or "Clear"} |
-| Context | {s} | 0.15 | {s*w} | {gap or "Clear"} |
-| **Ambiguity** | | | **{score}%** | |
-
-Next target: {weakest_dimension} — {rationale}
-```
-
-**Challenge modes** (local only):
-
-- **Round 4+ — Contrarian:** Challenge the spec's core assumption. "What if this constraint doesn't exist?" Test whether the framing is correct or habitual.
-- **Round 6+ — Simplifier:** Probe whether complexity can be removed. "What's the simplest version that satisfies the invariants?"
-- **Round 8+ — Ontologist (if ambiguity > 0.3):** "What IS this, really?" — find the essence.
-
-Each mode is used ONCE.
-
-**Soft limits (local only):**
-- **Round 3+**: Allow early approval if author says "enough", "looks good"
-- **Round 10**: Soft warning about round count
-- **Round 15**: Hard cap
-
-**When approved (local):** Print the summary and offer to update the spec with any refinements discovered during the interview.
+- **Remote mode**: single-pass PR comment with all findings — follow `references/remote-mode.md` (in this skill's directory) for the comment template and label handling.
+- **Local mode**: interactive Socratic interview — follow `references/local-mode.md` for the round protocol, challenge modes, and stop conditions.
 
 </Steps>
 
 <Examples>
-<Good>
-Remote mode — single-pass with all questions:
-```
-**Spec Analysis: Streaming Commitments**
-
-| Dimension | Score | Gap |
-|-----------|-------|-----|
-| Goal | 0.85 | Clear |
-| Constraints | 0.70 | Memory budget undefined |
-| Success Criteria | 0.50 | No new tests specified |
-| Context | 0.60 | Unclear which Dory tier is streamed |
-| **Ambiguity** | | **34%** |
-
-**Status: Questions remain** — 3 ambiguities to resolve.
-
-**Questions:**
-
-**1. [Success Criteria]** The Evaluation section says "existing tests pass" but
-doesn't specify new tests. What test would verify streaming produces identical
-commitments to the non-streaming path? What's the performance target?
-
-**2. [Context]** `DoryCommitmentScheme` uses a two-tier structure (tier-1 chunks
-→ tier-2 aggregation in `poly/commitment/dory/`). Which tier is streamed?
-
-**3. [Constraints]** What's the memory budget? The current non-streaming path
-peaks at ~2GB for large traces — should streaming reduce this, and to what?
-
-> After addressing these questions, update the spec and re-add the `claude-spec-review-request` label.
-```
-Why good: All questions posted at once, each tagged with the dimension it targets, clear next steps.
-</Good>
-
-<Good>
-Local mode — interactive round:
-```
-Round 2 | Targeting: Success Criteria | Ambiguity: 38%
-
-The Intent section defines a streaming commitment scheme, but the Evaluation
-section only mentions "existing tests pass." What NEW test would verify that
-streaming produces the same commitments as the non-streaming path? And what
-is the acceptable performance threshold (e.g., memory usage, throughput)?
-```
-Why good: One question, targets weakest dimension, specific to the spec content.
-</Good>
-
 <Good>
 Probing jolt-eval coverage:
 ```
@@ -219,31 +91,13 @@ door open, doesn't force a fit.
 <Good>
 Citing codebase context:
 ```
-I found that `DoryCommitmentScheme` in `poly/commitment/dory/` uses a two-tier
-structure (tier-1 chunks → tier-2 aggregation). The spec mentions "streaming
-commitments" but doesn't specify which tier is streamed. Is this streaming
+I found that `DoryCommitmentScheme` in `crates/jolt-prover-legacy/src/poly/commitment/dory/`
+uses a two-tier structure (tier-1 chunks → tier-2 aggregation). The spec mentions
+"streaming commitments" but doesn't specify which tier is streamed. Is this streaming
 at tier-1 (chunk-level), tier-2 (aggregation), or both?
 ```
 Why good: Explored first, cited specific types and files.
 </Good>
-
-<Bad>
-Asking about codebase facts:
-```
-"What commitment scheme does Jolt use?"
-```
-Why bad: Should have explored the codebase to find this.
-</Bad>
 </Examples>
-
-<Escalation_And_Stop_Conditions>
-- **Remote mode**: Single pass — no escalation needed. Either approve or list remaining questions.
-- **Local mode**:
-  - Hard cap at 15 rounds
-  - Soft warning at 10 rounds
-  - Early approval allowed at round 3+
-  - Ambiguity stalls (same score ±0.05 for 3 rounds): Activate Ontologist mode
-  - All dimensions at 0.9+: Approve immediately
-</Escalation_And_Stop_Conditions>
 
 Task: Analyze the spec. {{ARGUMENTS}}

--- a/.claude/skills/analyze-spec/references/local-mode.md
+++ b/.claude/skills/analyze-spec/references/local-mode.md
@@ -1,0 +1,43 @@
+# Local Mode — Interactive Socratic Interview
+
+Full iterative loop, one question at a time:
+
+**Each round:**
+1. Identify the dimension with the LOWEST clarity score
+2. State why this dimension is the bottleneck
+3. Ask ONE targeted question
+4. Wait for the author's response
+5. Re-score all dimensions
+6. Report progress:
+
+```
+Round {n} complete.
+
+| Dimension | Score | Weight | Weighted | Gap |
+|-----------|-------|--------|----------|-----|
+| Goal | {s} | 0.35 | {s*w} | {gap or "Clear"} |
+| Constraints | {s} | 0.20 | {s*w} | {gap or "Clear"} |
+| Success Criteria | {s} | 0.30 | {s*w} | {gap or "Clear"} |
+| Context | {s} | 0.15 | {s*w} | {gap or "Clear"} |
+| **Ambiguity** | | | **{score}%** | |
+
+Next target: {weakest_dimension} — {rationale}
+```
+
+**Challenge modes:**
+
+- **Round 4+ — Contrarian:** Challenge the spec's core assumption. "What if this constraint doesn't exist?" Test whether the framing is correct or habitual.
+- **Round 6+ — Simplifier:** Probe whether complexity can be removed. "What's the simplest version that satisfies the invariants?"
+- **Round 8+ — Ontologist (if ambiguity > 0.3):** "What IS this, really?" — find the essence.
+
+Each mode is used ONCE.
+
+**Stop conditions:**
+
+- All dimensions at 0.9+: approve immediately
+- Round 3+: allow early approval if the author says "enough", "looks good"
+- Ambiguity stalls (same score ±0.05 for 3 rounds): activate Ontologist mode
+- Round 10: soft warning about round count
+- Round 15: hard cap
+
+**When approved:** Print the summary and offer to update the spec with any refinements discovered during the interview.

--- a/.claude/skills/analyze-spec/references/remote-mode.md
+++ b/.claude/skills/analyze-spec/references/remote-mode.md
@@ -1,0 +1,46 @@
+# Remote Mode — Single-Pass Output
+
+Post a **single PR comment** with all findings:
+
+```
+**Spec Analysis: {spec title}**
+
+| Dimension | Score | Gap |
+|-----------|-------|-----|
+| Goal | {s} | {gap or "Clear"} |
+| Constraints | {s} | {gap or "Clear"} |
+| Success Criteria | {s} | {gap or "Clear"} |
+| Context | {s} | {gap or "Clear"} |
+| **Ambiguity** | | **{score}%** |
+
+{If ambiguity ≤ 20%:}
+**Status: Approved** — The spec is clear enough for one-shot implementation.
+
+**Summary:**
+- {what will be built}
+- {key invariants}
+- {critical evaluation criteria}
+
+**Next step:** Run `/implement-spec` to implement this spec:
+- [Open in Claude Code (cloud)](https://claude.ai/code) — run `/implement-spec` on this branch
+- Or run `/implement-spec` locally in Claude Code
+
+{If ambiguity > 20%:}
+**Status: Questions remain** — {n} ambiguities to resolve before implementation.
+
+**Questions:**
+
+**1. [{dimension}]** {question}
+
+**2. [{dimension}]** {question}
+
+...
+
+> After addressing these questions, update the spec and re-add the `claude-spec-review-request` label.
+```
+
+If approved, add the label: `gh pr edit --add-label claude-spec-approved`
+
+If NOT approved, do NOT add the label.
+
+Single pass — no escalation. Either approve or list remaining questions.

--- a/.claude/skills/ci-code-review/SKILL.md
+++ b/.claude/skills/ci-code-review/SKILL.md
@@ -99,7 +99,6 @@ Follow these steps:
    ```
 
    Key points:
-   - Always POST the review, even with an empty `comments` array, so authors see the review ran.
    - Use a heredoc with `'EOF'` (quoted) to prevent shell interpolation of `$`, backticks, etc.
    - The `line` field refers to the NEW file line number (right side of diff) for added/modified lines.
    - Get the head SHA via `gh api repos/{owner}/{repo}/pulls/{number} --jq '.head.sha'`.
@@ -139,5 +138,3 @@ Follow these steps:
 
 - Do NOT run builds/tests - CI handles that
 - Use `gh` for all GitHub interaction
-- When posting comments, post them to the specific lines of code
-- Make a todo list to track progress

--- a/.claude/skills/implement-spec/SKILL.md
+++ b/.claude/skills/implement-spec/SKILL.md
@@ -15,9 +15,9 @@ This skill runs locally or in Claude Code cloud (claude.ai/code) — NOT in CI. 
 - Read CLAUDE.md for project conventions, testing requirements, and architecture.
 - Each phase must complete before the next begins.
 - Parallel execution within phases where possible.
-- QA cycles repeat up to 5 times; if the same error persists 3 times, stop and report.
 - If something in the spec is ambiguous, post a PR comment rather than guessing.
 - Do not add features, refactor code, or make improvements beyond the spec.
+- If the spec lacks the `claude-spec-approved` label, warn that it hasn't been analyzed yet (implementation from an unanalyzed spec risks rework), but proceed if the user insists.
 </Execution_Policy>
 
 <Steps>
@@ -69,8 +69,8 @@ Cycle until all checks pass (up to 5 cycles):
 
 1. **Format**: `cargo fmt -q`
 2. **Lint** (both modes):
-   - `cargo clippy -p jolt-prover-legacy --features host --message-format=short -q --all-targets -- -D warnings`
-   - `cargo clippy -p jolt-prover-legacy --features host,zk --message-format=short -q --all-targets -- -D warnings`
+   - `cargo clippy --all --features host --message-format=short -q --all-targets -- -D warnings`
+   - `cargo clippy --all --features host,zk --message-format=short -q --all-targets -- -D warnings`
 3. **Test**: Run evaluation criteria from the spec, plus:
    - `cargo nextest run -p jolt-prover-legacy muldiv --cargo-quiet --features host`
    - `cargo nextest run -p jolt-prover-legacy muldiv --cargo-quiet --features host,zk`
@@ -113,19 +113,5 @@ Fix any issues found and re-validate.
 ```
 
 </Steps>
-
-<Examples>
-<Good>
-User: `/implement-spec`
-Action: Reads the spec from the PR, creates a plan, implements it, runs QA, validates, pushes commits.
-Why good: Full autonomous execution from spec to working code.
-</Good>
-
-<Bad>
-User: `/implement-spec` on a spec without `claude-spec-approved`
-Action: Should warn that the spec hasn't been analyzed yet, but proceed if the user insists.
-Why bad situation: Implementation from an unanalyzed spec risks rework.
-</Bad>
-</Examples>
 
 Task: Implement the spec in this PR. {{ARGUMENTS}}

--- a/.claude/skills/new-invariant/SKILL.md
+++ b/.claude/skills/new-invariant/SKILL.md
@@ -144,24 +144,4 @@ If any step fails, fix the issue and re-run.
 
 </Steps>
 
-<Examples>
-<Good>
-User: "/new-invariant sumcheck_eval_consistency"
-Action: Asks what property is being checked, creates the invariant file with proper Input type, registers it, creates fuzz target, runs tests.
-Why good: Follows the full pipeline, tests pass before reporting success.
-</Good>
-
-<Bad>
-User: "/new-invariant sumcheck_eval_consistency"
-Action: Creates the invariant file but forgets to add the variant to the `dispatch!` macro.
-Why bad: Code won't compile — the dispatch macro must match all enum variants.
-</Bad>
-
-<Bad>
-User: "/new-invariant my-invariant"
-Action: Accepts the name with a hyphen.
-Why bad: Rust identifiers use underscores, not hyphens. Should reject and suggest `my_invariant`.
-</Bad>
-</Examples>
-
 Task: Implement a new invariant for jolt-eval. {{ARGUMENTS}}

--- a/.claude/skills/new-objective/SKILL.md
+++ b/.claude/skills/new-objective/SKILL.md
@@ -41,102 +41,10 @@ This skill handles all the boilerplate: creating the objective struct, implement
 
 ## Phase 3: Implement
 
-### For Static Analysis Objectives
+Create the objective file following the full template for the objective kind (both in this skill's directory):
 
-Create `jolt-eval/src/objective/code_quality/<objective_name>.rs`:
-
-```rust
-use std::path::Path;
-use crate::objective::{
-    MeasurementError, Objective, OptimizationObjective, StaticAnalysisObjective,
-};
-
-pub const <UPPER_NAME>: OptimizationObjective =
-    OptimizationObjective::StaticAnalysis(StaticAnalysisObjective::<VariantName>(<Name>Objective {
-        target_dir: "<target_directory>",
-    }));
-
-#[derive(Clone, Copy, PartialEq, Eq, Hash)]
-pub struct <Name>Objective {
-    pub(crate) target_dir: &'static str,
-}
-
-impl <Name>Objective {
-    pub fn collect_measurement_in(&self, repo_root: &Path) -> Result<f64, MeasurementError> {
-        let src_dir = repo_root.join(self.target_dir);
-        // Implement measurement logic
-        todo!()
-    }
-}
-
-impl Objective for <Name>Objective {
-    type Setup = ();
-
-    fn name(&self) -> &str { "<objective_name>" }
-
-    fn description(&self) -> String {
-        format!("Description of measurement in {}", self.target_dir)
-    }
-
-    fn setup(&self) {}
-
-    fn collect_measurement(&self) -> Result<f64, MeasurementError> {
-        let repo_root = Path::new(env!("CARGO_MANIFEST_DIR")).parent().unwrap();
-        self.collect_measurement_in(repo_root)
-    }
-
-    fn units(&self) -> Option<&str> { Some("units") }
-}
-```
-
-### For Performance Objectives
-
-Create `jolt-eval/src/objective/performance/<objective_name>.rs`:
-
-```rust
-use crate::objective::Objective;
-
-pub const <UPPER_NAME>: OptimizationObjective =
-    OptimizationObjective::Performance(PerformanceObjective::<VariantName>(<Name>Objective));
-
-pub struct <Name>Setup {
-    // Pre-computed data for each iteration
-}
-
-#[derive(Clone, Copy, Default, PartialEq, Eq, Hash)]
-pub struct <Name>Objective;
-
-impl Objective for <Name>Objective {
-    type Setup = <Name>Setup;
-
-    fn name(&self) -> &str { "<objective_name>" }
-
-    fn description(&self) -> String {
-        "What is being benchmarked and at what scale".to_string()
-    }
-
-    fn setup(&self) -> <Name>Setup {
-        // Use thread_local! { static SHARED: ... } pattern for expensive one-time init
-        // that should be amortized across Criterion iterations.
-        // Return a fresh Setup that can be consumed by run().
-        todo!()
-    }
-
-    fn run(&self, setup: <Name>Setup) {
-        // The hot path that Criterion measures.
-        // Use std::hint::black_box() to prevent dead-code elimination.
-        todo!()
-    }
-
-    fn units(&self) -> Option<&str> { Some("s") }
-}
-```
-
-**Performance objective guidelines:**
-- Use `thread_local!` with a `Shared` struct for expensive setup (random data generation, etc.) that should be amortized
-- The `setup()` method is called per-iteration by Criterion — keep it cheap (clone from shared state)
-- The `run()` method is what Criterion measures — this is the hot path
-- Use `std::hint::black_box()` on the result to prevent the compiler from optimizing away the computation
+- **Static analysis**: `jolt-eval/src/objective/code_quality/<objective_name>.rs` — follow `references/static-analysis.md`
+- **Performance**: `jolt-eval/src/objective/performance/<objective_name>.rs` — follow `references/performance.md` (includes Criterion setup/run guidelines)
 
 ## Phase 4: Register in Enums
 
@@ -190,7 +98,7 @@ Edit `jolt-eval/src/objective/objective_fn/mod.rs`:
 
 ## Phase 6: Create Criterion Benchmark (performance objectives only)
 
-Create `jolt-eval/benches/<objective_name>.rs`:
+Performance objectives are measured via Criterion — without the bench file, the optimization harness can't measure them. Create `jolt-eval/benches/<objective_name>.rs`:
 
 ```rust
 use jolt_eval::objective::performance::<objective_name>::<Name>Objective;
@@ -223,25 +131,5 @@ cargo bench -p jolt-eval --bench <objective_name> -- --test
 If any step fails, fix the issue and re-run.
 
 </Steps>
-
-<Examples>
-<Good>
-User: "/new-objective cyclomatic_complexity"
-Action: Asks whether static or performance, creates the objective file, registers in all enums, adds objective function, runs tests.
-Why good: Full pipeline — every enum, dispatch method, and test count is updated.
-</Good>
-
-<Bad>
-User: "/new-objective my-objective"
-Action: Accepts the name with a hyphen.
-Why bad: Rust identifiers use underscores, not hyphens. Should reject and suggest `my_objective`.
-</Bad>
-
-<Bad>
-User: "/new-objective bind_compact"
-Action: Creates a performance objective but doesn't create the Criterion benchmark file.
-Why bad: Performance objectives are measured via Criterion — without the bench file, `cargo bench` won't find it and the optimization harness can't measure it.
-</Bad>
-</Examples>
 
 Task: Implement a new objective for jolt-eval. {{ARGUMENTS}}

--- a/.claude/skills/new-objective/references/performance.md
+++ b/.claude/skills/new-objective/references/performance.md
@@ -1,0 +1,48 @@
+# Performance Objective Template
+
+Create `jolt-eval/src/objective/performance/<objective_name>.rs`:
+
+```rust
+use crate::objective::Objective;
+
+pub const <UPPER_NAME>: OptimizationObjective =
+    OptimizationObjective::Performance(PerformanceObjective::<VariantName>(<Name>Objective));
+
+pub struct <Name>Setup {
+    // Pre-computed data for each iteration
+}
+
+#[derive(Clone, Copy, Default, PartialEq, Eq, Hash)]
+pub struct <Name>Objective;
+
+impl Objective for <Name>Objective {
+    type Setup = <Name>Setup;
+
+    fn name(&self) -> &str { "<objective_name>" }
+
+    fn description(&self) -> String {
+        "What is being benchmarked and at what scale".to_string()
+    }
+
+    fn setup(&self) -> <Name>Setup {
+        // Use thread_local! { static SHARED: ... } pattern for expensive one-time init
+        // that should be amortized across Criterion iterations.
+        // Return a fresh Setup that can be consumed by run().
+        todo!()
+    }
+
+    fn run(&self, setup: <Name>Setup) {
+        // The hot path that Criterion measures.
+        // Use std::hint::black_box() to prevent dead-code elimination.
+        todo!()
+    }
+
+    fn units(&self) -> Option<&str> { Some("s") }
+}
+```
+
+**Guidelines:**
+- Use `thread_local!` with a `Shared` struct for expensive setup (random data generation, etc.) that should be amortized
+- The `setup()` method is called per-iteration by Criterion — keep it cheap (clone from shared state)
+- The `run()` method is what Criterion measures — this is the hot path
+- Use `std::hint::black_box()` on the result to prevent the compiler from optimizing away the computation

--- a/.claude/skills/new-objective/references/static-analysis.md
+++ b/.claude/skills/new-objective/references/static-analysis.md
@@ -1,0 +1,47 @@
+# Static Analysis Objective Template
+
+Create `jolt-eval/src/objective/code_quality/<objective_name>.rs`:
+
+```rust
+use std::path::Path;
+use crate::objective::{
+    MeasurementError, Objective, OptimizationObjective, StaticAnalysisObjective,
+};
+
+pub const <UPPER_NAME>: OptimizationObjective =
+    OptimizationObjective::StaticAnalysis(StaticAnalysisObjective::<VariantName>(<Name>Objective {
+        target_dir: "<target_directory>",
+    }));
+
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+pub struct <Name>Objective {
+    pub(crate) target_dir: &'static str,
+}
+
+impl <Name>Objective {
+    pub fn collect_measurement_in(&self, repo_root: &Path) -> Result<f64, MeasurementError> {
+        let src_dir = repo_root.join(self.target_dir);
+        // Implement measurement logic
+        todo!()
+    }
+}
+
+impl Objective for <Name>Objective {
+    type Setup = ();
+
+    fn name(&self) -> &str { "<objective_name>" }
+
+    fn description(&self) -> String {
+        format!("Description of measurement in {}", self.target_dir)
+    }
+
+    fn setup(&self) {}
+
+    fn collect_measurement(&self) -> Result<f64, MeasurementError> {
+        let repo_root = Path::new(env!("CARGO_MANIFEST_DIR")).parent().unwrap();
+        self.collect_measurement_in(repo_root)
+    }
+
+    fn units(&self) -> Option<&str> { Some("units") }
+}
+```

--- a/.claude/skills/new-spec/SKILL.md
+++ b/.claude/skills/new-spec/SKILL.md
@@ -51,7 +51,7 @@ For any new properties the user adds that don't map to an existing `jolt-eval` i
 Record changes to existing `jolt-eval` invariants and any new ones to add in the "Invariants" section of the template.
 
 #### Intent — Non-Goals
-Ask: "What is explicitly out of scope?" Push back if non-goals are vague — "you said 'not performance-critical', but the hot path in `poly/` multiplies across thousands of rounds. Is there a concrete budget?"
+Ask: "What is explicitly out of scope?" Push back if non-goals are vague — "you said 'not performance-critical', but the hot path in `crates/jolt-poly/` multiplies across thousands of rounds. Is there a concrete budget?"
 
 #### Evaluation — Acceptance Criteria
 Ask: "What test would prove this works? Give me concrete, checkable criteria." Each criterion must be a checkbox item. Push for specificity — "existing tests pass" is not enough; ask what NEW tests are needed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,5 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
-
 ## Project Overview
 
 Jolt is a zkVM (zero-knowledge virtual machine) for RISC-V (RV64IMAC) that efficiently proves and verifies program execution. It uses sumcheck-based protocols, multilinear polynomial commitments (Dory), and the Twist/Shout lookup argument.
@@ -11,7 +9,7 @@ Jolt is a zkVM (zero-knowledge virtual machine) for RISC-V (RV64IMAC) that effic
 ### Linting and Formatting
 
 ```bash
-# CRITICAL: Must pass in BOTH standard and ZK modes
+# Must pass in both standard and ZK modes
 cargo clippy --all --features host -q --all-targets -- -D warnings
 cargo clippy --all --features host,zk -q --all-targets -- -D warnings
 cargo fmt -q
@@ -20,13 +18,13 @@ cargo fmt -q
 ### Testing
 
 ```bash
-# CRITICAL: Always use cargo nextest, never cargo test
+# Always cargo nextest, never cargo test
 cargo nextest run --cargo-quiet
 
 # Run specific test in specific package
 cargo nextest run -p [package_name] [test_name] --cargo-quiet
 
-# CRITICAL: Primary correctness check — run muldiv e2e test in BOTH modes
+# Primary correctness check — run muldiv e2e test in both modes
 cargo nextest run -p jolt-prover-legacy muldiv --cargo-quiet --features host
 cargo nextest run -p jolt-prover-legacy muldiv --cargo-quiet --features host,zk
 
@@ -60,9 +58,11 @@ RUST_LOG=debug cargo run --release --features allocative -p jolt-prover-legacy p
 
 ### Crate Structure
 
-Arkworks dependencies use a fork: `a16z/arkworks-algebra` branch `dev/twist-shout` (patched via `[patch.crates-io]` in root `Cargo.toml`).
+The workspace is mid-decomposition: `crates/` holds the modular stack (jolt-verifier, jolt-prover, jolt-sumcheck, jolt-poly, jolt-blindfold, jolt-witness, jolt-openings, jolt-r1cs, jolt-dory, jolt-transcript, …25 crates), while **crates/jolt-prover-legacy** is the legacy monolith mapped below. Top-level crates: `tracer`, `jolt-sdk`, `jolt-inlines`, `common`.
 
-**jolt-prover-legacy** — Core proving system
+Arkworks dependencies use a fork: `a16z/arkworks-algebra` branch `dev/twist-shout`, pinned in the root `Cargo.toml`.
+
+**jolt-prover-legacy** — Legacy core proving system
 
 - `host/`: Guest ELF compilation and program analysis (feature-gated behind `host`)
 - `zkvm/`: Jolt PIOP — prover, verifier, R1CS/Spartan, memory checking, instruction lookups
@@ -151,13 +151,9 @@ The `zk` Cargo feature (`cfg(feature = "zk")`) controls zero-knowledge mode:
 
 In ZK mode, `input_claim()` is never called so verifier params can use partial values (e.g., `init_eval = init_eval_public`). In standard mode, `input_claim()` IS called and the values must match the prover exactly. Any verifier param that decomposes a value for BlindFold constraints must reconstruct the full value for standard mode. Use `ram::reconstruct_full_eval()` to add advice contributions back.
 
-**Opening accumulator transcript changes (vs main):**
-
-On this branch, `ProverOpeningAccumulator::append_*` and `VerifierOpeningAccumulator::append_*` do NOT append claims to the Fiat-Shamir transcript (the `transcript` parameter was removed). Both sides are consistent. On main, these methods DO append `opening_claim` scalars.
-
 ### BlindFold Zero-Knowledge Protocol (subprotocols/blindfold/)
 
-BlindFold makes all sumcheck proofs zero-knowledge without SNARK composition. Instead of revealing sumcheck round polynomial coefficients, the prover sends Pedersen commitments. Sumcheck verifier checks are encoded into a small verifier R1CS, proved via Nova folding + Spartan.
+BlindFold makes all sumcheck proofs zero-knowledge without SNARK composition. Instead of revealing sumcheck round polynomial coefficients, the prover sends Pedersen commitments. Sumcheck verifier checks are encoded into a small verifier R1CS, proved via Nova folding + Spartan. (A modular port lives in `crates/jolt-blindfold`; the module map below is the legacy implementation.)
 
 **Module structure:**
 - `mod.rs`: `StageConfig`, `BakedPublicInputs`, `HyraxParams`, R1CS primitives (`Variable`, `LinearCombination`, `Constraint`)
@@ -202,7 +198,6 @@ Concrete implementations: `OuterRemainingSumcheckParams` (spartan/outer.rs), `Ra
 
 ### Performance
 
-- PERFORMANCE IS CRITICAL AND TOP PRIORITY
 - Profile before optimizing
 - Benchmark changes to `poly/` code — small regressions multiply across thousands of sumcheck rounds
 - Use `#[inline]` judiciously in hot paths
@@ -216,7 +211,6 @@ Concrete implementations: `OuterRemainingSumcheckParams` (spartan/outer.rs), `Ra
 
 ### Code Style
 
-- `cargo fmt` + `cargo clippy` with zero warnings
 - Codebase uses `non_snake_case` convention for math variables: `log_T`, `ram_K`, `log_K`, etc.
 
 ### Lint Policy
@@ -225,23 +219,6 @@ Concrete implementations: `OuterRemainingSumcheckParams` (spartan/outer.rs), `Ra
 - `.unwrap()` and `.expect()` are fine in tests. In non-test code, avoid them unless the alternative significantly hurts readability (e.g., infallible fixed-size array conversions). When used, annotate the function with `#[expect(clippy::unwrap_used)]` or `#[expect(clippy::expect_used)]`
 - Use `#[expect(clippy::...)]` on test modules to blanket-suppress test-inappropriate lints rather than per-function annotations
 
-### Comment Policy
+### Comments
 
-**Delete these comment types:**
-- Section separators (`// ==========`, `// ----------`)
-- Doc comments that restate the item name (`/// Sumcheck prover for X` on `XProver`)
-- Obvious comments (`/// Returns the count` on `get_count()`)
-- Commented-out code
-- TODOs without issue links
-
-**Keep these comment types:**
-- WHY something is done (when not obvious)
-- WARNING comments for non-obvious gotchas
-- SAFETY comments for unsafe blocks
-- Complex algorithm explanations (link to paper if applicable)
-- Public API docs that explain behavior, constraints, or invariants
-
-### Testing
-
-- Always use `cargo nextest` (never `cargo test`)
-- Run `muldiv` e2e test as primary correctness check
+Match the codebase's low comment density. Worth writing: WHY comments, WARNING for non-obvious gotchas, SAFETY on unsafe blocks, algorithm explanations (link to paper if applicable), public API docs stating behavior or invariants. TODOs need issue links.


### PR DESCRIPTION
## What

Context-engineering pass over the agent prompt files (CLAUDE.md + `.claude/skills/`), per Anthropic's updated guidance for Claude 5 models (rules → judgment, progressive disclosure, dedup, no stale facts).

### Stale facts fixed (verified against the repo)
- Crate paths updated for the `crates/` restructure: clippy command in implement-spec now covers all 25 crates (`-p jolt-prover-legacy` missed the modular stack), `poly/` → `crates/jolt-poly/`, dory path corrected
- Deleted the CLAUDE.md "opening accumulator transcript changes (vs main)" note — the branch it described merged; `append_*` is transcript-free on main now
- `[patch.crates-io]` mechanism note updated (fork pin moved), Crate Structure section now reflects the legacy/modular split, BlindFold section points at `crates/jolt-blindfold`

### Rightsizing
- Deduped repeated mandates (nextest/muldiv stated twice in CLAUDE.md, "always post review" ×3 in ci-code-review — semantic preserved, QA-cycle caps ×2 in implement-spec)
- Split mode-specific content into `references/` loaded on demand: analyze-spec (remote/local output protocols), new-objective (static-analysis/perf templates)
- Dropped guidance that's now model-default (comment delete-list, CAPS emphasis, todo-list scaffolding); kept all team process semantics, thresholds, and load-bearing gates

Net: −341/+207 lines; always-loaded skill weight down ~250 lines. All commands, macros, labels (`claude-spec-approved` etc.), and framework interfaces verified against current code before and after editing.