### PR TITLE
ci: pin mdbook-katex to 0.9.4 to fix mdbook deploy

### DIFF
--- a/.github/workflows/deploy-mdbook.yml
+++ b/.github/workflows/deploy-mdbook.yml
@@ -26,7 +26,8 @@ jobs:
         mdbook-version: '0.4.10'
 
     - name: Install mdbook-katex
-      run: cargo install mdbook-katex
+      # 0.9.4 is the last release compatible with mdbook 0.4.x; 0.10+ targets mdbook 0.5
+      run: cargo install mdbook-katex --version 0.9.4 --locked
 
     - run: mdbook build ./book
 
@@ -43,7 +44,8 @@ jobs:
         with:
           mdbook-version: '0.4.10'
       - name: Install mdbook-katex
-        run: cargo install mdbook-katex
+        # 0.9.4 is the last release compatible with mdbook 0.4.x; 0.10+ targets mdbook 0.5
+        run: cargo install mdbook-katex --version 0.9.4 --locked
 
       - run: mdbook build ./book
 

--- a/book/book.toml
+++ b/book/book.toml
@@ -1,7 +1,6 @@
 [book]
 authors = []
 language = "en"
-multilingual = false
 src = "src"
 title = "JoltBook"
 


### PR DESCRIPTION
## Problem

The mdBook deploy workflow has been failing since 2026-07-22 on both jobs (`deploy_firebase`, `deploy_gcloud`) at the `mdbook build ./book` step:

```
Error: Unable to parse the input
Caused by:
    unknown field `multilingual`, expected one of `title`, `authors`, `description`, `src`, `language`, `text-direction`
```

## Root cause

The workflow pins the mdbook binary at **0.4.10** but installs `mdbook-katex` **unpinned** via `cargo install`. mdbook-katex **0.10.0** (released 2026-07-22) is built against **mdbook 0.5**, whose config/book types are incompatible with what the mdbook 0.4.x binary sends over the preprocessor protocol:

1. mdbook 0.5 removed the `multilingual` config field, so 0.10.0 rejects any book.toml that still has it (the error above), and
2. even with that field removed, mdbook 0.5 renamed the Book struct's `sections` field to `items`, so parsing fails with `missing field 'items'` (reproduced locally).

## Fix

- Pin `mdbook-katex` to **0.9.4** (the last release built against mdbook 0.4.x) with `--locked` in both jobs.
- Drop the obsolete `multilingual = false` from `book/book.toml` — it's the default in 0.4.x and removed in 0.5, so this reduces friction for a future mdbook upgrade.

Verified locally: mdbook 0.4.x + mdbook-katex 0.9.4 builds the book cleanly with this config; unpinned mdbook-katex 0.10.0 reproduces the exact CI failure.

Note: upgrading to mdbook 0.5 + mdbook-katex 0.10 also builds, but was deliberately not taken here — mdbook 0.5's stricter markdown parsing emits unclosed-tag warnings on `how/appendix/multilinear-extensions.md`, so that upgrade deserves its own PR with a rendering check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)