### PR TITLE
docs: weekly freshness pass — fix drift after Akita verifier-path changes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,7 @@ cargo install --path . --locked
 ```bash
 # Execution trace (viewable in Perfetto)
 cargo run --release -p jolt-prover-legacy profile --name sha3 --format chrome
-# --name options: sha2, sha3, sha2-chain, fibonacci, btreemap
+# --name options: sha2, sha3, sha2-chain, sha3-chain, fibonacci, btreemap
 
 # With CPU/memory monitoring (adds counter tracks to Perfetto trace)
 cargo run --release --features monitor -p jolt-prover-legacy profile --name sha3 --format chrome
@@ -80,7 +80,7 @@ Arkworks dependencies use a fork: `a16z/arkworks-algebra` branch `dev/twist-shou
 
 **common** — Shared constants (`XLEN`, `REGISTER_COUNT`, thresholds) and `JoltDevice`/`MemoryLayout` types
 
-Feature flag hierarchy: `host` ⊃ `prover` ⊃ `minimal`. Most code is unconditional; `host/` is the main gated module.
+Feature flag hierarchy: `host` ⊃ `prover` ⊃ `minimal`. Most code is unconditional; `host/` is the main gated module. The `akita` feature selects the packed (lattice/Akita) commitment mode — mutually exclusive with `zk` (compile error on the combination).
 
 ### Key Type Parameters
 
@@ -145,7 +145,7 @@ The `zk` Cargo feature (`cfg(feature = "zk")`) controls zero-knowledge mode:
 - `JoltProof::opening_claims: Claims<F>` — `#[cfg(not(feature = "zk"))]`
 - `JoltProof::blindfold_proof: BlindFoldProof` — `#[cfg(feature = "zk")]`
 - Prover uses `#[cfg(feature = "zk")]` / `#[cfg(not(feature = "zk"))]` blocks — compile-time path selection, no runtime `zk_mode` field
-- Verifier detects mode from proof at runtime: `proof.stage1_sumcheck_proof.is_zk()` — stored as `VerifierOpeningAccumulator::zk_mode`
+- Verifier zk mode is fixed at compile time (`zk` feature → `JOLT_VERIFIER_CONFIG` in `crates/jolt-verifier/src/config.rs`); the proof self-describes its protocol (`JoltProof::protocol: JoltProtocolConfig`) and `validate_proof_config` rejects a mismatch fail-closed
 
 **CRITICAL — Verifier `new_from_verifier` must support both modes:**
 

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ To generate a trace, run e.g.
 
 ```cargo run --release -p jolt-prover-legacy profile --name sha3 --format chrome```
 
-Where `--name` can be `sha2`, `sha3`, `sha2-chain`, `fibonacci`, or `btreemap`. The corresponding guest programs can be found in the [`examples`](./examples/) directory. The benchmark inputs are provided in [`e2e_profiling.rs`](./crates/jolt-prover-legacy/benches/e2e_profiling.rs).
+Where `--name` can be `sha2`, `sha3`, `sha2-chain`, `sha3-chain`, `fibonacci`, or `btreemap`. The corresponding guest programs can be found in the [`examples`](./examples/) directory. The benchmark inputs are provided in [`e2e_profiling.rs`](./crates/jolt-prover-legacy/benches/e2e_profiling.rs).
 
 The above command will output a JSON file in the workspace rootwith a name `trace-<timestamp>.json`, which can be viewed in [Perfetto](https://ui.perfetto.dev/).
 


### PR DESCRIPTION
Weekly docs-freshness pass (week ending Jul 27, 2026). Reviewed 14 commits on main, including the Akita lattice PCS integration (#1675/#1676), the jolt-witness refactor (#1677), the CLAUDE.md rightsizing (#1700), CI changes (#1698/#1699), and dependabot bumps.

## What drifted

**CLAUDE.md — ZK feature gate section (caused by #1675):** claimed the verifier "detects mode from proof at runtime: `proof.stage1_sumcheck_proof.is_zk()` — stored as `VerifierOpeningAccumulator::zk_mode`". That mechanism is gone: zk mode is now fixed at compile time (`zk` feature → `JOLT_VERIFIER_CONFIG` in `crates/jolt-verifier/src/config.rs`), the proof self-describes its protocol (`JoltProof::protocol: JoltProtocolConfig`), and `validate_proof_config` rejects mismatches fail-closed. Verified against `crates/jolt-verifier/src/config.rs` and `verifier.rs` (`validate_proof_config(&JoltProtocolConfig::for_zk(checked.zk), proof.protocol)`); no `.is_zk()` call sites remain in `jolt-prover-legacy/src`.

**CLAUDE.md — feature flags (caused by #1675/#1676):** the new `akita` feature (packed lattice commitment mode) wasn't mentioned. Added one sentence noting it and its mutual exclusion with `zk` — verified against the `compile_error!` in `crates/jolt-verifier/src/config.rs` and the feature comment in `crates/jolt-prover-legacy/Cargo.toml`.

**CLAUDE.md + README — profile `--name` options (pre-existing staleness):** both lists omit `sha3-chain`. Verified against `BenchType` in `crates/jolt-prover-legacy/benches/e2e_profiling.rs` (btreemap, fibonacci, sha2, sha3, sha2-chain, sha3-chain).

## Checked, no drift found

- book/ (untouched this week; all `crates/jolt-prover-legacy/src/...` paths referenced in book pages still exist)
- agent-skills/jolt/SKILL.md (this week's SDK change only removed the internal `_ZK_FEATURE_ENABLED` verify arg; the documented user-facing API is unchanged)
- .claude/skills/* and CLAUDE.md structure (rightsized this week in #1700; crate count "25" matches `ls crates | wc -l`)
- CLAUDE.md cfg-gated proof fields, `prove_zk`/`prove` split, muldiv test target — all still accurate