### PR TITLE
feat(jolt-tracer-x86): experimental AOT x86-64 tracer backend (x86-tracer slices 2-5)

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -212,6 +212,43 @@ jobs:
       - name: Serial/parallel trace equivalence
         run: cargo run --profile ci -p tracer --example trace_equivalence
 
+  x86-tracer:
+    runs-on: ubuntu-latest
+    name: x86 AOT tracer backend (native x86-64)
+    steps:
+      - uses: actions/checkout@v7.0.1
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          components: rust-src
+          cache: false
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: release-tests
+          save-if: false
+      - name: Install nextest
+        uses: taiki-e/install-action@nextest
+      # Guest ELFs link ZeroOS, so building them needs its musl toolchain.
+      - name: Cache ZeroOS musl toolchain
+        id: cache-zeroos-musl
+        uses: actions/cache@v6
+        with:
+          path: ~/.zeroos/musl
+          key: zeroos-musl-toolchain-musl-1.2.3-gcc-9.4.0-Linux-x86_64
+      - name: Install ZeroOS musl toolchain
+        if: steps.cache-zeroos-musl.outputs.cache-hit != 'true'
+        run: |
+          curl -fsSL https://github.com/LayerZero-Labs/ZeroOS/releases/download/musl-toolchain-musl-1.2.3-gcc-9.4.0/zeroos-musl-toolchain-musl-1.2.3-gcc-9.4.0-Linux-x86_64.tar.gz -o /tmp/zeroos-musl.tar.gz
+          mkdir -p ~/.zeroos
+          tar -xzf /tmp/zeroos-musl.tar.gz -C ~/.zeroos
+      # The guest-dependent tests skip themselves without the CLI, so this
+      # install is what makes this job the backend's real coverage: it is the
+      # only place the differential and chunk-composition tests execute
+      # against native x86-64 hardware.
+      - name: Build and install jolt CLI
+        run: cargo install --path . --locked --force --profile ci --target-dir target
+      - name: Test jolt-tracer-x86
+        run: cargo nextest run --cargo-profile ci -p jolt-tracer-x86
+
   test-prover-zk:
     runs-on: ubuntu-latest
     name: Test jolt-prover-legacy (zk)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3917,6 +3917,7 @@ dependencies = [
  "dynasm",
  "dynasmrt",
  "iai-callgrind",
+ "jolt-inlines-keccak256",
  "jolt-inlines-sha2",
  "jolt-platform",
  "jolt-program",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3916,6 +3916,7 @@ dependencies = [
  "common",
  "dynasm",
  "dynasmrt",
+ "iai-callgrind",
  "jolt-platform",
  "jolt-program",
  "jolt-riscv",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2291,6 +2291,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
+name = "dynasm"
+version = "3.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f7d4c414c94bc830797115b8e5f434d58e7e80cb42ba88508c14bc6ea270625"
+dependencies = [
+ "bitflags 2.11.0",
+ "byteorder",
+ "lazy_static",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "dynasmrt"
+version = "3.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "602f7458a3859195fb840e6e0cce5f4330dd9dfbfece0edaf31fe427af346f55"
+dependencies = [
+ "byteorder",
+ "dynasm",
+ "fnv",
+ "memmap2",
+]
+
+[[package]]
 name = "ecdsa"
 version = "0.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2468,7 +2495,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3090,7 +3117,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3880,6 +3907,22 @@ dependencies = [
  "serde",
  "thiserror 2.0.18",
  "tracing",
+]
+
+[[package]]
+name = "jolt-tracer-x86"
+version = "0.1.0"
+dependencies = [
+ "common",
+ "dynasm",
+ "dynasmrt",
+ "jolt-platform",
+ "jolt-program",
+ "jolt-riscv",
+ "libc",
+ "postcard",
+ "rand 0.8.7",
+ "tracer",
 ]
 
 [[package]]
@@ -5994,7 +6037,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6851,7 +6894,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7490,7 +7533,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3374,6 +3374,7 @@ dependencies = [
  "jolt-program",
  "jolt-prover-legacy",
  "jolt-riscv",
+ "jolt-tracer-x86",
  "jolt-transcript",
  "jolt-verifier",
  "libc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1731,7 +1731,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3917,6 +3917,7 @@ dependencies = [
  "dynasm",
  "dynasmrt",
  "iai-callgrind",
+ "jolt-inlines-sha2",
  "jolt-platform",
  "jolt-program",
  "jolt-riscv",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ members = [
   "crates/jolt-dory",
   "crates/jolt-hyperkzg",
   "crates/jolt-riscv",
+  "crates/jolt-tracer-x86",
   "crates/jolt-transcript",
   "crates/jolt-utils",
   "crates/jolt-profiling",
@@ -443,6 +444,7 @@ jolt-utils = { path = "./crates/jolt-utils" }
 jolt-sumcheck = { path = "./crates/jolt-sumcheck" }
 jolt-riscv = { path = "./crates/jolt-riscv", default-features = false }
 jolt-program = { path = "./crates/jolt-program", default-features = false }
+jolt-tracer-x86 = { path = "./crates/jolt-tracer-x86" }
 jolt-lookup-tables = { path = "./crates/jolt-lookup-tables" }
 jolt-platform = { path = "./jolt-platform", default-features = false }
 jolt-sdk = { path = "./jolt-sdk", default-features = false }

--- a/crates/jolt-tracer-x86/Cargo.toml
+++ b/crates/jolt-tracer-x86/Cargo.toml
@@ -31,6 +31,7 @@ jolt-platform = { workspace = true, features = ["std"] }
 libc = "0.2"
 
 [dev-dependencies]
+jolt-inlines-keccak256 = { workspace = true, features = ["host"] }
 jolt-inlines-sha2 = { workspace = true, features = ["host"] }
 postcard = { workspace = true, features = ["use-std"] }
 rand = { workspace = true }

--- a/crates/jolt-tracer-x86/Cargo.toml
+++ b/crates/jolt-tracer-x86/Cargo.toml
@@ -36,6 +36,10 @@ jolt-inlines-sha2 = { workspace = true, features = ["host"] }
 postcard = { workspace = true, features = ["use-std"] }
 rand = { workspace = true }
 
+[[bin]]
+name = "jolt-emu-x86"
+path = "src/bin/jolt_emu_x86.rs"
+
 [[bench]]
 name = "iai"
 harness = false

--- a/crates/jolt-tracer-x86/Cargo.toml
+++ b/crates/jolt-tracer-x86/Cargo.toml
@@ -31,6 +31,7 @@ jolt-platform = { workspace = true, features = ["std"] }
 libc = "0.2"
 
 [dev-dependencies]
+jolt-inlines-sha2 = { workspace = true, features = ["host"] }
 postcard = { workspace = true, features = ["use-std"] }
 rand = { workspace = true }
 

--- a/crates/jolt-tracer-x86/Cargo.toml
+++ b/crates/jolt-tracer-x86/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "jolt-tracer-x86"
+version = "0.1.0"
+edition = "2021"
+description = "AOT x86-64 transpiling execution backend for Jolt trace generation"
+
+[lints]
+workspace = true
+
+[dependencies]
+common = { workspace = true, features = ["std"] }
+jolt-program = { workspace = true, features = ["image"] }
+jolt-riscv = { workspace = true }
+tracer = { workspace = true, features = ["std"] }
+
+[target.'cfg(all(target_arch = "x86_64", target_os = "linux"))'.dependencies]
+dynasm = "3.2"
+dynasmrt = "3.2"
+jolt-platform = { workspace = true, features = ["std"] }
+libc = "0.2"
+
+[dev-dependencies]
+postcard = { workspace = true, features = ["use-std"] }
+rand = { workspace = true }

--- a/crates/jolt-tracer-x86/Cargo.toml
+++ b/crates/jolt-tracer-x86/Cargo.toml
@@ -7,6 +7,16 @@ description = "AOT x86-64 transpiling execution backend for Jolt trace generatio
 [lints]
 workspace = true
 
+[features]
+# Per-instruction callgrind microbenchmarks (linux-x86_64 + valgrind only).
+iai = ["dep:iai-callgrind"]
+# Passthrough only: the transpiler fails fast on FIELD_* rows (spec Non-Goals).
+field-inline = [
+  "jolt-program/field-inline",
+  "jolt-riscv/field-inline",
+  "tracer/field-inline",
+]
+
 [dependencies]
 common = { workspace = true, features = ["std"] }
 jolt-program = { workspace = true, features = ["image"] }
@@ -16,9 +26,15 @@ tracer = { workspace = true, features = ["std"] }
 [target.'cfg(all(target_arch = "x86_64", target_os = "linux"))'.dependencies]
 dynasm = "3.2"
 dynasmrt = "3.2"
+iai-callgrind = { workspace = true, optional = true }
 jolt-platform = { workspace = true, features = ["std"] }
 libc = "0.2"
 
 [dev-dependencies]
 postcard = { workspace = true, features = ["use-std"] }
 rand = { workspace = true }
+
+[[bench]]
+name = "iai"
+harness = false
+required-features = ["iai"]

--- a/crates/jolt-tracer-x86/benches/iai.rs
+++ b/crates/jolt-tracer-x86/benches/iai.rs
@@ -1,0 +1,147 @@
+//! Per-instruction iai-callgrind microbenchmarks: callgrind instruction
+//! counts per row kind, measured over a straight-line program of 4096 copies
+//! of the row (compilation and memory-plane setup stay outside the measured
+//! region via `Prepared`). Control-flow kinds that cannot repeat
+//! straight-line use a `Jal +4` chain or a single dispatched row (`Jalr`).
+//!
+//! Requires valgrind and the `iai` feature; linux-x86_64 only (the feature
+//! is meaningless elsewhere):
+//!
+//! ```sh
+//! cargo bench -p jolt-tracer-x86 --features iai --bench iai
+//! ```
+
+#![cfg(all(target_arch = "x86_64", target_os = "linux"))]
+#![expect(clippy::expect_used)]
+
+use common::constants::REGISTER_COUNT;
+use iai_callgrind::{library_benchmark, library_benchmark_group, main};
+use jolt_riscv::{JoltInstructionKind, JoltInstructionRow, NormalizedOperands};
+use jolt_tracer_x86::harness::{
+    single_row_program, straight_line_program, Prepared, SCRATCH_START, TEST_ADDR,
+};
+use std::hint::black_box;
+
+const COUNT: usize = 4096;
+const REGS: usize = REGISTER_COUNT as usize;
+
+type Operands = (Option<u8>, Option<u8>, Option<u8>, i128);
+
+fn row(kind: JoltInstructionKind, operands: Operands) -> JoltInstructionRow {
+    let (rs1, rs2, rd, imm) = operands;
+    JoltInstructionRow {
+        instruction_kind: kind,
+        address: TEST_ADDR as usize,
+        operands: NormalizedOperands { rs1, rs2, rd, imm },
+        virtual_sequence_remaining: None,
+        is_first_in_sequence: true,
+        is_compressed: false,
+    }
+}
+
+fn bench_regs() -> [u64; REGS] {
+    let mut pre = [0u64; REGS];
+    // Distinct operand values; the branch benches rely on x5 != x6.
+    pre[5] = 1;
+    pre[6] = 2;
+    pre[7] = 1 << 20; // one-hot bitmask for the register-form shift
+    pre[8] = SCRATCH_START; // aligned base for memory ops
+    pre
+}
+
+/// Setup: straight-line repetition of a non-control-flow row (or a `Jal +4`
+/// chain, which is also address-sequential).
+fn straight(kind: JoltInstructionKind, operands: Operands) -> Prepared {
+    let program = straight_line_program(row(kind, operands), COUNT);
+    Prepared::new(&program, bench_regs()).expect("prepare failed")
+}
+
+/// Setup: one dispatched `Jalr` through the jump table.
+fn jalr_single() -> Prepared {
+    let mut pre = bench_regs();
+    pre[5] = TEST_ADDR + 8;
+    let program = single_row_program(row(JoltInstructionKind::JALR, (Some(5), None, Some(9), 0)));
+    Prepared::new(&program, pre).expect("prepare failed")
+}
+
+fn run(mut prepared: Prepared) -> u64 {
+    black_box(prepared.run_once().expect("run failed"))
+}
+
+use JoltInstructionKind as K;
+
+/// For kinds whose associated-const name collides with the enum variant name
+/// (the variant constructor wins path resolution), resolve by name instead.
+fn kind_by_name(name: &str) -> JoltInstructionKind {
+    JoltInstructionKind::from_name(name).expect("unknown kind name")
+}
+
+macro_rules! straight_benches {
+    ($($bench:ident => ($kind:expr, $rs1:expr, $rs2:expr, $rd:expr, $imm:expr);)*) => {
+        $(
+            #[library_benchmark]
+            #[bench::steady(args = ($kind, ($rs1, $rs2, $rd, $imm)), setup = straight)]
+            fn $bench(prepared: Prepared) -> u64 {
+                run(prepared)
+            }
+        )*
+
+        library_benchmark_group!(
+            name = per_instruction;
+            benchmarks = $($bench),*
+        );
+    };
+}
+
+straight_benches! {
+    iai_add => (K::ADD, Some(5), Some(6), Some(9), 0);
+    iai_sub => (K::SUB, Some(5), Some(6), Some(9), 0);
+    iai_and => (K::AND, Some(5), Some(6), Some(9), 0);
+    iai_or => (K::OR, Some(5), Some(6), Some(9), 0);
+    iai_xor => (K::XOR, Some(5), Some(6), Some(9), 0);
+    iai_mul => (K::MUL, Some(5), Some(6), Some(9), 0);
+    iai_mulhu => (K::MULHU, Some(5), Some(6), Some(9), 0);
+    iai_sltu => (K::SLTU, Some(5), Some(6), Some(9), 0);
+    iai_addi => (K::ADDI, Some(5), None, Some(9), 42);
+    iai_andi => (K::ANDI, Some(5), None, Some(9), 42);
+    iai_ori => (K::ORI, Some(5), None, Some(9), 42);
+    iai_xori => (K::XORI, Some(5), None, Some(9), 42);
+    iai_slti => (K::SLTI, Some(5), None, Some(9), 42);
+    iai_sltiu => (K::SLTIU, Some(5), None, Some(9), 42);
+    iai_muli => (K::VirtualMULI, Some(5), None, Some(9), 42);
+    iai_lui => (K::LUI, None, None, Some(9), 0x1234_5000);
+    iai_auipc => (K::AUIPC, None, None, Some(9), 0x1000);
+    iai_pow2 => (K::VirtualPow2, Some(5), None, Some(9), 0);
+    iai_shift_right_bitmask => (kind_by_name("VirtualShiftRightBitmask"), Some(5), None, Some(9), 0);
+    iai_sign_extend_word => (kind_by_name("VirtualSignExtendWord"), Some(5), None, Some(9), 0);
+    iai_zero_extend_word => (kind_by_name("VirtualZeroExtendWord"), Some(5), None, Some(9), 0);
+    iai_srai => (K::VirtualSRAI, Some(5), None, Some(9), 1 << 7);
+    iai_srli => (K::VirtualSRLI, Some(5), None, Some(9), 1 << 7);
+    iai_srl => (K::VirtualSRL, Some(5), Some(7), Some(9), 0);
+    iai_beq_not_taken => (K::BEQ, Some(5), Some(6), None, 8);
+    iai_bne_taken_next => (K::BNE, Some(5), Some(6), None, 4);
+    iai_ld => (K::LD, Some(8), None, Some(9), 0);
+    iai_sd => (K::SD, Some(8), Some(5), None, 0);
+    iai_assert_halfword_alignment => (K::VirtualAssertHalfwordAlignment, Some(8), None, None, 0);
+    iai_assert_word_alignment => (K::VirtualAssertWordAlignment, Some(8), None, None, 0);
+    iai_assert_lte => (K::VirtualAssertLTE, Some(5), Some(6), None, 0);
+    iai_fence => (K::FENCE, None, None, None, 0);
+    iai_host_io_unknown => (kind_by_name("VirtualHostIO"), None, None, None, 0);
+    iai_jal_chain => (K::JAL, None, None, Some(9), 4);
+}
+
+#[library_benchmark]
+#[bench::single(setup = jalr_single)]
+fn iai_jalr(prepared: Prepared) -> u64 {
+    run(prepared)
+}
+
+library_benchmark_group!(
+    name = per_instruction_control;
+    benchmarks = iai_jalr
+);
+
+main!(
+    library_benchmark_groups = per_instruction,
+    per_instruction_control
+);

--- a/crates/jolt-tracer-x86/src/bin/jolt_emu_x86.rs
+++ b/crates/jolt-tracer-x86/src/bin/jolt_emu_x86.rs
@@ -1,0 +1,232 @@
+//! ACT4 (riscv-arch-test) runner for the AOT x86-64 backend — the x86
+//! counterpart of the tracer's `jolt-emu`.
+//!
+//! `tests/arch-tests/run.sh` invokes the emulator with a single positional
+//! ELF path and judges the test by exit status alone. The arch tests halt by
+//! storing a result word to the `tohost` symbol and then spinning in `j .`
+//! (see `tests/arch-tests/jolt/rvmodel_macros.h`), so the backend's PC-stall
+//! termination ends the run naturally and the result can be read out of
+//! final memory — no mid-execution HTIF hook is needed.
+//!
+//! Exit codes:
+//! * 0 — the test passed (`tohost` payload decodes to endcode 0)
+//! * 1 — the test ran and failed
+//! * 2 — usage/IO error
+//! * 3 — the Jolt pipeline or the transpiler rejected the program (decode,
+//!   expansion, or an unimplemented row kind). Distinct from 1 so skip lists
+//!   can be regenerated mechanically and the two categories stay
+//!   distinguishable, per AC4's "skipped and listed" requirement.
+//! * 4 — a runtime fault (out-of-bounds access, bad jump target, helper
+//!   error)
+
+#![expect(clippy::print_stderr)]
+
+use std::process::ExitCode;
+
+/// Native implementation; the binary exists on every target so build and
+/// packaging scripts do not need per-target conditionals.
+#[cfg(all(target_arch = "x86_64", target_os = "linux"))]
+mod native {
+
+    use std::collections::HashMap;
+    use std::process::ExitCode;
+
+    use common::constants::RAM_START_ADDRESS;
+    use common::jolt_device::MemoryConfig;
+    use jolt_program::execution::TraceInputs;
+    use jolt_tracer_x86::X86TracerBackend;
+
+    const EXIT_FAILED: u8 = 1;
+    const EXIT_USAGE: u8 = 2;
+    const EXIT_REJECTED: u8 = 3;
+    const EXIT_FAULT: u8 = 4;
+
+    pub fn run() -> ExitCode {
+        let mut args = std::env::args().skip(1);
+        let Some(elf_path) = args.next() else {
+            eprintln!(
+                "usage: jolt-emu-x86 <elf> [--signature <path>] [--signature-granularity <n>]"
+            );
+            return ExitCode::from(EXIT_USAGE);
+        };
+
+        let mut signature_path: Option<String> = None;
+        let mut granularity: usize = 4;
+        while let Some(flag) = args.next() {
+            match flag.as_str() {
+                "-s" | "--signature" => signature_path = args.next(),
+                "--signature-granularity" => {
+                    granularity = args
+                        .next()
+                        .and_then(|value| value.parse().ok())
+                        .unwrap_or(4);
+                }
+                other => {
+                    eprintln!("unknown argument: {other}");
+                    return ExitCode::from(EXIT_USAGE);
+                }
+            }
+        }
+
+        let elf = match std::fs::read(&elf_path) {
+            Ok(bytes) => bytes,
+            Err(error) => {
+                eprintln!("failed to read {elf_path}: {error}");
+                return ExitCode::from(EXIT_USAGE);
+            }
+        };
+
+        // Symbol addresses come from the ELF directly; the Jolt program image
+        // discards the symbol table.
+        let symbols = symbol_map(&elf);
+        let tohost = symbols.get("tohost").copied().unwrap_or(0);
+
+        let program = match jolt_program::execution::build_jolt_program(&elf) {
+            Ok(program) => program,
+            Err(error) => {
+                eprintln!("{elf_path}: pipeline rejected the program: {error:?}");
+                return ExitCode::from(EXIT_REJECTED);
+            }
+        };
+        let memory_config = MemoryConfig {
+            program_size: Some(program.program_end - RAM_START_ADDRESS),
+            ..Default::default()
+        };
+        let inputs = TraceInputs::new(Vec::new(), Vec::new(), Vec::new(), memory_config);
+
+        let mut backend = X86TracerBackend::new();
+        let output = match backend.fast_run(&program, inputs) {
+            Ok(output) => output,
+            Err(error) => {
+                // Compile-time rejection and runtime faults both surface as
+                // TraceError; distinguish them for the skip-list tooling.
+                let message = format!("{error:?}");
+                eprintln!("{elf_path}: {message}");
+                return ExitCode::from(if message.contains("unsupported instruction kind") {
+                    EXIT_REJECTED
+                } else {
+                    EXIT_FAULT
+                });
+            }
+        };
+
+        // Final memory arrives as nonzero (address, byte) pairs, RAM-relative.
+        let memory: HashMap<u64, u8> = output.final_memory.bytes.into_iter().collect();
+        let read_byte = |address: u64| -> u8 {
+            address
+                .checked_sub(RAM_START_ADDRESS)
+                .and_then(|offset| memory.get(&offset).copied())
+                .unwrap_or(0)
+        };
+
+        if let Some(path) = signature_path {
+            if let Err(error) = write_signature(
+                &path,
+                symbols.get("begin_signature").copied().unwrap_or(0),
+                symbols.get("end_signature").copied().unwrap_or(0),
+                granularity.max(1),
+                read_byte,
+            ) {
+                eprintln!("failed to write signature to {path}: {error}");
+                return ExitCode::from(EXIT_USAGE);
+            }
+        }
+
+        if tohost == 0 {
+            // No `tohost` symbol at all: nothing to judge.
+            eprintln!("{elf_path}: no tohost symbol; cannot determine the result");
+            return ExitCode::from(EXIT_FAILED);
+        }
+
+        let mut value = 0u64;
+        for i in 0..8 {
+            value |= u64::from(read_byte(tohost + i)) << (i * 8);
+        }
+        if value == 0 {
+            // The guest stalled without executing a halt macro. `jolt-emu`
+            // reports success here (PC-stall return path); for an arch test that
+            // is a silent pass, so fail loudly instead.
+            eprintln!("{elf_path}: terminated without writing tohost");
+            return ExitCode::from(EXIT_FAILED);
+        }
+
+        // HTIF encoding, as decoded by Emulator::run_test.
+        let device = (value >> 56) & 0xFF;
+        let payload = value & 0xFFFF_FFFF_FFFF;
+        if device != 0 || payload & 1 != 1 {
+            eprintln!("{elf_path}: unexpected tohost value {value:#x}");
+            return ExitCode::from(EXIT_FAILED);
+        }
+        let endcode = payload >> 1;
+        if endcode == 0 {
+            ExitCode::SUCCESS
+        } else {
+            eprintln!("{elf_path}: failed with endcode {endcode}");
+            ExitCode::from(EXIT_FAILED)
+        }
+    }
+
+    /// Signature bytes, `granularity` per line, big-endian within a group —
+    /// byte-for-byte the format `Emulator::write_signature` produces.
+    fn write_signature(
+        path: &str,
+        begin: u64,
+        end: u64,
+        granularity: usize,
+        read_byte: impl Fn(u64) -> u8,
+    ) -> std::io::Result<()> {
+        use std::fmt::Write as _;
+
+        let mut out = String::new();
+        let mut address = begin;
+        while address < end {
+            for offset in (0..granularity as u64).rev() {
+                let _ = write!(out, "{:02x}", read_byte(address + offset));
+            }
+            out.push('\n');
+            address += granularity as u64;
+        }
+        std::fs::write(path, out)
+    }
+
+    /// `name -> address` for the ELF's symbols, mirroring the tracer's map
+    /// construction (NOTYPE and FUNC entries).
+    fn symbol_map(elf: &[u8]) -> HashMap<String, u64> {
+        use tracer::emulator::elf_analyzer::ElfAnalyzer;
+
+        let analyzer = ElfAnalyzer::new(elf);
+        if !analyzer.validate() {
+            return HashMap::new();
+        }
+        let header = analyzer.read_header();
+        let section_headers = analyzer.read_section_headers(&header);
+        let mut symbol_tables = Vec::new();
+        let mut string_tables = Vec::new();
+        for section in &section_headers {
+            match section.sh_type {
+                2 => symbol_tables.push(section),
+                3 => string_tables.push(section),
+                _ => {}
+            }
+        }
+        let Some(string_table) = string_tables.first() else {
+            return HashMap::new();
+        };
+        let entries = analyzer.read_symbol_entries(&header, &symbol_tables);
+        analyzer
+            .create_symbol_map(&entries, string_table)
+            .into_iter()
+            .collect()
+    }
+}
+
+#[cfg(all(target_arch = "x86_64", target_os = "linux"))]
+fn main() -> ExitCode {
+    native::run()
+}
+
+#[cfg(not(all(target_arch = "x86_64", target_os = "linux")))]
+fn main() -> ExitCode {
+    eprintln!("jolt-emu-x86 requires x86_64 Linux; use jolt-emu on this target");
+    ExitCode::from(2u8)
+}

--- a/crates/jolt-tracer-x86/src/lib.rs
+++ b/crates/jolt-tracer-x86/src/lib.rs
@@ -1,0 +1,42 @@
+//! AOT x86-64 transpiling execution backend for Jolt trace generation.
+//!
+//! Implements the `jolt-program` execution seam (`ExecutionBackend`,
+//! `ChunkedExecutionBackend`) by compiling a `JoltProgram`'s expanded bytecode
+//! to native x86-64 once per program (via dynasm-rs) and executing it in two
+//! modes: a fast checkpointing pass and a per-chunk recording pass.
+//!
+//! Native codegen is gated to `x86_64`-Linux (the SP1/ZisK precedent). On
+//! every other target this crate still compiles, and [`NativeBackend`]
+//! resolves to the reference interpreter, so call sites can select the
+//! fastest available backend unconditionally:
+//!
+//! ```ignore
+//! let mut backend = jolt_tracer_x86::NativeBackend::default();
+//! let output = program.trace_with(&mut backend, inputs)?;
+//! ```
+//!
+//! See `specs/x86-tracer-backend.md` for the design (row templates over the
+//! statically expanded bytecode; fail-fast on unsupported rows; bit-identical
+//! `TraceRow` streams vs. the reference `TracerBackend`).
+
+#[cfg(all(target_arch = "x86_64", target_os = "linux"))]
+mod native;
+
+#[cfg(all(target_arch = "x86_64", target_os = "linux"))]
+pub use native::X86TracerBackend;
+
+/// The fastest execution backend available on this target: the AOT x86-64
+/// transpiler on `x86_64`-Linux, the reference interpreter everywhere else.
+///
+/// This alias is the entire backend-selection surface; nothing switches by
+/// default.
+#[cfg(all(target_arch = "x86_64", target_os = "linux"))]
+pub type NativeBackend = X86TracerBackend;
+
+/// The fastest execution backend available on this target: the AOT x86-64
+/// transpiler on `x86_64`-Linux, the reference interpreter everywhere else.
+///
+/// This alias is the entire backend-selection surface; nothing switches by
+/// default.
+#[cfg(not(all(target_arch = "x86_64", target_os = "linux")))]
+pub type NativeBackend = tracer::TracerBackend;

--- a/crates/jolt-tracer-x86/src/lib.rs
+++ b/crates/jolt-tracer-x86/src/lib.rs
@@ -25,6 +25,10 @@ mod native;
 #[cfg(all(target_arch = "x86_64", target_os = "linux"))]
 pub use native::X86TracerBackend;
 
+#[doc(hidden)]
+#[cfg(all(target_arch = "x86_64", target_os = "linux"))]
+pub use native::harness;
+
 /// The fastest execution backend available on this target: the AOT x86-64
 /// transpiler on `x86_64`-Linux, the reference interpreter everywhere else.
 ///

--- a/crates/jolt-tracer-x86/src/native/compile/emit.rs
+++ b/crates/jolt-tracer-x86/src/native/compile/emit.rs
@@ -311,6 +311,38 @@ fn assert_alignment(e: &mut Emitter, row: &JoltInstructionRow, mask: i8, code: u
     dynasm!(e.ops ; .arch x64 ; ok:);
 }
 
+/// Load the low 32 bits of a guest register, zero-extended (32-bit mov).
+fn load_reg32(e: &mut Emitter, gpr: u8, reg: Option<u8>) {
+    match reg {
+        None | Some(0) => dynasm!(e.ops ; .arch x64 ; xor Rd(gpr), Rd(gpr)),
+        Some(r) => dynasm!(e.ops ; .arch x64 ; mov Rd(gpr), DWORD [r12 + reg_offset(r)]),
+    }
+}
+
+/// Load the low 32 bits of a guest register, sign-extended to 64.
+fn load_reg32_sext(e: &mut Emitter, gpr: u8, reg: Option<u8>) {
+    match reg {
+        None | Some(0) => dynasm!(e.ops ; .arch x64 ; xor Rq(gpr), Rq(gpr)),
+        Some(r) => dynasm!(e.ops ; .arch x64 ; movsxd Rq(gpr), DWORD [r12 + reg_offset(r)]),
+    }
+}
+
+/// `(x[rs1] ^ x[rs2]).rotate_right(n)`, 64-bit.
+fn xor_rot(e: &mut Emitter, row: &JoltInstructionRow, n: i8) {
+    load_reg(e, RAX, row.operands.rs1);
+    load_reg(e, RCX, row.operands.rs2);
+    dynasm!(e.ops ; .arch x64 ; xor rax, rcx ; ror rax, n);
+    store_rd(e, RAX, row.operands.rd);
+}
+
+/// `((x[rs1] as u32) ^ (x[rs2] as u32)).rotate_right(n)`, zero-extended.
+fn xor_rotw(e: &mut Emitter, row: &JoltInstructionRow, n: i8) {
+    load_reg32(e, RAX, row.operands.rs1);
+    load_reg32(e, RCX, row.operands.rs2);
+    dynasm!(e.ops ; .arch x64 ; xor eax, ecx ; ror eax, n);
+    store_rd(e, RAX, row.operands.rd);
+}
+
 pub fn row(e: &mut Emitter, row: &JoltInstructionRow) -> Result<(), TraceError> {
     use JoltInstructionKind as K;
 
@@ -466,6 +498,200 @@ pub fn row(e: &mut Emitter, row: &JoltInstructionRow) -> Result<(), TraceError> 
             dynasm!(e.ops ; .arch x64 ; ok:);
         }
 
+        K::Slt(_) => {
+            load_reg(e, RAX, row.operands.rs1);
+            load_reg(e, RCX, row.operands.rs2);
+            dynasm!(e.ops ; .arch x64 ; cmp rax, rcx);
+            set_cc_less(e, true, row.operands.rd);
+        }
+        K::Andn(_) => {
+            // rd = x[rs1] & !x[rs2]
+            load_reg(e, RAX, row.operands.rs1);
+            load_reg(e, RCX, row.operands.rs2);
+            dynasm!(e.ops ; .arch x64 ; not rcx ; and rax, rcx);
+            store_rd(e, RAX, row.operands.rd);
+        }
+        K::Pow2I(_) => {
+            // Static: rd = 1 << (imm % 64).
+            let value = 1i64 << ((row.operands.imm as u64) % 64);
+            load_imm(e, RAX, value);
+            store_rd(e, RAX, row.operands.rd);
+        }
+        K::Pow2IW(_) => {
+            let value = 1i64 << ((row.operands.imm as u64) % 32);
+            load_imm(e, RAX, value);
+            store_rd(e, RAX, row.operands.rd);
+        }
+        K::Pow2W(_) => {
+            // rd = 1 << ((x[rs1] as u64) % 32)
+            load_reg(e, RCX, row.operands.rs1);
+            dynasm!(e.ops ; .arch x64 ; and ecx, 31 ; mov eax, 1 ; shl rax, cl);
+            store_rd(e, RAX, row.operands.rd);
+        }
+        K::MovSign(_) => {
+            // rd = -1 if the sign bit is set else 0.
+            load_reg(e, RAX, row.operands.rs1);
+            dynasm!(e.ops ; .arch x64 ; sar rax, 63);
+            store_rd(e, RAX, row.operands.rd);
+        }
+        K::VirtualRev8W(_) => {
+            // Byte-reverse each 32-bit half independently: bswap swaps all 8
+            // bytes (including the halves); ror 32 swaps the halves back.
+            load_reg(e, RAX, row.operands.rs1);
+            dynasm!(e.ops ; .arch x64 ; bswap rax ; ror rax, 32);
+            store_rd(e, RAX, row.operands.rd);
+        }
+        K::VirtualRotri(_) => {
+            // Shift amount = imm.trailing_zeros() (bitmask encoding), mod 64.
+            let shift = (((row.operands.imm as u64).trailing_zeros()) % 64) as i8;
+            load_reg(e, RAX, row.operands.rs1);
+            if shift != 0 {
+                dynasm!(e.ops ; .arch x64 ; ror rax, shift);
+            }
+            store_rd(e, RAX, row.operands.rd);
+        }
+        K::VirtualRotriw(_) => {
+            // 32-bit rotate, result zero-extended (NOT sign-extended);
+            // shift = tz(imm).min(32), and a u32 rotate by 32 is the identity.
+            let shift = ((row.operands.imm as u64).trailing_zeros().min(32) & 31) as i8;
+            load_reg32(e, RAX, row.operands.rs1);
+            if shift != 0 {
+                dynasm!(e.ops ; .arch x64 ; ror eax, shift);
+            }
+            store_rd(e, RAX, row.operands.rd);
+        }
+        K::VirtualShiftRightBitmaski(_) => {
+            // Static: bits [63:shift] set (all-ones when shift == 0).
+            let shift = (row.operands.imm as u64) % 64;
+            let value = (((1u128 << (64 - shift)) - 1) << shift) as u64 as i64;
+            load_imm(e, RAX, value);
+            store_rd(e, RAX, row.operands.rd);
+        }
+        K::VirtualSra(_) => {
+            // Arithmetic sibling of VirtualSrl: shift = tz(x[rs2]), tzcnt(0)=64
+            // -> sar masks to 0, matching wrapping_shr(64).
+            load_reg(e, RCX, row.operands.rs2);
+            load_reg(e, RAX, row.operands.rs1);
+            dynasm!(e.ops ; .arch x64 ; tzcnt rcx, rcx ; sar rax, cl);
+            store_rd(e, RAX, row.operands.rd);
+        }
+        K::VirtualXorRot32(_) => xor_rot(e, row, 32),
+        K::VirtualXorRot24(_) => xor_rot(e, row, 24),
+        K::VirtualXorRot16(_) => xor_rot(e, row, 16),
+        K::VirtualXorRot63(_) => xor_rot(e, row, 63),
+        K::VirtualXorRotW16(_) => xor_rotw(e, row, 16),
+        K::VirtualXorRotW12(_) => xor_rotw(e, row, 12),
+        K::VirtualXorRotW8(_) => xor_rotw(e, row, 8),
+        K::VirtualXorRotW7(_) => xor_rotw(e, row, 7),
+        K::AssertEq(_) => {
+            // imm == 0: hard assert. imm != 0: "spoil" mode, warn-and-continue
+            // in the interpreter; a no-op here (registers unaffected).
+            if row.operands.imm == 0 {
+                load_reg(e, RAX, row.operands.rs1);
+                load_reg(e, RCX, row.operands.rs2);
+                dynasm!(e.ops
+                    ; .arch x64
+                    ; cmp rax, rcx
+                    ; je >ok
+                    ; mov rsi, 3
+                    ; mov rdx, rax
+                );
+                call_helper(e, helpers::assert_failed as *const () as usize);
+                dynasm!(e.ops ; .arch x64 ; ok:);
+            }
+        }
+        K::AssertValidDiv0(_) => {
+            // divisor == 0 implies quotient == u64::MAX.
+            load_reg(e, RAX, row.operands.rs1);
+            load_reg(e, RCX, row.operands.rs2);
+            dynasm!(e.ops
+                ; .arch x64
+                ; test rax, rax
+                ; jnz >ok
+                ; cmp rcx, -1
+                ; je >ok
+                ; mov rsi, 4
+                ; mov rdx, rcx
+            );
+            call_helper(e, helpers::assert_failed as *const () as usize);
+            dynasm!(e.ops ; .arch x64 ; ok:);
+        }
+        K::AssertValidUnsignedRemainder(_) => {
+            // divisor == 0 || remainder < divisor (unsigned).
+            load_reg(e, RAX, row.operands.rs1);
+            load_reg(e, RCX, row.operands.rs2);
+            dynasm!(e.ops
+                ; .arch x64
+                ; test rcx, rcx
+                ; jz >ok
+                ; cmp rax, rcx
+                ; jb >ok
+                ; mov rsi, 5
+                ; mov rdx, rax
+            );
+            call_helper(e, helpers::assert_failed as *const () as usize);
+            dynasm!(e.ops ; .arch x64 ; ok:);
+        }
+        K::AssertMulUNoOverflow(_) => {
+            // (x[rs1] as u64) * (x[rs2] as u64) must not overflow: unsigned
+            // mul leaves the high half in rdx.
+            load_reg(e, RAX, row.operands.rs1);
+            load_reg(e, RCX, row.operands.rs2);
+            dynasm!(e.ops
+                ; .arch x64
+                ; mul rcx
+                ; test rdx, rdx
+                ; jz >ok
+                ; mov rsi, 6
+                ; mov rdx, rax
+            );
+            call_helper(e, helpers::assert_failed as *const () as usize);
+            dynasm!(e.ops ; .arch x64 ; ok:);
+        }
+        K::VirtualChangeDivisor(_) => {
+            // rd = 1 if (dividend, divisor) == (i64::MIN, -1) else divisor.
+            load_reg(e, RCX, row.operands.rs1);
+            load_reg(e, RAX, row.operands.rs2);
+            dynasm!(e.ops
+                ; .arch x64
+                ; mov rdx, QWORD i64::MIN
+                ; cmp rcx, rdx
+                ; jne >done
+                ; cmp rax, -1
+                ; jne >done
+                ; mov eax, 1
+                ; done:
+            );
+            store_rd(e, RAX, row.operands.rd);
+        }
+        K::VirtualChangeDivisorW(_) => {
+            // 32-bit variant; the else branch sign-extends the low 32 bits of
+            // x[rs2] (upper bits discarded).
+            load_reg32_sext(e, RCX, row.operands.rs1);
+            load_reg32_sext(e, RAX, row.operands.rs2);
+            dynasm!(e.ops
+                ; .arch x64
+                ; cmp ecx, 0x8000_0000u32 as i32
+                ; jne >done
+                ; cmp eax, -1
+                ; jne >done
+                ; mov eax, 1
+                ; done:
+            );
+            store_rd(e, RAX, row.operands.rd);
+        }
+        K::VirtualAdviceLen(_) => {
+            call_helper(e, helpers::advice_remaining as *const () as usize);
+            store_rd(e, RAX, row.operands.rd);
+        }
+        K::VirtualAdviceLoad(_) => {
+            // num_bytes is a static row immediate (1, 2, 4 or 8); the helper
+            // errors on tape exhaustion (interpreter panics there).
+            let num_bytes = (row.operands.imm as u64) as i32;
+            dynasm!(e.ops ; .arch x64 ; mov rsi, num_bytes);
+            call_helper(e, helpers::advice_read as *const () as usize);
+            store_rd(e, RAX, row.operands.rd);
+        }
         K::Fence(_) => {}
 
         K::VirtualHostIO(_) => {

--- a/crates/jolt-tracer-x86/src/native/compile/emit.rs
+++ b/crates/jolt-tracer-x86/src/native/compile/emit.rs
@@ -22,8 +22,8 @@ use jolt_riscv::{JoltInstructionKind, JoltInstructionRow};
 
 use super::super::helpers;
 use super::super::state::{
-    reg_offset, ExitReason, OFF_EXIT, OFF_FAULT_ADDR, OFF_MEM_BASE, OFF_MEM_SIZE, OFF_PC,
-    OFF_TRACE_LEN,
+    advice_slot_offset, reg_offset, ExitReason, OFF_EXIT, OFF_FAULT_ADDR, OFF_MEM_BASE,
+    OFF_MEM_SIZE, OFF_PC, OFF_TRACE_LEN,
 };
 use super::Emitter;
 
@@ -341,6 +341,12 @@ fn xor_rotw(e: &mut Emitter, row: &JoltInstructionRow, n: i8) {
     load_reg32(e, RCX, row.operands.rs2);
     dynasm!(e.ops ; .arch x64 ; xor eax, ecx ; ror eax, n);
     store_rd(e, RAX, row.operands.rd);
+}
+
+/// Emit a group's advice computation (job index in rsi), before its rows.
+pub fn advice_compute(e: &mut Emitter, job_index: usize) {
+    dynasm!(e.ops ; .arch x64 ; mov rsi, job_index as i32);
+    call_helper(e, helpers::advice_compute as *const () as usize);
 }
 
 pub fn row(e: &mut Emitter, row: &JoltInstructionRow) -> Result<(), TraceError> {
@@ -692,15 +698,31 @@ pub fn row(e: &mut Emitter, row: &JoltInstructionRow) -> Result<(), TraceError> 
             call_helper(e, helpers::advice_read as *const () as usize);
             store_rd(e, RAX, row.operands.rd);
         }
+        K::VirtualAdvice(_) => {
+            // The value comes from this group's advice slots, filled before
+            // the group's first row ran; slots are consumed in row order.
+            let slot = e.advice_slot;
+            if slot >= super::super::state::ADVICE_SLOTS {
+                return Err(TraceError::Backend(
+                    "too many VirtualAdvice rows in one group",
+                ));
+            }
+            e.advice_slot += 1;
+            dynasm!(e.ops ; .arch x64 ; mov rax, QWORD [r12 + advice_slot_offset(slot)]);
+            store_rd(e, RAX, row.operands.rd);
+        }
+
         K::Fence(_) => {}
 
         K::VirtualHostIO(_) => {
             call_helper(e, helpers::host_io as *const () as usize);
         }
 
-        other => {
-            // Fail-fast at compile time: never a silent wrong-semantics
-            // execution (spec invariant 7).
+        // Every other final kind is implemented above; `Noop` never appears
+        // in executable bytecode. Fail fast rather than execute wrong
+        // semantics (spec invariant 7); a newly added kind lands here until
+        // it has a template.
+        other @ K::Noop(_) => {
             let _ = other;
             return Err(TraceError::Backend(
                 "jolt-tracer-x86: unsupported instruction kind in bytecode",

--- a/crates/jolt-tracer-x86/src/native/compile/emit.rs
+++ b/crates/jolt-tracer-x86/src/native/compile/emit.rs
@@ -24,7 +24,8 @@ use super::super::helpers;
 use super::super::state::{
     advice_slot_offset, reg_offset, ExitReason, OBSERVATION_SIZE, OBS_RAM_ADDRESS, OBS_RAM_POST,
     OBS_RAM_PRE, OBS_RD_POST, OBS_RD_PRE, OBS_ROW_INDEX, OBS_RS1, OBS_RS2, OFF_EXIT,
-    OFF_FAULT_ADDR, OFF_MEM_BASE, OFF_MEM_SIZE, OFF_OBS_CURSOR, OFF_OBS_END, OFF_PC, OFF_TRACE_LEN,
+    OFF_FAULT_ADDR, OFF_MEM_BASE, OFF_MEM_SIZE, OFF_OBS_CURSOR, OFF_OBS_END, OFF_PC, OFF_ROW_LIMIT,
+    OFF_TRACE_LEN,
 };
 use super::emitter::{EmitOutcome, RowEmitter};
 use super::{EmitMode, Emitter};
@@ -135,6 +136,22 @@ pub fn prologue(e: &mut Emitter) -> AssemblyOffset {
     );
     dispatch(e);
     entry
+}
+
+/// Emitted at each group start: if the row budget is spent, publish this
+/// group's (statically known) address as the resume PC and leave. Rows are
+/// only ever emitted whole, so a resumed run repeats no row.
+pub fn group_pause_check(e: &mut Emitter, address: u64) {
+    dynasm!(e.ops
+        ; .arch x64
+        ; cmp r14, QWORD [r12 + OFF_ROW_LIMIT]
+        ; jb >go
+        ; mov rax, QWORD address as i64
+        ; mov QWORD [r12 + OFF_PC], rax
+        ; mov QWORD [r12 + OFF_EXIT], ExitReason::Paused as u64 as i32
+        ; jmp ->exit
+        ; go:
+    );
 }
 
 pub struct Stubs {

--- a/crates/jolt-tracer-x86/src/native/compile/emit.rs
+++ b/crates/jolt-tracer-x86/src/native/compile/emit.rs
@@ -69,6 +69,39 @@ fn store_rd(e: &mut Emitter, gpr: u8, rd: Option<u8>) {
     }
 }
 
+/// Apply a binary op with the guest register `reg` as the second operand,
+/// reading it straight from the state plane (`op rax, [state+off]`) instead
+/// of loading it into a scratch register first. Saves one instruction and one
+/// register per ALU row, the most frequent shape in the bytecode.
+fn alu_reg_operand(e: &mut Emitter, op: AluRR, dst: u8, reg: Option<u8>) {
+    let Some(r) = reg.filter(|r| *r != 0) else {
+        // x0: fold the identity/annihilator rather than touching memory.
+        match op {
+            AluRR::Add | AluRR::Sub | AluRR::Or | AluRR::Xor => {}
+            AluRR::And | AluRR::Mul => dynasm!(e.ops ; .arch x64 ; xor Rq(dst), Rq(dst)),
+        }
+        return;
+    };
+    let offset = reg_offset(r);
+    match op {
+        AluRR::Add => dynasm!(e.ops ; .arch x64 ; add Rq(dst), QWORD [r12 + offset]),
+        AluRR::Sub => dynasm!(e.ops ; .arch x64 ; sub Rq(dst), QWORD [r12 + offset]),
+        AluRR::And => dynasm!(e.ops ; .arch x64 ; and Rq(dst), QWORD [r12 + offset]),
+        AluRR::Or => dynasm!(e.ops ; .arch x64 ; or Rq(dst), QWORD [r12 + offset]),
+        AluRR::Xor => dynasm!(e.ops ; .arch x64 ; xor Rq(dst), QWORD [r12 + offset]),
+        AluRR::Mul => dynasm!(e.ops ; .arch x64 ; imul Rq(dst), QWORD [r12 + offset]),
+    }
+}
+
+/// Compare against a guest register straight from the state plane.
+fn cmp_reg_operand(e: &mut Emitter, dst: u8, reg: Option<u8>) {
+    if let Some(r) = reg.filter(|r| *r != 0) {
+        dynasm!(e.ops ; .arch x64 ; cmp Rq(dst), QWORD [r12 + reg_offset(r)]);
+    } else {
+        dynasm!(e.ops ; .arch x64 ; cmp Rq(dst), 0);
+    }
+}
+
 fn load_imm(e: &mut Emitter, gpr: u8, value: i64) {
     if let Ok(v) = i32::try_from(value) {
         dynasm!(e.ops ; .arch x64 ; mov Rq(gpr), v);
@@ -196,15 +229,7 @@ enum AluRR {
 
 fn alu_rr(e: &mut Emitter, row: &JoltInstructionRow, op: AluRR) {
     load_reg(e, RAX, row.operands.rs1);
-    load_reg(e, RCX, row.operands.rs2);
-    match op {
-        AluRR::Add => dynasm!(e.ops ; .arch x64 ; add rax, rcx),
-        AluRR::Sub => dynasm!(e.ops ; .arch x64 ; sub rax, rcx),
-        AluRR::And => dynasm!(e.ops ; .arch x64 ; and rax, rcx),
-        AluRR::Or => dynasm!(e.ops ; .arch x64 ; or rax, rcx),
-        AluRR::Xor => dynasm!(e.ops ; .arch x64 ; xor rax, rcx),
-        AluRR::Mul => dynasm!(e.ops ; .arch x64 ; imul rax, rcx),
-    }
+    alu_reg_operand(e, op, RAX, row.operands.rs2);
     store_rd(e, RAX, row.operands.rd);
 }
 
@@ -235,8 +260,7 @@ fn branch(e: &mut Emitter, row: &JoltInstructionRow, cc: Cc) {
     let address = row.address as u64;
     let target = (row.address as i64).wrapping_add(row.operands.imm as i64) as u64;
     load_reg(e, RAX, row.operands.rs1);
-    load_reg(e, RCX, row.operands.rs2);
-    dynasm!(e.ops ; .arch x64 ; cmp rax, rcx);
+    cmp_reg_operand(e, RAX, row.operands.rs2);
     if target == address {
         // Taken branch to itself terminates (PC-stall). Invert: skip the
         // terminal sequence when not taken.
@@ -570,8 +594,7 @@ fn emit_row_template(e: &mut Emitter, row: &JoltInstructionRow) -> Result<EmitOu
 
         K::SltU(_) => {
             load_reg(e, RAX, row.operands.rs1);
-            load_reg(e, RCX, row.operands.rs2);
-            dynasm!(e.ops ; .arch x64 ; cmp rax, rcx);
+            cmp_reg_operand(e, RAX, row.operands.rs2);
             set_cc_less(e, false, row.operands.rd);
         }
         K::SltI(_) => {
@@ -698,8 +721,7 @@ fn emit_row_template(e: &mut Emitter, row: &JoltInstructionRow) -> Result<EmitOu
 
         K::Slt(_) => {
             load_reg(e, RAX, row.operands.rs1);
-            load_reg(e, RCX, row.operands.rs2);
-            dynasm!(e.ops ; .arch x64 ; cmp rax, rcx);
+            cmp_reg_operand(e, RAX, row.operands.rs2);
             set_cc_less(e, true, row.operands.rd);
         }
         K::Andn(_) => {

--- a/crates/jolt-tracer-x86/src/native/compile/emit.rs
+++ b/crates/jolt-tracer-x86/src/native/compile/emit.rs
@@ -40,11 +40,11 @@ impl RowEmitter for DynasmEmitter {
         cx: &mut Emitter,
         row: &JoltInstructionRow,
     ) -> Result<EmitOutcome, TraceError> {
-        emit_row_template(cx, row)
+        Self::emit_row_template(cx, row)
     }
 
     fn emit_advice_compute(&self, cx: &mut Emitter, job_index: usize) {
-        advice_compute(cx, job_index);
+        cx.emit_advice_compute(job_index);
     }
 }
 
@@ -54,168 +54,175 @@ const RDX: u8 = 2;
 
 const RAM_START: u64 = common::constants::RAM_START_ADDRESS;
 
-fn load_reg(e: &mut Emitter, gpr: u8, reg: Option<u8>) {
-    match reg {
-        None | Some(0) => dynasm!(e.ops ; .arch x64 ; xor Rq(gpr), Rq(gpr)),
-        Some(r) => dynasm!(e.ops ; .arch x64 ; mov Rq(gpr), QWORD [r12 + reg_offset(r)]),
-    }
-}
-
-fn store_rd(e: &mut Emitter, gpr: u8, rd: Option<u8>) {
-    if let Some(r) = rd {
-        if r != 0 {
-            dynasm!(e.ops ; .arch x64 ; mov QWORD [r12 + reg_offset(r)], Rq(gpr));
+impl Emitter {
+    fn load_reg(&mut self, gpr: u8, reg: Option<u8>) {
+        match reg {
+            None | Some(0) => dynasm!(self.ops ; .arch x64 ; xor Rq(gpr), Rq(gpr)),
+            Some(r) => dynasm!(self.ops ; .arch x64 ; mov Rq(gpr), QWORD [r12 + reg_offset(r)]),
         }
     }
-}
 
-/// Apply a binary op with the guest register `reg` as the second operand,
-/// reading it straight from the state plane (`op rax, [state+off]`) instead
-/// of loading it into a scratch register first. Saves one instruction and one
-/// register per ALU row, the most frequent shape in the bytecode.
-fn alu_reg_operand(e: &mut Emitter, op: AluRR, dst: u8, reg: Option<u8>) {
-    let Some(r) = reg.filter(|r| *r != 0) else {
-        // x0: fold the identity/annihilator rather than touching memory.
+    fn store_rd(&mut self, gpr: u8, rd: Option<u8>) {
+        if let Some(r) = rd {
+            if r != 0 {
+                dynasm!(self.ops ; .arch x64 ; mov QWORD [r12 + reg_offset(r)], Rq(gpr));
+            }
+        }
+    }
+
+    /// Apply a binary op with the guest register `reg` as the second operand,
+    /// reading it straight from the state plane (`op rax, [state+off]`) instead
+    /// of loading it into a scratch register first. Saves one instruction and one
+    /// register per ALU row, the most frequent shape in the bytecode.
+    fn alu_reg_operand(&mut self, op: AluRR, dst: u8, reg: Option<u8>) {
+        let Some(r) = reg.filter(|r| *r != 0) else {
+            // x0: fold the identity/annihilator rather than touching memory.
+            match op {
+                AluRR::Add | AluRR::Sub | AluRR::Or | AluRR::Xor => {}
+                AluRR::And | AluRR::Mul => {
+                    dynasm!(self.ops ; .arch x64 ; xor Rq(dst), Rq(dst));
+                }
+            }
+            return;
+        };
+        let offset = reg_offset(r);
         match op {
-            AluRR::Add | AluRR::Sub | AluRR::Or | AluRR::Xor => {}
-            AluRR::And | AluRR::Mul => dynasm!(e.ops ; .arch x64 ; xor Rq(dst), Rq(dst)),
+            AluRR::Add => dynasm!(self.ops ; .arch x64 ; add Rq(dst), QWORD [r12 + offset]),
+            AluRR::Sub => dynasm!(self.ops ; .arch x64 ; sub Rq(dst), QWORD [r12 + offset]),
+            AluRR::And => dynasm!(self.ops ; .arch x64 ; and Rq(dst), QWORD [r12 + offset]),
+            AluRR::Or => dynasm!(self.ops ; .arch x64 ; or Rq(dst), QWORD [r12 + offset]),
+            AluRR::Xor => dynasm!(self.ops ; .arch x64 ; xor Rq(dst), QWORD [r12 + offset]),
+            AluRR::Mul => dynasm!(self.ops ; .arch x64 ; imul Rq(dst), QWORD [r12 + offset]),
         }
-        return;
-    };
-    let offset = reg_offset(r);
-    match op {
-        AluRR::Add => dynasm!(e.ops ; .arch x64 ; add Rq(dst), QWORD [r12 + offset]),
-        AluRR::Sub => dynasm!(e.ops ; .arch x64 ; sub Rq(dst), QWORD [r12 + offset]),
-        AluRR::And => dynasm!(e.ops ; .arch x64 ; and Rq(dst), QWORD [r12 + offset]),
-        AluRR::Or => dynasm!(e.ops ; .arch x64 ; or Rq(dst), QWORD [r12 + offset]),
-        AluRR::Xor => dynasm!(e.ops ; .arch x64 ; xor Rq(dst), QWORD [r12 + offset]),
-        AluRR::Mul => dynasm!(e.ops ; .arch x64 ; imul Rq(dst), QWORD [r12 + offset]),
+    }
+
+    /// Compare against a guest register straight from the state plane.
+    fn cmp_reg_operand(&mut self, dst: u8, reg: Option<u8>) {
+        if let Some(r) = reg.filter(|r| *r != 0) {
+            dynasm!(self.ops ; .arch x64 ; cmp Rq(dst), QWORD [r12 + reg_offset(r)]);
+        } else {
+            dynasm!(self.ops ; .arch x64 ; cmp Rq(dst), 0);
+        }
+    }
+
+    fn load_imm(&mut self, gpr: u8, value: i64) {
+        if let Ok(v) = i32::try_from(value) {
+            dynasm!(self.ops ; .arch x64 ; mov Rq(gpr), v);
+        } else {
+            dynasm!(self.ops ; .arch x64 ; mov Rq(gpr), QWORD value);
+        }
+    }
+
+    /// Call a sysv64 helper: rdi = state, rsi/rdx = args (already set by caller
+    /// emission). Syncs trace_len before the call and checks the exit flag after.
+    fn call_helper(&mut self, f: usize) {
+        dynasm!(self.ops
+            ; .arch x64
+            ; mov QWORD [r12 + OFF_TRACE_LEN], r14
+            ; mov rdi, r12
+            ; mov rax, QWORD f as i64
+            ; call rax
+            ; cmp QWORD [r12 + OFF_EXIT], 0
+            ; jne ->exit
+        );
+    }
+
+    /// Terminal (PC-stall) sequence: record this row already happened (r14 was
+    /// incremented at row start), publish pc/exit, leave.
+    fn terminal(&mut self, address: u64) {
+        dynasm!(self.ops
+            ; .arch x64
+            ; mov rcx, QWORD address as i64
+            ; mov QWORD [r12 + OFF_PC], rcx
+            ; mov QWORD [r12 + OFF_EXIT], ExitReason::Terminated as u64 as i32
+            ; jmp ->exit
+        );
+    }
+
+    /// Indirect dispatch on the guest address in rax (clobbers rcx, rdx).
+    fn dispatch(&mut self) {
+        let span = self.text_span as i32;
+        dynasm!(self.ops
+            ; .arch x64
+            ; mov rcx, rax
+            ; mov rdx, QWORD self.text_base as i64
+            ; sub rcx, rdx
+            ; cmp rcx, span
+            ; jae ->bad_jump
+            ; mov rdx, QWORD [r15 + rcx * 4]
+            ; jmp rdx
+        );
     }
 }
 
-/// Compare against a guest register straight from the state plane.
-fn cmp_reg_operand(e: &mut Emitter, dst: u8, reg: Option<u8>) {
-    if let Some(r) = reg.filter(|r| *r != 0) {
-        dynasm!(e.ops ; .arch x64 ; cmp Rq(dst), QWORD [r12 + reg_offset(r)]);
-    } else {
-        dynasm!(e.ops ; .arch x64 ; cmp Rq(dst), 0);
+pub(super) struct Stubs {
+    pub(super) bad_jump: AssemblyOffset,
+}
+
+impl Emitter {
+    /// Function prologue: pin registers, dispatch to `state.pc`.
+    pub(super) fn emit_prologue(&mut self) -> AssemblyOffset {
+        let entry = self.ops.offset();
+        dynasm!(self.ops
+            ; .arch x64
+            ; push r12
+            ; push r13
+            ; push r14
+            ; push r15
+            ; sub rsp, 8
+            ; mov r12, rdi
+            ; mov r13, QWORD [r12 + OFF_MEM_BASE]
+            ; mov r14, QWORD [r12 + OFF_TRACE_LEN]
+            ; mov r15, rsi
+            ; mov rax, QWORD [r12 + OFF_PC]
+        );
+        self.dispatch();
+        entry
     }
-}
 
-fn load_imm(e: &mut Emitter, gpr: u8, value: i64) {
-    if let Ok(v) = i32::try_from(value) {
-        dynasm!(e.ops ; .arch x64 ; mov Rq(gpr), v);
-    } else {
-        dynasm!(e.ops ; .arch x64 ; mov Rq(gpr), QWORD value);
+    /// If the row budget is spent, publish the resumable group address and leave.
+    pub(super) fn emit_group_pause_check(&mut self, address: u64) {
+        dynasm!(self.ops
+            ; .arch x64
+            ; cmp r14, QWORD [r12 + OFF_ROW_LIMIT]
+            ; jb >go
+            ; mov rax, QWORD address as i64
+            ; mov QWORD [r12 + OFF_PC], rax
+            ; mov QWORD [r12 + OFF_EXIT], ExitReason::Paused as u64 as i32
+            ; jmp ->exit
+            ; go:
+        );
     }
-}
 
-/// Call a sysv64 helper: rdi = state, rsi/rdx = args (already set by caller
-/// emission). Syncs trace_len before the call and checks the exit flag after.
-fn call_helper(e: &mut Emitter, f: usize) {
-    dynasm!(e.ops
-        ; .arch x64
-        ; mov QWORD [r12 + OFF_TRACE_LEN], r14
-        ; mov rdi, r12
-        ; mov rax, QWORD f as i64
-        ; call rax
-        ; cmp QWORD [r12 + OFF_EXIT], 0
-        ; jne ->exit
-    );
-}
+    /// Falling off the end of the compiled program is a bad jump.
+    pub(super) fn emit_jump_to_bad_jump(&mut self) {
+        dynasm!(self.ops ; .arch x64 ; jmp ->bad_jump);
+    }
 
-/// Terminal (PC-stall) sequence: record this row already happened (r14 was
-/// incremented at row start), publish pc/exit, leave.
-fn terminal(e: &mut Emitter, address: u64) {
-    dynasm!(e.ops
-        ; .arch x64
-        ; mov rcx, QWORD address as i64
-        ; mov QWORD [r12 + OFF_PC], rcx
-        ; mov QWORD [r12 + OFF_EXIT], ExitReason::Terminated as u64 as i32
-        ; jmp ->exit
-    );
-}
-
-/// Indirect dispatch on the guest address in rax (clobbers rcx, rdx).
-fn dispatch(e: &mut Emitter) {
-    let span = e.text_span as i32;
-    dynasm!(e.ops
-        ; .arch x64
-        ; mov rcx, rax
-        ; mov rdx, QWORD e.text_base as i64
-        ; sub rcx, rdx
-        ; cmp rcx, span
-        ; jae ->bad_jump
-        ; mov rdx, QWORD [r15 + rcx * 4]
-        ; jmp rdx
-    );
-}
-
-/// Function prologue: pin registers, dispatch to `state.pc`.
-pub fn prologue(e: &mut Emitter) -> AssemblyOffset {
-    let entry = e.ops.offset();
-    dynasm!(e.ops
-        ; .arch x64
-        ; push r12
-        ; push r13
-        ; push r14
-        ; push r15
-        ; sub rsp, 8
-        ; mov r12, rdi
-        ; mov r13, QWORD [r12 + OFF_MEM_BASE]
-        ; mov r14, QWORD [r12 + OFF_TRACE_LEN]
-        ; mov r15, rsi
-        ; mov rax, QWORD [r12 + OFF_PC]
-    );
-    dispatch(e);
-    entry
-}
-
-/// Emitted at each group start: if the row budget is spent, publish this
-/// group's (statically known) address as the resume PC and leave. Rows are
-/// only ever emitted whole, so a resumed run repeats no row.
-pub fn group_pause_check(e: &mut Emitter, address: u64) {
-    dynasm!(e.ops
-        ; .arch x64
-        ; cmp r14, QWORD [r12 + OFF_ROW_LIMIT]
-        ; jb >go
-        ; mov rax, QWORD address as i64
-        ; mov QWORD [r12 + OFF_PC], rax
-        ; mov QWORD [r12 + OFF_EXIT], ExitReason::Paused as u64 as i32
-        ; jmp ->exit
-        ; go:
-    );
-}
-
-pub struct Stubs {
-    pub bad_jump: AssemblyOffset,
-}
-
-/// Falling off the end of the compiled program is a bad jump (rax holds pc).
-pub fn jump_to_bad_jump(e: &mut Emitter) {
-    dynasm!(e.ops ; .arch x64 ; jmp ->bad_jump);
-}
-
-pub fn stubs(e: &mut Emitter) -> Stubs {
-    let bad_jump = e.ops.offset();
-    dynasm!(e.ops
-        ; .arch x64
-        ; ->obs_overflow:
-        ; mov QWORD [r12 + OFF_EXIT], ExitReason::FaultObservationOverflow as u64 as i32
-        ; jmp ->exit
-        ; ->bad_jump:
-        ; mov QWORD [r12 + OFF_FAULT_ADDR], rax
-        ; mov QWORD [r12 + OFF_EXIT], ExitReason::FaultBadJumpTarget as u64 as i32
-        ; ->exit:
-        ; mov QWORD [r12 + OFF_TRACE_LEN], r14
-        ; add rsp, 8
-        ; pop r15
-        ; pop r14
-        ; pop r13
-        ; pop r12
-        ; ret
-    );
-    Stubs { bad_jump }
+    pub(super) fn emit_stubs(&mut self) -> Stubs {
+        dynasm!(self.ops
+            ; .arch x64
+            ; ->obs_overflow:
+            ; mov QWORD [r12 + OFF_EXIT], ExitReason::FaultObservationOverflow as u64 as i32
+            ; jmp ->exit
+        );
+        let bad_jump = self.ops.offset();
+        dynasm!(self.ops
+            ; .arch x64
+            ; ->bad_jump:
+            ; mov QWORD [r12 + OFF_FAULT_ADDR], rax
+            ; mov QWORD [r12 + OFF_EXIT], ExitReason::FaultBadJumpTarget as u64 as i32
+            ; ->exit:
+            ; mov QWORD [r12 + OFF_TRACE_LEN], r14
+            ; add rsp, 8
+            ; pop r15
+            ; pop r14
+            ; pop r13
+            ; pop r12
+            ; ret
+        );
+        Stubs { bad_jump }
+    }
 }
 
 enum AluRR {
@@ -227,24 +234,26 @@ enum AluRR {
     Mul,
 }
 
-fn alu_rr(e: &mut Emitter, row: &JoltInstructionRow, op: AluRR) {
-    load_reg(e, RAX, row.operands.rs1);
-    alu_reg_operand(e, op, RAX, row.operands.rs2);
-    store_rd(e, RAX, row.operands.rd);
-}
-
-fn alu_ri(e: &mut Emitter, row: &JoltInstructionRow, op: AluRR) {
-    load_reg(e, RAX, row.operands.rs1);
-    load_imm(e, RCX, row.operands.imm as i64);
-    match op {
-        AluRR::Add => dynasm!(e.ops ; .arch x64 ; add rax, rcx),
-        AluRR::And => dynasm!(e.ops ; .arch x64 ; and rax, rcx),
-        AluRR::Or => dynasm!(e.ops ; .arch x64 ; or rax, rcx),
-        AluRR::Xor => dynasm!(e.ops ; .arch x64 ; xor rax, rcx),
-        AluRR::Mul => dynasm!(e.ops ; .arch x64 ; imul rax, rcx),
-        AluRR::Sub => unreachable!("no reg-imm subtract in the row set"),
+impl DynasmEmitter {
+    fn emit_alu_rr(e: &mut Emitter, row: &JoltInstructionRow, op: AluRR) {
+        e.load_reg(RAX, row.operands.rs1);
+        e.alu_reg_operand(op, RAX, row.operands.rs2);
+        e.store_rd(RAX, row.operands.rd);
     }
-    store_rd(e, RAX, row.operands.rd);
+
+    fn emit_alu_ri(e: &mut Emitter, row: &JoltInstructionRow, op: AluRR) {
+        e.load_reg(RAX, row.operands.rs1);
+        e.load_imm(RCX, row.operands.imm as i64);
+        match op {
+            AluRR::Add => dynasm!(e.ops ; .arch x64 ; add rax, rcx),
+            AluRR::And => dynasm!(e.ops ; .arch x64 ; and rax, rcx),
+            AluRR::Or => dynasm!(e.ops ; .arch x64 ; or rax, rcx),
+            AluRR::Xor => dynasm!(e.ops ; .arch x64 ; xor rax, rcx),
+            AluRR::Mul => dynasm!(e.ops ; .arch x64 ; imul rax, rcx),
+            AluRR::Sub => unreachable!("no reg-imm subtract in the row set"),
+        }
+        e.store_rd(RAX, row.operands.rd);
+    }
 }
 
 enum Cc {
@@ -256,694 +265,713 @@ enum Cc {
     GeUnsigned,
 }
 
-fn branch(e: &mut Emitter, row: &JoltInstructionRow, cc: Cc) {
-    let address = row.address as u64;
-    let target = (row.address as i64).wrapping_add(row.operands.imm as i64) as u64;
-    load_reg(e, RAX, row.operands.rs1);
-    cmp_reg_operand(e, RAX, row.operands.rs2);
-    if target == address {
-        // Taken branch to itself terminates (PC-stall). Invert: skip the
-        // terminal sequence when not taken.
-        match cc {
-            Cc::Eq => dynasm!(e.ops ; .arch x64 ; jne >fall),
-            Cc::Ne => dynasm!(e.ops ; .arch x64 ; je >fall),
-            Cc::LtSigned => dynasm!(e.ops ; .arch x64 ; jge >fall),
-            Cc::GeSigned => dynasm!(e.ops ; .arch x64 ; jl >fall),
-            Cc::LtUnsigned => dynasm!(e.ops ; .arch x64 ; jae >fall),
-            Cc::GeUnsigned => dynasm!(e.ops ; .arch x64 ; jb >fall),
-        }
-        terminal(e, address);
-        dynasm!(e.ops ; .arch x64 ; fall:);
-    } else {
-        let label = e.label_for(target);
-        match cc {
-            Cc::Eq => dynasm!(e.ops ; .arch x64 ; je =>label),
-            Cc::Ne => dynasm!(e.ops ; .arch x64 ; jne =>label),
-            Cc::LtSigned => dynasm!(e.ops ; .arch x64 ; jl =>label),
-            Cc::GeSigned => dynasm!(e.ops ; .arch x64 ; jge =>label),
-            Cc::LtUnsigned => dynasm!(e.ops ; .arch x64 ; jb =>label),
-            Cc::GeUnsigned => dynasm!(e.ops ; .arch x64 ; jae =>label),
+impl DynasmEmitter {
+    fn emit_branch(e: &mut Emitter, row: &JoltInstructionRow, cc: Cc) {
+        let address = row.address as u64;
+        let target = (row.address as i64).wrapping_add(row.operands.imm as i64) as u64;
+        e.load_reg(RAX, row.operands.rs1);
+        e.cmp_reg_operand(RAX, row.operands.rs2);
+        if target == address {
+            // Taken branch to itself terminates (PC-stall). Invert: skip the
+            // terminal sequence when not taken.
+            match cc {
+                Cc::Eq => dynasm!(e.ops ; .arch x64 ; jne >fall),
+                Cc::Ne => dynasm!(e.ops ; .arch x64 ; je >fall),
+                Cc::LtSigned => dynasm!(e.ops ; .arch x64 ; jge >fall),
+                Cc::GeSigned => dynasm!(e.ops ; .arch x64 ; jl >fall),
+                Cc::LtUnsigned => dynasm!(e.ops ; .arch x64 ; jae >fall),
+                Cc::GeUnsigned => dynasm!(e.ops ; .arch x64 ; jb >fall),
+            }
+            e.terminal(address);
+            dynasm!(e.ops ; .arch x64 ; fall:);
+        } else {
+            let label = e.label_for(target);
+            match cc {
+                Cc::Eq => dynasm!(e.ops ; .arch x64 ; je =>label),
+                Cc::Ne => dynasm!(e.ops ; .arch x64 ; jne =>label),
+                Cc::LtSigned => dynasm!(e.ops ; .arch x64 ; jl =>label),
+                Cc::GeSigned => dynasm!(e.ops ; .arch x64 ; jge =>label),
+                Cc::LtUnsigned => dynasm!(e.ops ; .arch x64 ; jb =>label),
+                Cc::GeUnsigned => dynasm!(e.ops ; .arch x64 ; jae =>label),
+            }
         }
     }
 }
 
-fn set_cc_less(e: &mut Emitter, signed: bool, rd: Option<u8>) {
-    if signed {
-        dynasm!(e.ops ; .arch x64 ; setl al);
-    } else {
-        dynasm!(e.ops ; .arch x64 ; setb al);
+impl Emitter {
+    fn set_cc_less(&mut self, signed: bool, rd: Option<u8>) {
+        if signed {
+            dynasm!(self.ops ; .arch x64 ; setl al);
+        } else {
+            dynasm!(self.ops ; .arch x64 ; setb al);
+        }
+        dynasm!(self.ops ; .arch x64 ; movzx rax, al);
+        self.store_rd(RAX, rd);
     }
-    dynasm!(e.ops ; .arch x64 ; movzx rax, al);
-    store_rd(e, RAX, rd);
 }
 
 fn link_value(row: &JoltInstructionRow) -> i64 {
     row.address as i64 + if row.is_compressed { 2 } else { 4 }
 }
 
-/// `Ld`: fast path hits the RAM plane; device/unaligned/OOB funnel to the
-/// slow helper. Clobbers rax/rcx/rdx (+ helper scratch on the cold path).
-fn load_doubleword(e: &mut Emitter, row: &JoltInstructionRow) {
-    // EA = (x[rs1] as u64).wrapping_add(imm as i32 as u64) — exact cast chain.
-    let offset = row.operands.imm as i32;
-    load_reg(e, RAX, row.operands.rs1);
-    dynasm!(e.ops ; .arch x64 ; add rax, offset);
-    if e.mode == EmitMode::Record {
-        // The effective address is 8-aligned on the success path, so the
-        // reference's word-aligned floor equals it.
-        obs_reload(e);
-        dynasm!(e.ops ; .arch x64 ; mov QWORD [r10 + OBS_RAM_ADDRESS], rax);
-    }
-    dynasm!(e.ops
-        ; .arch x64
-        ; mov rcx, rax
-        ; mov rdx, QWORD RAM_START as i64
-        ; sub rcx, rdx
-        ; mov rdx, QWORD [r12 + OFF_MEM_SIZE]
-        ; sub rdx, 7
-        ; cmp rcx, rdx
-        ; jae >slow
-        ; test al, 7
-        ; jnz >slow
-        ; mov rax, QWORD [r13 + rcx]
-        ; jmp >done
-        ; slow:
-        ; mov rsi, rax
-    );
-    call_helper(e, helpers::slow_load_doubleword as *const () as usize);
-    dynasm!(e.ops ; .arch x64 ; done:);
-    if e.mode == EmitMode::Record {
-        // The reference records the whole doubleword read, whichever path
-        // produced it.
-        obs_reload(e);
-        dynasm!(e.ops ; .arch x64 ; mov QWORD [r10 + OBS_RAM_PRE], rax);
-    }
-    store_rd(e, RAX, row.operands.rd);
-}
-
-/// `Sd`: mirror of `Ld` with the store value in rsi's place.
-fn store_doubleword(e: &mut Emitter, row: &JoltInstructionRow) {
-    // EA = x[rs1].wrapping_add(imm) as u64 — imm used as full i64 here.
-    load_reg(e, RAX, row.operands.rs1);
-    load_imm(e, RCX, row.operands.imm as i64);
-    load_reg(e, RDX, row.operands.rs2);
-    dynasm!(e.ops ; .arch x64 ; add rax, rcx);
-    if e.mode == EmitMode::Record {
-        // The reference records the raw effective address and the stored
-        // value; the pre-value is captured on whichever path performs the
-        // write (fast path below, helper for the device region).
-        obs_reload(e);
+impl DynasmEmitter {
+    /// `Ld`: fast path hits the RAM plane; device/unaligned/OOB funnel to the
+    /// slow helper. Clobbers rax/rcx/rdx (+ helper scratch on the cold path).
+    fn emit_load_doubleword(e: &mut Emitter, row: &JoltInstructionRow) {
+        // EA = (x[rs1] as u64).wrapping_add(imm as i32 as u64) — exact cast chain.
+        let offset = row.operands.imm as i32;
+        e.load_reg(RAX, row.operands.rs1);
+        dynasm!(e.ops ; .arch x64 ; add rax, offset);
+        if e.mode == EmitMode::Record {
+            // The effective address is 8-aligned on the success path, so the
+            // reference's word-aligned floor equals it.
+            e.obs_reload();
+            dynasm!(e.ops ; .arch x64 ; mov QWORD [r10 + OBS_RAM_ADDRESS], rax);
+        }
         dynasm!(e.ops
             ; .arch x64
-            ; mov QWORD [r10 + OBS_RAM_ADDRESS], rax
-            ; mov QWORD [r10 + OBS_RAM_POST], rdx
+            ; mov rcx, rax
+            ; mov rdx, QWORD RAM_START as i64
+            ; sub rcx, rdx
+            ; mov rdx, QWORD [r12 + OFF_MEM_SIZE]
+            ; sub rdx, 7
+            ; cmp rcx, rdx
+            ; jae >slow
+            ; test al, 7
+            ; jnz >slow
+            ; mov rax, QWORD [r13 + rcx]
+            ; jmp >done
+            ; slow:
+            ; mov rsi, rax
         );
-    }
-    dynasm!(e.ops
-        ; .arch x64
-        ; mov rcx, rax
-        ; mov rsi, QWORD RAM_START as i64
-        ; sub rcx, rsi
-        ; mov rsi, QWORD [r12 + OFF_MEM_SIZE]
-        ; sub rsi, 7
-        ; cmp rcx, rsi
-        ; jae >slow
-        ; test al, 7
-        ; jnz >slow
-    );
-    if e.mode == EmitMode::Record {
-        obs_reload(e);
-        dynasm!(e.ops
-            ; .arch x64
-            ; mov r8, QWORD [r13 + rcx]
-            ; mov QWORD [r10 + OBS_RAM_PRE], r8
-        );
-    }
-    dynasm!(e.ops
-        ; .arch x64
-        ; mov QWORD [r13 + rcx], rdx
-        ; jmp >done
-        ; slow:
-        ; mov rsi, rax
-        // value already in rdx (helper arg 3)
-    );
-    call_helper(e, helpers::slow_store_doubleword as *const () as usize);
-    dynasm!(e.ops ; .arch x64 ; done:);
-}
-
-/// Alignment asserts: compute EA, test low bits, call the fatal helper on
-/// failure. `mask` is 1 (halfword) or 3 (word); `code` selects the message.
-fn assert_alignment(e: &mut Emitter, row: &JoltInstructionRow, mask: i8, code: u64) {
-    load_reg(e, RAX, row.operands.rs1);
-    load_imm(e, RCX, row.operands.imm as i64);
-    dynasm!(e.ops
-        ; .arch x64
-        ; add rax, rcx
-        ; test al, mask
-        ; jz >ok
-        ; mov rsi, code as i32
-        ; mov rdx, rax
-    );
-    call_helper(e, helpers::assert_failed as *const () as usize);
-    // assert_failed always sets the exit flag, so call_helper's check exits.
-    dynasm!(e.ops ; .arch x64 ; ok:);
-}
-
-/// Load the low 32 bits of a guest register, zero-extended (32-bit mov).
-fn load_reg32(e: &mut Emitter, gpr: u8, reg: Option<u8>) {
-    match reg {
-        None | Some(0) => dynasm!(e.ops ; .arch x64 ; xor Rd(gpr), Rd(gpr)),
-        Some(r) => dynasm!(e.ops ; .arch x64 ; mov Rd(gpr), DWORD [r12 + reg_offset(r)]),
-    }
-}
-
-/// Load the low 32 bits of a guest register, sign-extended to 64.
-fn load_reg32_sext(e: &mut Emitter, gpr: u8, reg: Option<u8>) {
-    match reg {
-        None | Some(0) => dynasm!(e.ops ; .arch x64 ; xor Rq(gpr), Rq(gpr)),
-        Some(r) => dynasm!(e.ops ; .arch x64 ; movsxd Rq(gpr), DWORD [r12 + reg_offset(r)]),
-    }
-}
-
-/// `(x[rs1] ^ x[rs2]).rotate_right(n)`, 64-bit.
-fn xor_rot(e: &mut Emitter, row: &JoltInstructionRow, n: i8) {
-    load_reg(e, RAX, row.operands.rs1);
-    load_reg(e, RCX, row.operands.rs2);
-    dynasm!(e.ops ; .arch x64 ; xor rax, rcx ; ror rax, n);
-    store_rd(e, RAX, row.operands.rd);
-}
-
-/// `((x[rs1] as u32) ^ (x[rs2] as u32)).rotate_right(n)`, zero-extended.
-fn xor_rotw(e: &mut Emitter, row: &JoltInstructionRow, n: i8) {
-    load_reg32(e, RAX, row.operands.rs1);
-    load_reg32(e, RCX, row.operands.rs2);
-    dynasm!(e.ops ; .arch x64 ; xor eax, ecx ; ror eax, n);
-    store_rd(e, RAX, row.operands.rd);
-}
-
-/// Emit a group's advice computation (job index in rsi), before its rows.
-pub fn advice_compute(e: &mut Emitter, job_index: usize) {
-    dynasm!(e.ops ; .arch x64 ; mov rsi, job_index as i32);
-    call_helper(e, helpers::advice_compute as *const () as usize);
-}
-
-/// Record mode: load the observation cursor into r10 and bounds-check it.
-/// Kept live only within one row's emission (helper calls clobber r10).
-fn obs_open(e: &mut Emitter, row_index: usize) {
-    dynasm!(e.ops
-        ; .arch x64
-        ; mov r10, QWORD [r12 + OFF_OBS_CURSOR]
-        ; cmp r10, QWORD [r12 + OFF_OBS_END]
-        ; jae ->obs_overflow
-        ; mov rax, QWORD row_index as i64
-        ; mov QWORD [r10 + OBS_ROW_INDEX], rax
-    );
-}
-
-/// Reload the cursor into r10. Every capture site does this: a row whose
-/// template calls a helper has had r10 clobbered (caller-saved), and the
-/// cursor is only advanced by `obs_close`, so the reload always lands on the
-/// same slot.
-fn obs_reload(e: &mut Emitter) {
-    dynasm!(e.ops ; .arch x64 ; mov r10, QWORD [r12 + OFF_OBS_CURSOR]);
-}
-
-/// Record mode: advance the cursor past this row's slot.
-fn obs_close(e: &mut Emitter) {
-    dynasm!(e.ops
-        ; .arch x64
-        ; mov r10, QWORD [r12 + OFF_OBS_CURSOR]
-        ; add r10, OBSERVATION_SIZE
-        ; mov QWORD [r12 + OFF_OBS_CURSOR], r10
-    );
-}
-
-/// Record mode: capture the register values this row reads and the
-/// destination's pre-value, before the row's own template runs.
-fn obs_registers_pre(e: &mut Emitter, row: &JoltInstructionRow) {
-    obs_reload(e);
-    for (slot, register) in [
-        (OBS_RS1, row.operands.rs1),
-        (OBS_RS2, row.operands.rs2),
-        (OBS_RD_PRE, row.operands.rd),
-    ] {
-        match register {
-            // x0 reads as zero, matching normalize_register_value.
-            None | Some(0) => dynasm!(e.ops
-                ; .arch x64
-                ; xor rax, rax
-                ; mov QWORD [r10 + slot], rax
-            ),
-            Some(r) => dynasm!(e.ops
-                ; .arch x64
-                ; mov rax, QWORD [r12 + reg_offset(r)]
-                ; mov QWORD [r10 + slot], rax
-            ),
+        e.call_helper(helpers::slow_load_doubleword as *const () as usize);
+        dynasm!(e.ops ; .arch x64 ; done:);
+        if e.mode == EmitMode::Record {
+            // The reference records the whole doubleword read, whichever path
+            // produced it.
+            e.obs_reload();
+            dynasm!(e.ops ; .arch x64 ; mov QWORD [r10 + OBS_RAM_PRE], rax);
         }
-    }
-}
-
-/// Record mode: store a statically known rd post-value (control-flow rows
-/// write their observation before transferring, so their post-value must be
-/// known without executing the template; for Jal/Jalr it is the link).
-fn obs_rd_post_static(e: &mut Emitter, row: &JoltInstructionRow, value: i64) {
-    obs_reload(e);
-    let value = match row.operands.rd {
-        None | Some(0) => 0,
-        Some(_) => value,
-    };
-    dynasm!(e.ops
-        ; .arch x64
-        ; mov rax, QWORD value
-        ; mov QWORD [r10 + OBS_RD_POST], rax
-    );
-}
-
-/// Record mode: capture the destination's post-value, after the template ran.
-fn obs_rd_post(e: &mut Emitter, row: &JoltInstructionRow) {
-    obs_reload(e);
-    match row.operands.rd {
-        None | Some(0) => dynasm!(e.ops
-            ; .arch x64
-            ; xor rax, rax
-            ; mov QWORD [r10 + OBS_RD_POST], rax
-        ),
-        Some(r) => dynasm!(e.ops
-            ; .arch x64
-            ; mov rax, QWORD [r12 + reg_offset(r)]
-            ; mov QWORD [r10 + OBS_RD_POST], rax
-        ),
-    }
-}
-
-fn emit_row_template(e: &mut Emitter, row: &JoltInstructionRow) -> Result<EmitOutcome, TraceError> {
-    use JoltInstructionKind as K;
-
-    // Every row is one trace row.
-    dynasm!(e.ops ; .arch x64 ; inc r14);
-
-    // Record mode brackets each row's template with value capture. Rows that
-    // transfer control never reach code emitted after their template, so
-    // theirs is written up front: branches have no destination, and Jal/Jalr
-    // post-values are the statically known link.
-    let record = e.mode == EmitMode::Record;
-    let transfers_control = matches!(
-        row.instruction_kind,
-        K::Beq(_)
-            | K::Bne(_)
-            | K::Blt(_)
-            | K::Bge(_)
-            | K::BltU(_)
-            | K::BgeU(_)
-            | K::Jal(_)
-            | K::Jalr(_)
-    );
-    if record {
-        obs_open(e, e.row_index);
-        obs_registers_pre(e, row);
-        if transfers_control {
-            let link = match row.instruction_kind {
-                K::Jal(_) | K::Jalr(_) => link_value(row),
-                _ => 0,
-            };
-            obs_rd_post_static(e, row, link);
-            obs_close(e);
-        }
+        e.store_rd(RAX, row.operands.rd);
     }
 
-    match &row.instruction_kind {
-        K::Add(_) => alu_rr(e, row, AluRR::Add),
-        K::Sub(_) => alu_rr(e, row, AluRR::Sub),
-        K::And(_) => alu_rr(e, row, AluRR::And),
-        K::Or(_) => alu_rr(e, row, AluRR::Or),
-        K::Xor(_) => alu_rr(e, row, AluRR::Xor),
-        K::Mul(_) => alu_rr(e, row, AluRR::Mul),
-        K::Addi(_) => alu_ri(e, row, AluRR::Add),
-        K::AndI(_) => alu_ri(e, row, AluRR::And),
-        K::OrI(_) => alu_ri(e, row, AluRR::Or),
-        K::XorI(_) => alu_ri(e, row, AluRR::Xor),
-        K::MulI(_) => alu_ri(e, row, AluRR::Mul),
-
-        K::MulHU(_) => {
-            // rd = high 64 bits of unsigned x[rs1] * x[rs2].
-            load_reg(e, RAX, row.operands.rs1);
-            load_reg(e, RCX, row.operands.rs2);
-            dynasm!(e.ops ; .arch x64 ; mul rcx);
-            store_rd(e, RDX, row.operands.rd);
-        }
-
-        K::SltU(_) => {
-            load_reg(e, RAX, row.operands.rs1);
-            cmp_reg_operand(e, RAX, row.operands.rs2);
-            set_cc_less(e, false, row.operands.rd);
-        }
-        K::SltI(_) => {
-            load_reg(e, RAX, row.operands.rs1);
-            load_imm(e, RCX, row.operands.imm as i64);
-            dynasm!(e.ops ; .arch x64 ; cmp rax, rcx);
-            set_cc_less(e, true, row.operands.rd);
-        }
-        K::SltIU(_) => {
-            load_reg(e, RAX, row.operands.rs1);
-            load_imm(e, RCX, row.operands.imm as i64);
-            dynasm!(e.ops ; .arch x64 ; cmp rax, rcx);
-            set_cc_less(e, false, row.operands.rd);
-        }
-
-        K::Lui(_) => {
-            load_imm(e, RAX, row.operands.imm as i64);
-            store_rd(e, RAX, row.operands.rd);
-        }
-        K::Auipc(_) => {
-            // rd = address + imm, fully static.
-            let value = (row.address as i64).wrapping_add(row.operands.imm as i64);
-            load_imm(e, RAX, value);
-            store_rd(e, RAX, row.operands.rd);
-        }
-
-        K::Pow2(_) => {
-            // rd = 1 << (x[rs1] % 64); shl's cl masking is exactly mod 64.
-            load_reg(e, RCX, row.operands.rs1);
-            dynasm!(e.ops ; .arch x64 ; mov eax, 1 ; shl rax, cl);
-            store_rd(e, RAX, row.operands.rd);
-        }
-        K::VirtualShiftRightBitmask(_) => {
-            // rd = u64::MAX << (x[rs1] & 63) — bits [63:shift] set.
-            load_reg(e, RCX, row.operands.rs1);
-            dynasm!(e.ops ; .arch x64 ; mov rax, -1 ; shl rax, cl);
-            store_rd(e, RAX, row.operands.rd);
-        }
-        K::VirtualSignExtendWord(_) => {
-            load_reg(e, RAX, row.operands.rs1);
-            dynasm!(e.ops ; .arch x64 ; movsxd rax, eax);
-            store_rd(e, RAX, row.operands.rd);
-        }
-        K::VirtualZeroExtendWord(_) => {
-            load_reg(e, RAX, row.operands.rs1);
-            dynasm!(e.ops ; .arch x64 ; mov eax, eax);
-            store_rd(e, RAX, row.operands.rd);
-        }
-        K::VirtualSrai(_) => {
-            // Shift amount = imm.trailing_zeros() (imm is a bitmask);
-            // wrapping_shr semantics = mod 64.
-            let shift = ((row.operands.imm as u64).trailing_zeros() % 64) as i8;
-            load_reg(e, RAX, row.operands.rs1);
-            dynasm!(e.ops ; .arch x64 ; sar rax, shift);
-            store_rd(e, RAX, row.operands.rd);
-        }
-        K::VirtualSrli(_) => {
-            let shift = ((row.operands.imm as u64).trailing_zeros() % 64) as i8;
-            load_reg(e, RAX, row.operands.rs1);
-            dynasm!(e.ops ; .arch x64 ; shr rax, shift);
-            store_rd(e, RAX, row.operands.rd);
-        }
-        K::VirtualSrl(_) => {
-            // Shift = x[rs2].trailing_zeros(); tzcnt(0) = 64 → shr masks to
-            // 0, matching wrapping_shr(64). Requires BMI1 (checked once).
-            load_reg(e, RCX, row.operands.rs2);
-            load_reg(e, RAX, row.operands.rs1);
-            dynasm!(e.ops ; .arch x64 ; tzcnt rcx, rcx ; shr rax, cl);
-            store_rd(e, RAX, row.operands.rd);
-        }
-
-        K::Beq(_) => branch(e, row, Cc::Eq),
-        K::Bne(_) => branch(e, row, Cc::Ne),
-        K::Blt(_) => branch(e, row, Cc::LtSigned),
-        K::Bge(_) => branch(e, row, Cc::GeSigned),
-        K::BltU(_) => branch(e, row, Cc::LtUnsigned),
-        K::BgeU(_) => branch(e, row, Cc::GeUnsigned),
-
-        K::Jal(_) => {
-            load_imm(e, RAX, link_value(row));
-            store_rd(e, RAX, row.operands.rd);
-            let target = (row.address as i64).wrapping_add(row.operands.imm as i64) as u64;
-            if target == row.address as u64 {
-                terminal(e, target);
-            } else {
-                let label = e.label_for(target);
-                dynasm!(e.ops ; .arch x64 ; jmp =>label);
-            }
-        }
-        K::Jalr(_) => {
-            // target = (x[rs1] + imm) & !1, computed before the link write
-            // (rs1 may alias rd).
-            load_reg(e, RAX, row.operands.rs1);
-            load_imm(e, RCX, row.operands.imm as i64);
-            dynasm!(e.ops ; .arch x64 ; add rax, rcx ; and rax, -2);
-            load_imm(e, RCX, link_value(row));
-            store_rd(e, RCX, row.operands.rd);
-            // PC-stall check against this row's own source address.
-            dynasm!(e.ops ; .arch x64 ; mov rcx, QWORD row.address as i64 ; cmp rax, rcx ; jne >go);
-            terminal(e, row.address as u64);
-            dynasm!(e.ops ; .arch x64 ; go:);
-            dispatch(e);
-        }
-
-        K::Ld(_) => load_doubleword(e, row),
-        K::Sd(_) => store_doubleword(e, row),
-
-        K::AssertHalfwordAlignment(_) => assert_alignment(e, row, 1, 0),
-        K::AssertWordAlignment(_) => assert_alignment(e, row, 3, 1),
-        K::AssertLte(_) => {
-            // assert!(x[rs1] as u64 <= x[rs2] as u64) — unsigned.
-            load_reg(e, RAX, row.operands.rs1);
-            load_reg(e, RCX, row.operands.rs2);
+    /// `Sd`: mirror of `Ld` with the store value in rsi's place.
+    fn emit_store_doubleword(e: &mut Emitter, row: &JoltInstructionRow) {
+        // EA = x[rs1].wrapping_add(imm) as u64 — imm used as full i64 here.
+        e.load_reg(RAX, row.operands.rs1);
+        e.load_imm(RCX, row.operands.imm as i64);
+        e.load_reg(RDX, row.operands.rs2);
+        dynasm!(e.ops ; .arch x64 ; add rax, rcx);
+        if e.mode == EmitMode::Record {
+            // The reference records the raw effective address and the stored
+            // value; the pre-value is captured on whichever path performs the
+            // write (fast path below, helper for the device region).
+            e.obs_reload();
             dynasm!(e.ops
                 ; .arch x64
-                ; cmp rax, rcx
-                ; jbe >ok
-                ; mov rsi, 2
-                ; mov rdx, rax
+                ; mov QWORD [r10 + OBS_RAM_ADDRESS], rax
+                ; mov QWORD [r10 + OBS_RAM_POST], rdx
             );
-            call_helper(e, helpers::assert_failed as *const () as usize);
-            dynasm!(e.ops ; .arch x64 ; ok:);
+        }
+        dynasm!(e.ops
+            ; .arch x64
+            ; mov rcx, rax
+            ; mov rsi, QWORD RAM_START as i64
+            ; sub rcx, rsi
+            ; mov rsi, QWORD [r12 + OFF_MEM_SIZE]
+            ; sub rsi, 7
+            ; cmp rcx, rsi
+            ; jae >slow
+            ; test al, 7
+            ; jnz >slow
+        );
+        if e.mode == EmitMode::Record {
+            e.obs_reload();
+            dynasm!(e.ops
+                ; .arch x64
+                ; mov r8, QWORD [r13 + rcx]
+                ; mov QWORD [r10 + OBS_RAM_PRE], r8
+            );
+        }
+        dynasm!(e.ops
+            ; .arch x64
+            ; mov QWORD [r13 + rcx], rdx
+            ; jmp >done
+            ; slow:
+            ; mov rsi, rax
+            // value already in rdx (helper arg 3)
+        );
+        e.call_helper(helpers::slow_store_doubleword as *const () as usize);
+        dynasm!(e.ops ; .arch x64 ; done:);
+    }
+
+    /// Alignment asserts: compute EA, test low bits, call the fatal helper on
+    /// failure. `mask` is 1 (halfword) or 3 (word); `code` selects the message.
+    fn emit_assert_alignment(e: &mut Emitter, row: &JoltInstructionRow, mask: i8, code: u64) {
+        e.load_reg(RAX, row.operands.rs1);
+        e.load_imm(RCX, row.operands.imm as i64);
+        dynasm!(e.ops
+            ; .arch x64
+            ; add rax, rcx
+            ; test al, mask
+            ; jz >ok
+            ; mov rsi, code as i32
+            ; mov rdx, rax
+        );
+        e.call_helper(helpers::assert_failed as *const () as usize);
+        // assert_failed always sets the exit flag, so call_helper's check exits.
+        dynasm!(e.ops ; .arch x64 ; ok:);
+    }
+}
+
+impl Emitter {
+    /// Load the low 32 bits of a guest register, zero-extended (32-bit mov).
+    fn load_reg32(&mut self, gpr: u8, reg: Option<u8>) {
+        match reg {
+            None | Some(0) => dynasm!(self.ops ; .arch x64 ; xor Rd(gpr), Rd(gpr)),
+            Some(r) => dynasm!(self.ops ; .arch x64 ; mov Rd(gpr), DWORD [r12 + reg_offset(r)]),
+        }
+    }
+
+    /// Load the low 32 bits of a guest register, sign-extended to 64.
+    fn load_reg32_sext(&mut self, gpr: u8, reg: Option<u8>) {
+        match reg {
+            None | Some(0) => dynasm!(self.ops ; .arch x64 ; xor Rq(gpr), Rq(gpr)),
+            Some(r) => {
+                dynasm!(self.ops ; .arch x64 ; movsxd Rq(gpr), DWORD [r12 + reg_offset(r)]);
+            }
+        }
+    }
+}
+
+impl DynasmEmitter {
+    /// `(x[rs1] ^ x[rs2]).rotate_right(n)`, 64-bit.
+    fn emit_xor_rot(e: &mut Emitter, row: &JoltInstructionRow, n: i8) {
+        e.load_reg(RAX, row.operands.rs1);
+        e.load_reg(RCX, row.operands.rs2);
+        dynasm!(e.ops ; .arch x64 ; xor rax, rcx ; ror rax, n);
+        e.store_rd(RAX, row.operands.rd);
+    }
+
+    /// `((x[rs1] as u32) ^ (x[rs2] as u32)).rotate_right(n)`, zero-extended.
+    fn emit_xor_rotw(e: &mut Emitter, row: &JoltInstructionRow, n: i8) {
+        e.load_reg32(RAX, row.operands.rs1);
+        e.load_reg32(RCX, row.operands.rs2);
+        dynasm!(e.ops ; .arch x64 ; xor eax, ecx ; ror eax, n);
+        e.store_rd(RAX, row.operands.rd);
+    }
+}
+
+impl Emitter {
+    /// Emit a group's advice computation before its rows.
+    pub(super) fn emit_advice_compute(&mut self, job_index: usize) {
+        dynasm!(self.ops ; .arch x64 ; mov rsi, job_index as i32);
+        self.call_helper(helpers::advice_compute as *const () as usize);
+    }
+
+    /// Record mode: load the observation cursor into r10 and bounds-check it.
+    /// Kept live only within one row's emission (helper calls clobber r10).
+    fn obs_open(&mut self, row_index: usize) {
+        dynasm!(self.ops
+            ; .arch x64
+            ; mov r10, QWORD [r12 + OFF_OBS_CURSOR]
+            ; cmp r10, QWORD [r12 + OFF_OBS_END]
+            ; jae ->obs_overflow
+            ; mov rax, QWORD row_index as i64
+            ; mov QWORD [r10 + OBS_ROW_INDEX], rax
+        );
+    }
+
+    /// Reload the cursor into r10. Every capture site does this: a row whose
+    /// template calls a helper has had r10 clobbered (caller-saved), and the
+    /// cursor is only advanced by `obs_close`, so the reload always lands on the
+    /// same slot.
+    fn obs_reload(&mut self) {
+        dynasm!(self.ops ; .arch x64 ; mov r10, QWORD [r12 + OFF_OBS_CURSOR]);
+    }
+
+    /// Record mode: advance the cursor past this row's slot.
+    fn obs_close(&mut self) {
+        dynasm!(self.ops
+            ; .arch x64
+            ; mov r10, QWORD [r12 + OFF_OBS_CURSOR]
+            ; add r10, OBSERVATION_SIZE
+            ; mov QWORD [r12 + OFF_OBS_CURSOR], r10
+        );
+    }
+
+    /// Record mode: capture the register values this row reads and the
+    /// destination's pre-value, before the row's own template runs.
+    fn obs_registers_pre(&mut self, row: &JoltInstructionRow) {
+        self.obs_reload();
+        for (slot, register) in [
+            (OBS_RS1, row.operands.rs1),
+            (OBS_RS2, row.operands.rs2),
+            (OBS_RD_PRE, row.operands.rd),
+        ] {
+            match register {
+                // x0 reads as zero, matching normalize_register_value.
+                None | Some(0) => dynasm!(self.ops
+                    ; .arch x64
+                    ; xor rax, rax
+                    ; mov QWORD [r10 + slot], rax
+                ),
+                Some(r) => dynasm!(self.ops
+                    ; .arch x64
+                    ; mov rax, QWORD [r12 + reg_offset(r)]
+                    ; mov QWORD [r10 + slot], rax
+                ),
+            }
+        }
+    }
+
+    /// Record mode: store a statically known rd post-value (control-flow rows
+    /// write their observation before transferring, so their post-value must be
+    /// known without executing the template; for Jal/Jalr it is the link).
+    fn obs_rd_post_static(&mut self, row: &JoltInstructionRow, value: i64) {
+        self.obs_reload();
+        let value = match row.operands.rd {
+            None | Some(0) => 0,
+            Some(_) => value,
+        };
+        dynasm!(self.ops
+            ; .arch x64
+            ; mov rax, QWORD value
+            ; mov QWORD [r10 + OBS_RD_POST], rax
+        );
+    }
+
+    /// Record mode: capture the destination's post-value, after the template ran.
+    fn obs_rd_post(&mut self, row: &JoltInstructionRow) {
+        self.obs_reload();
+        match row.operands.rd {
+            None | Some(0) => dynasm!(self.ops
+                ; .arch x64
+                ; xor rax, rax
+                ; mov QWORD [r10 + OBS_RD_POST], rax
+            ),
+            Some(r) => dynasm!(self.ops
+                ; .arch x64
+                ; mov rax, QWORD [r12 + reg_offset(r)]
+                ; mov QWORD [r10 + OBS_RD_POST], rax
+            ),
+        }
+    }
+}
+
+impl DynasmEmitter {
+    fn emit_row_template(
+        e: &mut Emitter,
+        row: &JoltInstructionRow,
+    ) -> Result<EmitOutcome, TraceError> {
+        use JoltInstructionKind as K;
+
+        // Every row is one trace row.
+        dynasm!(e.ops ; .arch x64 ; inc r14);
+
+        // Record mode brackets each row's template with value capture. Rows that
+        // transfer control never reach code emitted after their template, so
+        // theirs is written up front: branches have no destination, and Jal/Jalr
+        // post-values are the statically known link.
+        let record = e.mode == EmitMode::Record;
+        let transfers_control = matches!(
+            row.instruction_kind,
+            K::Beq(_)
+                | K::Bne(_)
+                | K::Blt(_)
+                | K::Bge(_)
+                | K::BltU(_)
+                | K::BgeU(_)
+                | K::Jal(_)
+                | K::Jalr(_)
+        );
+        if record {
+            e.obs_open(e.row_index);
+            e.obs_registers_pre(row);
+            if transfers_control {
+                let link = match row.instruction_kind {
+                    K::Jal(_) | K::Jalr(_) => link_value(row),
+                    _ => 0,
+                };
+                e.obs_rd_post_static(row, link);
+                e.obs_close();
+            }
         }
 
-        K::Slt(_) => {
-            load_reg(e, RAX, row.operands.rs1);
-            cmp_reg_operand(e, RAX, row.operands.rs2);
-            set_cc_less(e, true, row.operands.rd);
-        }
-        K::Andn(_) => {
-            // rd = x[rs1] & !x[rs2]
-            load_reg(e, RAX, row.operands.rs1);
-            load_reg(e, RCX, row.operands.rs2);
-            dynasm!(e.ops ; .arch x64 ; not rcx ; and rax, rcx);
-            store_rd(e, RAX, row.operands.rd);
-        }
-        K::Pow2I(_) => {
-            // Static: rd = 1 << (imm % 64).
-            let value = 1i64 << ((row.operands.imm as u64) % 64);
-            load_imm(e, RAX, value);
-            store_rd(e, RAX, row.operands.rd);
-        }
-        K::Pow2IW(_) => {
-            let value = 1i64 << ((row.operands.imm as u64) % 32);
-            load_imm(e, RAX, value);
-            store_rd(e, RAX, row.operands.rd);
-        }
-        K::Pow2W(_) => {
-            // rd = 1 << ((x[rs1] as u64) % 32)
-            load_reg(e, RCX, row.operands.rs1);
-            dynasm!(e.ops ; .arch x64 ; and ecx, 31 ; mov eax, 1 ; shl rax, cl);
-            store_rd(e, RAX, row.operands.rd);
-        }
-        K::MovSign(_) => {
-            // rd = -1 if the sign bit is set else 0.
-            load_reg(e, RAX, row.operands.rs1);
-            dynasm!(e.ops ; .arch x64 ; sar rax, 63);
-            store_rd(e, RAX, row.operands.rd);
-        }
-        K::VirtualRev8W(_) => {
-            // Byte-reverse each 32-bit half independently: bswap swaps all 8
-            // bytes (including the halves); ror 32 swaps the halves back.
-            load_reg(e, RAX, row.operands.rs1);
-            dynasm!(e.ops ; .arch x64 ; bswap rax ; ror rax, 32);
-            store_rd(e, RAX, row.operands.rd);
-        }
-        K::VirtualRotri(_) => {
-            // Shift amount = imm.trailing_zeros() (bitmask encoding), mod 64.
-            let shift = (((row.operands.imm as u64).trailing_zeros()) % 64) as i8;
-            load_reg(e, RAX, row.operands.rs1);
-            if shift != 0 {
-                dynasm!(e.ops ; .arch x64 ; ror rax, shift);
+        match &row.instruction_kind {
+            K::Add(_) => Self::emit_alu_rr(e, row, AluRR::Add),
+            K::Sub(_) => Self::emit_alu_rr(e, row, AluRR::Sub),
+            K::And(_) => Self::emit_alu_rr(e, row, AluRR::And),
+            K::Or(_) => Self::emit_alu_rr(e, row, AluRR::Or),
+            K::Xor(_) => Self::emit_alu_rr(e, row, AluRR::Xor),
+            K::Mul(_) => Self::emit_alu_rr(e, row, AluRR::Mul),
+            K::Addi(_) => Self::emit_alu_ri(e, row, AluRR::Add),
+            K::AndI(_) => Self::emit_alu_ri(e, row, AluRR::And),
+            K::OrI(_) => Self::emit_alu_ri(e, row, AluRR::Or),
+            K::XorI(_) => Self::emit_alu_ri(e, row, AluRR::Xor),
+            K::MulI(_) => Self::emit_alu_ri(e, row, AluRR::Mul),
+
+            K::MulHU(_) => {
+                // rd = high 64 bits of unsigned x[rs1] * x[rs2].
+                e.load_reg(RAX, row.operands.rs1);
+                e.load_reg(RCX, row.operands.rs2);
+                dynasm!(e.ops ; .arch x64 ; mul rcx);
+                e.store_rd(RDX, row.operands.rd);
             }
-            store_rd(e, RAX, row.operands.rd);
-        }
-        K::VirtualRotriw(_) => {
-            // 32-bit rotate, result zero-extended (NOT sign-extended);
-            // shift = tz(imm).min(32), and a u32 rotate by 32 is the identity.
-            let shift = ((row.operands.imm as u64).trailing_zeros().min(32) & 31) as i8;
-            load_reg32(e, RAX, row.operands.rs1);
-            if shift != 0 {
-                dynasm!(e.ops ; .arch x64 ; ror eax, shift);
+
+            K::SltU(_) => {
+                e.load_reg(RAX, row.operands.rs1);
+                e.cmp_reg_operand(RAX, row.operands.rs2);
+                e.set_cc_less(false, row.operands.rd);
             }
-            store_rd(e, RAX, row.operands.rd);
-        }
-        K::VirtualShiftRightBitmaski(_) => {
-            // Static: bits [63:shift] set (all-ones when shift == 0).
-            let shift = (row.operands.imm as u64) % 64;
-            let value = (((1u128 << (64 - shift)) - 1) << shift) as u64 as i64;
-            load_imm(e, RAX, value);
-            store_rd(e, RAX, row.operands.rd);
-        }
-        K::VirtualSra(_) => {
-            // Arithmetic sibling of VirtualSrl: shift = tz(x[rs2]), tzcnt(0)=64
-            // -> sar masks to 0, matching wrapping_shr(64).
-            load_reg(e, RCX, row.operands.rs2);
-            load_reg(e, RAX, row.operands.rs1);
-            dynasm!(e.ops ; .arch x64 ; tzcnt rcx, rcx ; sar rax, cl);
-            store_rd(e, RAX, row.operands.rd);
-        }
-        K::VirtualXorRot32(_) => xor_rot(e, row, 32),
-        K::VirtualXorRot24(_) => xor_rot(e, row, 24),
-        K::VirtualXorRot16(_) => xor_rot(e, row, 16),
-        K::VirtualXorRot63(_) => xor_rot(e, row, 63),
-        K::VirtualXorRotW16(_) => xor_rotw(e, row, 16),
-        K::VirtualXorRotW12(_) => xor_rotw(e, row, 12),
-        K::VirtualXorRotW8(_) => xor_rotw(e, row, 8),
-        K::VirtualXorRotW7(_) => xor_rotw(e, row, 7),
-        K::AssertEq(_) => {
-            // imm == 0: hard assert. imm != 0: "spoil" mode, warn-and-continue
-            // in the interpreter; a no-op here (registers unaffected).
-            if row.operands.imm == 0 {
-                load_reg(e, RAX, row.operands.rs1);
-                load_reg(e, RCX, row.operands.rs2);
+            K::SltI(_) => {
+                e.load_reg(RAX, row.operands.rs1);
+                e.load_imm(RCX, row.operands.imm as i64);
+                dynasm!(e.ops ; .arch x64 ; cmp rax, rcx);
+                e.set_cc_less(true, row.operands.rd);
+            }
+            K::SltIU(_) => {
+                e.load_reg(RAX, row.operands.rs1);
+                e.load_imm(RCX, row.operands.imm as i64);
+                dynasm!(e.ops ; .arch x64 ; cmp rax, rcx);
+                e.set_cc_less(false, row.operands.rd);
+            }
+
+            K::Lui(_) => {
+                e.load_imm(RAX, row.operands.imm as i64);
+                e.store_rd(RAX, row.operands.rd);
+            }
+            K::Auipc(_) => {
+                // rd = address + imm, fully static.
+                let value = (row.address as i64).wrapping_add(row.operands.imm as i64);
+                e.load_imm(RAX, value);
+                e.store_rd(RAX, row.operands.rd);
+            }
+
+            K::Pow2(_) => {
+                // rd = 1 << (x[rs1] % 64); shl's cl masking is exactly mod 64.
+                e.load_reg(RCX, row.operands.rs1);
+                dynasm!(e.ops ; .arch x64 ; mov eax, 1 ; shl rax, cl);
+                e.store_rd(RAX, row.operands.rd);
+            }
+            K::VirtualShiftRightBitmask(_) => {
+                // rd = u64::MAX << (x[rs1] & 63) — bits [63:shift] set.
+                e.load_reg(RCX, row.operands.rs1);
+                dynasm!(e.ops ; .arch x64 ; mov rax, -1 ; shl rax, cl);
+                e.store_rd(RAX, row.operands.rd);
+            }
+            K::VirtualSignExtendWord(_) => {
+                e.load_reg(RAX, row.operands.rs1);
+                dynasm!(e.ops ; .arch x64 ; movsxd rax, eax);
+                e.store_rd(RAX, row.operands.rd);
+            }
+            K::VirtualZeroExtendWord(_) => {
+                e.load_reg(RAX, row.operands.rs1);
+                dynasm!(e.ops ; .arch x64 ; mov eax, eax);
+                e.store_rd(RAX, row.operands.rd);
+            }
+            K::VirtualSrai(_) => {
+                // Shift amount = imm.trailing_zeros() (imm is a bitmask);
+                // wrapping_shr semantics = mod 64.
+                let shift = ((row.operands.imm as u64).trailing_zeros() % 64) as i8;
+                e.load_reg(RAX, row.operands.rs1);
+                dynasm!(e.ops ; .arch x64 ; sar rax, shift);
+                e.store_rd(RAX, row.operands.rd);
+            }
+            K::VirtualSrli(_) => {
+                let shift = ((row.operands.imm as u64).trailing_zeros() % 64) as i8;
+                e.load_reg(RAX, row.operands.rs1);
+                dynasm!(e.ops ; .arch x64 ; shr rax, shift);
+                e.store_rd(RAX, row.operands.rd);
+            }
+            K::VirtualSrl(_) => {
+                // Shift = x[rs2].trailing_zeros(); tzcnt(0) = 64 → shr masks to
+                // 0, matching wrapping_shr(64). Requires BMI1 (checked once).
+                e.load_reg(RCX, row.operands.rs2);
+                e.load_reg(RAX, row.operands.rs1);
+                dynasm!(e.ops ; .arch x64 ; tzcnt rcx, rcx ; shr rax, cl);
+                e.store_rd(RAX, row.operands.rd);
+            }
+
+            K::Beq(_) => Self::emit_branch(e, row, Cc::Eq),
+            K::Bne(_) => Self::emit_branch(e, row, Cc::Ne),
+            K::Blt(_) => Self::emit_branch(e, row, Cc::LtSigned),
+            K::Bge(_) => Self::emit_branch(e, row, Cc::GeSigned),
+            K::BltU(_) => Self::emit_branch(e, row, Cc::LtUnsigned),
+            K::BgeU(_) => Self::emit_branch(e, row, Cc::GeUnsigned),
+
+            K::Jal(_) => {
+                e.load_imm(RAX, link_value(row));
+                e.store_rd(RAX, row.operands.rd);
+                let target = (row.address as i64).wrapping_add(row.operands.imm as i64) as u64;
+                if target == row.address as u64 {
+                    e.terminal(target);
+                } else {
+                    let label = e.label_for(target);
+                    dynasm!(e.ops ; .arch x64 ; jmp =>label);
+                }
+            }
+            K::Jalr(_) => {
+                // target = (x[rs1] + imm) & !1, computed before the link write
+                // (rs1 may alias rd).
+                e.load_reg(RAX, row.operands.rs1);
+                e.load_imm(RCX, row.operands.imm as i64);
+                dynasm!(e.ops ; .arch x64 ; add rax, rcx ; and rax, -2);
+                e.load_imm(RCX, link_value(row));
+                e.store_rd(RCX, row.operands.rd);
+                // PC-stall check against this row's own source address.
+                dynasm!(e.ops ; .arch x64 ; mov rcx, QWORD row.address as i64 ; cmp rax, rcx ; jne >go);
+                e.terminal(row.address as u64);
+                dynasm!(e.ops ; .arch x64 ; go:);
+                e.dispatch();
+            }
+
+            K::Ld(_) => Self::emit_load_doubleword(e, row),
+            K::Sd(_) => Self::emit_store_doubleword(e, row),
+
+            K::AssertHalfwordAlignment(_) => Self::emit_assert_alignment(e, row, 1, 0),
+            K::AssertWordAlignment(_) => Self::emit_assert_alignment(e, row, 3, 1),
+            K::AssertLte(_) => {
+                // assert!(x[rs1] as u64 <= x[rs2] as u64) — unsigned.
+                e.load_reg(RAX, row.operands.rs1);
+                e.load_reg(RCX, row.operands.rs2);
                 dynasm!(e.ops
                     ; .arch x64
                     ; cmp rax, rcx
-                    ; je >ok
-                    ; mov rsi, 3
+                    ; jbe >ok
+                    ; mov rsi, 2
                     ; mov rdx, rax
                 );
-                call_helper(e, helpers::assert_failed as *const () as usize);
+                e.call_helper(helpers::assert_failed as *const () as usize);
                 dynasm!(e.ops ; .arch x64 ; ok:);
             }
-        }
-        K::AssertValidDiv0(_) => {
-            // divisor == 0 implies quotient == u64::MAX.
-            load_reg(e, RAX, row.operands.rs1);
-            load_reg(e, RCX, row.operands.rs2);
-            dynasm!(e.ops
-                ; .arch x64
-                ; test rax, rax
-                ; jnz >ok
-                ; cmp rcx, -1
-                ; je >ok
-                ; mov rsi, 4
-                ; mov rdx, rcx
-            );
-            call_helper(e, helpers::assert_failed as *const () as usize);
-            dynasm!(e.ops ; .arch x64 ; ok:);
-        }
-        K::AssertValidUnsignedRemainder(_) => {
-            // divisor == 0 || remainder < divisor (unsigned).
-            load_reg(e, RAX, row.operands.rs1);
-            load_reg(e, RCX, row.operands.rs2);
-            dynasm!(e.ops
-                ; .arch x64
-                ; test rcx, rcx
-                ; jz >ok
-                ; cmp rax, rcx
-                ; jb >ok
-                ; mov rsi, 5
-                ; mov rdx, rax
-            );
-            call_helper(e, helpers::assert_failed as *const () as usize);
-            dynasm!(e.ops ; .arch x64 ; ok:);
-        }
-        K::AssertMulUNoOverflow(_) => {
-            // (x[rs1] as u64) * (x[rs2] as u64) must not overflow: unsigned
-            // mul leaves the high half in rdx.
-            load_reg(e, RAX, row.operands.rs1);
-            load_reg(e, RCX, row.operands.rs2);
-            dynasm!(e.ops
-                ; .arch x64
-                ; mul rcx
-                ; test rdx, rdx
-                ; jz >ok
-                ; mov rsi, 6
-                ; mov rdx, rax
-            );
-            call_helper(e, helpers::assert_failed as *const () as usize);
-            dynasm!(e.ops ; .arch x64 ; ok:);
-        }
-        K::VirtualChangeDivisor(_) => {
-            // rd = 1 if (dividend, divisor) == (i64::MIN, -1) else divisor.
-            load_reg(e, RCX, row.operands.rs1);
-            load_reg(e, RAX, row.operands.rs2);
-            dynasm!(e.ops
-                ; .arch x64
-                ; mov rdx, QWORD i64::MIN
-                ; cmp rcx, rdx
-                ; jne >done
-                ; cmp rax, -1
-                ; jne >done
-                ; mov eax, 1
-                ; done:
-            );
-            store_rd(e, RAX, row.operands.rd);
-        }
-        K::VirtualChangeDivisorW(_) => {
-            // 32-bit variant; the else branch sign-extends the low 32 bits of
-            // x[rs2] (upper bits discarded).
-            load_reg32_sext(e, RCX, row.operands.rs1);
-            load_reg32_sext(e, RAX, row.operands.rs2);
-            dynasm!(e.ops
-                ; .arch x64
-                ; cmp ecx, 0x8000_0000u32 as i32
-                ; jne >done
-                ; cmp eax, -1
-                ; jne >done
-                ; mov eax, 1
-                ; done:
-            );
-            store_rd(e, RAX, row.operands.rd);
-        }
-        K::VirtualAdviceLen(_) => {
-            call_helper(e, helpers::advice_remaining as *const () as usize);
-            store_rd(e, RAX, row.operands.rd);
-        }
-        K::VirtualAdviceLoad(_) => {
-            // num_bytes is a static row immediate (1, 2, 4 or 8); the helper
-            // errors on tape exhaustion (interpreter panics there).
-            let num_bytes = (row.operands.imm as u64) as i32;
-            dynasm!(e.ops ; .arch x64 ; mov rsi, num_bytes);
-            call_helper(e, helpers::advice_read as *const () as usize);
-            store_rd(e, RAX, row.operands.rd);
-        }
-        K::VirtualAdvice(_) => {
-            // The value comes from this group's advice slots, filled before
-            // the group's first row ran; slots are consumed in row order.
-            let slot = e.advice_slot;
-            if slot >= super::super::state::ADVICE_SLOTS {
-                return Err(TraceError::Backend(
-                    "too many VirtualAdvice rows in one group",
-                ));
+
+            K::Slt(_) => {
+                e.load_reg(RAX, row.operands.rs1);
+                e.cmp_reg_operand(RAX, row.operands.rs2);
+                e.set_cc_less(true, row.operands.rd);
             }
-            e.advice_slot += 1;
-            dynasm!(e.ops ; .arch x64 ; mov rax, QWORD [r12 + advice_slot_offset(slot)]);
-            store_rd(e, RAX, row.operands.rd);
-        }
+            K::Andn(_) => {
+                // rd = x[rs1] & !x[rs2]
+                e.load_reg(RAX, row.operands.rs1);
+                e.load_reg(RCX, row.operands.rs2);
+                dynasm!(e.ops ; .arch x64 ; not rcx ; and rax, rcx);
+                e.store_rd(RAX, row.operands.rd);
+            }
+            K::Pow2I(_) => {
+                // Static: rd = 1 << (imm % 64).
+                let value = 1i64 << ((row.operands.imm as u64) % 64);
+                e.load_imm(RAX, value);
+                e.store_rd(RAX, row.operands.rd);
+            }
+            K::Pow2IW(_) => {
+                let value = 1i64 << ((row.operands.imm as u64) % 32);
+                e.load_imm(RAX, value);
+                e.store_rd(RAX, row.operands.rd);
+            }
+            K::Pow2W(_) => {
+                // rd = 1 << ((x[rs1] as u64) % 32)
+                e.load_reg(RCX, row.operands.rs1);
+                dynasm!(e.ops ; .arch x64 ; and ecx, 31 ; mov eax, 1 ; shl rax, cl);
+                e.store_rd(RAX, row.operands.rd);
+            }
+            K::MovSign(_) => {
+                // rd = -1 if the sign bit is set else 0.
+                e.load_reg(RAX, row.operands.rs1);
+                dynasm!(e.ops ; .arch x64 ; sar rax, 63);
+                e.store_rd(RAX, row.operands.rd);
+            }
+            K::VirtualRev8W(_) => {
+                // Byte-reverse each 32-bit half independently: bswap swaps all 8
+                // bytes (including the halves); ror 32 swaps the halves back.
+                e.load_reg(RAX, row.operands.rs1);
+                dynasm!(e.ops ; .arch x64 ; bswap rax ; ror rax, 32);
+                e.store_rd(RAX, row.operands.rd);
+            }
+            K::VirtualRotri(_) => {
+                // Shift amount = imm.trailing_zeros() (bitmask encoding), mod 64.
+                let shift = (((row.operands.imm as u64).trailing_zeros()) % 64) as i8;
+                e.load_reg(RAX, row.operands.rs1);
+                if shift != 0 {
+                    dynasm!(e.ops ; .arch x64 ; ror rax, shift);
+                }
+                e.store_rd(RAX, row.operands.rd);
+            }
+            K::VirtualRotriw(_) => {
+                // 32-bit rotate, result zero-extended (NOT sign-extended);
+                // shift = tz(imm).min(32), and a u32 rotate by 32 is the identity.
+                let shift = ((row.operands.imm as u64).trailing_zeros().min(32) & 31) as i8;
+                e.load_reg32(RAX, row.operands.rs1);
+                if shift != 0 {
+                    dynasm!(e.ops ; .arch x64 ; ror eax, shift);
+                }
+                e.store_rd(RAX, row.operands.rd);
+            }
+            K::VirtualShiftRightBitmaski(_) => {
+                // Static: bits [63:shift] set (all-ones when shift == 0).
+                let shift = (row.operands.imm as u64) % 64;
+                let value = (((1u128 << (64 - shift)) - 1) << shift) as u64 as i64;
+                e.load_imm(RAX, value);
+                e.store_rd(RAX, row.operands.rd);
+            }
+            K::VirtualSra(_) => {
+                // Arithmetic sibling of VirtualSrl: shift = tz(x[rs2]), tzcnt(0)=64
+                // -> sar masks to 0, matching wrapping_shr(64).
+                e.load_reg(RCX, row.operands.rs2);
+                e.load_reg(RAX, row.operands.rs1);
+                dynasm!(e.ops ; .arch x64 ; tzcnt rcx, rcx ; sar rax, cl);
+                e.store_rd(RAX, row.operands.rd);
+            }
+            K::VirtualXorRot32(_) => Self::emit_xor_rot(e, row, 32),
+            K::VirtualXorRot24(_) => Self::emit_xor_rot(e, row, 24),
+            K::VirtualXorRot16(_) => Self::emit_xor_rot(e, row, 16),
+            K::VirtualXorRot63(_) => Self::emit_xor_rot(e, row, 63),
+            K::VirtualXorRotW16(_) => Self::emit_xor_rotw(e, row, 16),
+            K::VirtualXorRotW12(_) => Self::emit_xor_rotw(e, row, 12),
+            K::VirtualXorRotW8(_) => Self::emit_xor_rotw(e, row, 8),
+            K::VirtualXorRotW7(_) => Self::emit_xor_rotw(e, row, 7),
+            K::AssertEq(_) => {
+                // imm == 0: hard assert. imm != 0: "spoil" mode, warn-and-continue
+                // in the interpreter; a no-op here (registers unaffected).
+                if row.operands.imm == 0 {
+                    e.load_reg(RAX, row.operands.rs1);
+                    e.load_reg(RCX, row.operands.rs2);
+                    dynasm!(e.ops
+                        ; .arch x64
+                        ; cmp rax, rcx
+                        ; je >ok
+                        ; mov rsi, 3
+                        ; mov rdx, rax
+                    );
+                    e.call_helper(helpers::assert_failed as *const () as usize);
+                    dynasm!(e.ops ; .arch x64 ; ok:);
+                }
+            }
+            K::AssertValidDiv0(_) => {
+                // divisor == 0 implies quotient == u64::MAX.
+                e.load_reg(RAX, row.operands.rs1);
+                e.load_reg(RCX, row.operands.rs2);
+                dynasm!(e.ops
+                    ; .arch x64
+                    ; test rax, rax
+                    ; jnz >ok
+                    ; cmp rcx, -1
+                    ; je >ok
+                    ; mov rsi, 4
+                    ; mov rdx, rcx
+                );
+                e.call_helper(helpers::assert_failed as *const () as usize);
+                dynasm!(e.ops ; .arch x64 ; ok:);
+            }
+            K::AssertValidUnsignedRemainder(_) => {
+                // divisor == 0 || remainder < divisor (unsigned).
+                e.load_reg(RAX, row.operands.rs1);
+                e.load_reg(RCX, row.operands.rs2);
+                dynasm!(e.ops
+                    ; .arch x64
+                    ; test rcx, rcx
+                    ; jz >ok
+                    ; cmp rax, rcx
+                    ; jb >ok
+                    ; mov rsi, 5
+                    ; mov rdx, rax
+                );
+                e.call_helper(helpers::assert_failed as *const () as usize);
+                dynasm!(e.ops ; .arch x64 ; ok:);
+            }
+            K::AssertMulUNoOverflow(_) => {
+                // (x[rs1] as u64) * (x[rs2] as u64) must not overflow: unsigned
+                // mul leaves the high half in rdx.
+                e.load_reg(RAX, row.operands.rs1);
+                e.load_reg(RCX, row.operands.rs2);
+                dynasm!(e.ops
+                    ; .arch x64
+                    ; mul rcx
+                    ; test rdx, rdx
+                    ; jz >ok
+                    ; mov rsi, 6
+                    ; mov rdx, rax
+                );
+                e.call_helper(helpers::assert_failed as *const () as usize);
+                dynasm!(e.ops ; .arch x64 ; ok:);
+            }
+            K::VirtualChangeDivisor(_) => {
+                // rd = 1 if (dividend, divisor) == (i64::MIN, -1) else divisor.
+                e.load_reg(RCX, row.operands.rs1);
+                e.load_reg(RAX, row.operands.rs2);
+                dynasm!(e.ops
+                    ; .arch x64
+                    ; mov rdx, QWORD i64::MIN
+                    ; cmp rcx, rdx
+                    ; jne >done
+                    ; cmp rax, -1
+                    ; jne >done
+                    ; mov eax, 1
+                    ; done:
+                );
+                e.store_rd(RAX, row.operands.rd);
+            }
+            K::VirtualChangeDivisorW(_) => {
+                // 32-bit variant; the else branch sign-extends the low 32 bits of
+                // x[rs2] (upper bits discarded).
+                e.load_reg32_sext(RCX, row.operands.rs1);
+                e.load_reg32_sext(RAX, row.operands.rs2);
+                dynasm!(e.ops
+                    ; .arch x64
+                    ; cmp ecx, 0x8000_0000u32 as i32
+                    ; jne >done
+                    ; cmp eax, -1
+                    ; jne >done
+                    ; mov eax, 1
+                    ; done:
+                );
+                e.store_rd(RAX, row.operands.rd);
+            }
+            K::VirtualAdviceLen(_) => {
+                e.call_helper(helpers::advice_remaining as *const () as usize);
+                e.store_rd(RAX, row.operands.rd);
+            }
+            K::VirtualAdviceLoad(_) => {
+                // num_bytes is a static row immediate (1, 2, 4 or 8); the helper
+                // errors on tape exhaustion (interpreter panics there).
+                let num_bytes = (row.operands.imm as u64) as i32;
+                dynasm!(e.ops ; .arch x64 ; mov rsi, num_bytes);
+                e.call_helper(helpers::advice_read as *const () as usize);
+                e.store_rd(RAX, row.operands.rd);
+            }
+            K::VirtualAdvice(_) => {
+                // The value comes from this group's advice slots, filled before
+                // the group's first row ran; slots are consumed in row order.
+                let slot = e.advice_slot;
+                if slot >= super::super::state::ADVICE_SLOTS {
+                    return Err(TraceError::Backend(
+                        "too many VirtualAdvice rows in one group",
+                    ));
+                }
+                e.advice_slot += 1;
+                dynasm!(e.ops ; .arch x64 ; mov rax, QWORD [r12 + advice_slot_offset(slot)]);
+                e.store_rd(RAX, row.operands.rd);
+            }
 
-        K::Fence(_) => {}
+            K::Fence(_) => {}
 
-        K::VirtualHostIO(_) => {
-            call_helper(e, helpers::host_io as *const () as usize);
-        }
+            K::VirtualHostIO(_) => {
+                e.call_helper(helpers::host_io as *const () as usize);
+            }
 
-        // Every other final kind is implemented above; `Noop` never appears
-        // in executable bytecode. Reporting `Unsupported` (rather than
-        // erroring) lets another emitter in the set claim the kind; the set
-        // raises the fail-fast error when none does.
-        other @ K::Noop(_) => {
-            let _ = other;
-            return Ok(EmitOutcome::Unsupported);
+            // Every other final kind is implemented above; `Noop` never appears
+            // in executable bytecode. Reporting `Unsupported` (rather than
+            // erroring) lets another emitter in the set claim the kind; the set
+            // raises the fail-fast error when none does.
+            other @ K::Noop(_) => {
+                let _ = other;
+                return Ok(EmitOutcome::Unsupported);
+            }
         }
+        if record && !transfers_control {
+            e.obs_rd_post(row);
+            e.obs_close();
+        }
+        Ok(EmitOutcome::Emitted)
     }
-    if record && !transfers_control {
-        obs_rd_post(e, row);
-        obs_close(e);
-    }
-    Ok(EmitOutcome::Emitted)
 }

--- a/crates/jolt-tracer-x86/src/native/compile/emit.rs
+++ b/crates/jolt-tracer-x86/src/native/compile/emit.rs
@@ -1,0 +1,485 @@
+//! Per-row-kind x86-64 templates.
+//!
+//! Semantics source of truth: the tracer's exec implementations
+//! (`tracer/src/instruction/*.rs`); every template must reproduce them
+//! bit-for-bit. Key interpreter facts baked in here:
+//! - registers are semantically `i64`, stored as raw 64-bit values;
+//! - the interpreter pre-increments PC before exec, so link values are
+//!   `address + (2 if compressed else 4)` and straight-line code never
+//!   maintains PC;
+//! - branch/`Jal` targets are `address + imm` (imm is a relative offset);
+//! - `Jalr` targets are `(x[rs1] + imm) & !1`;
+//! - the virtual right shifts take their shift amount from
+//!   `imm.trailing_zeros()` (the immediate is a bitmask, not a shift);
+//! - guest termination is the PC-stall convention: a jump/taken branch whose
+//!   target equals its own source address executes once, then execution
+//!   stops.
+
+use dynasm::dynasm;
+use dynasmrt::{AssemblyOffset, DynasmApi, DynasmLabelApi};
+use jolt_program::execution::TraceError;
+use jolt_riscv::{JoltInstructionKind, JoltInstructionRow};
+
+use super::super::helpers;
+use super::super::state::{
+    reg_offset, ExitReason, OFF_EXIT, OFF_FAULT_ADDR, OFF_MEM_BASE, OFF_MEM_SIZE, OFF_PC,
+    OFF_TRACE_LEN,
+};
+use super::Emitter;
+
+const RAX: u8 = 0;
+const RCX: u8 = 1;
+const RDX: u8 = 2;
+
+const RAM_START: u64 = common::constants::RAM_START_ADDRESS;
+
+fn load_reg(e: &mut Emitter, gpr: u8, reg: Option<u8>) {
+    match reg {
+        None | Some(0) => dynasm!(e.ops ; .arch x64 ; xor Rq(gpr), Rq(gpr)),
+        Some(r) => dynasm!(e.ops ; .arch x64 ; mov Rq(gpr), QWORD [r12 + reg_offset(r)]),
+    }
+}
+
+fn store_rd(e: &mut Emitter, gpr: u8, rd: Option<u8>) {
+    if let Some(r) = rd {
+        if r != 0 {
+            dynasm!(e.ops ; .arch x64 ; mov QWORD [r12 + reg_offset(r)], Rq(gpr));
+        }
+    }
+}
+
+fn load_imm(e: &mut Emitter, gpr: u8, value: i64) {
+    if let Ok(v) = i32::try_from(value) {
+        dynasm!(e.ops ; .arch x64 ; mov Rq(gpr), v);
+    } else {
+        dynasm!(e.ops ; .arch x64 ; mov Rq(gpr), QWORD value);
+    }
+}
+
+/// Call a sysv64 helper: rdi = state, rsi/rdx = args (already set by caller
+/// emission). Syncs trace_len before the call and checks the exit flag after.
+fn call_helper(e: &mut Emitter, f: usize) {
+    dynasm!(e.ops
+        ; .arch x64
+        ; mov QWORD [r12 + OFF_TRACE_LEN], r14
+        ; mov rdi, r12
+        ; mov rax, QWORD f as i64
+        ; call rax
+        ; cmp QWORD [r12 + OFF_EXIT], 0
+        ; jne ->exit
+    );
+}
+
+/// Terminal (PC-stall) sequence: record this row already happened (r14 was
+/// incremented at row start), publish pc/exit, leave.
+fn terminal(e: &mut Emitter, address: u64) {
+    dynasm!(e.ops
+        ; .arch x64
+        ; mov rcx, QWORD address as i64
+        ; mov QWORD [r12 + OFF_PC], rcx
+        ; mov QWORD [r12 + OFF_EXIT], ExitReason::Terminated as u64 as i32
+        ; jmp ->exit
+    );
+}
+
+/// Indirect dispatch on the guest address in rax (clobbers rcx, rdx).
+fn dispatch(e: &mut Emitter) {
+    let span = e.text_span as i32;
+    dynasm!(e.ops
+        ; .arch x64
+        ; mov rcx, rax
+        ; mov rdx, QWORD e.text_base as i64
+        ; sub rcx, rdx
+        ; cmp rcx, span
+        ; jae ->bad_jump
+        ; mov rdx, QWORD [r15 + rcx * 4]
+        ; jmp rdx
+    );
+}
+
+/// Function prologue: pin registers, dispatch to `state.pc`.
+pub fn prologue(e: &mut Emitter) -> AssemblyOffset {
+    let entry = e.ops.offset();
+    dynasm!(e.ops
+        ; .arch x64
+        ; push r12
+        ; push r13
+        ; push r14
+        ; push r15
+        ; sub rsp, 8
+        ; mov r12, rdi
+        ; mov r13, QWORD [r12 + OFF_MEM_BASE]
+        ; mov r14, QWORD [r12 + OFF_TRACE_LEN]
+        ; mov r15, rsi
+        ; mov rax, QWORD [r12 + OFF_PC]
+    );
+    dispatch(e);
+    entry
+}
+
+pub struct Stubs {
+    pub bad_jump: AssemblyOffset,
+}
+
+/// Falling off the end of the compiled program is a bad jump (rax holds pc).
+pub fn jump_to_bad_jump(e: &mut Emitter) {
+    dynasm!(e.ops ; .arch x64 ; jmp ->bad_jump);
+}
+
+pub fn stubs(e: &mut Emitter) -> Stubs {
+    let bad_jump = e.ops.offset();
+    dynasm!(e.ops
+        ; .arch x64
+        ; ->bad_jump:
+        ; mov QWORD [r12 + OFF_FAULT_ADDR], rax
+        ; mov QWORD [r12 + OFF_EXIT], ExitReason::FaultBadJumpTarget as u64 as i32
+        ; ->exit:
+        ; mov QWORD [r12 + OFF_TRACE_LEN], r14
+        ; add rsp, 8
+        ; pop r15
+        ; pop r14
+        ; pop r13
+        ; pop r12
+        ; ret
+    );
+    Stubs { bad_jump }
+}
+
+enum AluRR {
+    Add,
+    Sub,
+    And,
+    Or,
+    Xor,
+    Mul,
+}
+
+fn alu_rr(e: &mut Emitter, row: &JoltInstructionRow, op: AluRR) {
+    load_reg(e, RAX, row.operands.rs1);
+    load_reg(e, RCX, row.operands.rs2);
+    match op {
+        AluRR::Add => dynasm!(e.ops ; .arch x64 ; add rax, rcx),
+        AluRR::Sub => dynasm!(e.ops ; .arch x64 ; sub rax, rcx),
+        AluRR::And => dynasm!(e.ops ; .arch x64 ; and rax, rcx),
+        AluRR::Or => dynasm!(e.ops ; .arch x64 ; or rax, rcx),
+        AluRR::Xor => dynasm!(e.ops ; .arch x64 ; xor rax, rcx),
+        AluRR::Mul => dynasm!(e.ops ; .arch x64 ; imul rax, rcx),
+    }
+    store_rd(e, RAX, row.operands.rd);
+}
+
+fn alu_ri(e: &mut Emitter, row: &JoltInstructionRow, op: AluRR) {
+    load_reg(e, RAX, row.operands.rs1);
+    load_imm(e, RCX, row.operands.imm as i64);
+    match op {
+        AluRR::Add => dynasm!(e.ops ; .arch x64 ; add rax, rcx),
+        AluRR::And => dynasm!(e.ops ; .arch x64 ; and rax, rcx),
+        AluRR::Or => dynasm!(e.ops ; .arch x64 ; or rax, rcx),
+        AluRR::Xor => dynasm!(e.ops ; .arch x64 ; xor rax, rcx),
+        AluRR::Mul => dynasm!(e.ops ; .arch x64 ; imul rax, rcx),
+        AluRR::Sub => unreachable!("no reg-imm subtract in the row set"),
+    }
+    store_rd(e, RAX, row.operands.rd);
+}
+
+enum Cc {
+    Eq,
+    Ne,
+    LtSigned,
+    GeSigned,
+    LtUnsigned,
+    GeUnsigned,
+}
+
+fn branch(e: &mut Emitter, row: &JoltInstructionRow, cc: Cc) {
+    let address = row.address as u64;
+    let target = (row.address as i64).wrapping_add(row.operands.imm as i64) as u64;
+    load_reg(e, RAX, row.operands.rs1);
+    load_reg(e, RCX, row.operands.rs2);
+    dynasm!(e.ops ; .arch x64 ; cmp rax, rcx);
+    if target == address {
+        // Taken branch to itself terminates (PC-stall). Invert: skip the
+        // terminal sequence when not taken.
+        match cc {
+            Cc::Eq => dynasm!(e.ops ; .arch x64 ; jne >fall),
+            Cc::Ne => dynasm!(e.ops ; .arch x64 ; je >fall),
+            Cc::LtSigned => dynasm!(e.ops ; .arch x64 ; jge >fall),
+            Cc::GeSigned => dynasm!(e.ops ; .arch x64 ; jl >fall),
+            Cc::LtUnsigned => dynasm!(e.ops ; .arch x64 ; jae >fall),
+            Cc::GeUnsigned => dynasm!(e.ops ; .arch x64 ; jb >fall),
+        }
+        terminal(e, address);
+        dynasm!(e.ops ; .arch x64 ; fall:);
+    } else {
+        let label = e.label_for(target);
+        match cc {
+            Cc::Eq => dynasm!(e.ops ; .arch x64 ; je =>label),
+            Cc::Ne => dynasm!(e.ops ; .arch x64 ; jne =>label),
+            Cc::LtSigned => dynasm!(e.ops ; .arch x64 ; jl =>label),
+            Cc::GeSigned => dynasm!(e.ops ; .arch x64 ; jge =>label),
+            Cc::LtUnsigned => dynasm!(e.ops ; .arch x64 ; jb =>label),
+            Cc::GeUnsigned => dynasm!(e.ops ; .arch x64 ; jae =>label),
+        }
+    }
+}
+
+fn set_cc_less(e: &mut Emitter, signed: bool, rd: Option<u8>) {
+    if signed {
+        dynasm!(e.ops ; .arch x64 ; setl al);
+    } else {
+        dynasm!(e.ops ; .arch x64 ; setb al);
+    }
+    dynasm!(e.ops ; .arch x64 ; movzx rax, al);
+    store_rd(e, RAX, rd);
+}
+
+fn link_value(row: &JoltInstructionRow) -> i64 {
+    row.address as i64 + if row.is_compressed { 2 } else { 4 }
+}
+
+/// `Ld`: fast path hits the RAM plane; device/unaligned/OOB funnel to the
+/// slow helper. Clobbers rax/rcx/rdx (+ helper scratch on the cold path).
+fn load_doubleword(e: &mut Emitter, row: &JoltInstructionRow) {
+    // EA = (x[rs1] as u64).wrapping_add(imm as i32 as u64) — exact cast chain.
+    let offset = row.operands.imm as i32;
+    load_reg(e, RAX, row.operands.rs1);
+    dynasm!(e.ops
+        ; .arch x64
+        ; add rax, offset
+        ; mov rcx, rax
+        ; mov rdx, QWORD RAM_START as i64
+        ; sub rcx, rdx
+        ; mov rdx, QWORD [r12 + OFF_MEM_SIZE]
+        ; sub rdx, 7
+        ; cmp rcx, rdx
+        ; jae >slow
+        ; test al, 7
+        ; jnz >slow
+        ; mov rax, QWORD [r13 + rcx]
+        ; jmp >done
+        ; slow:
+        ; mov rsi, rax
+    );
+    call_helper(e, helpers::slow_load_doubleword as *const () as usize);
+    dynasm!(e.ops ; .arch x64 ; done:);
+    store_rd(e, RAX, row.operands.rd);
+}
+
+/// `Sd`: mirror of `Ld` with the store value in rsi's place.
+fn store_doubleword(e: &mut Emitter, row: &JoltInstructionRow) {
+    // EA = x[rs1].wrapping_add(imm) as u64 — imm used as full i64 here.
+    load_reg(e, RAX, row.operands.rs1);
+    load_imm(e, RCX, row.operands.imm as i64);
+    load_reg(e, RDX, row.operands.rs2);
+    dynasm!(e.ops
+        ; .arch x64
+        ; add rax, rcx
+        ; mov rcx, rax
+        ; mov rsi, QWORD RAM_START as i64
+        ; sub rcx, rsi
+        ; mov rsi, QWORD [r12 + OFF_MEM_SIZE]
+        ; sub rsi, 7
+        ; cmp rcx, rsi
+        ; jae >slow
+        ; test al, 7
+        ; jnz >slow
+        ; mov QWORD [r13 + rcx], rdx
+        ; jmp >done
+        ; slow:
+        ; mov rsi, rax
+        // value already in rdx (helper arg 3)
+    );
+    call_helper(e, helpers::slow_store_doubleword as *const () as usize);
+    dynasm!(e.ops ; .arch x64 ; done:);
+}
+
+/// Alignment asserts: compute EA, test low bits, call the fatal helper on
+/// failure. `mask` is 1 (halfword) or 3 (word); `code` selects the message.
+fn assert_alignment(e: &mut Emitter, row: &JoltInstructionRow, mask: i8, code: u64) {
+    load_reg(e, RAX, row.operands.rs1);
+    load_imm(e, RCX, row.operands.imm as i64);
+    dynasm!(e.ops
+        ; .arch x64
+        ; add rax, rcx
+        ; test al, mask
+        ; jz >ok
+        ; mov rsi, code as i32
+        ; mov rdx, rax
+    );
+    call_helper(e, helpers::assert_failed as *const () as usize);
+    // assert_failed always sets the exit flag, so call_helper's check exits.
+    dynasm!(e.ops ; .arch x64 ; ok:);
+}
+
+pub fn row(e: &mut Emitter, row: &JoltInstructionRow) -> Result<(), TraceError> {
+    use JoltInstructionKind as K;
+
+    // Every row is one trace row.
+    dynasm!(e.ops ; .arch x64 ; inc r14);
+
+    match &row.instruction_kind {
+        K::Add(_) => alu_rr(e, row, AluRR::Add),
+        K::Sub(_) => alu_rr(e, row, AluRR::Sub),
+        K::And(_) => alu_rr(e, row, AluRR::And),
+        K::Or(_) => alu_rr(e, row, AluRR::Or),
+        K::Xor(_) => alu_rr(e, row, AluRR::Xor),
+        K::Mul(_) => alu_rr(e, row, AluRR::Mul),
+        K::Addi(_) => alu_ri(e, row, AluRR::Add),
+        K::AndI(_) => alu_ri(e, row, AluRR::And),
+        K::OrI(_) => alu_ri(e, row, AluRR::Or),
+        K::XorI(_) => alu_ri(e, row, AluRR::Xor),
+        K::MulI(_) => alu_ri(e, row, AluRR::Mul),
+
+        K::MulHU(_) => {
+            // rd = high 64 bits of unsigned x[rs1] * x[rs2].
+            load_reg(e, RAX, row.operands.rs1);
+            load_reg(e, RCX, row.operands.rs2);
+            dynasm!(e.ops ; .arch x64 ; mul rcx);
+            store_rd(e, RDX, row.operands.rd);
+        }
+
+        K::SltU(_) => {
+            load_reg(e, RAX, row.operands.rs1);
+            load_reg(e, RCX, row.operands.rs2);
+            dynasm!(e.ops ; .arch x64 ; cmp rax, rcx);
+            set_cc_less(e, false, row.operands.rd);
+        }
+        K::SltI(_) => {
+            load_reg(e, RAX, row.operands.rs1);
+            load_imm(e, RCX, row.operands.imm as i64);
+            dynasm!(e.ops ; .arch x64 ; cmp rax, rcx);
+            set_cc_less(e, true, row.operands.rd);
+        }
+        K::SltIU(_) => {
+            load_reg(e, RAX, row.operands.rs1);
+            load_imm(e, RCX, row.operands.imm as i64);
+            dynasm!(e.ops ; .arch x64 ; cmp rax, rcx);
+            set_cc_less(e, false, row.operands.rd);
+        }
+
+        K::Lui(_) => {
+            load_imm(e, RAX, row.operands.imm as i64);
+            store_rd(e, RAX, row.operands.rd);
+        }
+        K::Auipc(_) => {
+            // rd = address + imm, fully static.
+            let value = (row.address as i64).wrapping_add(row.operands.imm as i64);
+            load_imm(e, RAX, value);
+            store_rd(e, RAX, row.operands.rd);
+        }
+
+        K::Pow2(_) => {
+            // rd = 1 << (x[rs1] % 64); shl's cl masking is exactly mod 64.
+            load_reg(e, RCX, row.operands.rs1);
+            dynasm!(e.ops ; .arch x64 ; mov eax, 1 ; shl rax, cl);
+            store_rd(e, RAX, row.operands.rd);
+        }
+        K::VirtualShiftRightBitmask(_) => {
+            // rd = u64::MAX << (x[rs1] & 63) — bits [63:shift] set.
+            load_reg(e, RCX, row.operands.rs1);
+            dynasm!(e.ops ; .arch x64 ; mov rax, -1 ; shl rax, cl);
+            store_rd(e, RAX, row.operands.rd);
+        }
+        K::VirtualSignExtendWord(_) => {
+            load_reg(e, RAX, row.operands.rs1);
+            dynasm!(e.ops ; .arch x64 ; movsxd rax, eax);
+            store_rd(e, RAX, row.operands.rd);
+        }
+        K::VirtualZeroExtendWord(_) => {
+            load_reg(e, RAX, row.operands.rs1);
+            dynasm!(e.ops ; .arch x64 ; mov eax, eax);
+            store_rd(e, RAX, row.operands.rd);
+        }
+        K::VirtualSrai(_) => {
+            // Shift amount = imm.trailing_zeros() (imm is a bitmask);
+            // wrapping_shr semantics = mod 64.
+            let shift = ((row.operands.imm as u64).trailing_zeros() % 64) as i8;
+            load_reg(e, RAX, row.operands.rs1);
+            dynasm!(e.ops ; .arch x64 ; sar rax, shift);
+            store_rd(e, RAX, row.operands.rd);
+        }
+        K::VirtualSrli(_) => {
+            let shift = ((row.operands.imm as u64).trailing_zeros() % 64) as i8;
+            load_reg(e, RAX, row.operands.rs1);
+            dynasm!(e.ops ; .arch x64 ; shr rax, shift);
+            store_rd(e, RAX, row.operands.rd);
+        }
+        K::VirtualSrl(_) => {
+            // Shift = x[rs2].trailing_zeros(); tzcnt(0) = 64 → shr masks to
+            // 0, matching wrapping_shr(64). Requires BMI1 (checked once).
+            load_reg(e, RCX, row.operands.rs2);
+            load_reg(e, RAX, row.operands.rs1);
+            dynasm!(e.ops ; .arch x64 ; tzcnt rcx, rcx ; shr rax, cl);
+            store_rd(e, RAX, row.operands.rd);
+        }
+
+        K::Beq(_) => branch(e, row, Cc::Eq),
+        K::Bne(_) => branch(e, row, Cc::Ne),
+        K::Blt(_) => branch(e, row, Cc::LtSigned),
+        K::Bge(_) => branch(e, row, Cc::GeSigned),
+        K::BltU(_) => branch(e, row, Cc::LtUnsigned),
+        K::BgeU(_) => branch(e, row, Cc::GeUnsigned),
+
+        K::Jal(_) => {
+            load_imm(e, RAX, link_value(row));
+            store_rd(e, RAX, row.operands.rd);
+            let target = (row.address as i64).wrapping_add(row.operands.imm as i64) as u64;
+            if target == row.address as u64 {
+                terminal(e, target);
+            } else {
+                let label = e.label_for(target);
+                dynasm!(e.ops ; .arch x64 ; jmp =>label);
+            }
+        }
+        K::Jalr(_) => {
+            // target = (x[rs1] + imm) & !1, computed before the link write
+            // (rs1 may alias rd).
+            load_reg(e, RAX, row.operands.rs1);
+            load_imm(e, RCX, row.operands.imm as i64);
+            dynasm!(e.ops ; .arch x64 ; add rax, rcx ; and rax, -2);
+            load_imm(e, RCX, link_value(row));
+            store_rd(e, RCX, row.operands.rd);
+            // PC-stall check against this row's own source address.
+            dynasm!(e.ops ; .arch x64 ; mov rcx, QWORD row.address as i64 ; cmp rax, rcx ; jne >go);
+            terminal(e, row.address as u64);
+            dynasm!(e.ops ; .arch x64 ; go:);
+            dispatch(e);
+        }
+
+        K::Ld(_) => load_doubleword(e, row),
+        K::Sd(_) => store_doubleword(e, row),
+
+        K::AssertHalfwordAlignment(_) => assert_alignment(e, row, 1, 0),
+        K::AssertWordAlignment(_) => assert_alignment(e, row, 3, 1),
+        K::AssertLte(_) => {
+            // assert!(x[rs1] as u64 <= x[rs2] as u64) — unsigned.
+            load_reg(e, RAX, row.operands.rs1);
+            load_reg(e, RCX, row.operands.rs2);
+            dynasm!(e.ops
+                ; .arch x64
+                ; cmp rax, rcx
+                ; jbe >ok
+                ; mov rsi, 2
+                ; mov rdx, rax
+            );
+            call_helper(e, helpers::assert_failed as *const () as usize);
+            dynasm!(e.ops ; .arch x64 ; ok:);
+        }
+
+        K::Fence(_) => {}
+
+        K::VirtualHostIO(_) => {
+            call_helper(e, helpers::host_io as *const () as usize);
+        }
+
+        other => {
+            // Fail-fast at compile time: never a silent wrong-semantics
+            // execution (spec invariant 7).
+            let _ = other;
+            return Err(TraceError::Backend(
+                "jolt-tracer-x86: unsupported instruction kind in bytecode",
+            ));
+        }
+    }
+    Ok(())
+}

--- a/crates/jolt-tracer-x86/src/native/compile/emit.rs
+++ b/crates/jolt-tracer-x86/src/native/compile/emit.rs
@@ -566,6 +566,13 @@ impl DynasmEmitter {
     ) -> Result<EmitOutcome, TraceError> {
         use JoltInstructionKind as K;
 
+        // Decline before any bytes are emitted: `EmitterSet` requires a
+        // declining emitter to leave the assembly untouched (it asserts the
+        // offset), so the next emitter in the set can claim the row cleanly.
+        if matches!(row.instruction_kind, K::Noop(_)) {
+            return Ok(EmitOutcome::Unsupported);
+        }
+
         // Every row is one trace row.
         dynasm!(e.ops ; .arch x64 ; inc r14);
 
@@ -968,13 +975,9 @@ impl DynasmEmitter {
             }
 
             // Every other final kind is implemented above; `Noop` never appears
-            // in executable bytecode. Reporting `Unsupported` (rather than
-            // erroring) lets another emitter in the set claim the kind; the set
-            // raises the fail-fast error when none does.
-            other @ K::Noop(_) => {
-                let _ = other;
-                return Ok(EmitOutcome::Unsupported);
-            }
+            // in executable bytecode and was declined before any emission (the
+            // early return above), so this arm only completes the match.
+            K::Noop(_) => return Ok(EmitOutcome::Unsupported),
         }
         if record && !transfers_control {
             e.obs_rd_post(row);

--- a/crates/jolt-tracer-x86/src/native/compile/emit.rs
+++ b/crates/jolt-tracer-x86/src/native/compile/emit.rs
@@ -25,7 +25,26 @@ use super::super::state::{
     advice_slot_offset, reg_offset, ExitReason, OFF_EXIT, OFF_FAULT_ADDR, OFF_MEM_BASE,
     OFF_MEM_SIZE, OFF_PC, OFF_TRACE_LEN,
 };
+use super::emitter::{EmitOutcome, RowEmitter};
 use super::Emitter;
+
+/// The dynasm-template emitter: the production implementor of the
+/// [`RowEmitter`] seam, covering every final-bytecode row kind.
+pub struct DynasmEmitter;
+
+impl RowEmitter for DynasmEmitter {
+    fn emit_row(
+        &self,
+        cx: &mut Emitter,
+        row: &JoltInstructionRow,
+    ) -> Result<EmitOutcome, TraceError> {
+        emit_row_template(cx, row)
+    }
+
+    fn emit_advice_compute(&self, cx: &mut Emitter, job_index: usize) {
+        advice_compute(cx, job_index);
+    }
+}
 
 const RAX: u8 = 0;
 const RCX: u8 = 1;
@@ -349,7 +368,7 @@ pub fn advice_compute(e: &mut Emitter, job_index: usize) {
     call_helper(e, helpers::advice_compute as *const () as usize);
 }
 
-pub fn row(e: &mut Emitter, row: &JoltInstructionRow) -> Result<(), TraceError> {
+fn emit_row_template(e: &mut Emitter, row: &JoltInstructionRow) -> Result<EmitOutcome, TraceError> {
     use JoltInstructionKind as K;
 
     // Every row is one trace row.
@@ -719,15 +738,13 @@ pub fn row(e: &mut Emitter, row: &JoltInstructionRow) -> Result<(), TraceError> 
         }
 
         // Every other final kind is implemented above; `Noop` never appears
-        // in executable bytecode. Fail fast rather than execute wrong
-        // semantics (spec invariant 7); a newly added kind lands here until
-        // it has a template.
+        // in executable bytecode. Reporting `Unsupported` (rather than
+        // erroring) lets another emitter in the set claim the kind; the set
+        // raises the fail-fast error when none does.
         other @ K::Noop(_) => {
             let _ = other;
-            return Err(TraceError::Backend(
-                "jolt-tracer-x86: unsupported instruction kind in bytecode",
-            ));
+            return Ok(EmitOutcome::Unsupported);
         }
     }
-    Ok(())
+    Ok(EmitOutcome::Emitted)
 }

--- a/crates/jolt-tracer-x86/src/native/compile/emit.rs
+++ b/crates/jolt-tracer-x86/src/native/compile/emit.rs
@@ -942,6 +942,14 @@ impl DynasmEmitter {
             K::VirtualAdvice(_) => {
                 // The value comes from this group's advice slots, filled before
                 // the group's first row ran; slots are consumed in row order.
+                // A group without an advice computation has no values to read
+                // (the slots still hold a previous group's), so refuse at
+                // compile time rather than emit a stale-slot read.
+                if !e.advice_ready {
+                    return Err(TraceError::Backend(
+                        "VirtualAdvice row in a group without an advice computation",
+                    ));
+                }
                 let slot = e.advice_slot;
                 if slot >= super::super::state::ADVICE_SLOTS {
                     return Err(TraceError::Backend(

--- a/crates/jolt-tracer-x86/src/native/compile/emit.rs
+++ b/crates/jolt-tracer-x86/src/native/compile/emit.rs
@@ -22,11 +22,12 @@ use jolt_riscv::{JoltInstructionKind, JoltInstructionRow};
 
 use super::super::helpers;
 use super::super::state::{
-    advice_slot_offset, reg_offset, ExitReason, OFF_EXIT, OFF_FAULT_ADDR, OFF_MEM_BASE,
-    OFF_MEM_SIZE, OFF_PC, OFF_TRACE_LEN,
+    advice_slot_offset, reg_offset, ExitReason, OBSERVATION_SIZE, OBS_RAM_ADDRESS, OBS_RAM_POST,
+    OBS_RAM_PRE, OBS_RD_POST, OBS_RD_PRE, OBS_ROW_INDEX, OBS_RS1, OBS_RS2, OFF_EXIT,
+    OFF_FAULT_ADDR, OFF_MEM_BASE, OFF_MEM_SIZE, OFF_OBS_CURSOR, OFF_OBS_END, OFF_PC, OFF_TRACE_LEN,
 };
 use super::emitter::{EmitOutcome, RowEmitter};
-use super::Emitter;
+use super::{EmitMode, Emitter};
 
 /// The dynasm-template emitter: the production implementor of the
 /// [`RowEmitter`] seam, covering every final-bytecode row kind.
@@ -149,6 +150,9 @@ pub fn stubs(e: &mut Emitter) -> Stubs {
     let bad_jump = e.ops.offset();
     dynasm!(e.ops
         ; .arch x64
+        ; ->obs_overflow:
+        ; mov QWORD [r12 + OFF_EXIT], ExitReason::FaultObservationOverflow as u64 as i32
+        ; jmp ->exit
         ; ->bad_jump:
         ; mov QWORD [r12 + OFF_FAULT_ADDR], rax
         ; mov QWORD [r12 + OFF_EXIT], ExitReason::FaultBadJumpTarget as u64 as i32
@@ -262,9 +266,15 @@ fn load_doubleword(e: &mut Emitter, row: &JoltInstructionRow) {
     // EA = (x[rs1] as u64).wrapping_add(imm as i32 as u64) — exact cast chain.
     let offset = row.operands.imm as i32;
     load_reg(e, RAX, row.operands.rs1);
+    dynasm!(e.ops ; .arch x64 ; add rax, offset);
+    if e.mode == EmitMode::Record {
+        // The effective address is 8-aligned on the success path, so the
+        // reference's word-aligned floor equals it.
+        obs_reload(e);
+        dynasm!(e.ops ; .arch x64 ; mov QWORD [r10 + OBS_RAM_ADDRESS], rax);
+    }
     dynasm!(e.ops
         ; .arch x64
-        ; add rax, offset
         ; mov rcx, rax
         ; mov rdx, QWORD RAM_START as i64
         ; sub rcx, rdx
@@ -281,6 +291,12 @@ fn load_doubleword(e: &mut Emitter, row: &JoltInstructionRow) {
     );
     call_helper(e, helpers::slow_load_doubleword as *const () as usize);
     dynasm!(e.ops ; .arch x64 ; done:);
+    if e.mode == EmitMode::Record {
+        // The reference records the whole doubleword read, whichever path
+        // produced it.
+        obs_reload(e);
+        dynasm!(e.ops ; .arch x64 ; mov QWORD [r10 + OBS_RAM_PRE], rax);
+    }
     store_rd(e, RAX, row.operands.rd);
 }
 
@@ -290,9 +306,20 @@ fn store_doubleword(e: &mut Emitter, row: &JoltInstructionRow) {
     load_reg(e, RAX, row.operands.rs1);
     load_imm(e, RCX, row.operands.imm as i64);
     load_reg(e, RDX, row.operands.rs2);
+    dynasm!(e.ops ; .arch x64 ; add rax, rcx);
+    if e.mode == EmitMode::Record {
+        // The reference records the raw effective address and the stored
+        // value; the pre-value is captured on whichever path performs the
+        // write (fast path below, helper for the device region).
+        obs_reload(e);
+        dynasm!(e.ops
+            ; .arch x64
+            ; mov QWORD [r10 + OBS_RAM_ADDRESS], rax
+            ; mov QWORD [r10 + OBS_RAM_POST], rdx
+        );
+    }
     dynasm!(e.ops
         ; .arch x64
-        ; add rax, rcx
         ; mov rcx, rax
         ; mov rsi, QWORD RAM_START as i64
         ; sub rcx, rsi
@@ -302,6 +329,17 @@ fn store_doubleword(e: &mut Emitter, row: &JoltInstructionRow) {
         ; jae >slow
         ; test al, 7
         ; jnz >slow
+    );
+    if e.mode == EmitMode::Record {
+        obs_reload(e);
+        dynasm!(e.ops
+            ; .arch x64
+            ; mov r8, QWORD [r13 + rcx]
+            ; mov QWORD [r10 + OBS_RAM_PRE], r8
+        );
+    }
+    dynasm!(e.ops
+        ; .arch x64
         ; mov QWORD [r13 + rcx], rdx
         ; jmp >done
         ; slow:
@@ -368,11 +406,129 @@ pub fn advice_compute(e: &mut Emitter, job_index: usize) {
     call_helper(e, helpers::advice_compute as *const () as usize);
 }
 
+/// Record mode: load the observation cursor into r10 and bounds-check it.
+/// Kept live only within one row's emission (helper calls clobber r10).
+fn obs_open(e: &mut Emitter, row_index: usize) {
+    dynasm!(e.ops
+        ; .arch x64
+        ; mov r10, QWORD [r12 + OFF_OBS_CURSOR]
+        ; cmp r10, QWORD [r12 + OFF_OBS_END]
+        ; jae ->obs_overflow
+        ; mov rax, QWORD row_index as i64
+        ; mov QWORD [r10 + OBS_ROW_INDEX], rax
+    );
+}
+
+/// Reload the cursor into r10. Every capture site does this: a row whose
+/// template calls a helper has had r10 clobbered (caller-saved), and the
+/// cursor is only advanced by `obs_close`, so the reload always lands on the
+/// same slot.
+fn obs_reload(e: &mut Emitter) {
+    dynasm!(e.ops ; .arch x64 ; mov r10, QWORD [r12 + OFF_OBS_CURSOR]);
+}
+
+/// Record mode: advance the cursor past this row's slot.
+fn obs_close(e: &mut Emitter) {
+    dynasm!(e.ops
+        ; .arch x64
+        ; mov r10, QWORD [r12 + OFF_OBS_CURSOR]
+        ; add r10, OBSERVATION_SIZE
+        ; mov QWORD [r12 + OFF_OBS_CURSOR], r10
+    );
+}
+
+/// Record mode: capture the register values this row reads and the
+/// destination's pre-value, before the row's own template runs.
+fn obs_registers_pre(e: &mut Emitter, row: &JoltInstructionRow) {
+    obs_reload(e);
+    for (slot, register) in [
+        (OBS_RS1, row.operands.rs1),
+        (OBS_RS2, row.operands.rs2),
+        (OBS_RD_PRE, row.operands.rd),
+    ] {
+        match register {
+            // x0 reads as zero, matching normalize_register_value.
+            None | Some(0) => dynasm!(e.ops
+                ; .arch x64
+                ; xor rax, rax
+                ; mov QWORD [r10 + slot], rax
+            ),
+            Some(r) => dynasm!(e.ops
+                ; .arch x64
+                ; mov rax, QWORD [r12 + reg_offset(r)]
+                ; mov QWORD [r10 + slot], rax
+            ),
+        }
+    }
+}
+
+/// Record mode: store a statically known rd post-value (control-flow rows
+/// write their observation before transferring, so their post-value must be
+/// known without executing the template; for Jal/Jalr it is the link).
+fn obs_rd_post_static(e: &mut Emitter, row: &JoltInstructionRow, value: i64) {
+    obs_reload(e);
+    let value = match row.operands.rd {
+        None | Some(0) => 0,
+        Some(_) => value,
+    };
+    dynasm!(e.ops
+        ; .arch x64
+        ; mov rax, QWORD value
+        ; mov QWORD [r10 + OBS_RD_POST], rax
+    );
+}
+
+/// Record mode: capture the destination's post-value, after the template ran.
+fn obs_rd_post(e: &mut Emitter, row: &JoltInstructionRow) {
+    obs_reload(e);
+    match row.operands.rd {
+        None | Some(0) => dynasm!(e.ops
+            ; .arch x64
+            ; xor rax, rax
+            ; mov QWORD [r10 + OBS_RD_POST], rax
+        ),
+        Some(r) => dynasm!(e.ops
+            ; .arch x64
+            ; mov rax, QWORD [r12 + reg_offset(r)]
+            ; mov QWORD [r10 + OBS_RD_POST], rax
+        ),
+    }
+}
+
 fn emit_row_template(e: &mut Emitter, row: &JoltInstructionRow) -> Result<EmitOutcome, TraceError> {
     use JoltInstructionKind as K;
 
     // Every row is one trace row.
     dynasm!(e.ops ; .arch x64 ; inc r14);
+
+    // Record mode brackets each row's template with value capture. Rows that
+    // transfer control never reach code emitted after their template, so
+    // theirs is written up front: branches have no destination, and Jal/Jalr
+    // post-values are the statically known link.
+    let record = e.mode == EmitMode::Record;
+    let transfers_control = matches!(
+        row.instruction_kind,
+        K::Beq(_)
+            | K::Bne(_)
+            | K::Blt(_)
+            | K::Bge(_)
+            | K::BltU(_)
+            | K::BgeU(_)
+            | K::Jal(_)
+            | K::Jalr(_)
+    );
+    if record {
+        obs_open(e, e.row_index);
+        obs_registers_pre(e, row);
+        if transfers_control {
+            let link = match row.instruction_kind {
+                K::Jal(_) | K::Jalr(_) => link_value(row),
+                _ => 0,
+            };
+            obs_rd_post_static(e, row, link);
+            obs_close(e);
+        }
+    }
 
     match &row.instruction_kind {
         K::Add(_) => alu_rr(e, row, AluRR::Add),
@@ -745,6 +901,10 @@ fn emit_row_template(e: &mut Emitter, row: &JoltInstructionRow) -> Result<EmitOu
             let _ = other;
             return Ok(EmitOutcome::Unsupported);
         }
+    }
+    if record && !transfers_control {
+        obs_rd_post(e, row);
+        obs_close(e);
     }
     Ok(EmitOutcome::Emitted)
 }

--- a/crates/jolt-tracer-x86/src/native/compile/emitter.rs
+++ b/crates/jolt-tracer-x86/src/native/compile/emitter.rs
@@ -13,6 +13,7 @@
 //! the driver: those are properties of the execution model, not of how a row
 //! is encoded.
 
+use dynasmrt::DynasmApi as _;
 use jolt_program::execution::TraceError;
 use jolt_riscv::JoltInstructionRow;
 
@@ -65,8 +66,17 @@ impl EmitterSet {
 
     pub fn emit_row(&self, cx: &mut Emitter, row: &JoltInstructionRow) -> Result<(), TraceError> {
         for emitter in &self.emitters {
+            let before = cx.ops.offset();
             if emitter.emit_row(cx, row)? == EmitOutcome::Emitted {
                 return Ok(());
+            }
+            // Contract: declining must be side-effect-free. Partial emission
+            // before a decline (a row prelude, say) would silently double the
+            // trace-row count once a later emitter claims the kind.
+            if cx.ops.offset() != before {
+                return Err(TraceError::Backend(
+                    "row emitter declined a kind after emitting code",
+                ));
             }
         }
         // No emitter handles this kind: refuse to compile rather than
@@ -148,5 +158,40 @@ mod tests {
         let program = single_row_program(add_row());
         let set = EmitterSet::from_emitters(vec![Box::new(DeclineAll)]);
         assert!(super::super::CompiledProgram::compile_with(&program, &set).is_err());
+    }
+
+    /// An emitter that emits bytes and then declines would double-count rows
+    /// once a later emitter claims the kind; the set must reject it.
+    struct EmitThenDecline;
+
+    impl RowEmitter for EmitThenDecline {
+        fn emit_row(
+            &self,
+            cx: &mut Emitter,
+            _row: &JoltInstructionRow,
+        ) -> Result<EmitOutcome, TraceError> {
+            use dynasmrt::DynasmApi as _;
+            cx.ops.push(0x90); // stray nop
+            Ok(EmitOutcome::Unsupported)
+        }
+
+        fn emit_advice_compute(&self, _cx: &mut Emitter, _job_index: usize) {}
+    }
+
+    #[test]
+    fn partial_emission_before_decline_is_rejected() {
+        let program = single_row_program(add_row());
+        let set = EmitterSet::from_emitters(vec![
+            Box::new(EmitThenDecline),
+            Box::new(super::super::emit::DynasmEmitter),
+        ]);
+        let error = match super::super::CompiledProgram::compile_with(&program, &set) {
+            Err(error) => format!("{error:?}"),
+            Ok(_) => String::from("compiled successfully"),
+        };
+        assert!(
+            error.contains("declined a kind after emitting"),
+            "expected the partial-emission error, got: {error}"
+        );
     }
 }

--- a/crates/jolt-tracer-x86/src/native/compile/emitter.rs
+++ b/crates/jolt-tracer-x86/src/native/compile/emitter.rs
@@ -1,0 +1,152 @@
+//! The `RowEmitter` seam: how one expanded-bytecode row becomes machine code.
+//!
+//! Code generation is isolated behind this trait so an alternate emitter —
+//! notably the copy-and-patch stencil route recorded in Alternative 11 of
+//! `specs/x86-tracer-backend.md` — can be compared against the dynasm
+//! templates per row kind, without touching the compile driver, the
+//! differential tests, or the benches. Emitters are ordered: the first one
+//! that claims a kind emits it, so a hybrid (stencils for some kinds, hand
+//! templates for the rest) needs no further plumbing.
+//!
+//! Everything outside per-row emission — the prologue, dispatch stubs, jump
+//! table, and group/chunk accounting — is shared infrastructure and stays in
+//! the driver: those are properties of the execution model, not of how a row
+//! is encoded.
+
+use jolt_program::execution::TraceError;
+use jolt_riscv::JoltInstructionRow;
+
+use super::Emitter;
+
+/// Whether an emitter handled a row.
+///
+/// Emitters report `Unsupported` instead of erroring so the next emitter in
+/// the set gets a chance; the set raises the fail-fast error only when no
+/// emitter claims the kind (spec invariant 7). This keeps the authoritative
+/// list of supported kinds in one place: the emitter's own match.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EmitOutcome {
+    Emitted,
+    Unsupported,
+}
+
+/// A code-generation strategy for expanded-bytecode rows.
+pub trait RowEmitter {
+    /// Emit code for one row, or report that this emitter does not handle
+    /// the row's kind.
+    fn emit_row(
+        &self,
+        cx: &mut Emitter,
+        row: &JoltInstructionRow,
+    ) -> Result<EmitOutcome, TraceError>;
+
+    /// Emit a source-instruction group's advice computation, which must run
+    /// before any of the group's rows.
+    fn emit_advice_compute(&self, cx: &mut Emitter, job_index: usize);
+}
+
+/// An ordered set of emitters. The first that claims a kind emits it.
+pub struct EmitterSet {
+    emitters: Vec<Box<dyn RowEmitter>>,
+}
+
+impl EmitterSet {
+    /// The production configuration: dynasm templates for every kind.
+    pub fn dynasm() -> Self {
+        Self {
+            emitters: vec![Box::new(super::emit::DynasmEmitter)],
+        }
+    }
+
+    /// Build a set from an explicit emitter list (front takes precedence).
+    pub fn from_emitters(emitters: Vec<Box<dyn RowEmitter>>) -> Self {
+        Self { emitters }
+    }
+
+    pub fn emit_row(&self, cx: &mut Emitter, row: &JoltInstructionRow) -> Result<(), TraceError> {
+        for emitter in &self.emitters {
+            if emitter.emit_row(cx, row)? == EmitOutcome::Emitted {
+                return Ok(());
+            }
+        }
+        // No emitter handles this kind: refuse to compile rather than
+        // execute wrong semantics (spec invariant 7).
+        Err(TraceError::Backend(
+            "jolt-tracer-x86: unsupported instruction kind in bytecode",
+        ))
+    }
+
+    /// Advice computation is emitted by the first emitter; it is execution
+    /// -model plumbing (a helper call), identical across strategies.
+    pub fn emit_advice_compute(
+        &self,
+        cx: &mut Emitter,
+        job_index: usize,
+    ) -> Result<(), TraceError> {
+        let emitter = self
+            .emitters
+            .first()
+            .ok_or(TraceError::Backend("no row emitter configured"))?;
+        emitter.emit_advice_compute(cx, job_index);
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::native::harness::{single_row_program, TEST_ADDR};
+    use jolt_riscv::{JoltInstructionKind, NormalizedOperands};
+
+    /// An emitter that claims nothing — stands in for a partial emitter
+    /// (e.g. stencils covering only some kinds) in the ordering tests.
+    struct DeclineAll;
+
+    impl RowEmitter for DeclineAll {
+        fn emit_row(
+            &self,
+            _cx: &mut Emitter,
+            _row: &JoltInstructionRow,
+        ) -> Result<EmitOutcome, TraceError> {
+            Ok(EmitOutcome::Unsupported)
+        }
+
+        fn emit_advice_compute(&self, _cx: &mut Emitter, _job_index: usize) {}
+    }
+
+    fn add_row() -> JoltInstructionRow {
+        JoltInstructionRow {
+            instruction_kind: JoltInstructionKind::ADD,
+            address: TEST_ADDR as usize,
+            operands: NormalizedOperands {
+                rs1: Some(1),
+                rs2: Some(2),
+                rd: Some(3),
+                imm: 0,
+            },
+            virtual_sequence_remaining: None,
+            is_first_in_sequence: true,
+            is_compressed: false,
+        }
+    }
+
+    /// A partial emitter ahead of the templates must fall through, not fail.
+    #[test]
+    fn declining_emitter_falls_through_to_the_next() {
+        let program = single_row_program(add_row());
+        let set = EmitterSet::from_emitters(vec![
+            Box::new(DeclineAll),
+            Box::new(super::super::emit::DynasmEmitter),
+        ]);
+        assert!(super::super::compile_with(&program, &set).is_ok());
+    }
+
+    /// When no emitter claims a kind, compilation fails fast rather than
+    /// emitting nothing for the row (spec invariant 7).
+    #[test]
+    fn unclaimed_kind_fails_compilation() {
+        let program = single_row_program(add_row());
+        let set = EmitterSet::from_emitters(vec![Box::new(DeclineAll)]);
+        assert!(super::super::compile_with(&program, &set).is_err());
+    }
+}

--- a/crates/jolt-tracer-x86/src/native/compile/emitter.rs
+++ b/crates/jolt-tracer-x86/src/native/compile/emitter.rs
@@ -138,7 +138,7 @@ mod tests {
             Box::new(DeclineAll),
             Box::new(super::super::emit::DynasmEmitter),
         ]);
-        assert!(super::super::compile_with(&program, &set).is_ok());
+        assert!(super::super::CompiledProgram::compile_with(&program, &set).is_ok());
     }
 
     /// When no emitter claims a kind, compilation fails fast rather than
@@ -147,6 +147,6 @@ mod tests {
     fn unclaimed_kind_fails_compilation() {
         let program = single_row_program(add_row());
         let set = EmitterSet::from_emitters(vec![Box::new(DeclineAll)]);
-        assert!(super::super::compile_with(&program, &set).is_err());
+        assert!(super::super::CompiledProgram::compile_with(&program, &set).is_err());
     }
 }

--- a/crates/jolt-tracer-x86/src/native/compile/mod.rs
+++ b/crates/jolt-tracer-x86/src/native/compile/mod.rs
@@ -50,6 +50,13 @@ impl CompiledProgram {
         self.advice_jobs.as_ptr()
     }
 
+    /// Host address of the fast body's entry point. Exposed so the safety
+    /// tests can assert the finalized mapping's permissions (AC11): code is
+    /// never writable and executable at the same time.
+    pub fn code_address(&self) -> usize {
+        self.fast.buffer.ptr(self.fast.entry) as usize
+    }
+
     /// Run the fast body: execution only, no row materialization.
     pub fn run(&self, state: &mut GuestState) -> Result<(), TraceError> {
         Self::run_body(&self.fast, state)

--- a/crates/jolt-tracer-x86/src/native/compile/mod.rs
+++ b/crates/jolt-tracer-x86/src/native/compile/mod.rs
@@ -1,0 +1,131 @@
+//! AOT compilation driver: expanded bytecode rows → executable x86-64.
+//!
+//! Register plan (SysV callee-saved, so helper calls preserve them):
+//!   r12 = &mut GuestState        r13 = guest RAM plane host base
+//!   r14 = trace_len (row count)  r15 = jump table base
+//! Scratch: rax rcx rdx rsi rdi r8–r11 (no guest state lives in scratch).
+//! Guest registers live in the `GuestState::x` array — correctness first;
+//! register-pinning optimizations belong to the performance slice, guarded
+//! by the differential tests.
+
+mod emit;
+
+use std::collections::BTreeMap;
+
+use dynasmrt::{x64::Assembler, AssemblyOffset, DynamicLabel, DynasmApi, DynasmLabelApi};
+use jolt_program::execution::{JoltProgram, TraceError};
+
+use super::state::GuestState;
+
+/// A compiled program: executable buffer plus the indirect-dispatch table.
+pub struct CompiledProgram {
+    buffer: dynasmrt::ExecutableBuffer,
+    entry: AssemblyOffset,
+    /// One host code address per halfword in `[text_base, text_end)`;
+    /// non-group-start slots point at the bad-jump stub.
+    jump_table: Vec<usize>,
+}
+
+impl CompiledProgram {
+    pub fn run(&self, state: &mut GuestState) -> Result<(), TraceError> {
+        let entry = self.buffer.ptr(self.entry);
+        // SAFETY: `entry` points into the finalized (read+execute) buffer at
+        // the prologue emitted by `compile`; the generated code only touches
+        // the GuestState plane, the RAM plane it carries, and the jump
+        // table, per the emitter's invariants.
+        let f: extern "sysv64" fn(*mut GuestState, *const usize) =
+            unsafe { core::mem::transmute(entry) };
+        f(state, self.jump_table.as_ptr());
+        Ok(())
+    }
+}
+
+pub(super) struct Emitter {
+    pub ops: Assembler,
+    /// Dynamic label per group-start guest address (branch/jump targets).
+    labels: BTreeMap<u64, DynamicLabel>,
+    /// Guest addresses that start a compiled group, with their code offsets.
+    group_offsets: Vec<(u64, AssemblyOffset)>,
+    pub text_base: u64,
+    pub text_span: u64,
+}
+
+impl Emitter {
+    pub fn label_for(&mut self, address: u64) -> DynamicLabel {
+        if let Some(&label) = self.labels.get(&address) {
+            return label;
+        }
+        let label = self.ops.new_dynamic_label();
+        let _ = self.labels.insert(address, label);
+        label
+    }
+}
+
+pub fn compile(program: &JoltProgram) -> Result<CompiledProgram, TraceError> {
+    // VirtualSRL uses `tzcnt`; on pre-BMI1 CPUs it silently decodes as `bsf`
+    // with different zero-input semantics, so refuse rather than mis-execute.
+    if !std::arch::is_x86_feature_detected!("bmi1") {
+        return Err(TraceError::Backend(
+            "jolt-tracer-x86 requires BMI1 (tzcnt) support",
+        ));
+    }
+    let rows = &program.expanded_bytecode;
+    if rows.is_empty() {
+        return Err(TraceError::Backend("program has no expanded bytecode"));
+    }
+
+    let text_base = rows.iter().map(|r| r.address as u64).min().unwrap_or(0);
+    let text_end = rows.iter().map(|r| r.address as u64).max().unwrap_or(0) + 4;
+    let text_span = text_end - text_base;
+
+    let mut emitter = Emitter {
+        ops: Assembler::new().map_err(|_| TraceError::Backend("failed to create x64 assembler"))?,
+        labels: BTreeMap::new(),
+        group_offsets: Vec::new(),
+        text_base,
+        text_span,
+    };
+
+    let entry = emit::prologue(&mut emitter);
+
+    let mut previous_address = None;
+    for row in rows {
+        let address = row.address as u64;
+        if previous_address != Some(address) {
+            // Group start: define the branch-target label and record the
+            // offset for the jump table.
+            let label = emitter.label_for(address);
+            let offset = emitter.ops.offset();
+            emitter.ops.dynamic_label(label);
+            emitter.group_offsets.push((address, offset));
+            previous_address = Some(address);
+        }
+        emit::row(&mut emitter, row)?;
+    }
+
+    // Execution falling off the end of the program is a bad jump.
+    emit::jump_to_bad_jump(&mut emitter);
+    let stubs = emit::stubs(&mut emitter);
+
+    let group_offsets = core::mem::take(&mut emitter.group_offsets);
+    let buffer = emitter
+        .ops
+        .finalize()
+        .map_err(|_| TraceError::Backend("x64 assembly finalize failed"))?;
+
+    // Build the halfword-granular dispatch table with the bad-jump stub as
+    // filler.
+    let bad_jump = buffer.ptr(stubs.bad_jump) as usize;
+    let slots = (text_span / 2) as usize;
+    let mut jump_table = vec![bad_jump; slots];
+    for (address, offset) in group_offsets {
+        let slot = ((address - text_base) / 2) as usize;
+        jump_table[slot] = buffer.ptr(offset) as usize;
+    }
+
+    Ok(CompiledProgram {
+        buffer,
+        entry,
+        jump_table,
+    })
+}

--- a/crates/jolt-tracer-x86/src/native/compile/mod.rs
+++ b/crates/jolt-tracer-x86/src/native/compile/mod.rs
@@ -17,7 +17,7 @@ use dynasmrt::{x64::Assembler, AssemblyOffset, DynamicLabel, DynasmApi, DynasmLa
 use jolt_program::execution::{JoltProgram, TraceError};
 use jolt_riscv::SourceInstructionKind;
 
-use super::state::{AdviceJob, GuestState};
+use super::state::{AdviceCompute, AdviceJob, GuestState};
 use emitter::EmitterSet;
 use jolt_riscv::JoltInstructionRow;
 
@@ -173,6 +173,9 @@ pub struct Emitter {
     /// Whether the current group emitted an advice computation (i.e. its
     /// `VirtualAdvice` rows have values to read).
     pub advice_ready: bool,
+    /// Index of the current group's advice job, until the group ends and its
+    /// consumed-slot count is patched in (see [`Self::finish_advice_group`]).
+    current_advice_job: Option<usize>,
     /// Dynamic label per group-start guest address (branch/jump targets).
     labels: BTreeMap<u64, DynamicLabel>,
     /// Guest addresses that start a compiled group, with their code offsets.
@@ -189,6 +192,24 @@ impl Emitter {
         let label = self.ops.new_dynamic_label();
         let _ = self.labels.insert(address, label);
         label
+    }
+
+    /// A group's rows are all emitted: record how many `VirtualAdvice` slots
+    /// it consumed on its job, so the runtime helper can check the computed
+    /// value count against it. Div computations provide exactly two values,
+    /// which makes over-consumption a compile-time error.
+    fn finish_advice_group(&mut self) -> Result<(), TraceError> {
+        let Some(index) = self.current_advice_job.take() else {
+            return Ok(());
+        };
+        let job = &mut self.advice_jobs[index];
+        job.advice_rows = self.advice_slot;
+        if matches!(job.compute, AdviceCompute::Div { .. }) && job.advice_rows > 2 {
+            return Err(TraceError::Backend(
+                "DIV/REM group consumes more advice values than its computation provides",
+            ));
+        }
+        Ok(())
     }
 }
 
@@ -222,6 +243,14 @@ impl CompiledBody {
         let text_base = rows.iter().map(|r| r.address as u64).min().unwrap_or(0);
         let text_end = rows.iter().map(|r| r.address as u64).max().unwrap_or(0) + 4;
         let text_span = text_end - text_base;
+        // The dispatch sequence compares the target's byte delta against the
+        // span as an i32 immediate; a larger span would sign-extend negative
+        // and let every in-range check pass vacuously.
+        if text_span > i32::MAX as u64 {
+            return Err(TraceError::Backend(
+                "program text span exceeds the dispatch table's addressable range",
+            ));
+        }
 
         let mut emitter = Emitter {
             mode,
@@ -232,6 +261,7 @@ impl CompiledBody {
             advice_jobs: Vec::new(),
             advice_slot: 0,
             advice_ready: false,
+            current_advice_job: None,
             labels: BTreeMap::new(),
             group_offsets: Vec::new(),
             text_base,
@@ -256,12 +286,17 @@ impl CompiledBody {
                     emitter.emit_group_pause_check(address);
                 }
                 previous_address = Some(address);
+                emitter.finish_advice_group()?;
                 emitter.advice_slot = 0;
                 emitter.advice_ready = false;
                 if let Some(source) = sources.get(&address) {
-                    if let Some(job) = AdviceJob::from_source(source)? {
-                        emitter.advice_jobs.push(job);
+                    if let Some(compute) = AdviceCompute::from_source(source)? {
+                        emitter.advice_jobs.push(AdviceJob {
+                            compute,
+                            advice_rows: 0,
+                        });
                         let index = emitter.advice_jobs.len() - 1;
+                        emitter.current_advice_job = Some(index);
                         emitters.emit_advice_compute(&mut emitter, index)?;
                         emitter.advice_ready = true;
                     }
@@ -269,6 +304,7 @@ impl CompiledBody {
             }
             emitters.emit_row(&mut emitter, row)?;
         }
+        emitter.finish_advice_group()?;
 
         // Execution falling off the end of the program is a bad jump.
         emitter.emit_jump_to_bad_jump();
@@ -302,7 +338,7 @@ impl CompiledBody {
     }
 }
 
-impl AdviceJob {
+impl AdviceCompute {
     /// The advice computation a source instruction's group needs, if any.
     fn from_source(
         source: &jolt_riscv::SourceInstruction<jolt_riscv::SourceInstructionRow>,

--- a/crates/jolt-tracer-x86/src/native/compile/mod.rs
+++ b/crates/jolt-tracer-x86/src/native/compile/mod.rs
@@ -14,8 +14,9 @@ use std::collections::BTreeMap;
 
 use dynasmrt::{x64::Assembler, AssemblyOffset, DynamicLabel, DynasmApi, DynasmLabelApi};
 use jolt_program::execution::{JoltProgram, TraceError};
+use jolt_riscv::SourceInstructionKind;
 
-use super::state::GuestState;
+use super::state::{AdviceJob, GuestState};
 
 /// A compiled program: executable buffer plus the indirect-dispatch table.
 pub struct CompiledProgram {
@@ -24,6 +25,15 @@ pub struct CompiledProgram {
     /// One host code address per halfword in `[text_base, text_end)`;
     /// non-group-start slots point at the bad-jump stub.
     jump_table: Vec<usize>,
+    /// Advice computations, one per group that needs them; generated code
+    /// passes indices into this table.
+    advice_jobs: Vec<AdviceJob>,
+}
+
+impl CompiledProgram {
+    pub fn advice_jobs_ptr(&self) -> *const AdviceJob {
+        self.advice_jobs.as_ptr()
+    }
 }
 
 impl CompiledProgram {
@@ -42,6 +52,13 @@ impl CompiledProgram {
 
 pub(super) struct Emitter {
     pub ops: Assembler,
+    /// Advice jobs collected so far (index = the job id in generated code).
+    pub advice_jobs: Vec<AdviceJob>,
+    /// Next `VirtualAdvice` slot within the current group.
+    pub advice_slot: usize,
+    /// Whether the current group emitted an advice computation (i.e. its
+    /// `VirtualAdvice` rows have values to read).
+    pub advice_ready: bool,
     /// Dynamic label per group-start guest address (branch/jump targets).
     labels: BTreeMap<u64, DynamicLabel>,
     /// Guest addresses that start a compiled group, with their code offsets.
@@ -78,8 +95,15 @@ pub fn compile(program: &JoltProgram) -> Result<CompiledProgram, TraceError> {
     let text_end = rows.iter().map(|r| r.address as u64).max().unwrap_or(0) + 4;
     let text_span = text_end - text_base;
 
+    // Source rows keyed by address: the expanded bytecode erases the source
+    // kind and inline key, which the per-group advice computations need.
+    let sources = source_rows(program)?;
+
     let mut emitter = Emitter {
         ops: Assembler::new().map_err(|_| TraceError::Backend("failed to create x64 assembler"))?,
+        advice_jobs: Vec::new(),
+        advice_slot: 0,
+        advice_ready: false,
         labels: BTreeMap::new(),
         group_offsets: Vec::new(),
         text_base,
@@ -92,13 +116,24 @@ pub fn compile(program: &JoltProgram) -> Result<CompiledProgram, TraceError> {
     for row in rows {
         let address = row.address as u64;
         if previous_address != Some(address) {
-            // Group start: define the branch-target label and record the
-            // offset for the jump table.
+            // Group start: define the branch-target label, record the jump
+            // table offset, and emit this group's advice computation (which
+            // must observe the pre-group register state) before its rows.
             let label = emitter.label_for(address);
             let offset = emitter.ops.offset();
             emitter.ops.dynamic_label(label);
             emitter.group_offsets.push((address, offset));
             previous_address = Some(address);
+            emitter.advice_slot = 0;
+            emitter.advice_ready = false;
+            if let Some(source) = sources.get(&address) {
+                if let Some(job) = advice_job(source)? {
+                    emitter.advice_jobs.push(job);
+                    let index = emitter.advice_jobs.len() - 1;
+                    emit::advice_compute(&mut emitter, index);
+                    emitter.advice_ready = true;
+                }
+            }
         }
         emit::row(&mut emitter, row)?;
     }
@@ -108,6 +143,7 @@ pub fn compile(program: &JoltProgram) -> Result<CompiledProgram, TraceError> {
     let stubs = emit::stubs(&mut emitter);
 
     let group_offsets = core::mem::take(&mut emitter.group_offsets);
+    let advice_jobs = core::mem::take(&mut emitter.advice_jobs);
     let buffer = emitter
         .ops
         .finalize()
@@ -127,5 +163,69 @@ pub fn compile(program: &JoltProgram) -> Result<CompiledProgram, TraceError> {
         buffer,
         entry,
         jump_table,
+        advice_jobs,
     })
+}
+
+/// Decode the program's source instructions and key them by address.
+///
+/// Programs assembled directly from rows (the test/bench harness) carry no
+/// ELF; they get an empty map, and any group that actually needs advice then
+/// fails at emission (see the `VirtualAdvice` arm) rather than here.
+fn source_rows(
+    program: &JoltProgram,
+) -> Result<
+    BTreeMap<u64, jolt_riscv::SourceInstruction<jolt_riscv::SourceInstructionRow>>,
+    TraceError,
+> {
+    if program.elf_bytes().is_empty() {
+        return Ok(BTreeMap::new());
+    }
+    let image = jolt_program::image::decode_elf(program.elf_bytes(), program.profile)
+        .map_err(|_| TraceError::Backend("failed to decode program ELF for source recovery"))?;
+    Ok(image
+        .instructions
+        .into_iter()
+        .map(|instruction| (instruction.row().address as u64, instruction))
+        .collect())
+}
+
+/// The advice computation a source instruction's group needs, if any.
+fn advice_job(
+    source: &jolt_riscv::SourceInstruction<jolt_riscv::SourceInstructionRow>,
+) -> Result<Option<AdviceJob>, TraceError> {
+    use SourceInstructionKind as S;
+    let row = source.row();
+    let (rs1, rs2) = (row.operands.rs1, row.operands.rs2);
+    // Codes mirror the tracer's per-variant advice formulas (helpers.rs).
+    let code = match source.kind() {
+        S::Div(_) | S::Rem(_) => 0u8,
+        S::DivW(_) | S::RemW(_) => 1,
+        S::DivU(_) | S::RemU(_) => 2,
+        S::DivUW(_) | S::RemUW(_) => 3,
+        S::InlineDispatch(_) => {
+            let inline = row
+                .inline
+                .ok_or(TraceError::Backend("inline source row without inline key"))?;
+            let registration = tracer::instruction::inline::find_inline_registration(
+                u32::from(inline.opcode),
+                u32::from(inline.funct3),
+                u32::from(inline.funct7),
+            )
+            .ok_or(TraceError::Backend("no registered inline for source row"))?;
+            let operands =
+                tracer::instruction::format::format_inline::FormatInline::from(row.operands);
+            return Ok(Some(AdviceJob::Inline {
+                registration,
+                operands,
+            }));
+        }
+        _ => return Ok(None),
+    };
+    let (Some(rs1), Some(rs2)) = (rs1, rs2) else {
+        return Err(TraceError::Backend(
+            "div-family source row missing operands",
+        ));
+    };
+    Ok(Some(AdviceJob::Div { code, rs1, rs2 }))
 }

--- a/crates/jolt-tracer-x86/src/native/compile/mod.rs
+++ b/crates/jolt-tracer-x86/src/native/compile/mod.rs
@@ -9,6 +9,7 @@
 //! by the differential tests.
 
 mod emit;
+pub mod emitter;
 
 use std::collections::BTreeMap;
 
@@ -17,6 +18,7 @@ use jolt_program::execution::{JoltProgram, TraceError};
 use jolt_riscv::SourceInstructionKind;
 
 use super::state::{AdviceJob, GuestState};
+use emitter::EmitterSet;
 
 /// A compiled program: executable buffer plus the indirect-dispatch table.
 pub struct CompiledProgram {
@@ -50,7 +52,9 @@ impl CompiledProgram {
     }
 }
 
-pub(super) struct Emitter {
+/// Emission context handed to a [`RowEmitter`](emitter::RowEmitter): the
+/// assembler plus the per-group state a row template may need.
+pub struct Emitter {
     pub ops: Assembler,
     /// Advice jobs collected so far (index = the job id in generated code).
     pub advice_jobs: Vec<AdviceJob>,
@@ -78,7 +82,17 @@ impl Emitter {
     }
 }
 
+/// Compile with the production emitter set (dynasm templates).
 pub fn compile(program: &JoltProgram) -> Result<CompiledProgram, TraceError> {
+    compile_with(program, &EmitterSet::dynasm())
+}
+
+/// Compile with an explicit emitter set — the A/B entry point for
+/// alternative row emitters (see `compile/emitter.rs`).
+pub fn compile_with(
+    program: &JoltProgram,
+    emitters: &EmitterSet,
+) -> Result<CompiledProgram, TraceError> {
     // VirtualSRL uses `tzcnt`; on pre-BMI1 CPUs it silently decodes as `bsf`
     // with different zero-input semantics, so refuse rather than mis-execute.
     if !std::arch::is_x86_feature_detected!("bmi1") {
@@ -130,12 +144,12 @@ pub fn compile(program: &JoltProgram) -> Result<CompiledProgram, TraceError> {
                 if let Some(job) = advice_job(source)? {
                     emitter.advice_jobs.push(job);
                     let index = emitter.advice_jobs.len() - 1;
-                    emit::advice_compute(&mut emitter, index);
+                    emitters.emit_advice_compute(&mut emitter, index)?;
                     emitter.advice_ready = true;
                 }
             }
         }
-        emit::row(&mut emitter, row)?;
+        emitters.emit_row(&mut emitter, row)?;
     }
 
     // Execution falling off the end of the program is a bad jump.

--- a/crates/jolt-tracer-x86/src/native/compile/mod.rs
+++ b/crates/jolt-tracer-x86/src/native/compile/mod.rs
@@ -19,16 +19,29 @@ use jolt_riscv::SourceInstructionKind;
 
 use super::state::{AdviceJob, GuestState};
 use emitter::EmitterSet;
+use jolt_riscv::JoltInstructionRow;
 
-/// A compiled program: executable buffer plus the indirect-dispatch table.
-pub struct CompiledProgram {
+/// One compiled code body (fast or record) with its dispatch table.
+struct CompiledBody {
     buffer: dynasmrt::ExecutableBuffer,
     entry: AssemblyOffset,
     /// One host code address per halfword in `[text_base, text_end)`;
     /// non-group-start slots point at the bad-jump stub.
     jump_table: Vec<usize>,
+}
+
+/// A compiled program: the two code bodies the spec calls for (fast and
+/// record, emitted from the same templates) plus the shared advice-job table.
+///
+/// The bodies are separate assemblies rather than two entry points in one:
+/// branch targets are dynamic labels per guest address, and a branch in the
+/// record body must land on the record body's copy of its target.
+pub struct CompiledProgram {
+    fast: CompiledBody,
+    record: CompiledBody,
     /// Advice computations, one per group that needs them; generated code
-    /// passes indices into this table.
+    /// passes indices into this table. Identical for both bodies (same rows,
+    /// same order), so it is collected once.
     advice_jobs: Vec<AdviceJob>,
 }
 
@@ -36,25 +49,48 @@ impl CompiledProgram {
     pub fn advice_jobs_ptr(&self) -> *const AdviceJob {
         self.advice_jobs.as_ptr()
     }
-}
 
-impl CompiledProgram {
+    /// Run the fast body: execution only, no row materialization.
     pub fn run(&self, state: &mut GuestState) -> Result<(), TraceError> {
-        let entry = self.buffer.ptr(self.entry);
+        Self::run_body(&self.fast, state)
+    }
+
+    /// Run the record body, filling the observation buffer described by
+    /// `GuestState::obs_cursor`/`obs_end`.
+    pub fn run_record(&self, state: &mut GuestState) -> Result<(), TraceError> {
+        Self::run_body(&self.record, state)
+    }
+
+    fn run_body(body: &CompiledBody, state: &mut GuestState) -> Result<(), TraceError> {
+        let entry = body.buffer.ptr(body.entry);
         // SAFETY: `entry` points into the finalized (read+execute) buffer at
         // the prologue emitted by `compile`; the generated code only touches
-        // the GuestState plane, the RAM plane it carries, and the jump
-        // table, per the emitter's invariants.
+        // the GuestState plane, the RAM plane it carries, the observation
+        // buffer, and the jump table, per the emitter's invariants.
         let f: extern "sysv64" fn(*mut GuestState, *const usize) =
             unsafe { core::mem::transmute(entry) };
-        f(state, self.jump_table.as_ptr());
+        f(state, body.jump_table.as_ptr());
         Ok(())
     }
+}
+
+/// Which code body is being emitted.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EmitMode {
+    /// No row materialization: execute only, for the fast pass.
+    Fast,
+    /// Additionally capture each row's dynamic values (see `Observation`).
+    Record,
 }
 
 /// Emission context handed to a [`RowEmitter`](emitter::RowEmitter): the
 /// assembler plus the per-group state a row template may need.
 pub struct Emitter {
+    /// Which body this emission belongs to.
+    pub mode: EmitMode,
+    /// Index of the row being emitted into `expanded_bytecode`; recorded in
+    /// each observation so the reassembly pass can recover the static half.
+    pub row_index: usize,
     pub ops: Assembler,
     /// Advice jobs collected so far (index = the job id in generated code).
     pub advice_jobs: Vec<AdviceJob>,
@@ -105,15 +141,36 @@ pub fn compile_with(
         return Err(TraceError::Backend("program has no expanded bytecode"));
     }
 
-    let text_base = rows.iter().map(|r| r.address as u64).min().unwrap_or(0);
-    let text_end = rows.iter().map(|r| r.address as u64).max().unwrap_or(0) + 4;
-    let text_span = text_end - text_base;
-
     // Source rows keyed by address: the expanded bytecode erases the source
     // kind and inline key, which the per-group advice computations need.
     let sources = source_rows(program)?;
 
+    let (fast, advice_jobs) = compile_body(rows, &sources, emitters, EmitMode::Fast)?;
+    let (record, _) = compile_body(rows, &sources, emitters, EmitMode::Record)?;
+
+    Ok(CompiledProgram {
+        fast,
+        record,
+        advice_jobs,
+    })
+}
+
+type SourceMap = BTreeMap<u64, jolt_riscv::SourceInstruction<jolt_riscv::SourceInstructionRow>>;
+
+/// Emit one code body over every expanded row.
+fn compile_body(
+    rows: &[JoltInstructionRow],
+    sources: &SourceMap,
+    emitters: &EmitterSet,
+    mode: EmitMode,
+) -> Result<(CompiledBody, Vec<AdviceJob>), TraceError> {
+    let text_base = rows.iter().map(|r| r.address as u64).min().unwrap_or(0);
+    let text_end = rows.iter().map(|r| r.address as u64).max().unwrap_or(0) + 4;
+    let text_span = text_end - text_base;
+
     let mut emitter = Emitter {
+        mode,
+        row_index: 0,
         ops: Assembler::new().map_err(|_| TraceError::Backend("failed to create x64 assembler"))?,
         advice_jobs: Vec::new(),
         advice_slot: 0,
@@ -127,7 +184,8 @@ pub fn compile_with(
     let entry = emit::prologue(&mut emitter);
 
     let mut previous_address = None;
-    for row in rows {
+    for (row_index, row) in rows.iter().enumerate() {
+        emitter.row_index = row_index;
         let address = row.address as u64;
         if previous_address != Some(address) {
             // Group start: define the branch-target label, record the jump
@@ -173,12 +231,14 @@ pub fn compile_with(
         jump_table[slot] = buffer.ptr(offset) as usize;
     }
 
-    Ok(CompiledProgram {
-        buffer,
-        entry,
-        jump_table,
+    Ok((
+        CompiledBody {
+            buffer,
+            entry,
+            jump_table,
+        },
         advice_jobs,
-    })
+    ))
 }
 
 /// Decode the program's source instructions and key them by address.

--- a/crates/jolt-tracer-x86/src/native/compile/mod.rs
+++ b/crates/jolt-tracer-x86/src/native/compile/mod.rs
@@ -202,6 +202,7 @@ fn compile_body(
             let offset = emitter.ops.offset();
             emitter.ops.dynamic_label(label);
             emitter.group_offsets.push((address, offset));
+            emit::group_pause_check(&mut emitter, address);
             previous_address = Some(address);
             emitter.advice_slot = 0;
             emitter.advice_ready = false;

--- a/crates/jolt-tracer-x86/src/native/compile/mod.rs
+++ b/crates/jolt-tracer-x86/src/native/compile/mod.rs
@@ -39,6 +39,9 @@ struct CompiledBody {
 pub struct CompiledProgram {
     fast: CompiledBody,
     record: CompiledBody,
+    /// Same two bodies, with the chunk-boundary pause check emitted.
+    fast_pausable: CompiledBody,
+    record_pausable: CompiledBody,
     /// Advice computations, one per group that needs them; generated code
     /// passes indices into this table. Identical for both bodies (same rows,
     /// same order), so it is collected once.
@@ -68,6 +71,17 @@ impl CompiledProgram {
         Self::run_body(&self.record, state)
     }
 
+    /// Run the pausable execute body: stops at the first group boundary at or
+    /// past `GuestState::row_limit`, publishing the resume PC.
+    pub fn run_pausable(&self, state: &mut GuestState) -> Result<(), TraceError> {
+        Self::run_body(&self.fast_pausable, state)
+    }
+
+    /// Run the pausable record body, for chunk replay.
+    pub fn run_record_pausable(&self, state: &mut GuestState) -> Result<(), TraceError> {
+        Self::run_body(&self.record_pausable, state)
+    }
+
     fn run_body(body: &CompiledBody, state: &mut GuestState) -> Result<(), TraceError> {
         let entry = body.buffer.ptr(body.entry);
         // SAFETY: `entry` points into the finalized (read+execute) buffer at
@@ -95,6 +109,9 @@ pub enum EmitMode {
 pub struct Emitter {
     /// Which body this emission belongs to.
     pub mode: EmitMode,
+    /// Whether this body can pause at group boundaries. Only the chunked
+    /// paths need that; the eager paths must not pay a per-group check.
+    pub pausable: bool,
     /// Index of the row being emitted into `expanded_bytecode`; recorded in
     /// each observation so the reassembly pass can recover the static half.
     pub row_index: usize,
@@ -152,12 +169,19 @@ pub fn compile_with(
     // kind and inline key, which the per-group advice computations need.
     let sources = source_rows(program)?;
 
-    let (fast, advice_jobs) = compile_body(rows, &sources, emitters, EmitMode::Fast)?;
-    let (record, _) = compile_body(rows, &sources, emitters, EmitMode::Record)?;
+    // Four bodies: {execute, record} x {eager, pausable}. Compilation is
+    // ~10ms per body, so keeping the eager paths free of the chunk-boundary
+    // check is worth the duplication.
+    let (fast, advice_jobs) = compile_body(rows, &sources, emitters, EmitMode::Fast, false)?;
+    let (record, _) = compile_body(rows, &sources, emitters, EmitMode::Record, false)?;
+    let (fast_pausable, _) = compile_body(rows, &sources, emitters, EmitMode::Fast, true)?;
+    let (record_pausable, _) = compile_body(rows, &sources, emitters, EmitMode::Record, true)?;
 
     Ok(CompiledProgram {
         fast,
         record,
+        fast_pausable,
+        record_pausable,
         advice_jobs,
     })
 }
@@ -170,6 +194,7 @@ fn compile_body(
     sources: &SourceMap,
     emitters: &EmitterSet,
     mode: EmitMode,
+    pausable: bool,
 ) -> Result<(CompiledBody, Vec<AdviceJob>), TraceError> {
     let text_base = rows.iter().map(|r| r.address as u64).min().unwrap_or(0);
     let text_end = rows.iter().map(|r| r.address as u64).max().unwrap_or(0) + 4;
@@ -177,6 +202,7 @@ fn compile_body(
 
     let mut emitter = Emitter {
         mode,
+        pausable,
         row_index: 0,
         ops: Assembler::new().map_err(|_| TraceError::Backend("failed to create x64 assembler"))?,
         advice_jobs: Vec::new(),
@@ -202,7 +228,9 @@ fn compile_body(
             let offset = emitter.ops.offset();
             emitter.ops.dynamic_label(label);
             emitter.group_offsets.push((address, offset));
-            emit::group_pause_check(&mut emitter, address);
+            if emitter.pausable {
+                emit::group_pause_check(&mut emitter, address);
+            }
             previous_address = Some(address);
             emitter.advice_slot = 0;
             emitter.advice_ready = false;

--- a/crates/jolt-tracer-x86/src/native/compile/mod.rs
+++ b/crates/jolt-tracer-x86/src/native/compile/mod.rs
@@ -49,6 +49,50 @@ pub struct CompiledProgram {
 }
 
 impl CompiledProgram {
+    /// Compile with the production emitter set (dynasm templates).
+    pub fn compile(program: &JoltProgram) -> Result<Self, TraceError> {
+        Self::compile_with(program, &EmitterSet::dynasm())
+    }
+
+    /// Compile with an explicit emitter set — the A/B entry point for
+    /// alternative row emitters (see `compile/emitter.rs`).
+    pub fn compile_with(program: &JoltProgram, emitters: &EmitterSet) -> Result<Self, TraceError> {
+        // VirtualSRL uses `tzcnt`; on pre-BMI1 CPUs it silently decodes as `bsf`
+        // with different zero-input semantics, so refuse rather than mis-execute.
+        if !std::arch::is_x86_feature_detected!("bmi1") {
+            return Err(TraceError::Backend(
+                "jolt-tracer-x86 requires BMI1 (tzcnt) support",
+            ));
+        }
+        let rows = &program.expanded_bytecode;
+        if rows.is_empty() {
+            return Err(TraceError::Backend("program has no expanded bytecode"));
+        }
+
+        // Source rows keyed by address: the expanded bytecode erases the source
+        // kind and inline key, which the per-group advice computations need.
+        let sources = Self::source_rows(program)?;
+
+        // Four bodies: {execute, record} x {eager, pausable}. Compilation is
+        // ~10ms per body, so keeping the eager paths free of the chunk-boundary
+        // check is worth the duplication.
+        let (fast, advice_jobs) =
+            CompiledBody::compile(rows, &sources, emitters, EmitMode::Fast, false)?;
+        let (record, _) = CompiledBody::compile(rows, &sources, emitters, EmitMode::Record, false)?;
+        let (fast_pausable, _) =
+            CompiledBody::compile(rows, &sources, emitters, EmitMode::Fast, true)?;
+        let (record_pausable, _) =
+            CompiledBody::compile(rows, &sources, emitters, EmitMode::Record, true)?;
+
+        Ok(Self {
+            fast,
+            record,
+            fast_pausable,
+            record_pausable,
+            advice_jobs,
+        })
+    }
+
     pub fn advice_jobs_ptr(&self) -> *const AdviceJob {
         self.advice_jobs.as_ptr()
     }
@@ -57,41 +101,47 @@ impl CompiledProgram {
     /// tests can assert the finalized mapping's permissions (AC11): code is
     /// never writable and executable at the same time.
     pub fn code_address(&self) -> usize {
-        self.fast.buffer.ptr(self.fast.entry) as usize
+        self.fast.code_address()
     }
 
     /// Run the fast body: execution only, no row materialization.
     pub fn run(&self, state: &mut GuestState) -> Result<(), TraceError> {
-        Self::run_body(&self.fast, state)
+        self.fast.run(state)
     }
 
     /// Run the record body, filling the observation buffer described by
     /// `GuestState::obs_cursor`/`obs_end`.
     pub fn run_record(&self, state: &mut GuestState) -> Result<(), TraceError> {
-        Self::run_body(&self.record, state)
+        self.record.run(state)
     }
 
     /// Run the pausable execute body: stops at the first group boundary at or
     /// past `GuestState::row_limit`, publishing the resume PC.
     pub fn run_pausable(&self, state: &mut GuestState) -> Result<(), TraceError> {
-        Self::run_body(&self.fast_pausable, state)
+        self.fast_pausable.run(state)
     }
 
     /// Run the pausable record body, for chunk replay.
     pub fn run_record_pausable(&self, state: &mut GuestState) -> Result<(), TraceError> {
-        Self::run_body(&self.record_pausable, state)
+        self.record_pausable.run(state)
     }
 
-    fn run_body(body: &CompiledBody, state: &mut GuestState) -> Result<(), TraceError> {
-        let entry = body.buffer.ptr(body.entry);
-        // SAFETY: `entry` points into the finalized (read+execute) buffer at
-        // the prologue emitted by `compile`; the generated code only touches
-        // the GuestState plane, the RAM plane it carries, the observation
-        // buffer, and the jump table, per the emitter's invariants.
-        let f: extern "sysv64" fn(*mut GuestState, *const usize) =
-            unsafe { core::mem::transmute(entry) };
-        f(state, body.jump_table.as_ptr());
-        Ok(())
+    /// Decode the program's source instructions and key them by address.
+    ///
+    /// Programs assembled directly from rows (the test/bench harness) carry no
+    /// ELF; they get an empty map, and any group that actually needs advice then
+    /// fails at emission rather than here.
+    fn source_rows(program: &JoltProgram) -> Result<SourceMap, TraceError> {
+        if program.elf_bytes().is_empty() {
+            return Ok(BTreeMap::new());
+        }
+        let image = jolt_program::image::decode_elf(program.elf_bytes(), program.profile)
+            .map_err(|_| TraceError::Backend("failed to decode program ELF for source recovery"))?;
+        Ok(image
+            .instructions
+            .into_iter()
+            .map(|instruction| (instruction.row().address as u64, instruction))
+            .collect())
     }
 }
 
@@ -142,200 +192,154 @@ impl Emitter {
     }
 }
 
-/// Compile with the production emitter set (dynasm templates).
-pub fn compile(program: &JoltProgram) -> Result<CompiledProgram, TraceError> {
-    compile_with(program, &EmitterSet::dynasm())
-}
-
-/// Compile with an explicit emitter set — the A/B entry point for
-/// alternative row emitters (see `compile/emitter.rs`).
-pub fn compile_with(
-    program: &JoltProgram,
-    emitters: &EmitterSet,
-) -> Result<CompiledProgram, TraceError> {
-    // VirtualSRL uses `tzcnt`; on pre-BMI1 CPUs it silently decodes as `bsf`
-    // with different zero-input semantics, so refuse rather than mis-execute.
-    if !std::arch::is_x86_feature_detected!("bmi1") {
-        return Err(TraceError::Backend(
-            "jolt-tracer-x86 requires BMI1 (tzcnt) support",
-        ));
-    }
-    let rows = &program.expanded_bytecode;
-    if rows.is_empty() {
-        return Err(TraceError::Backend("program has no expanded bytecode"));
-    }
-
-    // Source rows keyed by address: the expanded bytecode erases the source
-    // kind and inline key, which the per-group advice computations need.
-    let sources = source_rows(program)?;
-
-    // Four bodies: {execute, record} x {eager, pausable}. Compilation is
-    // ~10ms per body, so keeping the eager paths free of the chunk-boundary
-    // check is worth the duplication.
-    let (fast, advice_jobs) = compile_body(rows, &sources, emitters, EmitMode::Fast, false)?;
-    let (record, _) = compile_body(rows, &sources, emitters, EmitMode::Record, false)?;
-    let (fast_pausable, _) = compile_body(rows, &sources, emitters, EmitMode::Fast, true)?;
-    let (record_pausable, _) = compile_body(rows, &sources, emitters, EmitMode::Record, true)?;
-
-    Ok(CompiledProgram {
-        fast,
-        record,
-        fast_pausable,
-        record_pausable,
-        advice_jobs,
-    })
-}
-
 type SourceMap = BTreeMap<u64, jolt_riscv::SourceInstruction<jolt_riscv::SourceInstructionRow>>;
 
-/// Emit one code body over every expanded row.
-fn compile_body(
-    rows: &[JoltInstructionRow],
-    sources: &SourceMap,
-    emitters: &EmitterSet,
-    mode: EmitMode,
-    pausable: bool,
-) -> Result<(CompiledBody, Vec<AdviceJob>), TraceError> {
-    let text_base = rows.iter().map(|r| r.address as u64).min().unwrap_or(0);
-    let text_end = rows.iter().map(|r| r.address as u64).max().unwrap_or(0) + 4;
-    let text_span = text_end - text_base;
+impl CompiledBody {
+    fn code_address(&self) -> usize {
+        self.buffer.ptr(self.entry) as usize
+    }
 
-    let mut emitter = Emitter {
-        mode,
-        pausable,
-        row_index: 0,
-        ops: Assembler::new().map_err(|_| TraceError::Backend("failed to create x64 assembler"))?,
-        advice_jobs: Vec::new(),
-        advice_slot: 0,
-        advice_ready: false,
-        labels: BTreeMap::new(),
-        group_offsets: Vec::new(),
-        text_base,
-        text_span,
-    };
+    fn run(&self, state: &mut GuestState) -> Result<(), TraceError> {
+        let entry = self.buffer.ptr(self.entry);
+        // SAFETY: `entry` points into the finalized (read+execute) buffer at
+        // the prologue emitted by `compile`; the generated code only touches
+        // the GuestState plane, the RAM plane it carries, the observation
+        // buffer, and the jump table, per the emitter's invariants.
+        let f: extern "sysv64" fn(*mut GuestState, *const usize) =
+            unsafe { core::mem::transmute(entry) };
+        f(state, self.jump_table.as_ptr());
+        Ok(())
+    }
 
-    let entry = emit::prologue(&mut emitter);
+    /// Emit one code body over every expanded row.
+    fn compile(
+        rows: &[JoltInstructionRow],
+        sources: &SourceMap,
+        emitters: &EmitterSet,
+        mode: EmitMode,
+        pausable: bool,
+    ) -> Result<(Self, Vec<AdviceJob>), TraceError> {
+        let text_base = rows.iter().map(|r| r.address as u64).min().unwrap_or(0);
+        let text_end = rows.iter().map(|r| r.address as u64).max().unwrap_or(0) + 4;
+        let text_span = text_end - text_base;
 
-    let mut previous_address = None;
-    for (row_index, row) in rows.iter().enumerate() {
-        emitter.row_index = row_index;
-        let address = row.address as u64;
-        if previous_address != Some(address) {
-            // Group start: define the branch-target label, record the jump
-            // table offset, and emit this group's advice computation (which
-            // must observe the pre-group register state) before its rows.
-            let label = emitter.label_for(address);
-            let offset = emitter.ops.offset();
-            emitter.ops.dynamic_label(label);
-            emitter.group_offsets.push((address, offset));
-            if emitter.pausable {
-                emit::group_pause_check(&mut emitter, address);
-            }
-            previous_address = Some(address);
-            emitter.advice_slot = 0;
-            emitter.advice_ready = false;
-            if let Some(source) = sources.get(&address) {
-                if let Some(job) = advice_job(source)? {
-                    emitter.advice_jobs.push(job);
-                    let index = emitter.advice_jobs.len() - 1;
-                    emitters.emit_advice_compute(&mut emitter, index)?;
-                    emitter.advice_ready = true;
+        let mut emitter = Emitter {
+            mode,
+            pausable,
+            row_index: 0,
+            ops: Assembler::new()
+                .map_err(|_| TraceError::Backend("failed to create x64 assembler"))?,
+            advice_jobs: Vec::new(),
+            advice_slot: 0,
+            advice_ready: false,
+            labels: BTreeMap::new(),
+            group_offsets: Vec::new(),
+            text_base,
+            text_span,
+        };
+
+        let entry = emitter.emit_prologue();
+
+        let mut previous_address = None;
+        for (row_index, row) in rows.iter().enumerate() {
+            emitter.row_index = row_index;
+            let address = row.address as u64;
+            if previous_address != Some(address) {
+                // Group start: define the branch-target label, record the jump
+                // table offset, and emit this group's advice computation (which
+                // must observe the pre-group register state) before its rows.
+                let label = emitter.label_for(address);
+                let offset = emitter.ops.offset();
+                emitter.ops.dynamic_label(label);
+                emitter.group_offsets.push((address, offset));
+                if emitter.pausable {
+                    emitter.emit_group_pause_check(address);
+                }
+                previous_address = Some(address);
+                emitter.advice_slot = 0;
+                emitter.advice_ready = false;
+                if let Some(source) = sources.get(&address) {
+                    if let Some(job) = AdviceJob::from_source(source)? {
+                        emitter.advice_jobs.push(job);
+                        let index = emitter.advice_jobs.len() - 1;
+                        emitters.emit_advice_compute(&mut emitter, index)?;
+                        emitter.advice_ready = true;
+                    }
                 }
             }
+            emitters.emit_row(&mut emitter, row)?;
         }
-        emitters.emit_row(&mut emitter, row)?;
+
+        // Execution falling off the end of the program is a bad jump.
+        emitter.emit_jump_to_bad_jump();
+        let stubs = emitter.emit_stubs();
+
+        let group_offsets = core::mem::take(&mut emitter.group_offsets);
+        let advice_jobs = core::mem::take(&mut emitter.advice_jobs);
+        let buffer = emitter
+            .ops
+            .finalize()
+            .map_err(|_| TraceError::Backend("x64 assembly finalize failed"))?;
+
+        // Build the halfword-granular dispatch table with the bad-jump stub as
+        // filler.
+        let bad_jump = buffer.ptr(stubs.bad_jump) as usize;
+        let slots = (text_span / 2) as usize;
+        let mut jump_table = vec![bad_jump; slots];
+        for (address, offset) in group_offsets {
+            let slot = ((address - text_base) / 2) as usize;
+            jump_table[slot] = buffer.ptr(offset) as usize;
+        }
+
+        Ok((
+            Self {
+                buffer,
+                entry,
+                jump_table,
+            },
+            advice_jobs,
+        ))
     }
-
-    // Execution falling off the end of the program is a bad jump.
-    emit::jump_to_bad_jump(&mut emitter);
-    let stubs = emit::stubs(&mut emitter);
-
-    let group_offsets = core::mem::take(&mut emitter.group_offsets);
-    let advice_jobs = core::mem::take(&mut emitter.advice_jobs);
-    let buffer = emitter
-        .ops
-        .finalize()
-        .map_err(|_| TraceError::Backend("x64 assembly finalize failed"))?;
-
-    // Build the halfword-granular dispatch table with the bad-jump stub as
-    // filler.
-    let bad_jump = buffer.ptr(stubs.bad_jump) as usize;
-    let slots = (text_span / 2) as usize;
-    let mut jump_table = vec![bad_jump; slots];
-    for (address, offset) in group_offsets {
-        let slot = ((address - text_base) / 2) as usize;
-        jump_table[slot] = buffer.ptr(offset) as usize;
-    }
-
-    Ok((
-        CompiledBody {
-            buffer,
-            entry,
-            jump_table,
-        },
-        advice_jobs,
-    ))
 }
 
-/// Decode the program's source instructions and key them by address.
-///
-/// Programs assembled directly from rows (the test/bench harness) carry no
-/// ELF; they get an empty map, and any group that actually needs advice then
-/// fails at emission (see the `VirtualAdvice` arm) rather than here.
-fn source_rows(
-    program: &JoltProgram,
-) -> Result<
-    BTreeMap<u64, jolt_riscv::SourceInstruction<jolt_riscv::SourceInstructionRow>>,
-    TraceError,
-> {
-    if program.elf_bytes().is_empty() {
-        return Ok(BTreeMap::new());
+impl AdviceJob {
+    /// The advice computation a source instruction's group needs, if any.
+    fn from_source(
+        source: &jolt_riscv::SourceInstruction<jolt_riscv::SourceInstructionRow>,
+    ) -> Result<Option<Self>, TraceError> {
+        use SourceInstructionKind as S;
+        let row = source.row();
+        let (rs1, rs2) = (row.operands.rs1, row.operands.rs2);
+        // Codes mirror the tracer's per-variant advice formulas (helpers.rs).
+        let code = match source.kind() {
+            S::Div(_) | S::Rem(_) => 0u8,
+            S::DivW(_) | S::RemW(_) => 1,
+            S::DivU(_) | S::RemU(_) => 2,
+            S::DivUW(_) | S::RemUW(_) => 3,
+            S::InlineDispatch(_) => {
+                let inline = row
+                    .inline
+                    .ok_or(TraceError::Backend("inline source row without inline key"))?;
+                let registration = tracer::instruction::inline::find_inline_registration(
+                    u32::from(inline.opcode),
+                    u32::from(inline.funct3),
+                    u32::from(inline.funct7),
+                )
+                .ok_or(TraceError::Backend("no registered inline for source row"))?;
+                let operands =
+                    tracer::instruction::format::format_inline::FormatInline::from(row.operands);
+                return Ok(Some(Self::Inline {
+                    registration,
+                    operands,
+                }));
+            }
+            _ => return Ok(None),
+        };
+        let (Some(rs1), Some(rs2)) = (rs1, rs2) else {
+            return Err(TraceError::Backend(
+                "div-family source row missing operands",
+            ));
+        };
+        Ok(Some(Self::Div { code, rs1, rs2 }))
     }
-    let image = jolt_program::image::decode_elf(program.elf_bytes(), program.profile)
-        .map_err(|_| TraceError::Backend("failed to decode program ELF for source recovery"))?;
-    Ok(image
-        .instructions
-        .into_iter()
-        .map(|instruction| (instruction.row().address as u64, instruction))
-        .collect())
-}
-
-/// The advice computation a source instruction's group needs, if any.
-fn advice_job(
-    source: &jolt_riscv::SourceInstruction<jolt_riscv::SourceInstructionRow>,
-) -> Result<Option<AdviceJob>, TraceError> {
-    use SourceInstructionKind as S;
-    let row = source.row();
-    let (rs1, rs2) = (row.operands.rs1, row.operands.rs2);
-    // Codes mirror the tracer's per-variant advice formulas (helpers.rs).
-    let code = match source.kind() {
-        S::Div(_) | S::Rem(_) => 0u8,
-        S::DivW(_) | S::RemW(_) => 1,
-        S::DivU(_) | S::RemU(_) => 2,
-        S::DivUW(_) | S::RemUW(_) => 3,
-        S::InlineDispatch(_) => {
-            let inline = row
-                .inline
-                .ok_or(TraceError::Backend("inline source row without inline key"))?;
-            let registration = tracer::instruction::inline::find_inline_registration(
-                u32::from(inline.opcode),
-                u32::from(inline.funct3),
-                u32::from(inline.funct7),
-            )
-            .ok_or(TraceError::Backend("no registered inline for source row"))?;
-            let operands =
-                tracer::instruction::format::format_inline::FormatInline::from(row.operands);
-            return Ok(Some(AdviceJob::Inline {
-                registration,
-                operands,
-            }));
-        }
-        _ => return Ok(None),
-    };
-    let (Some(rs1), Some(rs2)) = (rs1, rs2) else {
-        return Err(TraceError::Backend(
-            "div-family source row missing operands",
-        ));
-    };
-    Ok(Some(AdviceJob::Div { code, rs1, rs2 }))
 }

--- a/crates/jolt-tracer-x86/src/native/harness.rs
+++ b/crates/jolt-tracer-x86/src/native/harness.rs
@@ -8,6 +8,12 @@ use jolt_program::execution::{JoltProgram, TraceError};
 use jolt_riscv::{JoltInstructionKind, JoltInstructionRow, NormalizedOperands};
 
 use super::compile;
+
+/// The row-emission seam, re-exported so emitter A/B experiments (benches,
+/// integration tests, the Alternative 11 stencil spike) can build their own
+/// `EmitterSet` and compile with it.
+pub use super::compile::emitter::{EmitOutcome, EmitterSet, RowEmitter};
+pub use super::compile::{compile_with, CompiledProgram};
 use super::memory::MemoryPlane;
 use super::state::{ExitReason, GuestState, HostContext};
 

--- a/crates/jolt-tracer-x86/src/native/harness.rs
+++ b/crates/jolt-tracer-x86/src/native/harness.rs
@@ -7,13 +7,11 @@ use common::jolt_device::{JoltDevice, MemoryConfig};
 use jolt_program::execution::{JoltProgram, TraceError};
 use jolt_riscv::{JoltInstructionKind, JoltInstructionRow, NormalizedOperands};
 
-use super::compile;
-
 /// The row-emission seam, re-exported so emitter A/B experiments (benches,
 /// integration tests, the Alternative 11 stencil spike) can build their own
 /// `EmitterSet` and compile with it.
 pub use super::compile::emitter::{EmitOutcome, EmitterSet, RowEmitter};
-pub use super::compile::{compile_with, CompiledProgram};
+pub use super::compile::CompiledProgram;
 use super::memory::MemoryPlane;
 use super::state::{ExitReason, GuestState, HostContext};
 
@@ -94,19 +92,19 @@ pub fn straight_line_program(mut row: JoltInstructionRow, count: usize) -> JoltP
 
 /// Compile without running (fail-fast coverage checks).
 pub fn compile_only(program: &JoltProgram) -> Result<(), TraceError> {
-    compile::compile(program).map(|_| ())
+    CompiledProgram::compile(program).map(|_| ())
 }
 
 /// Compile and hand back the artifact, so callers that inspect the live code
 /// mapping (the safety tests) keep it alive while they look.
 pub fn compile_program(program: &JoltProgram) -> Result<CompiledProgram, TraceError> {
-    compile::compile(program)
+    CompiledProgram::compile(program)
 }
 
 /// A compiled synthetic program plus its memory plane, reusable across runs
 /// (for microbenchmarks: compilation stays outside the measured region).
 pub struct Prepared {
-    compiled: compile::CompiledProgram,
+    compiled: CompiledProgram,
     plane: MemoryPlane,
     entry: u64,
     pre_regs: [u64; REGISTER_COUNT as usize],
@@ -118,7 +116,7 @@ impl Prepared {
         pre_regs: [u64; REGISTER_COUNT as usize],
     ) -> Result<Self, TraceError> {
         Ok(Self {
-            compiled: compile::compile(program)?,
+            compiled: CompiledProgram::compile(program)?,
             plane: MemoryPlane::new(MEM_CAPACITY as usize)?,
             entry: program.entry_address,
             pre_regs,
@@ -181,7 +179,7 @@ pub fn run_program(
     scratch: &[u64],
     advice: &[u8],
 ) -> Result<Outcome, TraceError> {
-    let compiled = compile::compile(program)?;
+    let compiled = CompiledProgram::compile(program)?;
 
     let plane = MemoryPlane::new(MEM_CAPACITY as usize)?;
     let base = plane.base();

--- a/crates/jolt-tracer-x86/src/native/harness.rs
+++ b/crates/jolt-tracer-x86/src/native/harness.rs
@@ -130,6 +130,8 @@ impl Prepared {
             mem_base: self.plane.base() as u64,
             mem_size: self.plane.size() as u64,
             host: &raw mut host,
+            advice_slots: [0; crate::native::state::ADVICE_SLOTS],
+            advice_jobs: self.compiled.advice_jobs_ptr(),
         });
         guest.x[0] = 0;
         self.compiled.run(&mut guest)?;
@@ -191,6 +193,8 @@ pub fn run_program(
         mem_base: plane.base() as u64,
         mem_size: plane.size() as u64,
         host: &raw mut host,
+        advice_slots: [0; crate::native::state::ADVICE_SLOTS],
+        advice_jobs: compiled.advice_jobs_ptr(),
     });
     guest.x[0] = 0;
 

--- a/crates/jolt-tracer-x86/src/native/harness.rs
+++ b/crates/jolt-tracer-x86/src/native/harness.rs
@@ -144,6 +144,7 @@ impl Prepared {
             host: &raw mut host,
             advice_slots: [0; crate::native::state::ADVICE_SLOTS],
             advice_jobs: self.compiled.advice_jobs_ptr(),
+            row_limit: u64::MAX,
             obs_cursor: core::ptr::null_mut(),
             obs_end: core::ptr::null_mut(),
         });
@@ -211,6 +212,7 @@ pub fn run_program(
         host: &raw mut host,
         advice_slots: [0; crate::native::state::ADVICE_SLOTS],
         advice_jobs: compiled.advice_jobs_ptr(),
+        row_limit: u64::MAX,
         obs_cursor: core::ptr::null_mut(),
         obs_end: core::ptr::null_mut(),
     });

--- a/crates/jolt-tracer-x86/src/native/harness.rs
+++ b/crates/jolt-tracer-x86/src/native/harness.rs
@@ -1,0 +1,215 @@
+//! Test/bench harness: build tiny synthetic programs around individual rows
+//! and execute them natively. Hidden API — consumed by the per-instruction
+//! differential tests and the iai microbenchmarks.
+
+use common::constants::{RAM_START_ADDRESS, REGISTER_COUNT};
+use common::jolt_device::{JoltDevice, MemoryConfig};
+use jolt_program::execution::{JoltProgram, TraceError};
+use jolt_riscv::{JoltInstructionKind, JoltInstructionRow, NormalizedOperands};
+
+use super::compile;
+use super::memory::MemoryPlane;
+use super::state::{ExitReason, GuestState, HostContext};
+
+/// Source address of the row under test. Terminal rows (always-taken
+/// self-branches with no register effects) catch the fall-through and the
+/// ±8 branch targets.
+pub const TEST_ADDR: u64 = RAM_START_ADDRESS + 0x1000;
+/// RAM scratch region seeded identically on both sides for memory-op rows.
+pub const SCRATCH_START: u64 = RAM_START_ADDRESS + 0x2000;
+pub const SCRATCH_DWORDS: usize = 512;
+/// Plane/interpreter memory capacity for harness runs.
+pub const MEM_CAPACITY: u64 = 1 << 20;
+
+pub fn memory_config() -> MemoryConfig {
+    MemoryConfig {
+        heap_size: MEM_CAPACITY,
+        program_size: Some(1024),
+        ..Default::default()
+    }
+}
+
+/// An always-taken self-branch: `Beq x0, x0, 0`. Terminates via PC-stall
+/// with no register or memory effects.
+fn terminal_row(address: u64) -> JoltInstructionRow {
+    JoltInstructionRow {
+        instruction_kind: JoltInstructionKind::BEQ,
+        address: address as usize,
+        operands: NormalizedOperands {
+            rs1: Some(0),
+            rs2: Some(0),
+            rd: None,
+            imm: 0,
+        },
+        virtual_sequence_remaining: None,
+        is_first_in_sequence: true,
+        is_compressed: false,
+    }
+}
+
+/// Synthetic program: terminals at `TEST_ADDR - 8`, `+ 4`, `+ 8` around the
+/// row under test, so every generated control transfer lands on a compiled
+/// group.
+pub fn single_row_program(row: JoltInstructionRow) -> JoltProgram {
+    assert_eq!(row.address as u64, TEST_ADDR, "row must sit at TEST_ADDR");
+    let rows = vec![
+        terminal_row(TEST_ADDR - 8),
+        row,
+        terminal_row(TEST_ADDR + 4),
+        terminal_row(TEST_ADDR + 8),
+    ];
+    JoltProgram::from_parts(
+        Vec::new(),
+        rows,
+        Vec::new(),
+        RAM_START_ADDRESS + 1024,
+        TEST_ADDR,
+    )
+}
+
+/// A straight-line program: `count` copies of the row at consecutive
+/// addresses followed by a fall-through terminal (for microbenchmarks).
+/// The row must not transfer control (or must be a `Jal` with `imm = 4`).
+pub fn straight_line_program(mut row: JoltInstructionRow, count: usize) -> JoltProgram {
+    let mut rows = Vec::with_capacity(count + 1);
+    for i in 0..count {
+        row.address = (TEST_ADDR + 4 * i as u64) as usize;
+        rows.push(row);
+    }
+    rows.push(terminal_row(TEST_ADDR + 4 * count as u64));
+    JoltProgram::from_parts(
+        Vec::new(),
+        rows,
+        Vec::new(),
+        RAM_START_ADDRESS + 1024,
+        TEST_ADDR,
+    )
+}
+
+/// Compile without running (fail-fast coverage checks).
+pub fn compile_only(program: &JoltProgram) -> Result<(), TraceError> {
+    compile::compile(program).map(|_| ())
+}
+
+/// A compiled synthetic program plus its memory plane, reusable across runs
+/// (for microbenchmarks: compilation stays outside the measured region).
+pub struct Prepared {
+    compiled: compile::CompiledProgram,
+    plane: MemoryPlane,
+    entry: u64,
+    pre_regs: [u64; REGISTER_COUNT as usize],
+}
+
+impl Prepared {
+    pub fn new(
+        program: &JoltProgram,
+        pre_regs: [u64; REGISTER_COUNT as usize],
+    ) -> Result<Self, TraceError> {
+        Ok(Self {
+            compiled: compile::compile(program)?,
+            plane: MemoryPlane::new(MEM_CAPACITY as usize)?,
+            entry: program.entry_address,
+            pre_regs,
+        })
+    }
+
+    /// Run once from the initial register state; returns the row count.
+    pub fn run_once(&mut self) -> Result<u64, TraceError> {
+        let mut host = HostContext {
+            device: JoltDevice::new(&memory_config()),
+            advice_tape: Vec::new(),
+            helper_error: None,
+        };
+        let mut guest = Box::new(GuestState {
+            x: self.pre_regs,
+            pc: self.entry,
+            trace_len: 0,
+            exit: ExitReason::Running as u64,
+            fault_addr: 0,
+            mem_base: self.plane.base() as u64,
+            mem_size: self.plane.size() as u64,
+            host: &raw mut host,
+        });
+        guest.x[0] = 0;
+        self.compiled.run(&mut guest)?;
+        if guest.exit != ExitReason::Terminated as u64 {
+            return Err(TraceError::Backend("benchmark program did not terminate"));
+        }
+        Ok(guest.trace_len)
+    }
+}
+
+pub struct Outcome {
+    pub regs: [u64; REGISTER_COUNT as usize],
+    pub pc: u64,
+    pub trace_len: u64,
+    /// Scratch region contents after the run, as dwords.
+    pub scratch: Vec<u64>,
+    pub advice_tape: Vec<u8>,
+    pub exit: u64,
+    pub helper_error: Option<String>,
+}
+
+/// Compile and run a synthetic program natively.
+///
+/// `pre_regs` seeds the guest registers; `scratch` seeds
+/// `[SCRATCH_START, SCRATCH_START + 8 * SCRATCH_DWORDS)`.
+pub fn run_program(
+    program: &JoltProgram,
+    pre_regs: &[u64; REGISTER_COUNT as usize],
+    scratch: &[u64],
+) -> Result<Outcome, TraceError> {
+    let compiled = compile::compile(program)?;
+
+    let plane = MemoryPlane::new(MEM_CAPACITY as usize)?;
+    let base = plane.base();
+    for (i, &dword) in scratch.iter().enumerate() {
+        let offset = (SCRATCH_START - RAM_START_ADDRESS) as usize + i * 8;
+        // SAFETY: scratch region is far inside MEM_CAPACITY.
+        unsafe {
+            base.add(offset)
+                .cast::<u8>()
+                .copy_from(dword.to_le_bytes().as_ptr(), 8);
+        }
+    }
+
+    let mut host = HostContext {
+        device: JoltDevice::new(&memory_config()),
+        advice_tape: Vec::new(),
+        helper_error: None,
+    };
+    let mut guest = Box::new(GuestState {
+        x: *pre_regs,
+        pc: program.entry_address,
+        trace_len: 0,
+        exit: ExitReason::Running as u64,
+        fault_addr: 0,
+        mem_base: plane.base() as u64,
+        mem_size: plane.size() as u64,
+        host: &raw mut host,
+    });
+    guest.x[0] = 0;
+
+    compiled.run(&mut guest)?;
+
+    let mut scratch_out = vec![0u64; SCRATCH_DWORDS];
+    for (i, slot) in scratch_out.iter_mut().enumerate() {
+        let offset = (SCRATCH_START - RAM_START_ADDRESS) as usize + i * 8;
+        let mut bytes = [0u8; 8];
+        // SAFETY: scratch region is far inside MEM_CAPACITY.
+        unsafe {
+            base.add(offset).cast::<u8>().copy_to(bytes.as_mut_ptr(), 8);
+        }
+        *slot = u64::from_le_bytes(bytes);
+    }
+
+    Ok(Outcome {
+        regs: guest.x,
+        pc: guest.pc,
+        trace_len: guest.trace_len,
+        scratch: scratch_out,
+        advice_tape: host.advice_tape,
+        exit: guest.exit,
+        helper_error: host.helper_error,
+    })
+}

--- a/crates/jolt-tracer-x86/src/native/harness.rs
+++ b/crates/jolt-tracer-x86/src/native/harness.rs
@@ -138,6 +138,8 @@ impl Prepared {
             host: &raw mut host,
             advice_slots: [0; crate::native::state::ADVICE_SLOTS],
             advice_jobs: self.compiled.advice_jobs_ptr(),
+            obs_cursor: core::ptr::null_mut(),
+            obs_end: core::ptr::null_mut(),
         });
         guest.x[0] = 0;
         self.compiled.run(&mut guest)?;
@@ -201,6 +203,8 @@ pub fn run_program(
         host: &raw mut host,
         advice_slots: [0; crate::native::state::ADVICE_SLOTS],
         advice_jobs: compiled.advice_jobs_ptr(),
+        obs_cursor: core::ptr::null_mut(),
+        obs_end: core::ptr::null_mut(),
     });
     guest.x[0] = 0;
 

--- a/crates/jolt-tracer-x86/src/native/harness.rs
+++ b/crates/jolt-tracer-x86/src/native/harness.rs
@@ -97,6 +97,12 @@ pub fn compile_only(program: &JoltProgram) -> Result<(), TraceError> {
     compile::compile(program).map(|_| ())
 }
 
+/// Compile and hand back the artifact, so callers that inspect the live code
+/// mapping (the safety tests) keep it alive while they look.
+pub fn compile_program(program: &JoltProgram) -> Result<CompiledProgram, TraceError> {
+    compile::compile(program)
+}
+
 /// A compiled synthetic program plus its memory plane, reusable across runs
 /// (for microbenchmarks: compilation stays outside the measured region).
 pub struct Prepared {
@@ -158,6 +164,8 @@ pub struct Outcome {
     pub scratch: Vec<u64>,
     pub advice_tape: Vec<u8>,
     pub exit: u64,
+    /// Faulting guest address when `exit` reports a memory fault.
+    pub fault_addr: u64,
     pub helper_error: Option<String>,
 }
 
@@ -228,6 +236,7 @@ pub fn run_program(
         scratch: scratch_out,
         advice_tape: host.advice_tape,
         exit: guest.exit,
+        fault_addr: guest.fault_addr,
         helper_error: host.helper_error,
     })
 }

--- a/crates/jolt-tracer-x86/src/native/harness.rs
+++ b/crates/jolt-tracer-x86/src/native/harness.rs
@@ -118,6 +118,7 @@ impl Prepared {
         let mut host = HostContext {
             device: JoltDevice::new(&memory_config()),
             advice_tape: Vec::new(),
+            advice_cursor: 0,
             helper_error: None,
         };
         let mut guest = Box::new(GuestState {
@@ -153,11 +154,13 @@ pub struct Outcome {
 /// Compile and run a synthetic program natively.
 ///
 /// `pre_regs` seeds the guest registers; `scratch` seeds
-/// `[SCRATCH_START, SCRATCH_START + 8 * SCRATCH_DWORDS)`.
+/// `[SCRATCH_START, SCRATCH_START + 8 * SCRATCH_DWORDS)`; `advice` seeds the
+/// runtime advice tape (cursor at 0).
 pub fn run_program(
     program: &JoltProgram,
     pre_regs: &[u64; REGISTER_COUNT as usize],
     scratch: &[u64],
+    advice: &[u8],
 ) -> Result<Outcome, TraceError> {
     let compiled = compile::compile(program)?;
 
@@ -175,7 +178,8 @@ pub fn run_program(
 
     let mut host = HostContext {
         device: JoltDevice::new(&memory_config()),
-        advice_tape: Vec::new(),
+        advice_tape: advice.to_vec(),
+        advice_cursor: 0,
         helper_error: None,
     };
     let mut guest = Box::new(GuestState {

--- a/crates/jolt-tracer-x86/src/native/helpers.rs
+++ b/crates/jolt-tracer-x86/src/native/helpers.rs
@@ -10,7 +10,7 @@
 
 use common::constants::RAM_START_ADDRESS;
 
-use super::state::{AdviceJob, ExitReason, GuestState, HostContext, ADVICE_SLOTS};
+use super::state::{AdviceCompute, ExitReason, GuestState, HostContext};
 
 // jolt-platform host-IO ABI (mirrors tracer/src/emulator/cpu.rs handlers).
 use jolt_platform::{
@@ -228,8 +228,8 @@ pub extern "sysv64" fn advice_compute(state: *mut GuestState, job_index: u64) ->
     // SAFETY: `advice_jobs` points at the compiled program's job table, which
     // outlives the run; generated code only passes indices it emitted.
     let job = unsafe { &*state.advice_jobs.add(job_index as usize) };
-    match job {
-        AdviceJob::Div { code, rs1, rs2 } => {
+    match &job.compute {
+        AdviceCompute::Div { code, rs1, rs2 } => {
             let x = state.x[*rs1 as usize] as i64;
             let y = state.x[*rs2 as usize] as i64;
             let (a, b) = match code {
@@ -269,7 +269,7 @@ pub extern "sysv64" fn advice_compute(state: *mut GuestState, job_index: u64) ->
             state.advice_slots[1] = b;
             0
         }
-        AdviceJob::Inline {
+        AdviceCompute::Inline {
             registration,
             operands,
         } => {
@@ -292,18 +292,23 @@ pub extern "sysv64" fn advice_compute(state: *mut GuestState, job_index: u64) ->
                     );
                 }
             };
-            let Some(values) = values else { return 0 };
-            if values.len() > ADVICE_SLOTS {
+            // The provided count must match the group's VirtualAdvice rows
+            // exactly — a short vector would leave stale slots to be read as
+            // advice. The interpreter panics on the same mismatch
+            // ("did not provide enough values" / "provided too many values");
+            // this backend errors (spec invariant 7 asymmetry).
+            let provided = values.as_ref().map_or(0, std::collections::VecDeque::len);
+            if provided != job.advice_rows {
                 return fail(
                     state,
                     host,
                     format!(
-                        "inline {} produced {} advice values (max {ADVICE_SLOTS})",
-                        registration.name,
-                        values.len()
+                        "inline {} provided {provided} advice values; its group reads {}",
+                        registration.name, job.advice_rows
                     ),
                 );
             }
+            let Some(values) = values else { return 0 };
             for (slot, value) in values.into_iter().enumerate() {
                 state.advice_slots[slot] = value;
             }

--- a/crates/jolt-tracer-x86/src/native/helpers.rs
+++ b/crates/jolt-tracer-x86/src/native/helpers.rs
@@ -1,0 +1,157 @@
+//! `extern "C"` helpers called from generated code.
+//!
+//! ABI: sysv64, first argument is always `*mut GuestState`. Pinned registers
+//! (r12–r15) are callee-saved, so helpers preserve them for free.
+//!
+//! Error protocol: a failing helper writes `GuestState::exit` (and
+//! `HostContext::helper_error` / `fault_addr` as appropriate); generated code
+//! tests `exit` after each helper call and jumps to the exit stub when
+//! nonzero. Return values travel in rax.
+
+use common::constants::RAM_START_ADDRESS;
+
+use super::state::{ExitReason, GuestState, HostContext};
+
+// jolt-platform host-IO ABI (mirrors tracer/src/emulator/cpu.rs handlers).
+use jolt_platform::{
+    JOLT_ADVICE_WRITE_CALL_ID, JOLT_CYCLE_MARKER_END, JOLT_CYCLE_MARKER_START,
+    JOLT_CYCLE_TRACK_CALL_ID, JOLT_PRINT_CALL_ID, JOLT_PRINT_LINE, JOLT_PRINT_STRING,
+};
+
+fn host_context<'a>(state: *mut GuestState) -> (&'a mut GuestState, &'a mut HostContext) {
+    // SAFETY: generated code passes the GuestState it was launched with; its
+    // `host` pointer outlives the run (both are owned by the driver frame).
+    unsafe { (&mut *state, &mut *(*state).host) }
+}
+
+fn fail(state: &mut GuestState, host: &mut HostContext, message: String) -> u64 {
+    host.helper_error = Some(message);
+    state.exit = ExitReason::FaultHelper as u64;
+    0
+}
+
+/// Read one guest byte, routing RAM to the plane and lower addresses to the
+/// device (mirrors `Mmu::load`).
+fn read_guest_byte(state: &GuestState, host: &HostContext, address: u64) -> u8 {
+    if address >= RAM_START_ADDRESS {
+        let offset = address - RAM_START_ADDRESS;
+        if offset < state.mem_size {
+            // SAFETY: offset bounds-checked against the plane size.
+            return unsafe { (state.mem_base as *const u8).add(offset as usize).read() };
+        }
+        return 0;
+    }
+    host.device.load(address)
+}
+
+/// `VirtualHostIO`: call id in a0 (x10), args in a1–a3 (x11–x13).
+/// No rd write, no RAM-access row (matches the interpreter).
+// Guest prints go to stdout by definition (mirrors the interpreter's
+// handle_jolt_print).
+#[expect(clippy::print_stdout)]
+pub extern "sysv64" fn host_io(state: *mut GuestState) -> u64 {
+    let (state, host) = host_context(state);
+    let call_id = state.x[10] as u32;
+    if call_id == JOLT_ADVICE_WRITE_CALL_ID {
+        let ptr = state.x[11];
+        let len = state.x[12];
+        for i in 0..len {
+            let byte = read_guest_byte(state, host, ptr.wrapping_add(i));
+            host.advice_tape.push(byte);
+        }
+        return 0;
+    }
+    let ptr = state.x[11] as u32 as u64;
+    let len = state.x[12] as u32 as usize;
+    let event = state.x[13] as u32;
+    match call_id {
+        JOLT_CYCLE_TRACK_CALL_ID => {
+            // Diagnostics only in the interpreter (logged cycle counts);
+            // reproduce the validation, skip the logging.
+            if event != JOLT_CYCLE_MARKER_START && event != JOLT_CYCLE_MARKER_END {
+                return fail(state, host, format!("unknown cycle marker event {event}"));
+            }
+            0
+        }
+        JOLT_PRINT_CALL_ID => {
+            let mut bytes = Vec::with_capacity(len);
+            for i in 0..len as u64 {
+                bytes.push(read_guest_byte(state, host, ptr.wrapping_add(i)));
+            }
+            let text = String::from_utf8_lossy(&bytes);
+            match event {
+                JOLT_PRINT_STRING => print!("{text}"),
+                JOLT_PRINT_LINE => println!("{text}"),
+                other => return fail(state, host, format!("unknown print event {other}")),
+            }
+            0
+        }
+        // Unknown call ids are silently ignored by the interpreter.
+        _ => 0,
+    }
+}
+
+/// `Ld` slow path: device-region, unaligned, or out-of-bounds effective
+/// addresses. Returns the loaded doubleword in rax on success.
+pub extern "sysv64" fn slow_load_doubleword(state: *mut GuestState, address: u64) -> u64 {
+    let (state, host) = host_context(state);
+    if !address.is_multiple_of(8) {
+        // The interpreter panics ("Unaligned load_doubleword"); surface as a
+        // helper error instead (spec invariant 7 asymmetry).
+        return fail(
+            state,
+            host,
+            format!("unaligned load_doubleword: {address:#x}"),
+        );
+    }
+    if address >= RAM_START_ADDRESS {
+        // In range would have taken the fast path; this is out of bounds.
+        state.fault_addr = address;
+        state.exit = ExitReason::FaultOutOfBounds as u64;
+        return 0;
+    }
+    let mut value = 0u64;
+    for i in 0..8 {
+        value |= (host.device.load(address + i) as u64) << (i * 8);
+    }
+    value
+}
+
+/// `Sd` slow path: device-region, unaligned, or out-of-bounds effective
+/// addresses. `JoltDevice::store` also handles the panic/termination bits.
+pub extern "sysv64" fn slow_store_doubleword(
+    state: *mut GuestState,
+    address: u64,
+    value: u64,
+) -> u64 {
+    let (state, host) = host_context(state);
+    if !address.is_multiple_of(8) {
+        return fail(
+            state,
+            host,
+            format!("unaligned store_doubleword: {address:#x}"),
+        );
+    }
+    if address >= RAM_START_ADDRESS {
+        state.fault_addr = address;
+        state.exit = ExitReason::FaultOutOfBounds as u64;
+        return 0;
+    }
+    for i in 0..8 {
+        host.device.store(address + i, (value >> (i * 8)) as u8);
+    }
+    0
+}
+
+/// A virtual assert failed. The interpreter panics; the x86 backend surfaces
+/// a `TraceError` (accepted asymmetry, spec invariant 7).
+pub extern "sysv64" fn assert_failed(state: *mut GuestState, code: u64, value: u64) -> u64 {
+    let (state, host) = host_context(state);
+    let message = match code {
+        0 => format!("RAM access (LH or LHU) is not halfword aligned: {value:x}"),
+        1 => format!("RAM access (LW or LWU) is not word aligned: {value:x}"),
+        2 => "VirtualAssertLTE failed".to_string(),
+        _ => format!("assert {code} failed with value {value:x}"),
+    };
+    fail(state, host, message)
+}

--- a/crates/jolt-tracer-x86/src/native/helpers.rs
+++ b/crates/jolt-tracer-x86/src/native/helpers.rs
@@ -10,7 +10,7 @@
 
 use common::constants::RAM_START_ADDRESS;
 
-use super::state::{ExitReason, GuestState, HostContext};
+use super::state::{AdviceJob, ExitReason, GuestState, HostContext, ADVICE_SLOTS};
 
 // jolt-platform host-IO ABI (mirrors tracer/src/emulator/cpu.rs handlers).
 use jolt_platform::{
@@ -158,6 +158,128 @@ pub extern "sysv64" fn assert_failed(state: *mut GuestState, code: u64, value: u
         _ => format!("assert {code} failed with value {value:x}"),
     };
     fail(state, host, message)
+}
+
+/// Guest-state view handed to registered inline advice builders.
+///
+/// The same `build_advice` functions the interpreter uses run unchanged here
+/// (the seam's purpose): reads go to this backend's register array and memory
+/// plane instead of the interpreter's `Cpu`.
+struct GuestAdviceContext<'a> {
+    state: &'a mut GuestState,
+    host: &'a HostContext,
+}
+
+impl tracer::InlineAdviceContext for GuestAdviceContext<'_> {
+    fn register(&self, index: usize) -> u64 {
+        self.state.x[index]
+    }
+
+    fn load_doubleword(&mut self, address: u64) -> Option<u64> {
+        if !address.is_multiple_of(8) {
+            return None;
+        }
+        if address >= RAM_START_ADDRESS {
+            let offset = address - RAM_START_ADDRESS;
+            if offset + 8 > self.state.mem_size {
+                return None;
+            }
+            // SAFETY: offset + 8 is within the mapped plane.
+            let mut bytes = [0u8; 8];
+            // SAFETY: offset + 8 <= mem_size, so the read stays inside the
+            // mapped guest-memory plane.
+            unsafe {
+                (self.state.mem_base as *const u8)
+                    .add(offset as usize)
+                    .copy_to(bytes.as_mut_ptr(), 8);
+            }
+            return Some(u64::from_le_bytes(bytes));
+        }
+        let mut value = 0u64;
+        for i in 0..8 {
+            value |= (self.host.device.load(address + i) as u64) << (i * 8);
+        }
+        Some(value)
+    }
+}
+
+/// Compute one source-instruction group's runtime advice into
+/// `GuestState::advice_slots`, before any of the group's rows execute (the
+/// interpreter computes these from the same pre-group register state).
+pub extern "sysv64" fn advice_compute(state: *mut GuestState, job_index: u64) -> u64 {
+    let (state, host) = host_context(state);
+    // SAFETY: `advice_jobs` points at the compiled program's job table, which
+    // outlives the run; generated code only passes indices it emitted.
+    let job = unsafe { &*state.advice_jobs.add(job_index as usize) };
+    match job {
+        AdviceJob::Div { code, rs1, rs2 } => {
+            let x = state.x[*rs1 as usize] as i64;
+            let y = state.x[*rs2 as usize] as i64;
+            let (a, b) = match code {
+                // DIV / REM: [quotient, |remainder|]
+                0 => {
+                    if y == 0 {
+                        (u64::MAX, x.unsigned_abs())
+                    } else if x == i64::MIN && y == -1 {
+                        (x as u64, 0)
+                    } else {
+                        ((x / y) as u64, (x % y).unsigned_abs())
+                    }
+                }
+                // DIVW / REMW: 32-bit, quotient sign-extended
+                1 => {
+                    let x = x as i32;
+                    let y = y as i32;
+                    let (q, r) = if y == 0 {
+                        (-1i32, x.unsigned_abs())
+                    } else if y == -1 && x == i32::MIN {
+                        (i32::MIN, 0)
+                    } else {
+                        (x / y, (x % y).unsigned_abs())
+                    };
+                    (q as u64, r as u64)
+                }
+                // DIVU / REMU: [quotient]
+                2 => ((x as u64).checked_div(y as u64).unwrap_or(u64::MAX), 0),
+                // DIVUW / REMUW: 32-bit, zero-extended
+                _ => {
+                    let x = x as u32;
+                    let y = y as u32;
+                    (x.checked_div(y).map_or(u64::from(u32::MAX), u64::from), 0)
+                }
+            };
+            state.advice_slots[0] = a;
+            state.advice_slots[1] = b;
+            0
+        }
+        AdviceJob::Inline {
+            registration,
+            operands,
+        } => {
+            let operands = *operands;
+            let build = registration.build_advice;
+            let values = {
+                let mut context = GuestAdviceContext { state, host };
+                build(operands, &mut context)
+            };
+            let Some(values) = values else { return 0 };
+            if values.len() > ADVICE_SLOTS {
+                return fail(
+                    state,
+                    host,
+                    format!(
+                        "inline {} produced {} advice values (max {ADVICE_SLOTS})",
+                        registration.name,
+                        values.len()
+                    ),
+                );
+            }
+            for (slot, value) in values.into_iter().enumerate() {
+                state.advice_slots[slot] = value;
+            }
+            0
+        }
+    }
 }
 
 /// `VirtualAdviceLen`: bytes left on the advice tape.

--- a/crates/jolt-tracer-x86/src/native/helpers.rs
+++ b/crates/jolt-tracer-x86/src/native/helpers.rs
@@ -279,6 +279,19 @@ pub extern "sysv64" fn advice_compute(state: *mut GuestState, job_index: u64) ->
                 let mut context = GuestAdviceContext { state, host };
                 build(operands, &mut context)
             };
+            // Advice faults (invalid guest pointer in an operand register) are
+            // surfaced as helper errors here — this backend has an error
+            // channel, unlike the reference tracer, which panics.
+            let values = match values {
+                Ok(values) => values,
+                Err(e) => {
+                    return fail(
+                        state,
+                        host,
+                        format!("inline {} advice failed: {e}", registration.name),
+                    );
+                }
+            };
             let Some(values) = values else { return 0 };
             if values.len() > ADVICE_SLOTS {
                 return fail(

--- a/crates/jolt-tracer-x86/src/native/helpers.rs
+++ b/crates/jolt-tracer-x86/src/native/helpers.rs
@@ -117,6 +117,22 @@ pub extern "sysv64" fn slow_load_doubleword(state: *mut GuestState, address: u64
     value
 }
 
+/// Record the pre-value of a device-region store into the current row's
+/// observation slot. The fast RAM path captures this inline; the device path
+/// cannot (the bytes live in `JoltDevice`), so the helper does it.
+fn record_device_store_pre(state: &mut GuestState, host: &HostContext, address: u64) {
+    if state.obs_cursor.is_null() || state.obs_cursor >= state.obs_end {
+        return;
+    }
+    let mut pre = 0u64;
+    for i in 0..8 {
+        pre |= (host.device.load(address + i) as u64) << (i * 8);
+    }
+    // SAFETY: the cursor is in bounds (checked above) and points at the slot
+    // generated code is currently filling for this row.
+    unsafe { (*state.obs_cursor).ram_pre = pre };
+}
+
 /// `Sd` slow path: device-region, unaligned, or out-of-bounds effective
 /// addresses. `JoltDevice::store` also handles the panic/termination bits.
 pub extern "sysv64" fn slow_store_doubleword(
@@ -137,6 +153,7 @@ pub extern "sysv64" fn slow_store_doubleword(
         state.exit = ExitReason::FaultOutOfBounds as u64;
         return 0;
     }
+    record_device_store_pre(state, host, address);
     for i in 0..8 {
         host.device.store(address + i, (value >> (i * 8)) as u8);
     }

--- a/crates/jolt-tracer-x86/src/native/helpers.rs
+++ b/crates/jolt-tracer-x86/src/native/helpers.rs
@@ -151,7 +151,33 @@ pub extern "sysv64" fn assert_failed(state: *mut GuestState, code: u64, value: u
         0 => format!("RAM access (LH or LHU) is not halfword aligned: {value:x}"),
         1 => format!("RAM access (LW or LWU) is not word aligned: {value:x}"),
         2 => "VirtualAssertLTE failed".to_string(),
+        3 => format!("VirtualAssertEQ failed (lhs {value:x})"),
+        4 => format!("VirtualAssertValidDiv0 failed (quotient {value:x})"),
+        5 => format!("VirtualAssertValidUnsignedRemainder failed (remainder {value:x})"),
+        6 => "VirtualAssertMulUNoOverflow failed".to_string(),
         _ => format!("assert {code} failed with value {value:x}"),
     };
     fail(state, host, message)
+}
+
+/// `VirtualAdviceLen`: bytes left on the advice tape.
+pub extern "sysv64" fn advice_remaining(state: *mut GuestState) -> u64 {
+    let (_state, host) = host_context(state);
+    host.advice_tape.len().saturating_sub(host.advice_cursor) as u64
+}
+
+/// `VirtualAdviceLoad`: read `num_bytes` (1/2/4/8) little-endian from the
+/// tape, zero-filled; exhaustion is a helper error (the interpreter panics).
+pub extern "sysv64" fn advice_read(state: *mut GuestState, num_bytes: u64) -> u64 {
+    let (state, host) = host_context(state);
+    let n = num_bytes as usize;
+    if host.advice_cursor + n > host.advice_tape.len() {
+        return fail(state, host, "Failed to read from advice tape".to_string());
+    }
+    let mut value = 0u64;
+    for i in 0..n {
+        value |= (host.advice_tape[host.advice_cursor + i] as u64) << (i * 8);
+    }
+    host.advice_cursor += n;
+    value
 }

--- a/crates/jolt-tracer-x86/src/native/memory.rs
+++ b/crates/jolt-tracer-x86/src/native/memory.rs
@@ -66,6 +66,19 @@ impl MemoryPlane {
         self.size
     }
 
+    /// Copy the whole plane out, for a chunk checkpoint.
+    pub fn to_vec(&self) -> Vec<u8> {
+        // SAFETY: the whole range [base, base+size) is mapped and readable.
+        unsafe { core::slice::from_raw_parts(self.base, self.size) }.to_vec()
+    }
+
+    /// Restore a previously captured image (same size by construction).
+    pub fn restore(&mut self, image: &[u8]) {
+        let len = image.len().min(self.size);
+        // SAFETY: len <= self.size, and image is a distinct allocation.
+        unsafe { self.base.copy_from_nonoverlapping(image.as_ptr(), len) };
+    }
+
     /// Copy out all nonzero bytes as `(address, byte)` pairs, RAM-relative
     /// (address 0 = `RAM_START_ADDRESS`) — the convention the reference
     /// backend's `Memory::materialized_nonzero_bytes` uses for

--- a/crates/jolt-tracer-x86/src/native/memory.rs
+++ b/crates/jolt-tracer-x86/src/native/memory.rs
@@ -1,0 +1,91 @@
+//! Guest RAM plane: one anonymous mmap covering `[RAM_START_ADDRESS,
+//! RAM_START_ADDRESS + size)`, addressed by generated code as
+//! `mem_base + (guest_addr - RAM_START_ADDRESS)` after an explicit bounds
+//! check. Untouched pages cost no physical memory (`MAP_NORESERVE`).
+//!
+//! Addresses below `RAM_START_ADDRESS` (the `JoltDevice` I/O region) never
+//! reach this plane; generated code routes them to `extern "C"` helpers.
+
+use common::constants::RAM_START_ADDRESS;
+use jolt_program::execution::TraceError;
+
+pub struct MemoryPlane {
+    base: *mut u8,
+    size: usize,
+}
+
+// SAFETY: MemoryPlane exclusively owns its mapping; sending it between
+// threads transfers that ownership.
+unsafe impl Send for MemoryPlane {}
+
+impl MemoryPlane {
+    /// Map a zeroed plane of `size` bytes.
+    pub fn new(size: usize) -> Result<Self, TraceError> {
+        // SAFETY: anonymous private mapping with no file backing; length is
+        // nonzero and page-rounded by the kernel. The pointer is checked
+        // before use.
+        let base = unsafe {
+            libc::mmap(
+                core::ptr::null_mut(),
+                size,
+                libc::PROT_READ | libc::PROT_WRITE,
+                libc::MAP_PRIVATE | libc::MAP_ANONYMOUS | libc::MAP_NORESERVE,
+                -1,
+                0,
+            )
+        };
+        if base == libc::MAP_FAILED {
+            return Err(TraceError::Backend("failed to mmap guest memory plane"));
+        }
+        Ok(Self {
+            base: base.cast::<u8>(),
+            size,
+        })
+    }
+
+    /// Write the program image (`(guest_address, byte)` pairs) into the plane.
+    pub fn init_from_image(&mut self, memory_init: &[(u64, u8)]) -> Result<(), TraceError> {
+        for &(address, byte) in memory_init {
+            let offset = address
+                .checked_sub(RAM_START_ADDRESS)
+                .filter(|&o| o < self.size as u64)
+                .ok_or(TraceError::Backend(
+                    "program image byte outside the guest memory plane",
+                ))?;
+            // SAFETY: offset < size, so the write is within the mapping.
+            unsafe { self.base.add(offset as usize).write(byte) };
+        }
+        Ok(())
+    }
+
+    pub fn base(&self) -> *mut u8 {
+        self.base
+    }
+
+    pub fn size(&self) -> usize {
+        self.size
+    }
+
+    /// Copy out all nonzero bytes as `(address, byte)` pairs, RAM-relative
+    /// (address 0 = `RAM_START_ADDRESS`) — the convention the reference
+    /// backend's `Memory::materialized_nonzero_bytes` uses for
+    /// `TraceOutput::final_memory`.
+    pub fn materialized_nonzero_bytes(&self) -> Vec<(u64, u8)> {
+        let mut bytes = Vec::new();
+        // SAFETY: the whole range [base, base+size) is mapped and readable.
+        let slice = unsafe { core::slice::from_raw_parts(self.base, self.size) };
+        for (offset, &byte) in slice.iter().enumerate() {
+            if byte != 0 {
+                bytes.push((offset as u64, byte));
+            }
+        }
+        bytes
+    }
+}
+
+impl Drop for MemoryPlane {
+    fn drop(&mut self) {
+        // SAFETY: base/size describe the mapping created in `new`.
+        let _ = unsafe { libc::munmap(self.base.cast(), self.size) };
+    }
+}

--- a/crates/jolt-tracer-x86/src/native/mod.rs
+++ b/crates/jolt-tracer-x86/src/native/mod.rs
@@ -2,6 +2,8 @@
 //! bytecode and the execution driver.
 
 mod compile;
+#[doc(hidden)]
+pub mod harness;
 mod helpers;
 mod memory;
 mod state;

--- a/crates/jolt-tracer-x86/src/native/mod.rs
+++ b/crates/jolt-tracer-x86/src/native/mod.rs
@@ -86,6 +86,7 @@ impl X86TracerBackend {
         let mut host = HostContext {
             device,
             advice_tape: inputs.advice_tape.clone().unwrap_or_default(),
+            advice_cursor: 0,
             helper_error: None,
         };
 

--- a/crates/jolt-tracer-x86/src/native/mod.rs
+++ b/crates/jolt-tracer-x86/src/native/mod.rs
@@ -1,0 +1,161 @@
+//! Native (x86_64-linux) implementation: AOT compilation of expanded
+//! bytecode and the execution driver.
+
+mod compile;
+mod helpers;
+mod memory;
+mod state;
+
+use std::sync::Arc;
+
+use common::jolt_device::JoltDevice;
+use jolt_program::execution::{
+    ExecutionBackend, JoltProgram, MemoryImage, OwnedTrace, TraceError, TraceInputs, TraceOutput,
+};
+
+use compile::CompiledProgram;
+use memory::MemoryPlane;
+use state::{ExitReason, GuestState, HostContext};
+
+/// AOT x86-64 transpiling execution backend.
+///
+/// Compiles a [`JoltProgram`]'s expanded bytecode to native code on first use
+/// and caches the artifact keyed by the program's identity, so repeated
+/// traces and chunk replays reuse it.
+#[derive(Default)]
+pub struct X86TracerBackend {
+    cache: Option<CachedProgram>,
+}
+
+struct CachedProgram {
+    fingerprint: u64,
+    compiled: Arc<CompiledProgram>,
+}
+
+/// Result of a fast (non-recording) pass.
+pub struct FastRunOutput {
+    pub trace_len: usize,
+    pub device: JoltDevice,
+    pub final_memory: MemoryImage,
+    pub advice_tape: Vec<u8>,
+}
+
+impl X86TracerBackend {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    fn compiled(&mut self, program: &JoltProgram) -> Result<Arc<CompiledProgram>, TraceError> {
+        let fingerprint = fingerprint(program.elf_bytes());
+        if let Some(cached) = &self.cache {
+            if cached.fingerprint == fingerprint {
+                return Ok(Arc::clone(&cached.compiled));
+            }
+        }
+        let compiled = Arc::new(compile::compile(program)?);
+        self.cache = Some(CachedProgram {
+            fingerprint,
+            compiled: Arc::clone(&compiled),
+        });
+        Ok(compiled)
+    }
+
+    /// Fast pass: run the program to completion without materializing trace
+    /// rows. (Checkpoint logging joins in the chunked-execution slice.)
+    pub fn fast_run(
+        &mut self,
+        program: &JoltProgram,
+        inputs: TraceInputs,
+    ) -> Result<FastRunOutput, TraceError> {
+        if program.elf_bytes().is_empty() {
+            return Err(TraceError::MissingElfBytes);
+        }
+        let compiled = self.compiled(program)?;
+
+        let mut device = JoltDevice::new(&inputs.memory_config);
+        device.inputs.clone_from(&inputs.inputs);
+        device.trusted_advice.clone_from(&inputs.trusted_advice);
+        device.untrusted_advice.clone_from(&inputs.untrusted_advice);
+
+        let plane_size = device.memory_layout.get_total_memory_size();
+        let mut plane = MemoryPlane::new(plane_size as usize)?;
+        plane.init_from_image(&program.memory_init)?;
+
+        let mut host = HostContext {
+            device,
+            advice_tape: inputs.advice_tape.clone().unwrap_or_default(),
+            helper_error: None,
+        };
+
+        let mut guest = Box::new(GuestState {
+            x: [0; common::constants::REGISTER_COUNT as usize],
+            pc: program.entry_address,
+            trace_len: 0,
+            exit: ExitReason::Running as u64,
+            fault_addr: 0,
+            mem_base: plane.base() as u64,
+            mem_size: plane.size() as u64,
+            host: &raw mut host,
+        });
+
+        compiled.run(&mut guest)?;
+
+        match guest.exit {
+            e if e == ExitReason::Terminated as u64 => {}
+            e if e == ExitReason::FaultOutOfBounds as u64 => {
+                return Err(TraceError::Backend("guest RAM access out of bounds"));
+            }
+            e if e == ExitReason::FaultBadJumpTarget as u64 => {
+                return Err(TraceError::Backend(
+                    "indirect jump to a non-compiled address",
+                ));
+            }
+            _ => {
+                if let Some(message) = host.helper_error.take() {
+                    tracing_error(&message);
+                }
+                return Err(TraceError::Backend("host helper reported an error"));
+            }
+        }
+
+        Ok(FastRunOutput {
+            trace_len: guest.trace_len as usize,
+            device: host.device,
+            final_memory: MemoryImage {
+                bytes: plane.materialized_nonzero_bytes(),
+            },
+            advice_tape: host.advice_tape,
+        })
+    }
+}
+
+#[expect(clippy::print_stderr)]
+fn tracing_error(message: &str) {
+    eprintln!("jolt-tracer-x86 helper error: {message}");
+}
+
+impl ExecutionBackend for X86TracerBackend {
+    type Trace = OwnedTrace;
+
+    fn trace(
+        &mut self,
+        _program: &JoltProgram,
+        _inputs: TraceInputs,
+    ) -> Result<TraceOutput<Self::Trace>, TraceError> {
+        // Record mode lands in the full-coverage slice; fail fast until then
+        // so no caller silently gets an empty trace.
+        Err(TraceError::Backend(
+            "jolt-tracer-x86 record mode is not implemented yet (use fast_run)",
+        ))
+    }
+}
+
+/// FNV-1a over the ELF bytes: cheap, stable identity for the compile cache.
+fn fingerprint(bytes: &[u8]) -> u64 {
+    let mut hash = 0xcbf2_9ce4_8422_2325u64;
+    for &byte in bytes {
+        hash ^= byte as u64;
+        hash = hash.wrapping_mul(0x0000_0100_0000_01b3);
+    }
+    hash
+}

--- a/crates/jolt-tracer-x86/src/native/mod.rs
+++ b/crates/jolt-tracer-x86/src/native/mod.rs
@@ -12,12 +12,14 @@ use std::sync::Arc;
 
 use common::jolt_device::JoltDevice;
 use jolt_program::execution::{
-    ExecutionBackend, JoltProgram, MemoryImage, OwnedTrace, TraceError, TraceInputs, TraceOutput,
+    ExecutionBackend, JoltProgram, MemoryImage, OwnedTrace, RamAccess, RamRead, RamWrite,
+    RegisterRead, RegisterState, RegisterWrite, TraceError, TraceInputs, TraceOutput, TraceRow,
 };
+use jolt_riscv::{JoltInstructionKind, JoltInstructionRow};
 
 use compile::CompiledProgram;
 use memory::MemoryPlane;
-use state::{ExitReason, GuestState, HostContext};
+use state::{ExitReason, GuestState, HostContext, Observation};
 
 /// AOT x86-64 transpiling execution backend.
 ///
@@ -62,6 +64,72 @@ impl X86TracerBackend {
         Ok(compiled)
     }
 
+    /// Recording pass: execute with per-row value capture into an
+    /// observation buffer sized to `expected_rows` (plus slack, so a
+    /// divergence overflows loudly instead of writing out of bounds).
+    fn record_run(
+        &mut self,
+        program: &JoltProgram,
+        inputs: TraceInputs,
+        expected_rows: usize,
+    ) -> Result<RecordRunOutput, TraceError> {
+        let compiled = self.compiled(program)?;
+
+        let mut device = JoltDevice::new(&inputs.memory_config);
+        device.inputs.clone_from(&inputs.inputs);
+        device.trusted_advice.clone_from(&inputs.trusted_advice);
+        device.untrusted_advice.clone_from(&inputs.untrusted_advice);
+
+        let plane_size = device.memory_layout.get_total_memory_size();
+        let mut plane = MemoryPlane::new(plane_size as usize)?;
+        plane.init_from_image(&program.memory_init)?;
+
+        let mut host = HostContext {
+            device,
+            advice_tape: inputs.advice_tape.clone().unwrap_or_default(),
+            advice_cursor: 0,
+            helper_error: None,
+        };
+
+        let mut observations = vec![Observation::default(); expected_rows + 1];
+        let obs_start = observations.as_mut_ptr();
+        // SAFETY: one-past-the-end of the allocation, only ever compared
+        // against, never dereferenced.
+        let obs_end = unsafe { obs_start.add(observations.len()) };
+
+        let mut guest = Box::new(GuestState {
+            x: [0; common::constants::REGISTER_COUNT as usize],
+            pc: program.entry_address,
+            trace_len: 0,
+            exit: ExitReason::Running as u64,
+            fault_addr: 0,
+            mem_base: plane.base() as u64,
+            mem_size: plane.size() as u64,
+            host: &raw mut host,
+            advice_slots: [0; crate::native::state::ADVICE_SLOTS],
+            advice_jobs: compiled.advice_jobs_ptr(),
+            obs_cursor: obs_start,
+            obs_end,
+        });
+
+        compiled.run_record(&mut guest)?;
+        check_exit(&guest, &mut host)?;
+
+        // The cursor's advance is the recorded row count.
+        let recorded =
+            (guest.obs_cursor as usize - obs_start as usize) / core::mem::size_of::<Observation>();
+        observations.truncate(recorded);
+
+        Ok(RecordRunOutput {
+            observations,
+            device: host.device,
+            final_memory: MemoryImage {
+                bytes: plane.materialized_nonzero_bytes(),
+            },
+            advice_tape: host.advice_tape,
+        })
+    }
+
     /// Fast pass: run the program to completion without materializing trace
     /// rows. (Checkpoint logging joins in the chunked-execution slice.)
     pub fn fast_run(
@@ -101,27 +169,12 @@ impl X86TracerBackend {
             host: &raw mut host,
             advice_slots: [0; crate::native::state::ADVICE_SLOTS],
             advice_jobs: compiled.advice_jobs_ptr(),
+            obs_cursor: core::ptr::null_mut(),
+            obs_end: core::ptr::null_mut(),
         });
 
         compiled.run(&mut guest)?;
-
-        match guest.exit {
-            e if e == ExitReason::Terminated as u64 => {}
-            e if e == ExitReason::FaultOutOfBounds as u64 => {
-                return Err(TraceError::Backend("guest RAM access out of bounds"));
-            }
-            e if e == ExitReason::FaultBadJumpTarget as u64 => {
-                return Err(TraceError::Backend(
-                    "indirect jump to a non-compiled address",
-                ));
-            }
-            _ => {
-                if let Some(message) = host.helper_error.take() {
-                    tracing_error(&message);
-                }
-                return Err(TraceError::Backend("host helper reported an error"));
-            }
-        }
+        check_exit(&guest, &mut host)?;
 
         Ok(FastRunOutput {
             trace_len: guest.trace_len as usize,
@@ -134,6 +187,33 @@ impl X86TracerBackend {
     }
 }
 
+/// Translate a generated-code exit into a `TraceError`.
+fn check_exit(guest: &GuestState, host: &mut HostContext) -> Result<(), TraceError> {
+    match guest.exit {
+        e if e == ExitReason::Terminated as u64 => {}
+        e if e == ExitReason::FaultOutOfBounds as u64 => {
+            return Err(TraceError::Backend("guest RAM access out of bounds"));
+        }
+        e if e == ExitReason::FaultBadJumpTarget as u64 => {
+            return Err(TraceError::Backend(
+                "indirect jump to a non-compiled address",
+            ));
+        }
+        e if e == ExitReason::FaultObservationOverflow as u64 => {
+            return Err(TraceError::Backend(
+                "record pass overflowed the observation buffer (row-count divergence)",
+            ));
+        }
+        _ => {
+            if let Some(message) = host.helper_error.take() {
+                tracing_error(&message);
+            }
+            return Err(TraceError::Backend("host helper reported an error"));
+        }
+    }
+    Ok(())
+}
+
 #[expect(clippy::print_stderr)]
 fn tracing_error(message: &str) {
     eprintln!("jolt-tracer-x86 helper error: {message}");
@@ -142,16 +222,102 @@ fn tracing_error(message: &str) {
 impl ExecutionBackend for X86TracerBackend {
     type Trace = OwnedTrace;
 
+    /// Record mode: a fast pass sizes the observation buffer exactly, then the
+    /// record body fills it and a Rust pass reassembles `TraceRow`s.
+    ///
+    /// Two passes cost about 12% over recording alone (the fast pass runs at
+    /// several hundred MHz) and buy an exactly-sized buffer plus a
+    /// cross-check: if the record body emits a different row count than the
+    /// fast pass counted, the two diverged and that is a bug, caught here
+    /// rather than in a proof.
     fn trace(
         &mut self,
-        _program: &JoltProgram,
-        _inputs: TraceInputs,
+        program: &JoltProgram,
+        inputs: TraceInputs,
     ) -> Result<TraceOutput<Self::Trace>, TraceError> {
-        // Record mode lands in the full-coverage slice; fail fast until then
-        // so no caller silently gets an empty trace.
-        Err(TraceError::Backend(
-            "jolt-tracer-x86 record mode is not implemented yet (use fast_run)",
-        ))
+        let expected = self.fast_run(program, inputs.clone())?;
+        let record = self.record_run(program, inputs, expected.trace_len)?;
+
+        if record.observations.len() != expected.trace_len {
+            return Err(TraceError::Backend(
+                "record pass emitted a different row count than the fast pass",
+            ));
+        }
+        let rows = reassemble_rows(&program.expanded_bytecode, &record.observations)?;
+        Ok(TraceOutput::new(
+            OwnedTrace::new(rows),
+            record.device,
+            Some(record.final_memory),
+        )
+        .with_advice_tape(Some(record.advice_tape)))
+    }
+}
+
+/// Result of a recording pass.
+struct RecordRunOutput {
+    observations: Vec<Observation>,
+    device: JoltDevice,
+    final_memory: MemoryImage,
+    advice_tape: Vec<u8>,
+}
+
+/// Rebuild `TraceRow`s from the static bytecode plus the recorded dynamic
+/// values. Generated code cannot construct `TraceRow` directly (its `Option`
+/// fields have no guaranteed layout), so this is the seam between the two.
+fn reassemble_rows(
+    bytecode: &[JoltInstructionRow],
+    observations: &[Observation],
+) -> Result<Vec<TraceRow>, TraceError> {
+    let mut rows = Vec::with_capacity(observations.len());
+    for observation in observations {
+        let row = bytecode
+            .get(observation.row_index as usize)
+            .ok_or(TraceError::Backend("observation row index out of range"))?;
+        rows.push(TraceRow {
+            instruction: *row,
+            registers: RegisterState {
+                rs1: register_read(row.operands.rs1, observation.rs1),
+                rs2: register_read(row.operands.rs2, observation.rs2),
+                rd: row.operands.rd.map(|register| RegisterWrite {
+                    register,
+                    // x0 reads as zero on both sides of a write.
+                    pre_value: if register == 0 { 0 } else { observation.rd_pre },
+                    post_value: if register == 0 {
+                        0
+                    } else {
+                        observation.rd_post
+                    },
+                }),
+            },
+            ram_access: ram_access(row.instruction_kind, observation),
+            #[cfg(feature = "field-inline")]
+            field_inline: None,
+        });
+    }
+    Ok(rows)
+}
+
+fn register_read(register: Option<u8>, value: u64) -> Option<RegisterRead> {
+    register.map(|register| RegisterRead {
+        register,
+        value: if register == 0 { 0 } else { value },
+    })
+}
+
+/// Which RAM access a row records is a static property of its kind: only
+/// `Ld` and `Sd` touch RAM in final bytecode.
+fn ram_access(kind: JoltInstructionKind, observation: &Observation) -> RamAccess {
+    match kind {
+        JoltInstructionKind::LD => RamAccess::Read(RamRead {
+            address: observation.ram_address,
+            value: observation.ram_pre,
+        }),
+        JoltInstructionKind::SD => RamAccess::Write(RamWrite {
+            address: observation.ram_address,
+            pre_value: observation.ram_pre,
+            post_value: observation.ram_post,
+        }),
+        _ => RamAccess::NoOp,
     }
 }
 

--- a/crates/jolt-tracer-x86/src/native/mod.rs
+++ b/crates/jolt-tracer-x86/src/native/mod.rs
@@ -251,8 +251,8 @@ impl ExecutionBackend for X86TracerBackend {
             OwnedTrace::new(rows),
             record.device,
             Some(record.final_memory),
-        )
-        .with_advice_tape(Some(record.advice_tape)))
+            Some(record.advice_tape),
+        ))
     }
 }
 

--- a/crates/jolt-tracer-x86/src/native/mod.rs
+++ b/crates/jolt-tracer-x86/src/native/mod.rs
@@ -38,9 +38,33 @@ struct CachedProgram {
 }
 
 impl CachedProgram {
-    /// FNV-1a over the ELF bytes: cheap, stable identity for the compile cache.
-    fn fingerprint(bytes: &[u8]) -> u64 {
-        let mut hash = 0xcbf2_9ce4_8422_2325u64;
+    /// Cheap, stable identity for the compile cache.
+    ///
+    /// The compiled artifact is a function of the expanded bytecode, which
+    /// `build_jolt_program*` derives deterministically from the ELF, the
+    /// instruction profile, and the linked inline registry (fixed at link
+    /// time). Hashing millions of rows per trace call would cost more than
+    /// the compile it saves, so the key is FNV-1a over the ELF bytes plus the
+    /// profile and two cheap bytecode guards (length, entry) that also
+    /// separate hand-assembled `from_parts` programs sharing an ELF.
+    fn fingerprint(program: &JoltProgram) -> u64 {
+        let mut hash = Self::fnv_extend(0xcbf2_9ce4_8422_2325, program.elf_bytes());
+        // Domain-separated so source and inline extension lists cannot alias.
+        for &extension in program.profile.source_extensions {
+            hash = Self::fnv_extend(hash, &[b'S', extension as u8]);
+        }
+        for &extension in program.profile.inline_extensions {
+            hash = Self::fnv_extend(hash, &[b'I', extension as u8]);
+        }
+        hash = Self::fnv_extend(
+            hash,
+            &(program.expanded_bytecode.len() as u64).to_le_bytes(),
+        );
+        hash = Self::fnv_extend(hash, &program.entry_address.to_le_bytes());
+        hash
+    }
+
+    fn fnv_extend(mut hash: u64, bytes: &[u8]) -> u64 {
         for &byte in bytes {
             hash ^= byte as u64;
             hash = hash.wrapping_mul(0x0000_0100_0000_01b3);
@@ -63,7 +87,7 @@ impl X86TracerBackend {
     }
 
     fn compiled(&mut self, program: &JoltProgram) -> Result<Arc<CompiledProgram>, TraceError> {
-        let fingerprint = CachedProgram::fingerprint(program.elf_bytes());
+        let fingerprint = CachedProgram::fingerprint(program);
         if let Some(cached) = &self.cache {
             if cached.fingerprint == fingerprint {
                 return Ok(Arc::clone(&cached.compiled));
@@ -588,5 +612,84 @@ impl ChunkedExecutionBackend for X86TracerBackend {
             &observations[checkpoint.skip_rows..],
         )?;
         Ok(OwnedTrace::new(rows))
+    }
+}
+
+#[cfg(test)]
+#[expect(clippy::expect_used)]
+mod tests {
+    use super::*;
+    use jolt_riscv::{NormalizedOperands, RV64IMAC_JOLT, RV64IMAC_JOLT_ALL_INLINES};
+
+    /// A one-row program (an always-taken self-branch) that compiles under
+    /// any profile, with a fake ELF identity for cache-key tests.
+    fn program_with_profile(profile: jolt_riscv::JoltInstructionProfile) -> JoltProgram {
+        let terminal = JoltInstructionRow {
+            instruction_kind: JoltInstructionKind::BEQ,
+            address: 0x8000_1000,
+            operands: NormalizedOperands {
+                rs1: Some(0),
+                rs2: Some(0),
+                rd: None,
+                imm: 0,
+            },
+            virtual_sequence_remaining: None,
+            is_first_in_sequence: true,
+            is_compressed: false,
+        };
+        JoltProgram::from_parts_with_profile(
+            Vec::new(),
+            vec![terminal],
+            Vec::new(),
+            0x8000_0400,
+            0x8000_1000,
+            profile,
+        )
+    }
+
+    /// Same ELF under a different instruction profile expands to different
+    /// bytecode, so it must miss the compile cache and recompile.
+    #[test]
+    fn cache_recompiles_when_only_the_profile_differs() {
+        let base = program_with_profile(RV64IMAC_JOLT);
+        let mut inlines = base.clone();
+        inlines.profile = RV64IMAC_JOLT_ALL_INLINES;
+        assert_ne!(
+            CachedProgram::fingerprint(&base),
+            CachedProgram::fingerprint(&inlines),
+            "profile must be part of the cache key"
+        );
+
+        let mut backend = X86TracerBackend::new();
+        let first = backend.compiled(&base).expect("compile failed");
+        let second = backend.compiled(&inlines).expect("compile failed");
+        assert!(
+            !Arc::ptr_eq(&first, &second),
+            "same-ELF program with a different profile reused the cached artifact"
+        );
+        // Unchanged identity is a hit, not a recompile.
+        let third = backend.compiled(&inlines).expect("compile failed");
+        assert!(Arc::ptr_eq(&second, &third));
+    }
+
+    /// Hand-assembled programs share an (empty) ELF; the bytecode guards must
+    /// still separate them.
+    #[test]
+    fn cache_key_separates_programs_sharing_an_elf() {
+        let one = program_with_profile(RV64IMAC_JOLT);
+        let mut two = one.clone();
+        two.expanded_bytecode
+            .extend_from_slice(&one.expanded_bytecode);
+        assert_ne!(
+            CachedProgram::fingerprint(&one),
+            CachedProgram::fingerprint(&two)
+        );
+
+        let mut entry = one.clone();
+        entry.entry_address += 4;
+        assert_ne!(
+            CachedProgram::fingerprint(&one),
+            CachedProgram::fingerprint(&entry)
+        );
     }
 }

--- a/crates/jolt-tracer-x86/src/native/mod.rs
+++ b/crates/jolt-tracer-x86/src/native/mod.rs
@@ -37,6 +37,18 @@ struct CachedProgram {
     compiled: Arc<CompiledProgram>,
 }
 
+impl CachedProgram {
+    /// FNV-1a over the ELF bytes: cheap, stable identity for the compile cache.
+    fn fingerprint(bytes: &[u8]) -> u64 {
+        let mut hash = 0xcbf2_9ce4_8422_2325u64;
+        for &byte in bytes {
+            hash ^= byte as u64;
+            hash = hash.wrapping_mul(0x0000_0100_0000_01b3);
+        }
+        hash
+    }
+}
+
 /// Result of a fast (non-recording) pass.
 pub struct FastRunOutput {
     pub trace_len: usize,
@@ -51,13 +63,13 @@ impl X86TracerBackend {
     }
 
     fn compiled(&mut self, program: &JoltProgram) -> Result<Arc<CompiledProgram>, TraceError> {
-        let fingerprint = fingerprint(program.elf_bytes());
+        let fingerprint = CachedProgram::fingerprint(program.elf_bytes());
         if let Some(cached) = &self.cache {
             if cached.fingerprint == fingerprint {
                 return Ok(Arc::clone(&cached.compiled));
             }
         }
-        let compiled = Arc::new(compile::compile(program)?);
+        let compiled = Arc::new(CompiledProgram::compile(program)?);
         self.cache = Some(CachedProgram {
             fingerprint,
             compiled: Arc::clone(&compiled),
@@ -115,7 +127,7 @@ impl X86TracerBackend {
         });
 
         compiled.run_record(&mut guest)?;
-        check_exit(&guest, &mut host)?;
+        guest.check_exit(&mut host)?;
 
         // The cursor's advance is the recorded row count.
         let recorded =
@@ -177,7 +189,7 @@ impl X86TracerBackend {
         });
 
         compiled.run(&mut guest)?;
-        check_exit(&guest, &mut host)?;
+        guest.check_exit(&mut host)?;
 
         Ok(FastRunOutput {
             trace_len: guest.trace_len as usize,
@@ -188,38 +200,6 @@ impl X86TracerBackend {
             advice_tape: host.advice_tape,
         })
     }
-}
-
-/// Translate a generated-code exit into a `TraceError`.
-fn check_exit(guest: &GuestState, host: &mut HostContext) -> Result<(), TraceError> {
-    match guest.exit {
-        e if e == ExitReason::Terminated as u64 => {}
-        e if e == ExitReason::FaultOutOfBounds as u64 => {
-            return Err(TraceError::Backend("guest RAM access out of bounds"));
-        }
-        e if e == ExitReason::FaultBadJumpTarget as u64 => {
-            return Err(TraceError::Backend(
-                "indirect jump to a non-compiled address",
-            ));
-        }
-        e if e == ExitReason::FaultObservationOverflow as u64 => {
-            return Err(TraceError::Backend(
-                "record pass overflowed the observation buffer (row-count divergence)",
-            ));
-        }
-        _ => {
-            if let Some(message) = host.helper_error.take() {
-                tracing_error(&message);
-            }
-            return Err(TraceError::Backend("host helper reported an error"));
-        }
-    }
-    Ok(())
-}
-
-#[expect(clippy::print_stderr)]
-fn tracing_error(message: &str) {
-    eprintln!("jolt-tracer-x86 helper error: {message}");
 }
 
 impl ExecutionBackend for X86TracerBackend {
@@ -246,7 +226,7 @@ impl ExecutionBackend for X86TracerBackend {
                 "record pass emitted a different row count than the fast pass",
             ));
         }
-        let rows = reassemble_rows(&program.expanded_bytecode, &record.observations)?;
+        let rows = Observation::reassemble_rows(&program.expanded_bytecode, &record.observations)?;
         Ok(TraceOutput::new(
             OwnedTrace::new(rows),
             record.device,
@@ -264,90 +244,67 @@ struct RecordRunOutput {
     advice_tape: Vec<u8>,
 }
 
-/// Longest run of rows sharing a source address, i.e. the largest expansion
-/// a single source instruction produces.
-fn longest_group(bytecode: &[JoltInstructionRow]) -> usize {
-    let mut longest = 1usize;
-    let mut current = 1usize;
-    for pair in bytecode.windows(2) {
-        if pair[0].address == pair[1].address {
-            current += 1;
-            longest = longest.max(current);
-        } else {
-            current = 1;
+impl Observation {
+    /// Rebuild `TraceRow`s from the static bytecode plus the recorded dynamic
+    /// values. Generated code cannot construct `TraceRow` directly (its
+    /// `Option` fields have no guaranteed layout), so this is the seam between
+    /// the two.
+    fn reassemble_rows(
+        bytecode: &[JoltInstructionRow],
+        observations: &[Self],
+    ) -> Result<Vec<TraceRow>, TraceError> {
+        let mut rows = Vec::with_capacity(observations.len());
+        for observation in observations {
+            let row = bytecode
+                .get(observation.row_index as usize)
+                .ok_or(TraceError::Backend("observation row index out of range"))?;
+            rows.push(TraceRow {
+                instruction: *row,
+                registers: RegisterState {
+                    rs1: Self::register_read(row.operands.rs1, observation.rs1),
+                    rs2: Self::register_read(row.operands.rs2, observation.rs2),
+                    rd: row.operands.rd.map(|register| RegisterWrite {
+                        register,
+                        // x0 reads as zero on both sides of a write.
+                        pre_value: if register == 0 { 0 } else { observation.rd_pre },
+                        post_value: if register == 0 {
+                            0
+                        } else {
+                            observation.rd_post
+                        },
+                    }),
+                },
+                ram_access: observation.ram_access(row.instruction_kind),
+                #[cfg(feature = "field-inline")]
+                field_inline: None,
+            });
+        }
+        Ok(rows)
+    }
+
+    fn register_read(register: Option<u8>, value: u64) -> Option<RegisterRead> {
+        register.map(|register| RegisterRead {
+            register,
+            value: if register == 0 { 0 } else { value },
+        })
+    }
+
+    /// Which RAM access a row records is a static property of its kind: only
+    /// `Ld` and `Sd` touch RAM in final bytecode.
+    fn ram_access(&self, kind: JoltInstructionKind) -> RamAccess {
+        match kind {
+            JoltInstructionKind::LD => RamAccess::Read(RamRead {
+                address: self.ram_address,
+                value: self.ram_pre,
+            }),
+            JoltInstructionKind::SD => RamAccess::Write(RamWrite {
+                address: self.ram_address,
+                pre_value: self.ram_pre,
+                post_value: self.ram_post,
+            }),
+            _ => RamAccess::NoOp,
         }
     }
-    longest
-}
-
-/// Rebuild `TraceRow`s from the static bytecode plus the recorded dynamic
-/// values. Generated code cannot construct `TraceRow` directly (its `Option`
-/// fields have no guaranteed layout), so this is the seam between the two.
-fn reassemble_rows(
-    bytecode: &[JoltInstructionRow],
-    observations: &[Observation],
-) -> Result<Vec<TraceRow>, TraceError> {
-    let mut rows = Vec::with_capacity(observations.len());
-    for observation in observations {
-        let row = bytecode
-            .get(observation.row_index as usize)
-            .ok_or(TraceError::Backend("observation row index out of range"))?;
-        rows.push(TraceRow {
-            instruction: *row,
-            registers: RegisterState {
-                rs1: register_read(row.operands.rs1, observation.rs1),
-                rs2: register_read(row.operands.rs2, observation.rs2),
-                rd: row.operands.rd.map(|register| RegisterWrite {
-                    register,
-                    // x0 reads as zero on both sides of a write.
-                    pre_value: if register == 0 { 0 } else { observation.rd_pre },
-                    post_value: if register == 0 {
-                        0
-                    } else {
-                        observation.rd_post
-                    },
-                }),
-            },
-            ram_access: ram_access(row.instruction_kind, observation),
-            #[cfg(feature = "field-inline")]
-            field_inline: None,
-        });
-    }
-    Ok(rows)
-}
-
-fn register_read(register: Option<u8>, value: u64) -> Option<RegisterRead> {
-    register.map(|register| RegisterRead {
-        register,
-        value: if register == 0 { 0 } else { value },
-    })
-}
-
-/// Which RAM access a row records is a static property of its kind: only
-/// `Ld` and `Sd` touch RAM in final bytecode.
-fn ram_access(kind: JoltInstructionKind, observation: &Observation) -> RamAccess {
-    match kind {
-        JoltInstructionKind::LD => RamAccess::Read(RamRead {
-            address: observation.ram_address,
-            value: observation.ram_pre,
-        }),
-        JoltInstructionKind::SD => RamAccess::Write(RamWrite {
-            address: observation.ram_address,
-            pre_value: observation.ram_pre,
-            post_value: observation.ram_post,
-        }),
-        _ => RamAccess::NoOp,
-    }
-}
-
-/// FNV-1a over the ELF bytes: cheap, stable identity for the compile cache.
-fn fingerprint(bytes: &[u8]) -> u64 {
-    let mut hash = 0xcbf2_9ce4_8422_2325u64;
-    for &byte in bytes {
-        hash ^= byte as u64;
-        hash = hash.wrapping_mul(0x0000_0100_0000_01b3);
-    }
-    hash
 }
 
 /// A resume point for the chunked contract: the guest state at a group
@@ -380,6 +337,23 @@ pub struct X86Checkpoint {
     max_group_rows: usize,
 }
 
+impl X86Checkpoint {
+    /// Largest expansion of one source instruction in the static bytecode.
+    fn max_group_rows(bytecode: &[JoltInstructionRow]) -> usize {
+        let mut longest = 1usize;
+        let mut current = 1usize;
+        for pair in bytecode.windows(2) {
+            if pair[0].address == pair[1].address {
+                current += 1;
+                longest = longest.max(current);
+            } else {
+                current = 1;
+            }
+        }
+        longest
+    }
+}
+
 /// Guest state at a group boundary: everything a replay needs to resume.
 struct Boundary {
     registers: [u64; common::constants::REGISTER_COUNT as usize],
@@ -394,6 +368,43 @@ struct Boundary {
     device_panic: bool,
     advice_tape: Vec<u8>,
     advice_cursor: usize,
+}
+
+impl Boundary {
+    fn capture(
+        guest: &GuestState,
+        host: &HostContext,
+        plane: &MemoryPlane,
+        memory_config: common::jolt_device::MemoryConfig,
+    ) -> Arc<Self> {
+        Arc::new(Self {
+            registers: guest.x,
+            pc: guest.pc,
+            memory: plane.to_vec(),
+            memory_config,
+            device_inputs: host.device.inputs.clone(),
+            device_trusted_advice: host.device.trusted_advice.clone(),
+            device_untrusted_advice: host.device.untrusted_advice.clone(),
+            device_outputs: host.device.outputs.clone(),
+            device_panic: host.device.panic,
+            advice_tape: host.advice_tape.clone(),
+            advice_cursor: host.advice_cursor,
+        })
+    }
+
+    fn restore_device(&self) -> JoltDevice {
+        let mut device = JoltDevice::new(&self.memory_config);
+        device.inputs.clone_from(&self.device_inputs);
+        device
+            .trusted_advice
+            .clone_from(&self.device_trusted_advice);
+        device
+            .untrusted_advice
+            .clone_from(&self.device_untrusted_advice);
+        device.outputs.clone_from(&self.device_outputs);
+        device.panic = self.device_panic;
+        device
+    }
 }
 
 // SAFETY: every field is owned data or an Arc to an immutable artifact (the
@@ -460,23 +471,11 @@ impl ChunkedExecutionBackend for X86TracerBackend {
         // initial state, which every early chunk resumes from.
         let mut boundaries: Vec<(usize, Arc<Boundary>)> = Vec::new();
         let bytecode = Arc::new(program.expanded_bytecode.clone());
-        let max_group_rows = longest_group(&bytecode);
-        let snapshot = |guest: &GuestState, host: &HostContext, plane: &MemoryPlane| {
-            Arc::new(Boundary {
-                registers: guest.x,
-                pc: guest.pc,
-                memory: plane.to_vec(),
-                memory_config: inputs.memory_config,
-                device_inputs: host.device.inputs.clone(),
-                device_trusted_advice: host.device.trusted_advice.clone(),
-                device_untrusted_advice: host.device.untrusted_advice.clone(),
-                device_outputs: host.device.outputs.clone(),
-                device_panic: host.device.panic,
-                advice_tape: host.advice_tape.clone(),
-                advice_cursor: host.advice_cursor,
-            })
-        };
-        boundaries.push((0, snapshot(&guest, &host, &plane)));
+        let max_group_rows = X86Checkpoint::max_group_rows(&bytecode);
+        boundaries.push((
+            0,
+            Boundary::capture(&guest, &host, &plane, inputs.memory_config),
+        ));
 
         // Run in increments, capturing a boundary at each pause. Checkpoints
         // carry a full image, so they are spaced at least this far apart
@@ -488,10 +487,13 @@ impl ChunkedExecutionBackend for X86TracerBackend {
             compiled.run_pausable(&mut guest)?;
             if guest.exit == ExitReason::Paused as u64 {
                 guest.exit = ExitReason::Running as u64;
-                boundaries.push((guest.trace_len as usize, snapshot(&guest, &host, &plane)));
+                boundaries.push((
+                    guest.trace_len as usize,
+                    Boundary::capture(&guest, &host, &plane, inputs.memory_config),
+                ));
                 continue;
             }
-            check_exit(&guest, &mut host)?;
+            guest.check_exit(&mut host)?;
             break;
         }
         let trace_len = guest.trace_len as usize;
@@ -531,16 +533,7 @@ impl ChunkedExecutionBackend for X86TracerBackend {
     /// leading rows the boundary precedes and keeping exactly this chunk's.
     fn replay_chunk(&self, checkpoint: &Self::Checkpoint) -> Result<Self::Trace, TraceError> {
         let boundary = &checkpoint.boundary;
-        let mut device = JoltDevice::new(&boundary.memory_config);
-        device.inputs.clone_from(&boundary.device_inputs);
-        device
-            .trusted_advice
-            .clone_from(&boundary.device_trusted_advice);
-        device
-            .untrusted_advice
-            .clone_from(&boundary.device_untrusted_advice);
-        device.outputs.clone_from(&boundary.device_outputs);
-        device.panic = boundary.device_panic;
+        let device = boundary.restore_device();
 
         let mut plane = MemoryPlane::new(boundary.memory.len())?;
         plane.restore(&boundary.memory);
@@ -579,7 +572,7 @@ impl ChunkedExecutionBackend for X86TracerBackend {
 
         checkpoint.compiled.run_record_pausable(&mut guest)?;
         if guest.exit != ExitReason::Paused as u64 {
-            check_exit(&guest, &mut host)?;
+            guest.check_exit(&mut host)?;
         }
 
         let recorded =
@@ -590,7 +583,10 @@ impl ChunkedExecutionBackend for X86TracerBackend {
             ));
         }
         observations.truncate(needed);
-        let rows = reassemble_rows(&checkpoint.bytecode, &observations[checkpoint.skip_rows..])?;
+        let rows = Observation::reassemble_rows(
+            &checkpoint.bytecode,
+            &observations[checkpoint.skip_rows..],
+        )?;
         Ok(OwnedTrace::new(rows))
     }
 }

--- a/crates/jolt-tracer-x86/src/native/mod.rs
+++ b/crates/jolt-tracer-x86/src/native/mod.rs
@@ -27,9 +27,25 @@ use state::{ExitReason, GuestState, HostContext, Observation};
 /// Compiles a [`JoltProgram`]'s expanded bytecode to native code on first use
 /// and caches the artifact keyed by the program's identity, so repeated
 /// traces and chunk replays reuse it.
-#[derive(Default)]
 pub struct X86TracerBackend {
     cache: Option<CachedProgram>,
+    /// Minimum row distance between checkpoint snapshots in [`Self::execute`]
+    /// (each carries a full memory image; `skip_rows` covers the gap to the
+    /// chunk mark). Production default is [`MIN_SPACING_ROWS`]; tests lower it
+    /// to force the pause/resume machinery on small guests.
+    min_checkpoint_spacing_rows: usize,
+}
+
+/// Default minimum spacing between checkpoint snapshots, in rows.
+const MIN_SPACING_ROWS: usize = 1 << 16;
+
+impl Default for X86TracerBackend {
+    fn default() -> Self {
+        Self {
+            cache: None,
+            min_checkpoint_spacing_rows: MIN_SPACING_ROWS,
+        }
+    }
 }
 
 struct CachedProgram {
@@ -84,6 +100,15 @@ pub struct FastRunOutput {
 impl X86TracerBackend {
     pub fn new() -> Self {
         Self::default()
+    }
+
+    /// Override the minimum checkpoint spacing (rows). Test seam: production
+    /// keeps the default, tests shrink it so small guests exercise the
+    /// pause/resume path (`Paused` exits, multi-boundary selection, boundary
+    /// restore) that real spacing only reaches past 2^16 rows.
+    #[doc(hidden)]
+    pub fn set_min_checkpoint_spacing_rows(&mut self, rows: usize) {
+        self.min_checkpoint_spacing_rows = rows.max(1);
     }
 
     fn compiled(&mut self, program: &JoltProgram) -> Result<Arc<CompiledProgram>, TraceError> {
@@ -362,6 +387,15 @@ pub struct X86Checkpoint {
 }
 
 impl X86Checkpoint {
+    /// Rows this checkpoint discards between its boundary and the chunk mark.
+    /// Test seam: lets the chunk-composition tests assert that checkpoints
+    /// resume from nearby boundaries (i.e. that pausing actually happened)
+    /// rather than replaying the whole prefix.
+    #[doc(hidden)]
+    pub fn skip_rows(&self) -> usize {
+        self.skip_rows
+    }
+
     /// Largest expansion of one source instruction in the static bytecode.
     fn max_group_rows(bytecode: &[JoltInstructionRow]) -> usize {
         let mut longest = 1usize;
@@ -504,8 +538,7 @@ impl ChunkedExecutionBackend for X86TracerBackend {
         // Run in increments, capturing a boundary at each pause. Checkpoints
         // carry a full image, so they are spaced at least this far apart
         // regardless of how small chunk_size is; `skip_rows` covers the gap.
-        const MIN_SPACING_ROWS: usize = 1 << 16;
-        let spacing = chunk_size.max(MIN_SPACING_ROWS);
+        let spacing = chunk_size.max(self.min_checkpoint_spacing_rows);
         loop {
             guest.row_limit = (guest.trace_len as usize + spacing) as u64;
             compiled.run_pausable(&mut guest)?;

--- a/crates/jolt-tracer-x86/src/native/mod.rs
+++ b/crates/jolt-tracer-x86/src/native/mod.rs
@@ -12,8 +12,9 @@ use std::sync::Arc;
 
 use common::jolt_device::JoltDevice;
 use jolt_program::execution::{
-    ExecutionBackend, JoltProgram, MemoryImage, OwnedTrace, RamAccess, RamRead, RamWrite,
-    RegisterRead, RegisterState, RegisterWrite, TraceError, TraceInputs, TraceOutput, TraceRow,
+    ChunkedExecutionBackend, ExecutionBackend, ExecutionSummary, JoltProgram, MemoryImage,
+    OwnedTrace, RamAccess, RamRead, RamWrite, RegisterRead, RegisterState, RegisterWrite,
+    TraceError, TraceInputs, TraceOutput, TraceRow,
 };
 use jolt_riscv::{JoltInstructionKind, JoltInstructionRow};
 
@@ -108,6 +109,7 @@ impl X86TracerBackend {
             host: &raw mut host,
             advice_slots: [0; crate::native::state::ADVICE_SLOTS],
             advice_jobs: compiled.advice_jobs_ptr(),
+            row_limit: u64::MAX,
             obs_cursor: obs_start,
             obs_end,
         });
@@ -169,6 +171,7 @@ impl X86TracerBackend {
             host: &raw mut host,
             advice_slots: [0; crate::native::state::ADVICE_SLOTS],
             advice_jobs: compiled.advice_jobs_ptr(),
+            row_limit: u64::MAX,
             obs_cursor: core::ptr::null_mut(),
             obs_end: core::ptr::null_mut(),
         });
@@ -261,6 +264,22 @@ struct RecordRunOutput {
     advice_tape: Vec<u8>,
 }
 
+/// Longest run of rows sharing a source address, i.e. the largest expansion
+/// a single source instruction produces.
+fn longest_group(bytecode: &[JoltInstructionRow]) -> usize {
+    let mut longest = 1usize;
+    let mut current = 1usize;
+    for pair in bytecode.windows(2) {
+        if pair[0].address == pair[1].address {
+            current += 1;
+            longest = longest.max(current);
+        } else {
+            current = 1;
+        }
+    }
+    longest
+}
+
 /// Rebuild `TraceRow`s from the static bytecode plus the recorded dynamic
 /// values. Generated code cannot construct `TraceRow` directly (its `Option`
 /// fields have no guaranteed layout), so this is the seam between the two.
@@ -329,4 +348,249 @@ fn fingerprint(bytes: &[u8]) -> u64 {
         hash = hash.wrapping_mul(0x0000_0100_0000_01b3);
     }
     hash
+}
+
+/// A resume point for the chunked contract: the guest state at a group
+/// boundary plus the memory image needed to replay from it.
+///
+/// The spec's preferred design is an access-value log (replay answers reads
+/// from the log, needing no image). This implementation snapshots the memory
+/// plane instead, which is the same tradeoff #1717's parallel machinery
+/// makes: correctness first, and the image is what makes a chunk replayable
+/// with no dependence on any other chunk. The `Checkpoint` associated type
+/// is deliberately opaque, so switching to logs later changes nothing for
+/// consumers.
+pub struct X86Checkpoint {
+    compiled: Arc<CompiledProgram>,
+    /// The program's expanded bytecode, shared with every checkpoint: row
+    /// reassembly needs the static half of each row.
+    bytecode: Arc<Vec<JoltInstructionRow>>,
+    /// The resume state, shared by every chunk that resumes from it. Boundary
+    /// images are plane-sized (tens of MB), so sharing is not an optimization
+    /// but a requirement: one image per chunk would exhaust memory at small
+    /// chunk sizes.
+    boundary: Arc<Boundary>,
+    /// Rows to discard after resuming (the boundary may precede the mark).
+    skip_rows: usize,
+    /// Rows this chunk emits.
+    take_rows: usize,
+    /// Longest source-instruction group in the program. Replay can only stop
+    /// at a group boundary, so it may overshoot its window by up to this
+    /// much; the observation buffer carries that slack.
+    max_group_rows: usize,
+}
+
+/// Guest state at a group boundary: everything a replay needs to resume.
+struct Boundary {
+    registers: [u64; common::constants::REGISTER_COUNT as usize],
+    pc: u64,
+    /// Full plane image at the boundary.
+    memory: Vec<u8>,
+    memory_config: common::jolt_device::MemoryConfig,
+    device_inputs: Vec<u8>,
+    device_trusted_advice: Vec<u8>,
+    device_untrusted_advice: Vec<u8>,
+    device_outputs: Vec<u8>,
+    device_panic: bool,
+    advice_tape: Vec<u8>,
+    advice_cursor: usize,
+}
+
+// SAFETY: every field is owned data or an Arc to an immutable artifact (the
+// compiled code and the bytecode), so the checkpoint can move between
+// threads.
+unsafe impl Send for X86Checkpoint {}
+// SAFETY: replay only reads the checkpoint, copying its image and registers
+// into fresh per-replay state, so shared references are safe to use
+// concurrently; there is no interior mutability.
+unsafe impl Sync for X86Checkpoint {}
+
+impl ChunkedExecutionBackend for X86TracerBackend {
+    type Checkpoint = X86Checkpoint;
+
+    /// Fast pass with checkpoint capture: run in row-bounded increments,
+    /// pausing at the first group boundary at or past each mark and
+    /// snapshotting the state there.
+    fn execute(
+        &mut self,
+        program: &JoltProgram,
+        inputs: TraceInputs,
+        chunk_size: usize,
+    ) -> Result<ExecutionSummary<Self::Checkpoint>, TraceError> {
+        if program.elf_bytes().is_empty() {
+            return Err(TraceError::MissingElfBytes);
+        }
+        if chunk_size == 0 {
+            return Err(TraceError::Backend("chunk_size must be nonzero"));
+        }
+        let compiled = self.compiled(program)?;
+
+        let mut device = JoltDevice::new(&inputs.memory_config);
+        device.inputs.clone_from(&inputs.inputs);
+        device.trusted_advice.clone_from(&inputs.trusted_advice);
+        device.untrusted_advice.clone_from(&inputs.untrusted_advice);
+
+        let plane_size = device.memory_layout.get_total_memory_size();
+        let mut plane = MemoryPlane::new(plane_size as usize)?;
+        plane.init_from_image(&program.memory_init)?;
+
+        let mut host = HostContext {
+            device,
+            advice_tape: inputs.advice_tape.clone().unwrap_or_default(),
+            advice_cursor: 0,
+            helper_error: None,
+        };
+        let mut guest = Box::new(GuestState {
+            x: [0; common::constants::REGISTER_COUNT as usize],
+            pc: program.entry_address,
+            trace_len: 0,
+            exit: ExitReason::Running as u64,
+            fault_addr: 0,
+            mem_base: plane.base() as u64,
+            mem_size: plane.size() as u64,
+            host: &raw mut host,
+            advice_slots: [0; crate::native::state::ADVICE_SLOTS],
+            advice_jobs: compiled.advice_jobs_ptr(),
+            row_limit: 0,
+            obs_cursor: core::ptr::null_mut(),
+            obs_end: core::ptr::null_mut(),
+        });
+
+        // Boundaries: (rows_before, snapshot). The first is the program's
+        // initial state, which every early chunk resumes from.
+        let mut boundaries: Vec<(usize, Arc<Boundary>)> = Vec::new();
+        let bytecode = Arc::new(program.expanded_bytecode.clone());
+        let max_group_rows = longest_group(&bytecode);
+        let snapshot = |guest: &GuestState, host: &HostContext, plane: &MemoryPlane| {
+            Arc::new(Boundary {
+                registers: guest.x,
+                pc: guest.pc,
+                memory: plane.to_vec(),
+                memory_config: inputs.memory_config,
+                device_inputs: host.device.inputs.clone(),
+                device_trusted_advice: host.device.trusted_advice.clone(),
+                device_untrusted_advice: host.device.untrusted_advice.clone(),
+                device_outputs: host.device.outputs.clone(),
+                device_panic: host.device.panic,
+                advice_tape: host.advice_tape.clone(),
+                advice_cursor: host.advice_cursor,
+            })
+        };
+        boundaries.push((0, snapshot(&guest, &host, &plane)));
+
+        // Run in increments, capturing a boundary at each pause. Checkpoints
+        // carry a full image, so they are spaced at least this far apart
+        // regardless of how small chunk_size is; `skip_rows` covers the gap.
+        const MIN_SPACING_ROWS: usize = 1 << 16;
+        let spacing = chunk_size.max(MIN_SPACING_ROWS);
+        loop {
+            guest.row_limit = (guest.trace_len as usize + spacing) as u64;
+            compiled.run(&mut guest)?;
+            if guest.exit == ExitReason::Paused as u64 {
+                guest.exit = ExitReason::Running as u64;
+                boundaries.push((guest.trace_len as usize, snapshot(&guest, &host, &plane)));
+                continue;
+            }
+            check_exit(&guest, &mut host)?;
+            break;
+        }
+        let trace_len = guest.trace_len as usize;
+
+        // One contract checkpoint per chunk mark, resuming from the latest
+        // boundary at or before it.
+        let mut checkpoints = Vec::with_capacity(trace_len.div_ceil(chunk_size));
+        let mut index = 0usize;
+        for chunk in 0..trace_len.div_ceil(chunk_size) {
+            let mark = chunk * chunk_size;
+            while index + 1 < boundaries.len() && boundaries[index + 1].0 <= mark {
+                index += 1;
+            }
+            let (rows_before, boundary) = &boundaries[index];
+            checkpoints.push(X86Checkpoint {
+                compiled: Arc::clone(&compiled),
+                bytecode: Arc::clone(&bytecode),
+                boundary: Arc::clone(boundary),
+                skip_rows: mark - rows_before,
+                take_rows: chunk_size.min(trace_len - mark),
+                max_group_rows,
+            });
+        }
+
+        Ok(ExecutionSummary {
+            checkpoints,
+            trace_len,
+            device: host.device,
+            final_memory: Some(MemoryImage {
+                bytes: plane.materialized_nonzero_bytes(),
+            }),
+            advice_tape: Some(host.advice_tape),
+        })
+    }
+
+    /// Replay one chunk in record mode from its checkpoint, discarding the
+    /// leading rows the boundary precedes and keeping exactly this chunk's.
+    fn replay_chunk(&self, checkpoint: &Self::Checkpoint) -> Result<Self::Trace, TraceError> {
+        let boundary = &checkpoint.boundary;
+        let mut device = JoltDevice::new(&boundary.memory_config);
+        device.inputs.clone_from(&boundary.device_inputs);
+        device
+            .trusted_advice
+            .clone_from(&boundary.device_trusted_advice);
+        device
+            .untrusted_advice
+            .clone_from(&boundary.device_untrusted_advice);
+        device.outputs.clone_from(&boundary.device_outputs);
+        device.panic = boundary.device_panic;
+
+        let mut plane = MemoryPlane::new(boundary.memory.len())?;
+        plane.restore(&boundary.memory);
+
+        let mut host = HostContext {
+            device,
+            advice_tape: boundary.advice_tape.clone(),
+            advice_cursor: boundary.advice_cursor,
+            helper_error: None,
+        };
+
+        let needed = checkpoint.skip_rows + checkpoint.take_rows;
+        // Slack for the overshoot: the row budget is checked at group starts,
+        // so a replay stops at the first boundary at or past `needed`.
+        let mut observations = vec![Observation::default(); needed + checkpoint.max_group_rows + 1];
+        let obs_start = observations.as_mut_ptr();
+        // SAFETY: one past the end of the allocation; compared, never read.
+        let obs_end = unsafe { obs_start.add(observations.len()) };
+
+        let mut guest = Box::new(GuestState {
+            x: boundary.registers,
+            pc: boundary.pc,
+            trace_len: 0,
+            exit: ExitReason::Running as u64,
+            fault_addr: 0,
+            mem_base: plane.base() as u64,
+            mem_size: plane.size() as u64,
+            host: &raw mut host,
+            advice_slots: [0; crate::native::state::ADVICE_SLOTS],
+            advice_jobs: checkpoint.compiled.advice_jobs_ptr(),
+            // Stop at the first group boundary at or past the window.
+            row_limit: needed as u64,
+            obs_cursor: obs_start,
+            obs_end,
+        });
+
+        checkpoint.compiled.run_record(&mut guest)?;
+        if guest.exit != ExitReason::Paused as u64 {
+            check_exit(&guest, &mut host)?;
+        }
+
+        let recorded =
+            (guest.obs_cursor as usize - obs_start as usize) / core::mem::size_of::<Observation>();
+        if recorded < needed {
+            return Err(TraceError::Backend(
+                "chunk replay produced fewer rows than the chunk window",
+            ));
+        }
+        observations.truncate(needed);
+        let rows = reassemble_rows(&checkpoint.bytecode, &observations[checkpoint.skip_rows..])?;
+        Ok(OwnedTrace::new(rows))
+    }
 }

--- a/crates/jolt-tracer-x86/src/native/mod.rs
+++ b/crates/jolt-tracer-x86/src/native/mod.rs
@@ -485,7 +485,7 @@ impl ChunkedExecutionBackend for X86TracerBackend {
         let spacing = chunk_size.max(MIN_SPACING_ROWS);
         loop {
             guest.row_limit = (guest.trace_len as usize + spacing) as u64;
-            compiled.run(&mut guest)?;
+            compiled.run_pausable(&mut guest)?;
             if guest.exit == ExitReason::Paused as u64 {
                 guest.exit = ExitReason::Running as u64;
                 boundaries.push((guest.trace_len as usize, snapshot(&guest, &host, &plane)));
@@ -577,7 +577,7 @@ impl ChunkedExecutionBackend for X86TracerBackend {
             obs_end,
         });
 
-        checkpoint.compiled.run_record(&mut guest)?;
+        checkpoint.compiled.run_record_pausable(&mut guest)?;
         if guest.exit != ExitReason::Paused as u64 {
             check_exit(&guest, &mut host)?;
         }

--- a/crates/jolt-tracer-x86/src/native/mod.rs
+++ b/crates/jolt-tracer-x86/src/native/mod.rs
@@ -99,6 +99,8 @@ impl X86TracerBackend {
             mem_base: plane.base() as u64,
             mem_size: plane.size() as u64,
             host: &raw mut host,
+            advice_slots: [0; crate::native::state::ADVICE_SLOTS],
+            advice_jobs: compiled.advice_jobs_ptr(),
         });
 
         compiled.run(&mut guest)?;

--- a/crates/jolt-tracer-x86/src/native/mod.rs
+++ b/crates/jolt-tracer-x86/src/native/mod.rs
@@ -465,14 +465,15 @@ impl Boundary {
     }
 }
 
-// SAFETY: every field is owned data or an Arc to an immutable artifact (the
-// compiled code and the bytecode), so the checkpoint can move between
-// threads.
-unsafe impl Send for X86Checkpoint {}
-// SAFETY: replay only reads the checkpoint, copying its image and registers
-// into fresh per-replay state, so shared references are safe to use
-// concurrently; there is no interior mutability.
-unsafe impl Sync for X86Checkpoint {}
+// Checkpoints are Send + Sync by construction: every field is owned data or
+// an Arc to an immutable artifact (the compiled code, the bytecode, the
+// boundary snapshot), so the auto traits apply — no unsafe impls, which would
+// silently vouch for a future non-thread-safe field. This assertion keeps the
+// property from regressing, since parallel chunk replay depends on it.
+const _: () = {
+    const fn assert_send_sync<T: Send + Sync>() {}
+    assert_send_sync::<X86Checkpoint>();
+};
 
 impl ChunkedExecutionBackend for X86TracerBackend {
     type Checkpoint = X86Checkpoint;

--- a/crates/jolt-tracer-x86/src/native/state.rs
+++ b/crates/jolt-tracer-x86/src/native/state.rs
@@ -24,6 +24,9 @@ pub enum ExitReason {
     /// Record mode ran out of observation slots (the record pass emitted more
     /// rows than the fast pass counted, i.e. the two diverged).
     FaultObservationOverflow = 5,
+    /// Paused at a group boundary having reached `row_limit`; `pc` holds the
+    /// resume point, so calling the body again continues the execution.
+    Paused = 6,
 }
 
 /// State shared with generated code. Field offsets are load-bearing.
@@ -53,6 +56,10 @@ pub struct GuestState {
     /// Per-program advice-job table (borrowed from the compiled artifact);
     /// generated code passes a job index, helpers dereference it.
     pub advice_jobs: *const AdviceJob,
+    /// Pause once `trace_len` reaches this, at the next group boundary (the
+    /// only place a resumable PC is statically known). `u64::MAX` disables
+    /// pausing, which is what the eager paths use.
+    pub row_limit: u64,
     /// Record mode: next observation slot, bumped per emitted row.
     pub obs_cursor: *mut Observation,
     /// Record mode: one past the last writable slot.
@@ -129,7 +136,8 @@ pub const OFF_MEM_SIZE: i32 = OFF_MEM_BASE + 8;
 pub const OFF_HOST: i32 = OFF_MEM_SIZE + 8;
 pub const OFF_ADVICE_SLOTS: i32 = OFF_HOST + 8;
 pub const OFF_ADVICE_JOBS: i32 = OFF_ADVICE_SLOTS + (ADVICE_SLOTS as i32) * 8;
-pub const OFF_OBS_CURSOR: i32 = OFF_ADVICE_JOBS + 8;
+pub const OFF_ROW_LIMIT: i32 = OFF_ADVICE_JOBS + 8;
+pub const OFF_OBS_CURSOR: i32 = OFF_ROW_LIMIT + 8;
 pub const OFF_OBS_END: i32 = OFF_OBS_CURSOR + 8;
 
 const _: () = {
@@ -143,6 +151,7 @@ const _: () = {
     assert!(core::mem::offset_of!(GuestState, host) == OFF_HOST as usize);
     assert!(core::mem::offset_of!(GuestState, advice_slots) == OFF_ADVICE_SLOTS as usize);
     assert!(core::mem::offset_of!(GuestState, advice_jobs) == OFF_ADVICE_JOBS as usize);
+    assert!(core::mem::offset_of!(GuestState, row_limit) == OFF_ROW_LIMIT as usize);
     assert!(core::mem::offset_of!(GuestState, obs_cursor) == OFF_OBS_CURSOR as usize);
     assert!(core::mem::offset_of!(GuestState, obs_end) == OFF_OBS_END as usize);
 };

--- a/crates/jolt-tracer-x86/src/native/state.rs
+++ b/crates/jolt-tracer-x86/src/native/state.rs
@@ -146,7 +146,18 @@ const _: () = {
 pub const ADVICE_SLOTS: usize = 16;
 
 /// One group's advice computation, resolved at compile time.
-pub enum AdviceJob {
+pub struct AdviceJob {
+    pub compute: AdviceCompute,
+    /// Number of `VirtualAdvice` rows in the job's group, i.e. how many
+    /// values the computation must provide. Patched in once the group's rows
+    /// have been emitted; the runtime helper checks the provided count
+    /// against it so a short advice vector fails loudly instead of leaving
+    /// stale slots to be read (the interpreter panics on the same mismatch).
+    pub advice_rows: usize,
+}
+
+/// How a group's advice values are computed.
+pub enum AdviceCompute {
     /// DIV/REM family: `code` selects the variant's formula.
     Div { code: u8, rs1: u8, rs2: u8 },
     /// A registered inline's `build_advice`, called through

--- a/crates/jolt-tracer-x86/src/native/state.rs
+++ b/crates/jolt-tracer-x86/src/native/state.rs
@@ -44,6 +44,28 @@ pub struct GuestState {
     pub mem_size: u64,
     /// Host context for helper calls (device, advice tape, panic state).
     pub host: *mut HostContext,
+    /// Runtime advice values for the group being executed, filled by the
+    /// group's advice helper and read by its `VirtualAdvice` rows in order.
+    pub advice_slots: [u64; ADVICE_SLOTS],
+    /// Per-program advice-job table (borrowed from the compiled artifact);
+    /// generated code passes a job index, helpers dereference it.
+    pub advice_jobs: *const AdviceJob,
+}
+
+/// Maximum runtime advice values one source-instruction group can need
+/// (largest today: the modular-division inlines at 8).
+pub const ADVICE_SLOTS: usize = 16;
+
+/// One group's advice computation, resolved at compile time.
+pub enum AdviceJob {
+    /// DIV/REM family: `code` selects the variant's formula.
+    Div { code: u8, rs1: u8, rs2: u8 },
+    /// A registered inline's `build_advice`, called through
+    /// [`InlineAdviceContext`](tracer::InlineAdviceContext).
+    Inline {
+        registration: &'static tracer::InlineRegistration,
+        operands: tracer::instruction::format::format_inline::FormatInline,
+    },
 }
 
 pub const OFF_X: i32 = 0;
@@ -54,6 +76,7 @@ pub const OFF_FAULT_ADDR: i32 = OFF_EXIT + 8;
 pub const OFF_MEM_BASE: i32 = OFF_FAULT_ADDR + 8;
 pub const OFF_MEM_SIZE: i32 = OFF_MEM_BASE + 8;
 pub const OFF_HOST: i32 = OFF_MEM_SIZE + 8;
+pub const OFF_ADVICE_SLOTS: i32 = OFF_HOST + 8;
 
 const _: () = {
     assert!(core::mem::offset_of!(GuestState, x) == OFF_X as usize);
@@ -64,7 +87,13 @@ const _: () = {
     assert!(core::mem::offset_of!(GuestState, mem_base) == OFF_MEM_BASE as usize);
     assert!(core::mem::offset_of!(GuestState, mem_size) == OFF_MEM_SIZE as usize);
     assert!(core::mem::offset_of!(GuestState, host) == OFF_HOST as usize);
+    assert!(core::mem::offset_of!(GuestState, advice_slots) == OFF_ADVICE_SLOTS as usize);
 };
+
+#[inline]
+pub const fn advice_slot_offset(slot: usize) -> i32 {
+    OFF_ADVICE_SLOTS + (slot as i32) * 8
+}
 
 #[inline]
 pub const fn reg_offset(register: u8) -> i32 {

--- a/crates/jolt-tracer-x86/src/native/state.rs
+++ b/crates/jolt-tracer-x86/src/native/state.rs
@@ -21,6 +21,9 @@ pub enum ExitReason {
     FaultBadJumpTarget = 3,
     /// A host helper reported an error (e.g. device access violation).
     FaultHelper = 4,
+    /// Record mode ran out of observation slots (the record pass emitted more
+    /// rows than the fast pass counted, i.e. the two diverged).
+    FaultObservationOverflow = 5,
 }
 
 /// State shared with generated code. Field offsets are load-bearing.
@@ -50,7 +53,55 @@ pub struct GuestState {
     /// Per-program advice-job table (borrowed from the compiled artifact);
     /// generated code passes a job index, helpers dereference it.
     pub advice_jobs: *const AdviceJob,
+    /// Record mode: next observation slot, bumped per emitted row.
+    pub obs_cursor: *mut Observation,
+    /// Record mode: one past the last writable slot.
+    pub obs_end: *mut Observation,
 }
+
+/// One row's dynamic values, written by generated code in record mode.
+///
+/// Generated code cannot construct a `TraceRow` (its `Option` fields have no
+/// guaranteed layout), so it writes this fixed POD instead and a Rust pass
+/// reassembles rows afterwards, taking the static half from
+/// `expanded_bytecode[row_index]`. 64 bytes keeps the cursor bump a shift and
+/// the write pattern cache-friendly; the fields a given kind does not use are
+/// simply ignored by the reassembly pass.
+#[derive(Debug, Clone, Copy, Default)]
+#[repr(C)]
+pub struct Observation {
+    pub row_index: u64,
+    pub rs1: u64,
+    pub rs2: u64,
+    pub rd_pre: u64,
+    pub rd_post: u64,
+    pub ram_address: u64,
+    pub ram_pre: u64,
+    pub ram_post: u64,
+}
+
+pub const OBSERVATION_SIZE: i32 = core::mem::size_of::<Observation>() as i32;
+
+pub const OBS_ROW_INDEX: i32 = 0;
+pub const OBS_RS1: i32 = 8;
+pub const OBS_RS2: i32 = 16;
+pub const OBS_RD_PRE: i32 = 24;
+pub const OBS_RD_POST: i32 = 32;
+pub const OBS_RAM_ADDRESS: i32 = 40;
+pub const OBS_RAM_PRE: i32 = 48;
+pub const OBS_RAM_POST: i32 = 56;
+
+const _: () = {
+    assert!(OBSERVATION_SIZE == 64);
+    assert!(core::mem::offset_of!(Observation, row_index) == OBS_ROW_INDEX as usize);
+    assert!(core::mem::offset_of!(Observation, rs1) == OBS_RS1 as usize);
+    assert!(core::mem::offset_of!(Observation, rs2) == OBS_RS2 as usize);
+    assert!(core::mem::offset_of!(Observation, rd_pre) == OBS_RD_PRE as usize);
+    assert!(core::mem::offset_of!(Observation, rd_post) == OBS_RD_POST as usize);
+    assert!(core::mem::offset_of!(Observation, ram_address) == OBS_RAM_ADDRESS as usize);
+    assert!(core::mem::offset_of!(Observation, ram_pre) == OBS_RAM_PRE as usize);
+    assert!(core::mem::offset_of!(Observation, ram_post) == OBS_RAM_POST as usize);
+};
 
 /// Maximum runtime advice values one source-instruction group can need
 /// (largest today: the modular-division inlines at 8).
@@ -77,6 +128,9 @@ pub const OFF_MEM_BASE: i32 = OFF_FAULT_ADDR + 8;
 pub const OFF_MEM_SIZE: i32 = OFF_MEM_BASE + 8;
 pub const OFF_HOST: i32 = OFF_MEM_SIZE + 8;
 pub const OFF_ADVICE_SLOTS: i32 = OFF_HOST + 8;
+pub const OFF_ADVICE_JOBS: i32 = OFF_ADVICE_SLOTS + (ADVICE_SLOTS as i32) * 8;
+pub const OFF_OBS_CURSOR: i32 = OFF_ADVICE_JOBS + 8;
+pub const OFF_OBS_END: i32 = OFF_OBS_CURSOR + 8;
 
 const _: () = {
     assert!(core::mem::offset_of!(GuestState, x) == OFF_X as usize);
@@ -88,6 +142,9 @@ const _: () = {
     assert!(core::mem::offset_of!(GuestState, mem_size) == OFF_MEM_SIZE as usize);
     assert!(core::mem::offset_of!(GuestState, host) == OFF_HOST as usize);
     assert!(core::mem::offset_of!(GuestState, advice_slots) == OFF_ADVICE_SLOTS as usize);
+    assert!(core::mem::offset_of!(GuestState, advice_jobs) == OFF_ADVICE_JOBS as usize);
+    assert!(core::mem::offset_of!(GuestState, obs_cursor) == OFF_OBS_CURSOR as usize);
+    assert!(core::mem::offset_of!(GuestState, obs_end) == OFF_OBS_END as usize);
 };
 
 #[inline]

--- a/crates/jolt-tracer-x86/src/native/state.rs
+++ b/crates/jolt-tracer-x86/src/native/state.rs
@@ -75,9 +75,10 @@ pub const fn reg_offset(register: u8) -> i32 {
 /// code directly (only through `extern "C"` helpers), so layout is free.
 pub struct HostContext {
     pub device: JoltDevice,
-    /// Populated runtime advice tape (bytes; a read cursor joins with the
-    /// advice-load kinds).
+    /// Runtime advice tape bytes (append-only; reads go through the cursor).
     pub advice_tape: Vec<u8>,
+    /// Read cursor into `advice_tape` (advice-load kinds).
+    pub advice_cursor: usize,
     /// Set when a helper encounters an unrecoverable condition; carries the
     /// message surfaced in the resulting `TraceError`.
     pub helper_error: Option<String>,

--- a/crates/jolt-tracer-x86/src/native/state.rs
+++ b/crates/jolt-tracer-x86/src/native/state.rs
@@ -6,6 +6,7 @@
 
 use common::constants::REGISTER_COUNT;
 use common::jolt_device::JoltDevice;
+use jolt_program::execution::TraceError;
 
 /// Why generated code returned to the host.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -64,6 +65,36 @@ pub struct GuestState {
     pub obs_cursor: *mut Observation,
     /// Record mode: one past the last writable slot.
     pub obs_end: *mut Observation,
+}
+
+impl GuestState {
+    /// Translate the generated-code exit state into the backend error channel.
+    #[expect(clippy::print_stderr)]
+    pub fn check_exit(&self, host: &mut HostContext) -> Result<(), TraceError> {
+        match self.exit {
+            e if e == ExitReason::Terminated as u64 => {}
+            e if e == ExitReason::FaultOutOfBounds as u64 => {
+                return Err(TraceError::Backend("guest RAM access out of bounds"));
+            }
+            e if e == ExitReason::FaultBadJumpTarget as u64 => {
+                return Err(TraceError::Backend(
+                    "indirect jump to a non-compiled address",
+                ));
+            }
+            e if e == ExitReason::FaultObservationOverflow as u64 => {
+                return Err(TraceError::Backend(
+                    "record pass overflowed the observation buffer (row-count divergence)",
+                ));
+            }
+            _ => {
+                if let Some(message) = host.helper_error.take() {
+                    eprintln!("jolt-tracer-x86 helper error: {message}");
+                }
+                return Err(TraceError::Backend("host helper reported an error"));
+            }
+        }
+        Ok(())
+    }
 }
 
 /// One row's dynamic values, written by generated code in record mode.

--- a/crates/jolt-tracer-x86/src/native/state.rs
+++ b/crates/jolt-tracer-x86/src/native/state.rs
@@ -1,0 +1,84 @@
+//! Guest state plane shared between generated code and Rust helpers.
+//!
+//! Generated code addresses this struct through a pinned register with
+//! hardcoded field offsets, so the layout is `repr(C)` and offsets are
+//! asserted at compile time.
+
+use common::constants::REGISTER_COUNT;
+use common::jolt_device::JoltDevice;
+
+/// Why generated code returned to the host.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u64)]
+pub enum ExitReason {
+    /// Still running (initial value; never observed on return).
+    Running = 0,
+    /// Guest terminated via the PC-stall convention (`j .`).
+    Terminated = 1,
+    /// Guest RAM access outside the memory plane.
+    FaultOutOfBounds = 2,
+    /// Indirect jump to an address that is not a compiled group start.
+    FaultBadJumpTarget = 3,
+    /// A host helper reported an error (e.g. device access violation).
+    FaultHelper = 4,
+}
+
+/// State shared with generated code. Field offsets are load-bearing.
+#[repr(C)]
+pub struct GuestState {
+    /// All 128 guest registers (32 architectural + 96 virtual), by index.
+    pub x: [u64; REGISTER_COUNT as usize],
+    /// Guest PC (source address of the current group). Written by generated
+    /// code only at indirect control flow and on exit.
+    pub pc: u64,
+    /// Trace rows executed so far.
+    pub trace_len: u64,
+    /// [`ExitReason`] as a raw u64 (written by generated code).
+    pub exit: u64,
+    /// Faulting guest address when `exit` is a fault.
+    pub fault_addr: u64,
+    /// Host base of the guest RAM plane (also pinned in a register; stored
+    /// here so helpers can reconstruct it from `&mut GuestState` alone).
+    pub mem_base: u64,
+    /// Size in bytes of the RAM plane.
+    pub mem_size: u64,
+    /// Host context for helper calls (device, advice tape, panic state).
+    pub host: *mut HostContext,
+}
+
+pub const OFF_X: i32 = 0;
+pub const OFF_PC: i32 = (REGISTER_COUNT as i32) * 8;
+pub const OFF_TRACE_LEN: i32 = OFF_PC + 8;
+pub const OFF_EXIT: i32 = OFF_TRACE_LEN + 8;
+pub const OFF_FAULT_ADDR: i32 = OFF_EXIT + 8;
+pub const OFF_MEM_BASE: i32 = OFF_FAULT_ADDR + 8;
+pub const OFF_MEM_SIZE: i32 = OFF_MEM_BASE + 8;
+pub const OFF_HOST: i32 = OFF_MEM_SIZE + 8;
+
+const _: () = {
+    assert!(core::mem::offset_of!(GuestState, x) == OFF_X as usize);
+    assert!(core::mem::offset_of!(GuestState, pc) == OFF_PC as usize);
+    assert!(core::mem::offset_of!(GuestState, trace_len) == OFF_TRACE_LEN as usize);
+    assert!(core::mem::offset_of!(GuestState, exit) == OFF_EXIT as usize);
+    assert!(core::mem::offset_of!(GuestState, fault_addr) == OFF_FAULT_ADDR as usize);
+    assert!(core::mem::offset_of!(GuestState, mem_base) == OFF_MEM_BASE as usize);
+    assert!(core::mem::offset_of!(GuestState, mem_size) == OFF_MEM_SIZE as usize);
+    assert!(core::mem::offset_of!(GuestState, host) == OFF_HOST as usize);
+};
+
+#[inline]
+pub const fn reg_offset(register: u8) -> i32 {
+    OFF_X + (register as i32) * 8
+}
+
+/// Host-side context reachable from helper calls. Not addressed by generated
+/// code directly (only through `extern "C"` helpers), so layout is free.
+pub struct HostContext {
+    pub device: JoltDevice,
+    /// Populated runtime advice tape (bytes; a read cursor joins with the
+    /// advice-load kinds).
+    pub advice_tape: Vec<u8>,
+    /// Set when a helper encounters an unrecoverable condition; carries the
+    /// message surfaced in the resulting `TraceError`.
+    pub helper_error: Option<String>,
+}

--- a/crates/jolt-tracer-x86/tests/chunked.rs
+++ b/crates/jolt-tracer-x86/tests/chunked.rs
@@ -6,64 +6,22 @@
 #![cfg(all(target_arch = "x86_64", target_os = "linux"))]
 #![expect(clippy::expect_used)]
 
-use jolt_program::execution::{
-    ChunkedExecutionBackend, ExecutionBackend, JoltProgram, TraceInputs, TraceRow,
-};
+use jolt_program::execution::{ChunkedExecutionBackend, ExecutionBackend, TraceRow};
 use jolt_tracer_x86::X86TracerBackend;
 
 use jolt_inlines_keccak256 as _;
 use jolt_inlines_sha2 as _;
 
-fn build_guest_elf(package: &str, func: &str) -> Vec<u8> {
-    let target_dir = format!("/tmp/jolt-guest-targets/{package}-{func}");
-    let output = std::process::Command::new("jolt")
-        .args([
-            "build",
-            "-p",
-            package,
-            "--stack-size",
-            &common::constants::DEFAULT_STACK_SIZE.to_string(),
-            "--heap-size",
-            &common::constants::DEFAULT_HEAP_SIZE.to_string(),
-            "--",
-            "--release",
-            "--target-dir",
-            &target_dir,
-            "--features",
-            "guest",
-        ])
-        .env("JOLT_FUNC_NAME", func)
-        .output()
-        .expect("failed to run jolt CLI");
-    assert!(output.status.success(), "guest build failed");
-    let elf_path = format!("{target_dir}/riscv64imac-unknown-none-elf/release/{package}");
-    std::fs::read(&elf_path).expect("failed to read guest ELF")
-}
-
-fn setup(package: &str, func: &str, input: Vec<u8>) -> (JoltProgram, TraceInputs) {
-    let elf = build_guest_elf(package, func);
-    let mut provider = tracer::TracerInlineExpansionProvider::new();
-    let program = jolt_program::build_jolt_program_with_inline_provider(
-        &elf,
-        &mut provider,
-        jolt_riscv::RV64IMAC_JOLT_ALL_INLINES,
-    )
-    .expect("failed to build Jolt program");
-    let memory_config = common::jolt_device::MemoryConfig {
-        program_size: Some(program.program_end - common::constants::RAM_START_ADDRESS),
-        ..Default::default()
-    };
-    (
-        program,
-        TraceInputs::new(input, Vec::new(), Vec::new(), memory_config),
-    )
-}
+mod common;
+use common::setup;
 
 /// Invariant 3: chunks compose to the eager trace, for any chunk size and in
 /// any replay order.
 fn assert_chunks_compose(package: &str, func: &str, input: Vec<u8>, chunk_sizes: &[usize]) {
     std::env::remove_var("TRACER_PARALLEL");
-    let (program, inputs) = setup(package, func, input);
+    let Some((program, inputs)) = setup(package, func, input) else {
+        return;
+    };
 
     let mut backend = X86TracerBackend::new();
     let eager = backend

--- a/crates/jolt-tracer-x86/tests/chunked.rs
+++ b/crates/jolt-tracer-x86/tests/chunked.rs
@@ -1,0 +1,135 @@
+//! Chunked execution for the AOT backend (spec slice 4, invariant 3).
+//!
+//! The concatenation of replayed chunks must equal the eager trace for every
+//! chunk size, including degenerate ones, and independently of replay order.
+
+#![cfg(all(target_arch = "x86_64", target_os = "linux"))]
+#![expect(clippy::expect_used)]
+
+use jolt_program::execution::{
+    ChunkedExecutionBackend, ExecutionBackend, JoltProgram, TraceInputs, TraceRow,
+};
+use jolt_tracer_x86::X86TracerBackend;
+
+use jolt_inlines_keccak256 as _;
+use jolt_inlines_sha2 as _;
+
+fn build_guest_elf(package: &str, func: &str) -> Vec<u8> {
+    let target_dir = format!("/tmp/jolt-guest-targets/{package}-{func}");
+    let output = std::process::Command::new("jolt")
+        .args([
+            "build",
+            "-p",
+            package,
+            "--stack-size",
+            &common::constants::DEFAULT_STACK_SIZE.to_string(),
+            "--heap-size",
+            &common::constants::DEFAULT_HEAP_SIZE.to_string(),
+            "--",
+            "--release",
+            "--target-dir",
+            &target_dir,
+            "--features",
+            "guest",
+        ])
+        .env("JOLT_FUNC_NAME", func)
+        .output()
+        .expect("failed to run jolt CLI");
+    assert!(output.status.success(), "guest build failed");
+    let elf_path = format!("{target_dir}/riscv64imac-unknown-none-elf/release/{package}");
+    std::fs::read(&elf_path).expect("failed to read guest ELF")
+}
+
+fn setup(package: &str, func: &str, input: Vec<u8>) -> (JoltProgram, TraceInputs) {
+    let elf = build_guest_elf(package, func);
+    let mut provider = tracer::TracerInlineExpansionProvider::new();
+    let program = jolt_program::build_jolt_program_with_inline_provider(
+        &elf,
+        &mut provider,
+        jolt_riscv::RV64IMAC_JOLT_ALL_INLINES,
+    )
+    .expect("failed to build Jolt program");
+    let memory_config = common::jolt_device::MemoryConfig {
+        program_size: Some(program.program_end - common::constants::RAM_START_ADDRESS),
+        ..Default::default()
+    };
+    (
+        program,
+        TraceInputs::new(input, Vec::new(), Vec::new(), memory_config),
+    )
+}
+
+/// Invariant 3: chunks compose to the eager trace, for any chunk size and in
+/// any replay order.
+fn assert_chunks_compose(package: &str, func: &str, input: Vec<u8>, chunk_sizes: &[usize]) {
+    std::env::remove_var("TRACER_PARALLEL");
+    let (program, inputs) = setup(package, func, input);
+
+    let mut backend = X86TracerBackend::new();
+    let eager = backend
+        .trace(&program, inputs.clone())
+        .expect("eager record trace failed");
+    let expected = eager.trace.rows();
+    assert!(!expected.is_empty());
+
+    for &chunk_size in chunk_sizes {
+        let summary = backend
+            .execute(&program, inputs.clone(), chunk_size)
+            .expect("chunked execute failed");
+        assert_eq!(
+            summary.trace_len,
+            expected.len(),
+            "chunk_size {chunk_size}: trace length"
+        );
+        assert_eq!(
+            summary.checkpoints.len(),
+            expected.len().div_ceil(chunk_size),
+            "chunk_size {chunk_size}: checkpoint count"
+        );
+
+        // Replay in reverse to show order independence.
+        let mut chunks: Vec<Vec<TraceRow>> = summary
+            .checkpoints
+            .iter()
+            .rev()
+            .map(|checkpoint| {
+                backend
+                    .replay_chunk(checkpoint)
+                    .expect("replay failed")
+                    .into_rows()
+            })
+            .collect();
+        chunks.reverse();
+
+        let concatenated: Vec<TraceRow> = chunks.into_iter().flatten().collect();
+        assert_eq!(
+            concatenated.len(),
+            expected.len(),
+            "chunk_size {chunk_size}: concatenated length"
+        );
+        for (index, (got, want)) in concatenated.iter().zip(expected.iter()).enumerate() {
+            assert_eq!(got, want, "chunk_size {chunk_size}: row {index} diverged");
+        }
+    }
+}
+
+#[test]
+fn fibonacci_chunks_compose() {
+    assert_chunks_compose(
+        "fibonacci-guest",
+        "fib",
+        postcard::to_stdvec(&40u32).expect("postcard"),
+        // Degenerate sizes included: 1 forces boundaries inside multi-row
+        // groups, and a size past the trace length is a single chunk.
+        &[1, 7, 100, 1 << 18],
+    );
+}
+
+#[test]
+fn muldiv_chunks_compose() {
+    let mut input = postcard::to_stdvec(&7u32).expect("postcard");
+    input.extend(postcard::to_stdvec(&11u32).expect("postcard"));
+    input.extend(postcard::to_stdvec(&3u32).expect("postcard"));
+    // Exercises the DIV/REM advice groups across chunk boundaries.
+    assert_chunks_compose("muldiv-guest", "muldiv", input, &[1, 13, 1000]);
+}

--- a/crates/jolt-tracer-x86/tests/chunked.rs
+++ b/crates/jolt-tracer-x86/tests/chunked.rs
@@ -16,8 +16,18 @@ mod common;
 use common::setup;
 
 /// Invariant 3: chunks compose to the eager trace, for any chunk size and in
-/// any replay order.
-fn assert_chunks_compose(package: &str, func: &str, input: Vec<u8>, chunk_sizes: &[usize]) {
+/// any replay order. With `dense_boundaries`, additionally shrink the
+/// checkpoint spacing to a fraction of the trace and assert every checkpoint
+/// resumes from a nearby boundary — proving the pause/resume machinery
+/// (`Paused` exits, multi-boundary selection, boundary restore) actually ran,
+/// which the production spacing of 2^16 rows never does on guests this small.
+fn assert_chunks_compose_spaced(
+    package: &str,
+    func: &str,
+    input: Vec<u8>,
+    chunk_sizes: &[usize],
+    dense_boundaries: bool,
+) {
     std::env::remove_var("TRACER_PARALLEL");
     let Some((program, inputs)) = setup(package, func, input) else {
         return;
@@ -29,6 +39,13 @@ fn assert_chunks_compose(package: &str, func: &str, input: Vec<u8>, chunk_sizes:
         .expect("eager record trace failed");
     let expected = eager.trace.rows();
     assert!(!expected.is_empty());
+
+    // Sized from the measured trace so several pauses are guaranteed
+    // regardless of how many rows the guest's startup contributes.
+    let min_spacing = dense_boundaries.then(|| (expected.len() / 8).max(8));
+    if let Some(rows) = min_spacing {
+        backend.set_min_checkpoint_spacing_rows(rows);
+    }
 
     for &chunk_size in chunk_sizes {
         let summary = backend
@@ -44,6 +61,26 @@ fn assert_chunks_compose(package: &str, func: &str, input: Vec<u8>, chunk_sizes:
             expected.len().div_ceil(chunk_size),
             "chunk_size {chunk_size}: checkpoint count"
         );
+        if let Some(rows) = min_spacing {
+            // A boundary exists at most spacing + one group past any mark, so
+            // every checkpoint must resume from nearby. With a single (initial)
+            // boundary — i.e. if pausing never fired — late chunks would skip
+            // nearly the whole trace and this bound fails.
+            let spacing = chunk_size.max(rows);
+            let max_skip = summary
+                .checkpoints
+                .iter()
+                .map(|checkpoint| checkpoint.skip_rows())
+                .max()
+                .unwrap_or(0);
+            assert!(
+                max_skip < 2 * spacing,
+                "chunk_size {chunk_size}: max skip_rows {max_skip} exceeds the \
+                 boundary spacing bound {} — checkpoints are not resuming from \
+                 paused boundaries",
+                2 * spacing
+            );
+        }
 
         // Replay in reverse to show order independence.
         let mut chunks: Vec<Vec<TraceRow>> = summary
@@ -71,6 +108,10 @@ fn assert_chunks_compose(package: &str, func: &str, input: Vec<u8>, chunk_sizes:
     }
 }
 
+fn assert_chunks_compose(package: &str, func: &str, input: Vec<u8>, chunk_sizes: &[usize]) {
+    assert_chunks_compose_spaced(package, func, input, chunk_sizes, false);
+}
+
 #[test]
 fn fibonacci_chunks_compose() {
     assert_chunks_compose(
@@ -90,4 +131,31 @@ fn muldiv_chunks_compose() {
     input.extend(postcard::to_stdvec(&3u32).expect("postcard"));
     // Exercises the DIV/REM advice groups across chunk boundaries.
     assert_chunks_compose("muldiv-guest", "muldiv", input, &[1, 13, 1000]);
+}
+
+/// The pause/resume machinery under dense checkpoints: a small spacing forces
+/// many `Paused` exits and resumes on a small guest, so replay restores
+/// registers, memory, device state, and the advice cursor from real
+/// mid-program boundaries — the paths production spacing (2^16 rows) only
+/// reaches on million-row traces.
+#[test]
+fn fibonacci_chunks_compose_with_dense_boundaries() {
+    assert_chunks_compose_spaced(
+        "fibonacci-guest",
+        "fib",
+        postcard::to_stdvec(&60u32).expect("postcard"),
+        &[1, 7, 64, 100],
+        true,
+    );
+}
+
+/// Dense boundaries across DIV/REM advice groups: resuming at a group whose
+/// advice computation re-runs from restored registers must reproduce the
+/// eager rows exactly.
+#[test]
+fn muldiv_chunks_compose_with_dense_boundaries() {
+    let mut input = postcard::to_stdvec(&1_000_003u32).expect("postcard");
+    input.extend(postcard::to_stdvec(&997u32).expect("postcard"));
+    input.extend(postcard::to_stdvec(&13u32).expect("postcard"));
+    assert_chunks_compose_spaced("muldiv-guest", "muldiv", input, &[1, 13, 100], true);
 }

--- a/crates/jolt-tracer-x86/tests/common/mod.rs
+++ b/crates/jolt-tracer-x86/tests/common/mod.rs
@@ -1,0 +1,74 @@
+//! Shared guest-build helper for the integration tests.
+//!
+//! Guest ELFs are produced by the `jolt` CLI, which is not present in every
+//! CI job. `setup` returns `None` when the CLI cannot be spawned so that
+//! guest-dependent tests skip instead of failing; a build that starts and
+//! then fails is a real error and panics. The `x86-tracer` workflow job
+//! installs the CLI, so the skip path never hides a regression there.
+
+#![expect(clippy::expect_used, clippy::panic, clippy::print_stderr)]
+
+use jolt_program::execution::{JoltProgram, TraceInputs};
+
+/// Build a guest and wrap it in a `JoltProgram` plus `TraceInputs`.
+///
+/// `None` means the `jolt` CLI is unavailable and the caller should skip.
+pub fn setup(package: &str, func: &str, input: Vec<u8>) -> Option<(JoltProgram, TraceInputs)> {
+    let elf = guest_elf(package, func)?;
+    let mut provider = tracer::TracerInlineExpansionProvider::new();
+    let program = jolt_program::build_jolt_program_with_inline_provider(
+        &elf,
+        &mut provider,
+        jolt_riscv::RV64IMAC_JOLT_ALL_INLINES,
+    )
+    .expect("failed to build Jolt program");
+    let memory_config = common::jolt_device::MemoryConfig {
+        program_size: Some(program.program_end - common::constants::RAM_START_ADDRESS),
+        ..Default::default()
+    };
+    let inputs = TraceInputs::new(input, Vec::new(), Vec::new(), memory_config);
+    Some((program, inputs))
+}
+
+fn guest_elf(package: &str, func: &str) -> Option<Vec<u8>> {
+    let target_dir = format!("/tmp/jolt-guest-targets/{package}-{func}");
+    let output = match std::process::Command::new("jolt")
+        .args([
+            "build",
+            "-p",
+            package,
+            "--stack-size",
+            &common::constants::DEFAULT_STACK_SIZE.to_string(),
+            "--heap-size",
+            &common::constants::DEFAULT_HEAP_SIZE.to_string(),
+            "--",
+            "--release",
+            "--target-dir",
+            &target_dir,
+            "--features",
+            "guest",
+        ])
+        .env("JOLT_FUNC_NAME", func)
+        .output()
+    {
+        Ok(output) => output,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            eprintln!(
+                "SKIP: the `jolt` CLI is not installed, so guest `{package}` cannot be built. \
+                 Install it with `cargo install --path .` to run this test."
+            );
+            return None;
+        }
+        Err(e) => panic!("failed to run the `jolt` CLI: {e}"),
+    };
+    assert!(
+        output.status.success(),
+        "failed to build {package}:\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let elf_path = format!("{target_dir}/riscv64imac-unknown-none-elf/release/{package}");
+    Some(
+        std::fs::read(&elf_path)
+            .unwrap_or_else(|e| panic!("failed to read guest ELF at {elf_path}: {e}")),
+    )
+}

--- a/crates/jolt-tracer-x86/tests/fast_run_equivalence.rs
+++ b/crates/jolt-tracer-x86/tests/fast_run_equivalence.rs
@@ -1,0 +1,83 @@
+//! Whole-guest fast-pass equivalence: run the fibonacci guest through the
+//! x86 backend's fast (non-recording) pass and compare row count, device
+//! outputs, and final memory against the reference interpreter.
+//!
+//! Native-only: on other targets this file compiles to nothing.
+
+#![cfg(all(target_arch = "x86_64", target_os = "linux"))]
+#![expect(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+
+use jolt_program::execution::{ExecutionBackend, JoltProgram, TraceInputs};
+use jolt_tracer_x86::X86TracerBackend;
+use tracer::TracerBackend;
+
+fn build_guest_elf(package: &str, func: &str) -> Vec<u8> {
+    let target_dir = format!("/tmp/jolt-guest-targets/{package}-{func}");
+    let output = std::process::Command::new("jolt")
+        .args([
+            "build",
+            "-p",
+            package,
+            "--stack-size",
+            &common::constants::DEFAULT_STACK_SIZE.to_string(),
+            "--heap-size",
+            &common::constants::DEFAULT_HEAP_SIZE.to_string(),
+            "--",
+            "--release",
+            "--target-dir",
+            &target_dir,
+            "--features",
+            "guest",
+        ])
+        .env("JOLT_FUNC_NAME", func)
+        .output()
+        .expect("failed to run jolt CLI — install with: cargo install --path .");
+    assert!(
+        output.status.success(),
+        "failed to build {package}:\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let elf_path = format!("{target_dir}/riscv64imac-unknown-none-elf/release/{package}");
+    std::fs::read(&elf_path).unwrap_or_else(|e| panic!("failed to read ELF at {elf_path}: {e}"))
+}
+
+fn setup(package: &str, func: &str, input: Vec<u8>) -> (JoltProgram, TraceInputs) {
+    let elf = build_guest_elf(package, func);
+    let program =
+        jolt_program::execution::build_jolt_program(&elf).expect("failed to build Jolt program");
+    let memory_config = common::jolt_device::MemoryConfig {
+        program_size: Some(program.program_end - common::constants::RAM_START_ADDRESS),
+        ..Default::default()
+    };
+    let inputs = TraceInputs::new(input, Vec::new(), Vec::new(), memory_config);
+    (program, inputs)
+}
+
+#[test]
+fn fibonacci_fast_run_matches_reference() {
+    let (program, inputs) = setup(
+        "fibonacci-guest",
+        "fib",
+        postcard::to_stdvec(&100u32).unwrap(),
+    );
+
+    let reference = TracerBackend::new()
+        .trace(&program, inputs.clone())
+        .expect("reference trace failed");
+    let reference_rows = reference.trace.rows();
+
+    let mut backend = X86TracerBackend::new();
+    let fast = backend
+        .fast_run(&program, inputs)
+        .expect("x86 fast run failed");
+
+    assert_eq!(fast.trace_len, reference_rows.len(), "row count");
+    assert_eq!(fast.device.outputs, reference.device.outputs, "outputs");
+    assert_eq!(fast.device.panic, reference.device.panic, "panic flag");
+    assert_eq!(
+        Some(fast.final_memory),
+        reference.final_memory,
+        "final memory"
+    );
+    assert_eq!(Some(fast.advice_tape), reference.advice_tape, "advice tape");
+}

--- a/crates/jolt-tracer-x86/tests/fast_run_equivalence.rs
+++ b/crates/jolt-tracer-x86/tests/fast_run_equivalence.rs
@@ -8,6 +8,10 @@
 #![expect(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 
 use jolt_program::execution::{ExecutionBackend, JoltProgram, TraceInputs};
+
+// Link inline registrations for the inline-bearing guests.
+use jolt_inlines_keccak256 as _;
+use jolt_inlines_sha2 as _;
 use jolt_tracer_x86::X86TracerBackend;
 use tracer::TracerBackend;
 
@@ -43,8 +47,13 @@ fn build_guest_elf(package: &str, func: &str) -> Vec<u8> {
 
 fn setup(package: &str, func: &str, input: Vec<u8>) -> (JoltProgram, TraceInputs) {
     let elf = build_guest_elf(package, func);
-    let program =
-        jolt_program::execution::build_jolt_program(&elf).expect("failed to build Jolt program");
+    let mut provider = tracer::TracerInlineExpansionProvider::new();
+    let program = jolt_program::build_jolt_program_with_inline_provider(
+        &elf,
+        &mut provider,
+        jolt_riscv::RV64IMAC_JOLT_ALL_INLINES,
+    )
+    .expect("failed to build Jolt program");
     let memory_config = common::jolt_device::MemoryConfig {
         program_size: Some(program.program_end - common::constants::RAM_START_ADDRESS),
         ..Default::default()
@@ -53,16 +62,13 @@ fn setup(package: &str, func: &str, input: Vec<u8>) -> (JoltProgram, TraceInputs
     (program, inputs)
 }
 
-#[test]
-fn fibonacci_fast_run_matches_reference() {
+/// Run a guest through both engines and assert the fast pass agrees with the
+/// reference on everything the fast pass observes.
+fn assert_fast_run_matches(package: &str, func: &str, input: Vec<u8>) {
     // Pin the reference to serial mode (the tracer env-dispatches to the
     // parallel pipeline).
     std::env::remove_var("TRACER_PARALLEL");
-    let (program, inputs) = setup(
-        "fibonacci-guest",
-        "fib",
-        postcard::to_stdvec(&100u32).unwrap(),
-    );
+    let (program, inputs) = setup(package, func, input);
 
     let reference = TracerBackend::new()
         .trace(&program, inputs.clone())
@@ -74,13 +80,55 @@ fn fibonacci_fast_run_matches_reference() {
         .fast_run(&program, inputs)
         .expect("x86 fast run failed");
 
-    assert_eq!(fast.trace_len, reference_rows.len(), "row count");
-    assert_eq!(fast.device.outputs, reference.device.outputs, "outputs");
-    assert_eq!(fast.device.panic, reference.device.panic, "panic flag");
+    assert_eq!(fast.trace_len, reference_rows.len(), "{package}: row count");
+    assert_eq!(
+        fast.device.outputs, reference.device.outputs,
+        "{package}: outputs"
+    );
+    assert_eq!(
+        fast.device.panic, reference.device.panic,
+        "{package}: panic flag"
+    );
     assert_eq!(
         Some(fast.final_memory),
         reference.final_memory,
-        "final memory"
+        "{package}: final memory"
     );
-    assert_eq!(Some(fast.advice_tape), reference.advice_tape, "advice tape");
+    assert_eq!(
+        Some(fast.advice_tape),
+        reference.advice_tape,
+        "{package}: advice tape"
+    );
+}
+
+#[test]
+fn fibonacci_fast_run_matches_reference() {
+    assert_fast_run_matches(
+        "fibonacci-guest",
+        "fib",
+        postcard::to_stdvec(&100u32).unwrap(),
+    );
+}
+
+#[test]
+fn sha2_chain_fast_run_matches_reference() {
+    let mut input = postcard::to_stdvec(&[5u8; 32]).unwrap();
+    input.append(&mut postcard::to_stdvec(&8u32).unwrap());
+    assert_fast_run_matches("sha2-chain-guest", "sha2_chain", input);
+}
+
+#[test]
+fn sha3_chain_fast_run_matches_reference() {
+    let mut input = postcard::to_stdvec(&[5u8; 32]).unwrap();
+    input.append(&mut postcard::to_stdvec(&4u32).unwrap());
+    assert_fast_run_matches("sha3-chain-guest", "sha3_chain", input);
+}
+
+#[test]
+fn btreemap_fast_run_matches_reference() {
+    assert_fast_run_matches(
+        "btreemap-guest",
+        "btreemap",
+        postcard::to_stdvec(&20u32).unwrap(),
+    );
 }

--- a/crates/jolt-tracer-x86/tests/fast_run_equivalence.rs
+++ b/crates/jolt-tracer-x86/tests/fast_run_equivalence.rs
@@ -101,6 +101,69 @@ fn assert_fast_run_matches(package: &str, func: &str, input: Vec<u8>) {
     );
 }
 
+/// Record mode: the full `TraceRow` stream must be identical to the
+/// reference interpreter's, row for row. This is the strongest equivalence
+/// statement the backend can make (spec invariant 1) and what proof
+/// byte-equality rests on.
+fn assert_record_matches(package: &str, func: &str, input: Vec<u8>) {
+    std::env::remove_var("TRACER_PARALLEL");
+    let (program, inputs) = setup(package, func, input);
+
+    let reference = TracerBackend::new()
+        .trace(&program, inputs.clone())
+        .expect("reference trace failed");
+    let expected = reference.trace.rows();
+
+    let mut backend = X86TracerBackend::new();
+    let actual_output = backend
+        .trace(&program, inputs)
+        .expect("x86 record trace failed");
+    let actual = actual_output.trace.rows();
+
+    assert_eq!(actual.len(), expected.len(), "{package}: row count");
+    for (index, (got, want)) in actual.iter().zip(expected.iter()).enumerate() {
+        assert_eq!(
+            got, want,
+            "{package}: row {index} diverged\n  got:  {got:?}\n  want: {want:?}"
+        );
+    }
+    assert_eq!(
+        actual_output.device.outputs, reference.device.outputs,
+        "{package}: outputs"
+    );
+    assert_eq!(
+        actual_output.final_memory, reference.final_memory,
+        "{package}: final memory"
+    );
+}
+
+#[test]
+fn fibonacci_record_matches_reference() {
+    assert_record_matches(
+        "fibonacci-guest",
+        "fib",
+        postcard::to_stdvec(&50u32).unwrap(),
+    );
+}
+
+#[test]
+fn muldiv_record_matches_reference() {
+    // DIV/REM advice groups plus RAM traffic.
+    assert_record_matches("muldiv-guest", "muldiv", {
+        let mut bytes = postcard::to_stdvec(&7u32).unwrap();
+        bytes.extend(postcard::to_stdvec(&11u32).unwrap());
+        bytes.extend(postcard::to_stdvec(&3u32).unwrap());
+        bytes
+    });
+}
+
+#[test]
+fn sha2_chain_record_matches_reference() {
+    let mut input = postcard::to_stdvec(&[5u8; 32]).unwrap();
+    input.append(&mut postcard::to_stdvec(&2u32).unwrap());
+    assert_record_matches("sha2-chain-guest", "sha2_chain", input);
+}
+
 #[test]
 fn fibonacci_fast_run_matches_reference() {
     assert_fast_run_matches(

--- a/crates/jolt-tracer-x86/tests/fast_run_equivalence.rs
+++ b/crates/jolt-tracer-x86/tests/fast_run_equivalence.rs
@@ -5,9 +5,9 @@
 //! Native-only: on other targets this file compiles to nothing.
 
 #![cfg(all(target_arch = "x86_64", target_os = "linux"))]
-#![expect(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+#![expect(clippy::unwrap_used, clippy::expect_used)]
 
-use jolt_program::execution::{ExecutionBackend, JoltProgram, TraceInputs};
+use jolt_program::execution::ExecutionBackend;
 
 // Link inline registrations for the inline-bearing guests.
 use jolt_inlines_keccak256 as _;
@@ -15,52 +15,8 @@ use jolt_inlines_sha2 as _;
 use jolt_tracer_x86::X86TracerBackend;
 use tracer::TracerBackend;
 
-fn build_guest_elf(package: &str, func: &str) -> Vec<u8> {
-    let target_dir = format!("/tmp/jolt-guest-targets/{package}-{func}");
-    let output = std::process::Command::new("jolt")
-        .args([
-            "build",
-            "-p",
-            package,
-            "--stack-size",
-            &common::constants::DEFAULT_STACK_SIZE.to_string(),
-            "--heap-size",
-            &common::constants::DEFAULT_HEAP_SIZE.to_string(),
-            "--",
-            "--release",
-            "--target-dir",
-            &target_dir,
-            "--features",
-            "guest",
-        ])
-        .env("JOLT_FUNC_NAME", func)
-        .output()
-        .expect("failed to run jolt CLI — install with: cargo install --path .");
-    assert!(
-        output.status.success(),
-        "failed to build {package}:\n{}",
-        String::from_utf8_lossy(&output.stderr)
-    );
-    let elf_path = format!("{target_dir}/riscv64imac-unknown-none-elf/release/{package}");
-    std::fs::read(&elf_path).unwrap_or_else(|e| panic!("failed to read ELF at {elf_path}: {e}"))
-}
-
-fn setup(package: &str, func: &str, input: Vec<u8>) -> (JoltProgram, TraceInputs) {
-    let elf = build_guest_elf(package, func);
-    let mut provider = tracer::TracerInlineExpansionProvider::new();
-    let program = jolt_program::build_jolt_program_with_inline_provider(
-        &elf,
-        &mut provider,
-        jolt_riscv::RV64IMAC_JOLT_ALL_INLINES,
-    )
-    .expect("failed to build Jolt program");
-    let memory_config = common::jolt_device::MemoryConfig {
-        program_size: Some(program.program_end - common::constants::RAM_START_ADDRESS),
-        ..Default::default()
-    };
-    let inputs = TraceInputs::new(input, Vec::new(), Vec::new(), memory_config);
-    (program, inputs)
-}
+mod common;
+use common::setup;
 
 /// Run a guest through both engines and assert the fast pass agrees with the
 /// reference on everything the fast pass observes.
@@ -68,7 +24,9 @@ fn assert_fast_run_matches(package: &str, func: &str, input: Vec<u8>) {
     // Pin the reference to serial mode (the tracer env-dispatches to the
     // parallel pipeline).
     std::env::remove_var("TRACER_PARALLEL");
-    let (program, inputs) = setup(package, func, input);
+    let Some((program, inputs)) = setup(package, func, input) else {
+        return;
+    };
 
     let reference = TracerBackend::new()
         .trace(&program, inputs.clone())
@@ -107,7 +65,9 @@ fn assert_fast_run_matches(package: &str, func: &str, input: Vec<u8>) {
 /// byte-equality rests on.
 fn assert_record_matches(package: &str, func: &str, input: Vec<u8>) {
     std::env::remove_var("TRACER_PARALLEL");
-    let (program, inputs) = setup(package, func, input);
+    let Some((program, inputs)) = setup(package, func, input) else {
+        return;
+    };
 
     let reference = TracerBackend::new()
         .trace(&program, inputs.clone())

--- a/crates/jolt-tracer-x86/tests/fast_run_equivalence.rs
+++ b/crates/jolt-tracer-x86/tests/fast_run_equivalence.rs
@@ -164,6 +164,30 @@ fn sha2_chain_record_matches_reference() {
     assert_record_matches("sha2-chain-guest", "sha2_chain", input);
 }
 
+/// Production-scale row-stream equality. The small-guest tests above pin
+/// semantics; this one exercises the same comparison over millions of rows
+/// with realistic memory and control-flow patterns, which is the substance
+/// AC7's proof byte-equality would provide (a proof is a deterministic
+/// function of the trace, so byte-identical rows imply byte-identical
+/// proofs). Ignored by default: it needs a few GB and ~10s.
+#[test]
+#[ignore = "scale test: several GB of trace rows"]
+fn fibonacci_scale_record_matches_reference() {
+    assert_record_matches(
+        "fibonacci-guest",
+        "fib",
+        postcard::to_stdvec(&400_000_u32).unwrap(),
+    );
+}
+
+#[test]
+#[ignore = "scale test: several GB of trace rows"]
+fn sha2_chain_scale_record_matches_reference() {
+    let mut input = postcard::to_stdvec(&[5u8; 32]).unwrap();
+    input.append(&mut postcard::to_stdvec(&256u32).unwrap());
+    assert_record_matches("sha2-chain-guest", "sha2_chain", input);
+}
+
 #[test]
 fn fibonacci_fast_run_matches_reference() {
     assert_fast_run_matches(

--- a/crates/jolt-tracer-x86/tests/fast_run_equivalence.rs
+++ b/crates/jolt-tracer-x86/tests/fast_run_equivalence.rs
@@ -125,6 +125,16 @@ fn sha3_chain_fast_run_matches_reference() {
 }
 
 #[test]
+fn muldiv_fast_run_matches_reference() {
+    // Exercises the DIV/REM advice groups (VirtualAdvice slots).
+    assert_fast_run_matches(
+        "muldiv-guest",
+        "muldiv",
+        vec![0xbd, 0xaa, 0xde, 0x5, 0x11, 0x5c],
+    );
+}
+
+#[test]
 fn btreemap_fast_run_matches_reference() {
     assert_fast_run_matches(
         "btreemap-guest",

--- a/crates/jolt-tracer-x86/tests/fast_run_equivalence.rs
+++ b/crates/jolt-tracer-x86/tests/fast_run_equivalence.rs
@@ -55,6 +55,9 @@ fn setup(package: &str, func: &str, input: Vec<u8>) -> (JoltProgram, TraceInputs
 
 #[test]
 fn fibonacci_fast_run_matches_reference() {
+    // Pin the reference to serial mode (the tracer env-dispatches to the
+    // parallel pipeline).
+    std::env::remove_var("TRACER_PARALLEL");
     let (program, inputs) = setup(
         "fibonacci-guest",
         "fib",

--- a/crates/jolt-tracer-x86/tests/kind_inventory.rs
+++ b/crates/jolt-tracer-x86/tests/kind_inventory.rs
@@ -1,0 +1,82 @@
+//! Dev tool: histogram of `JoltInstructionKind`s in a guest's expanded
+//! bytecode. Portable (no native codegen); drives template coverage for the
+//! transpiler bring-up. Run with:
+//!
+//! ```sh
+//! cargo nextest run -p jolt-tracer-x86 kind_inventory --cargo-quiet --run-ignored all --no-capture
+//! ```
+
+#![expect(clippy::expect_used, clippy::print_stdout, clippy::panic)]
+
+use std::collections::BTreeMap;
+
+fn build_guest_elf(package: &str, func: &str) -> Vec<u8> {
+    let target_dir = format!("/tmp/jolt-guest-targets/{package}-{func}");
+    let output = std::process::Command::new("jolt")
+        .args([
+            "build",
+            "-p",
+            package,
+            "--stack-size",
+            &common::constants::DEFAULT_STACK_SIZE.to_string(),
+            "--heap-size",
+            &common::constants::DEFAULT_HEAP_SIZE.to_string(),
+            "--",
+            "--release",
+            "--target-dir",
+            &target_dir,
+            "--features",
+            "guest",
+        ])
+        .env("JOLT_FUNC_NAME", func)
+        .output()
+        .expect("failed to run jolt CLI — install with: cargo install --path .");
+    assert!(
+        output.status.success(),
+        "failed to build {package}:\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let elf_path = format!("{target_dir}/riscv64imac-unknown-none-elf/release/{package}");
+    std::fs::read(&elf_path).unwrap_or_else(|e| panic!("failed to read ELF at {elf_path}: {e}"))
+}
+
+fn kind_histogram(package: &str, func: &str) -> BTreeMap<String, usize> {
+    let elf = build_guest_elf(package, func);
+    let program =
+        jolt_program::execution::build_jolt_program(&elf).expect("failed to build Jolt program");
+    let mut histogram = BTreeMap::new();
+    for row in &program.expanded_bytecode {
+        *histogram
+            .entry(format!("{:?}", row.instruction_kind))
+            .or_insert(0) += 1;
+    }
+    histogram
+}
+
+#[test]
+#[ignore = "dev tool: prints the static-bytecode kind histogram for a guest"]
+fn fibonacci_kind_inventory() {
+    let histogram = kind_histogram("fibonacci-guest", "fib");
+    println!(
+        "fibonacci-guest expanded-bytecode kinds ({}):",
+        histogram.len()
+    );
+    for (kind, count) in &histogram {
+        println!("  {kind:40} {count}");
+    }
+    assert!(!histogram.is_empty());
+}
+
+#[test]
+#[ignore = "dev tool: prints the static-bytecode kind histogram for a guest"]
+fn muldiv_kind_inventory() {
+    let histogram = kind_histogram("muldiv-guest", "muldiv");
+    println!(
+        "muldiv-guest expanded-bytecode kinds ({}):",
+        histogram.len()
+    );
+    for (kind, count) in &histogram {
+        println!("  {kind:40} {count}");
+    }
+    assert!(!histogram.is_empty());
+}

--- a/crates/jolt-tracer-x86/tests/kind_inventory.rs
+++ b/crates/jolt-tracer-x86/tests/kind_inventory.rs
@@ -6,7 +6,7 @@
 //! cargo nextest run -p jolt-tracer-x86 kind_inventory --cargo-quiet --run-ignored all --no-capture
 //! ```
 
-#![expect(clippy::expect_used, clippy::print_stdout, clippy::panic)]
+#![expect(clippy::print_stdout)]
 
 use std::collections::BTreeMap;
 
@@ -14,45 +14,13 @@ use std::collections::BTreeMap;
 use jolt_inlines_keccak256 as _;
 use jolt_inlines_sha2 as _;
 
-fn build_guest_elf(package: &str, func: &str) -> Vec<u8> {
-    let target_dir = format!("/tmp/jolt-guest-targets/{package}-{func}");
-    let output = std::process::Command::new("jolt")
-        .args([
-            "build",
-            "-p",
-            package,
-            "--stack-size",
-            &common::constants::DEFAULT_STACK_SIZE.to_string(),
-            "--heap-size",
-            &common::constants::DEFAULT_HEAP_SIZE.to_string(),
-            "--",
-            "--release",
-            "--target-dir",
-            &target_dir,
-            "--features",
-            "guest",
-        ])
-        .env("JOLT_FUNC_NAME", func)
-        .output()
-        .expect("failed to run jolt CLI — install with: cargo install --path .");
-    assert!(
-        output.status.success(),
-        "failed to build {package}:\n{}",
-        String::from_utf8_lossy(&output.stderr)
-    );
-    let elf_path = format!("{target_dir}/riscv64imac-unknown-none-elf/release/{package}");
-    std::fs::read(&elf_path).unwrap_or_else(|e| panic!("failed to read ELF at {elf_path}: {e}"))
-}
+mod common;
+use common::setup;
 
 fn kind_histogram(package: &str, func: &str) -> BTreeMap<String, usize> {
-    let elf = build_guest_elf(package, func);
-    let mut provider = tracer::TracerInlineExpansionProvider::new();
-    let program = jolt_program::build_jolt_program_with_inline_provider(
-        &elf,
-        &mut provider,
-        jolt_riscv::RV64IMAC_JOLT_ALL_INLINES,
-    )
-    .expect("failed to build Jolt program");
+    let Some((program, _)) = setup(package, func, Vec::new()) else {
+        return BTreeMap::new();
+    };
     let mut histogram = BTreeMap::new();
     for row in &program.expanded_bytecode {
         *histogram

--- a/crates/jolt-tracer-x86/tests/kind_inventory.rs
+++ b/crates/jolt-tracer-x86/tests/kind_inventory.rs
@@ -10,6 +10,10 @@
 
 use std::collections::BTreeMap;
 
+// Link inline registrations for inline-bearing guests.
+use jolt_inlines_keccak256 as _;
+use jolt_inlines_sha2 as _;
+
 fn build_guest_elf(package: &str, func: &str) -> Vec<u8> {
     let target_dir = format!("/tmp/jolt-guest-targets/{package}-{func}");
     let output = std::process::Command::new("jolt")
@@ -42,8 +46,13 @@ fn build_guest_elf(package: &str, func: &str) -> Vec<u8> {
 
 fn kind_histogram(package: &str, func: &str) -> BTreeMap<String, usize> {
     let elf = build_guest_elf(package, func);
-    let program =
-        jolt_program::execution::build_jolt_program(&elf).expect("failed to build Jolt program");
+    let mut provider = tracer::TracerInlineExpansionProvider::new();
+    let program = jolt_program::build_jolt_program_with_inline_provider(
+        &elf,
+        &mut provider,
+        jolt_riscv::RV64IMAC_JOLT_ALL_INLINES,
+    )
+    .expect("failed to build Jolt program");
     let mut histogram = BTreeMap::new();
     for row in &program.expanded_bytecode {
         *histogram
@@ -59,6 +68,48 @@ fn fibonacci_kind_inventory() {
     let histogram = kind_histogram("fibonacci-guest", "fib");
     println!(
         "fibonacci-guest expanded-bytecode kinds ({}):",
+        histogram.len()
+    );
+    for (kind, count) in &histogram {
+        println!("  {kind:40} {count}");
+    }
+    assert!(!histogram.is_empty());
+}
+
+#[test]
+#[ignore = "dev tool: prints the static-bytecode kind histogram for a guest"]
+fn sha2_chain_kind_inventory() {
+    let histogram = kind_histogram("sha2-chain-guest", "sha2_chain");
+    println!(
+        "sha2-chain-guest expanded-bytecode kinds ({}):",
+        histogram.len()
+    );
+    for (kind, count) in &histogram {
+        println!("  {kind:40} {count}");
+    }
+    assert!(!histogram.is_empty());
+}
+
+#[test]
+#[ignore = "dev tool: prints the static-bytecode kind histogram for a guest"]
+fn sha3_chain_kind_inventory() {
+    let histogram = kind_histogram("sha3-chain-guest", "sha3_chain");
+    println!(
+        "sha3-chain-guest expanded-bytecode kinds ({}):",
+        histogram.len()
+    );
+    for (kind, count) in &histogram {
+        println!("  {kind:40} {count}");
+    }
+    assert!(!histogram.is_empty());
+}
+
+#[test]
+#[ignore = "dev tool: prints the static-bytecode kind histogram for a guest"]
+fn btreemap_kind_inventory() {
+    let histogram = kind_histogram("btreemap-guest", "btreemap");
+    println!(
+        "btreemap-guest expanded-bytecode kinds ({}):",
         histogram.len()
     );
     for (kind, count) in &histogram {

--- a/crates/jolt-tracer-x86/tests/per_instruction_diff.rs
+++ b/crates/jolt-tracer-x86/tests/per_instruction_diff.rs
@@ -106,6 +106,10 @@ const SUPPORTED: &[&str] = &[
     "VirtualChangeDivisorW",
     "VirtualAdviceLen",
     "VirtualAdviceLoad",
+    // Slice 3b: value comes from the group's advice slots, so the
+    // single-row harness cannot drive it; whole-guest gates cover it
+    // (muldiv's DIV/REM groups).
+    "VirtualAdvice",
 ];
 
 fn class_by_marker(marker: &str) -> Class {
@@ -693,5 +697,5 @@ difftests! {
 /// test fails.
 #[test]
 fn supported_kinds_all_have_difftests() {
-    assert_eq!(SUPPORTED.len(), 66);
+    assert_eq!(SUPPORTED.len(), 67);
 }

--- a/crates/jolt-tracer-x86/tests/per_instruction_diff.rs
+++ b/crates/jolt-tracer-x86/tests/per_instruction_diff.rs
@@ -78,6 +78,34 @@ const SUPPORTED: &[&str] = &[
     "VirtualZeroExtendWord",
     "Xor",
     "XorI",
+    // Slice 3 (fast-pass coverage):
+    "Slt",
+    "Andn",
+    "Pow2I",
+    "Pow2W",
+    "Pow2IW",
+    "MovSign",
+    "VirtualRev8W",
+    "VirtualRotri",
+    "VirtualRotriw",
+    "VirtualShiftRightBitmaski",
+    "VirtualSra",
+    "VirtualXorRot32",
+    "VirtualXorRot24",
+    "VirtualXorRot16",
+    "VirtualXorRot63",
+    "VirtualXorRotW16",
+    "VirtualXorRotW12",
+    "VirtualXorRotW8",
+    "VirtualXorRotW7",
+    "AssertEq",
+    "AssertValidDiv0",
+    "AssertValidUnsignedRemainder",
+    "AssertMulUNoOverflow",
+    "VirtualChangeDivisor",
+    "VirtualChangeDivisorW",
+    "VirtualAdviceLen",
+    "VirtualAdviceLoad",
 ];
 
 fn class_by_marker(marker: &str) -> Class {
@@ -147,6 +175,7 @@ struct Instance {
     row: JoltInstructionRow,
     pre_regs: [u64; REGS],
     scratch: Vec<u64>,
+    advice: Vec<u8>,
 }
 
 fn base_instance(rng: &mut StdRng, kind: JoltInstructionKind) -> Instance {
@@ -159,6 +188,7 @@ fn base_instance(rng: &mut StdRng, kind: JoltInstructionKind) -> Instance {
         row: default_row(kind),
         pre_regs,
         scratch,
+        advice: Vec::new(),
     }
 }
 
@@ -360,6 +390,114 @@ fn host_io(rng: &mut StdRng) -> Instance {
     i
 }
 
+fn imm_j_u64(rng: &mut StdRng, kind: JoltInstructionKind) -> Instance {
+    // FormatJ: rd + a raw u64 immediate (stored bit-preserving in i128).
+    let mut i = base_instance(rng, kind);
+    i.row.operands.rd = Some(rd(rng));
+    i.row.operands.imm = (rng.gen::<u64>() as i64) as i128;
+    i
+}
+
+fn assert_eq_gen(rng: &mut StdRng) -> Instance {
+    let mut i = base_instance(rng, K::VirtualAssertEQ);
+    let rs1 = rd(rng);
+    let rs2 = rd(rng);
+    i.row.operands.rs1 = Some(rs1);
+    i.row.operands.rs2 = Some(rs2);
+    if rng.gen_ratio(1, 10) {
+        // Spoil mode: warn-and-continue on both sides.
+        i.row.operands.imm = 1;
+    } else {
+        i.row.operands.imm = 0;
+        i.pre_regs[rs2 as usize] = i.pre_regs[rs1 as usize];
+    }
+    i
+}
+
+fn assert_valid_div0(rng: &mut StdRng) -> Instance {
+    let mut i = base_instance(rng, K::VirtualAssertValidDiv0);
+    let rs1 = rd(rng);
+    let rs2 = rd(rng);
+    i.row.operands.rs1 = Some(rs1);
+    i.row.operands.rs2 = Some(rs2);
+    if rng.gen() {
+        // divisor == 0 requires quotient == u64::MAX.
+        i.pre_regs[rs1 as usize] = 0;
+        i.pre_regs[rs2 as usize] = u64::MAX;
+        if rs1 == rs2 {
+            i.pre_regs[rs1 as usize] = u64::MAX; // MAX != 0, valid either way
+        }
+    } else if i.pre_regs[rs1 as usize] == 0 {
+        i.pre_regs[rs1 as usize] = 1;
+    }
+    i
+}
+
+fn assert_valid_unsigned_remainder(rng: &mut StdRng) -> Instance {
+    let mut i = base_instance(rng, K::VirtualAssertValidUnsignedRemainder);
+    let rs1 = rd(rng);
+    let rs2 = rd(rng);
+    i.row.operands.rs1 = Some(rs1);
+    i.row.operands.rs2 = Some(rs2);
+    if rs1 == rs2 {
+        // remainder == divisor is only valid when both are zero.
+        i.pre_regs[rs1 as usize] = 0;
+    } else if rng.gen_ratio(1, 5) {
+        i.pre_regs[rs2 as usize] = 0; // divisor 0: anything passes
+    } else {
+        let divisor = i.pre_regs[rs2 as usize].max(1);
+        i.pre_regs[rs2 as usize] = divisor;
+        i.pre_regs[rs1 as usize] %= divisor;
+    }
+    i
+}
+
+fn assert_mulu_no_overflow(rng: &mut StdRng) -> Instance {
+    let mut i = base_instance(rng, K::VirtualAssertMulUNoOverflow);
+    let rs1 = rd(rng);
+    let rs2 = rd(rng);
+    i.row.operands.rs1 = Some(rs1);
+    i.row.operands.rs2 = Some(rs2);
+    // Keep both factors below 2^32 so the product cannot overflow.
+    i.pre_regs[rs1 as usize] &= 0xFFFF_FFFF;
+    i.pre_regs[rs2 as usize] &= 0xFFFF_FFFF;
+    i
+}
+
+fn change_divisor(rng: &mut StdRng, name: &str, wide: bool) -> Instance {
+    let mut i = alu_rr(rng, kind_by_name(name));
+    if rng.gen_ratio(1, 4) {
+        // Exercise the MIN/-1 edge.
+        let rs1 = i.row.operands.rs1.unwrap();
+        let rs2 = i.row.operands.rs2.unwrap();
+        if rs1 != 0 && rs2 != 0 && rs1 != rs2 {
+            i.pre_regs[rs1 as usize] = if wide {
+                i64::MIN as u64
+            } else {
+                (i32::MIN as i64) as u64
+            };
+            i.pre_regs[rs2 as usize] = u64::MAX; // -1
+        }
+    }
+    i
+}
+
+fn advice_len(rng: &mut StdRng) -> Instance {
+    let mut i = base_instance(rng, kind_by_name("VirtualAdviceLen"));
+    i.row.operands.rs1 = Some(reg(rng));
+    i.row.operands.rd = Some(rd(rng));
+    i.advice = (0..rng.gen_range(0..64)).map(|_| rng.gen()).collect();
+    i
+}
+
+fn advice_load(rng: &mut StdRng) -> Instance {
+    let mut i = base_instance(rng, kind_by_name("VirtualAdviceLoad"));
+    i.row.operands.rd = Some(rd(rng));
+    i.row.operands.imm = *[1i128, 2, 4, 8].get(rng.gen_range(0..4)).unwrap();
+    i.advice = (0..8 + rng.gen_range(0..32)).map(|_| rng.gen()).collect();
+    i
+}
+
 // ── Reference execution ─────────────────────────────────────────────
 
 struct RefOutcome {
@@ -382,6 +520,7 @@ fn reference_run(instance: &Instance) -> RefOutcome {
     for (index, &value) in instance.pre_regs.iter().enumerate().skip(1) {
         cpu.x[index] = value as i64;
     }
+    cpu.advice_tape = tracer::AdviceTape::from_bytes(instance.advice.clone());
     // The interpreter pre-increments PC before exec (tick_operate); link
     // values and fall-through PCs depend on it.
     cpu.update_pc(TEST_ADDR + 4);
@@ -419,8 +558,13 @@ fn run_difftest(name: &str, generate: fn(&mut StdRng) -> Instance) {
         let reference = reference_run(&instance);
 
         let program = single_row_program(instance.row);
-        let native = run_program(&program, &instance.pre_regs, &instance.scratch)
-            .unwrap_or_else(|e| panic!("{name}[{iteration}]: native run failed: {e:?}"));
+        let native = run_program(
+            &program,
+            &instance.pre_regs,
+            &instance.scratch,
+            &instance.advice,
+        )
+        .unwrap_or_else(|e| panic!("{name}[{iteration}]: native run failed: {e:?}"));
 
         assert_eq!(
             native.exit, 1,
@@ -515,6 +659,33 @@ difftests! {
     diff_assert_lte => assert_lte;
     diff_fence => fence;
     diff_host_io => host_io;
+    diff_slt => |r| alu_rr(r, K::SLT);
+    diff_andn => |r| alu_rr(r, K::ANDN);
+    diff_pow2i => |r| imm_j_u64(r, K::VirtualPow2I);
+    diff_pow2w => |r| unary(r, K::VirtualPow2W);
+    diff_pow2iw => |r| imm_j_u64(r, K::VirtualPow2IW);
+    diff_movsign => |r| unary(r, K::VirtualMovsign);
+    diff_rev8w => |r| unary(r, kind_by_name("VirtualRev8W"));
+    diff_rotri => |r| shift_imm(r, K::VirtualROTRI);
+    diff_rotriw => |r| shift_imm(r, K::VirtualROTRIW);
+    diff_shift_right_bitmaski => |r| imm_j_u64(r, K::VirtualShiftRightBitmaskI);
+    diff_sra_reg => |r| shift_reg(r, K::VirtualSRA);
+    diff_xorrot32 => |r| alu_rr(r, K::VirtualXORROT32);
+    diff_xorrot24 => |r| alu_rr(r, K::VirtualXORROT24);
+    diff_xorrot16 => |r| alu_rr(r, K::VirtualXORROT16);
+    diff_xorrot63 => |r| alu_rr(r, K::VirtualXORROT63);
+    diff_xorrotw16 => |r| alu_rr(r, K::VirtualXORROTW16);
+    diff_xorrotw12 => |r| alu_rr(r, K::VirtualXORROTW12);
+    diff_xorrotw8 => |r| alu_rr(r, K::VirtualXORROTW8);
+    diff_xorrotw7 => |r| alu_rr(r, K::VirtualXORROTW7);
+    diff_assert_eq => assert_eq_gen;
+    diff_assert_valid_div0 => assert_valid_div0;
+    diff_assert_valid_unsigned_remainder => assert_valid_unsigned_remainder;
+    diff_assert_mulu_no_overflow => assert_mulu_no_overflow;
+    diff_change_divisor => |r| change_divisor(r, "VirtualChangeDivisor", true);
+    diff_change_divisor_w => |r| change_divisor(r, "VirtualChangeDivisorW", false);
+    diff_advice_len => advice_len;
+    diff_advice_load => advice_load;
 }
 
 /// Every supported kind has a differential test above (one test per kind,
@@ -522,5 +693,5 @@ difftests! {
 /// test fails.
 #[test]
 fn supported_kinds_all_have_difftests() {
-    assert_eq!(SUPPORTED.len(), 39);
+    assert_eq!(SUPPORTED.len(), 66);
 }

--- a/crates/jolt-tracer-x86/tests/per_instruction_diff.rs
+++ b/crates/jolt-tracer-x86/tests/per_instruction_diff.rs
@@ -1,0 +1,526 @@
+//! Per-instruction differential tests: for every implemented row kind, run
+//! ≥1000 random operand/state instances through the AOT backend and the
+//! reference interpreter `Cpu`, comparing full register state, PC, scratch
+//! memory, and the advice tape (modeled on the tracer's execute-vs-trace
+//! harness).
+//!
+//! Coverage is exhaustive by construction: `classify` matches every
+//! `JoltInstructionKind` variant without a wildcard, so a new kind in
+//! jolt-riscv fails to compile here until it is classified, and
+//! `classification_matches_compiler` asserts the classification agrees with
+//! what the transpiler actually accepts.
+
+#![cfg(all(target_arch = "x86_64", target_os = "linux"))]
+#![expect(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+
+use common::constants::REGISTER_COUNT;
+use common::jolt_device::JoltDevice;
+use jolt_platform::JOLT_ADVICE_WRITE_CALL_ID;
+use jolt_riscv::{JoltInstructionKind, JoltInstructionRow, NormalizedOperands};
+use jolt_tracer_x86::harness::{
+    self, run_program, single_row_program, MEM_CAPACITY, SCRATCH_DWORDS, SCRATCH_START, TEST_ADDR,
+};
+use rand::rngs::StdRng;
+use rand::{Rng, SeedableRng};
+use tracer::emulator::cpu::Cpu;
+use tracer::emulator::terminal::DummyTerminal;
+use tracer::instruction::Instruction;
+
+const N: usize = 1000;
+const REGS: usize = REGISTER_COUNT as usize;
+
+// ── Kind classification (compile-time exhaustive) ───────────────────
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Class {
+    Supported,
+    NotYetSupported,
+}
+
+/// Marker names of the kinds the transpiler implements (slice 2: base ISA).
+const SUPPORTED: &[&str] = &[
+    "Add",
+    "Addi",
+    "And",
+    "AndI",
+    "AssertHalfwordAlignment",
+    "AssertLte",
+    "AssertWordAlignment",
+    "Auipc",
+    "Beq",
+    "Bge",
+    "BgeU",
+    "Blt",
+    "BltU",
+    "Bne",
+    "Fence",
+    "Jal",
+    "Jalr",
+    "Ld",
+    "Lui",
+    "Mul",
+    "MulHU",
+    "MulI",
+    "Or",
+    "OrI",
+    "Pow2",
+    "Sd",
+    "SltI",
+    "SltIU",
+    "SltU",
+    "Sub",
+    "VirtualHostIO",
+    "VirtualShiftRightBitmask",
+    "VirtualSignExtendWord",
+    "VirtualSrai",
+    "VirtualSrl",
+    "VirtualSrli",
+    "VirtualZeroExtendWord",
+    "Xor",
+    "XorI",
+];
+
+fn class_by_marker(marker: &str) -> Class {
+    if SUPPORTED.contains(&marker) {
+        Class::Supported
+    } else {
+        Class::NotYetSupported
+    }
+}
+
+macro_rules! classify_kinds {
+    (
+        instructions: [$($(#[$meta:meta])* $instr:ident => $marker:ident => ($tag:expr, $name:expr)),* $(,)?]
+    ) => {
+        /// Exhaustive (no wildcard): a new `JoltInstructionKind` fails to
+        /// compile until classified.
+        fn classify(kind: &JoltInstructionKind) -> Class {
+            match kind {
+                JoltInstructionKind::Noop(_) => Class::NotYetSupported,
+                $(
+                    $(#[$meta])*
+                    JoltInstructionKind::$marker(_) => class_by_marker(stringify!($marker)),
+                )*
+            }
+        }
+    };
+}
+jolt_riscv::for_each_jolt_instruction_kind!(classify_kinds);
+
+fn default_row(kind: JoltInstructionKind) -> JoltInstructionRow {
+    JoltInstructionRow {
+        instruction_kind: kind,
+        address: TEST_ADDR as usize,
+        operands: NormalizedOperands {
+            rs1: None,
+            rs2: None,
+            rd: None,
+            imm: 0,
+        },
+        virtual_sequence_remaining: None,
+        is_first_in_sequence: true,
+        is_compressed: false,
+    }
+}
+
+/// The classification must agree with what the transpiler accepts: every
+/// supported kind compiles, every unsupported kind fails fast.
+#[test]
+fn classification_matches_compiler() {
+    for &kind in JoltInstructionKind::ALL {
+        let program = single_row_program(default_row(kind));
+        let compiles = harness::compile_only(&program).is_ok();
+        let classified = classify(&kind) == Class::Supported;
+        assert_eq!(
+            compiles,
+            classified,
+            "kind {} ({:?}): compiler acceptance disagrees with classification",
+            kind.name(),
+            kind
+        );
+    }
+}
+
+// ── Random row/state generation ─────────────────────────────────────
+
+struct Instance {
+    row: JoltInstructionRow,
+    pre_regs: [u64; REGS],
+    scratch: Vec<u64>,
+}
+
+fn base_instance(rng: &mut StdRng, kind: JoltInstructionKind) -> Instance {
+    let mut pre_regs = [0u64; REGS];
+    for reg in pre_regs.iter_mut().skip(1) {
+        *reg = rng.gen();
+    }
+    let scratch: Vec<u64> = (0..SCRATCH_DWORDS).map(|_| rng.gen()).collect();
+    Instance {
+        row: default_row(kind),
+        pre_regs,
+        scratch,
+    }
+}
+
+fn reg(rng: &mut StdRng) -> u8 {
+    rng.gen_range(0..REGS as u8)
+}
+
+fn rd(rng: &mut StdRng) -> u8 {
+    rng.gen_range(1..REGS as u8)
+}
+
+fn imm12(rng: &mut StdRng) -> i128 {
+    rng.gen_range(-2048i64..2048) as i128
+}
+
+/// Pin `x[reg]` so that `x[reg] + imm == target` (wrapping).
+fn pin_base(instance: &mut Instance, register: u8, imm: i128, target: u64) {
+    assert_ne!(register, 0, "cannot pin x0");
+    instance.pre_regs[register as usize] = target.wrapping_sub(imm as i64 as u64);
+}
+
+fn alu_rr(rng: &mut StdRng, kind: JoltInstructionKind) -> Instance {
+    let mut i = base_instance(rng, kind);
+    i.row.operands.rs1 = Some(reg(rng));
+    i.row.operands.rs2 = Some(reg(rng));
+    i.row.operands.rd = Some(rd(rng));
+    i
+}
+
+fn alu_ri(rng: &mut StdRng, kind: JoltInstructionKind, wide_imm: bool) -> Instance {
+    let mut i = base_instance(rng, kind);
+    i.row.operands.rs1 = Some(reg(rng));
+    i.row.operands.rd = Some(rd(rng));
+    i.row.operands.imm = if wide_imm {
+        rng.gen::<i64>() as i128
+    } else {
+        imm12(rng)
+    };
+    i
+}
+
+fn upper_imm(rng: &mut StdRng, kind: JoltInstructionKind) -> Instance {
+    let mut i = base_instance(rng, kind);
+    i.row.operands.rd = Some(rd(rng));
+    // 20-bit immediate << 12, sign-extended (the U-format decode invariant).
+    i.row.operands.imm = ((rng.gen_range(-(1i64 << 19)..(1i64 << 19))) << 12) as i128;
+    i
+}
+
+fn unary(rng: &mut StdRng, kind: JoltInstructionKind) -> Instance {
+    let mut i = base_instance(rng, kind);
+    i.row.operands.rs1 = Some(reg(rng));
+    i.row.operands.rd = Some(rd(rng));
+    i
+}
+
+fn shift_imm(rng: &mut StdRng, kind: JoltInstructionKind) -> Instance {
+    let mut i = base_instance(rng, kind);
+    i.row.operands.rs1 = Some(reg(rng));
+    i.row.operands.rd = Some(rd(rng));
+    // The immediate is a bitmask; shift = imm.trailing_zeros(). One-hot
+    // values are the real invariant; 0 exercises the trailing_zeros(0)=64
+    // edge on both sides.
+    i.row.operands.imm = if rng.gen_ratio(1, 20) {
+        0
+    } else {
+        (1u64 << rng.gen_range(0..64)) as i128
+    };
+    i
+}
+
+fn shift_reg(rng: &mut StdRng, kind: JoltInstructionKind) -> Instance {
+    let mut i = alu_rr(rng, kind);
+    // rs2 carries a bitmask; mix one-hot, zero, and arbitrary values.
+    let rs2 = i.row.operands.rs2.unwrap();
+    if rs2 != 0 {
+        i.pre_regs[rs2 as usize] = match rng.gen_range(0..3) {
+            0 => 1u64 << rng.gen_range(0..64),
+            1 => 0,
+            _ => rng.gen(),
+        };
+    }
+    i
+}
+
+fn branch(rng: &mut StdRng, kind: JoltInstructionKind) -> Instance {
+    let mut i = base_instance(rng, kind);
+    let rs1 = reg(rng);
+    let rs2 = reg(rng);
+    i.row.operands.rs1 = Some(rs1);
+    i.row.operands.rs2 = Some(rs2);
+    i.row.operands.imm = if rng.gen() { 8 } else { -8 };
+    // Half the time force equality so both outcomes are exercised.
+    if rng.gen() && rs1 != 0 && rs2 != 0 {
+        i.pre_regs[rs2 as usize] = i.pre_regs[rs1 as usize];
+    }
+    i
+}
+
+fn jal(rng: &mut StdRng) -> Instance {
+    let mut i = base_instance(rng, JoltInstructionKind::JAL);
+    i.row.operands.rd = Some(rd(rng));
+    i.row.operands.imm = if rng.gen() { 8 } else { -8 };
+    i
+}
+
+fn jalr(rng: &mut StdRng) -> Instance {
+    let mut i = base_instance(rng, JoltInstructionKind::JALR);
+    let rs1 = rd(rng); // nonzero so the base can be pinned
+    i.row.operands.rs1 = Some(rs1);
+    i.row.operands.rd = Some(rd(rng)); // may alias rs1 (ordering test)
+    let imm = (rng.gen_range(-8i64..8) * 2) as i128;
+    i.row.operands.imm = imm;
+    let target = if rng.gen() {
+        TEST_ADDR + 8
+    } else {
+        TEST_ADDR - 8
+    };
+    pin_base(&mut i, rs1, imm, target);
+    i
+}
+
+fn scratch_slot(rng: &mut StdRng) -> u64 {
+    SCRATCH_START + 8 * rng.gen_range(0..SCRATCH_DWORDS as u64)
+}
+
+fn load(rng: &mut StdRng) -> Instance {
+    let mut i = base_instance(rng, JoltInstructionKind::LD);
+    let rs1 = rd(rng);
+    i.row.operands.rs1 = Some(rs1);
+    i.row.operands.rd = Some(rd(rng));
+    let imm = imm12(rng);
+    i.row.operands.imm = imm;
+    pin_base(&mut i, rs1, imm, scratch_slot(rng));
+    i
+}
+
+fn store(rng: &mut StdRng) -> Instance {
+    let mut i = base_instance(rng, JoltInstructionKind::SD);
+    let rs1 = rd(rng);
+    i.row.operands.rs1 = Some(rs1);
+    i.row.operands.rs2 = Some(reg(rng));
+    let imm = imm12(rng);
+    i.row.operands.imm = imm;
+    pin_base(&mut i, rs1, imm, scratch_slot(rng));
+    i
+}
+
+fn assert_align(rng: &mut StdRng, kind: JoltInstructionKind, align: u64) -> Instance {
+    let mut i = base_instance(rng, kind);
+    let rs1 = rd(rng);
+    i.row.operands.rs1 = Some(rs1);
+    // FormatAssert immediates are wrapped-to-u64 offsets; keep them small
+    // and pin the base so the (passing) alignment holds.
+    let imm = (rng.gen_range(0..16u64) * align) as i128;
+    i.row.operands.imm = imm;
+    let target = SCRATCH_START + align * rng.gen_range(0..64u64);
+    pin_base(&mut i, rs1, imm, target);
+    i
+}
+
+fn assert_lte(rng: &mut StdRng) -> Instance {
+    let mut i = base_instance(rng, JoltInstructionKind::VirtualAssertLTE);
+    let rs1 = rd(rng);
+    let rs2 = rd(rng);
+    i.row.operands.rs1 = Some(rs1);
+    i.row.operands.rs2 = Some(rs2);
+    // Ensure the (passing) invariant x[rs1] <= x[rs2].
+    let a = i.pre_regs[rs1 as usize];
+    let b = i.pre_regs[rs2 as usize];
+    if a > b {
+        i.pre_regs[rs1 as usize] = b;
+        i.pre_regs[rs2 as usize] = a;
+    }
+    if rs1 == rs2 || rng.gen_ratio(1, 10) {
+        i.pre_regs[rs2 as usize] = i.pre_regs[rs1 as usize];
+    }
+    i
+}
+
+fn fence(rng: &mut StdRng) -> Instance {
+    base_instance(rng, JoltInstructionKind::FENCE)
+}
+
+fn host_io(rng: &mut StdRng) -> Instance {
+    let mut i = base_instance(rng, kind_by_name("VirtualHostIO"));
+    i.row.operands.rs1 = Some(reg(rng));
+    // FormatI unwraps rd; the exec never writes it (parity holds either way).
+    i.row.operands.rd = Some(rd(rng));
+    // a0 selects the call: unknown ids are no-ops on both sides; advice
+    // writes append guest bytes to the tape on both sides.
+    if rng.gen() {
+        i.pre_regs[10] = JOLT_ADVICE_WRITE_CALL_ID as u64;
+        i.pre_regs[11] = scratch_slot(rng);
+        i.pre_regs[12] = rng.gen_range(0..48);
+    } else {
+        i.pre_regs[10] = rng.gen::<u32>() as u64 | 1 << 33; // unknown id
+    }
+    i
+}
+
+// ── Reference execution ─────────────────────────────────────────────
+
+struct RefOutcome {
+    regs: [u64; REGS],
+    pc: u64,
+    scratch: Vec<u64>,
+    advice_tape: Vec<u8>,
+}
+
+fn reference_run(instance: &Instance) -> RefOutcome {
+    let mut cpu = Cpu::new(Box::new(DummyTerminal {}));
+    cpu.get_mut_mmu().jolt_device = Some(JoltDevice::new(&harness::memory_config()));
+    cpu.get_mut_mmu().init_memory(MEM_CAPACITY);
+    for (slot, &dword) in instance.scratch.iter().enumerate() {
+        let _ = cpu
+            .mmu
+            .store_doubleword(SCRATCH_START + 8 * slot as u64, dword)
+            .unwrap();
+    }
+    for (index, &value) in instance.pre_regs.iter().enumerate().skip(1) {
+        cpu.x[index] = value as i64;
+    }
+    // The interpreter pre-increments PC before exec (tick_operate); link
+    // values and fall-through PCs depend on it.
+    cpu.update_pc(TEST_ADDR + 4);
+
+    let instruction =
+        Instruction::try_from_jolt_instruction_row(instance.row).expect("row not executable");
+    instruction.trace(&mut cpu, None);
+
+    let mut regs = [0u64; REGS];
+    for (slot, &value) in cpu.x.iter().enumerate() {
+        regs[slot] = value as u64;
+    }
+    let scratch = (0..SCRATCH_DWORDS)
+        .map(|slot| {
+            cpu.mmu
+                .load_doubleword(SCRATCH_START + 8 * slot as u64)
+                .unwrap()
+                .0
+        })
+        .collect();
+    RefOutcome {
+        regs,
+        pc: cpu.read_pc(),
+        scratch,
+        advice_tape: cpu.advice_tape.clone().into_bytes(),
+    }
+}
+
+// ── The differential loop ───────────────────────────────────────────
+
+fn run_difftest(name: &str, generate: fn(&mut StdRng) -> Instance) {
+    let mut rng = StdRng::seed_from_u64(0x1717_5EED);
+    for iteration in 0..N {
+        let instance = generate(&mut rng);
+        let reference = reference_run(&instance);
+
+        let program = single_row_program(instance.row);
+        let native = run_program(&program, &instance.pre_regs, &instance.scratch)
+            .unwrap_or_else(|e| panic!("{name}[{iteration}]: native run failed: {e:?}"));
+
+        assert_eq!(
+            native.exit, 1,
+            "{name}[{iteration}]: expected termination, got exit {} ({:?}) row {:?}",
+            native.exit, native.helper_error, instance.row
+        );
+        assert_eq!(
+            native.trace_len, 2,
+            "{name}[{iteration}]: row + terminal expected"
+        );
+        assert_eq!(
+            native.pc, reference.pc,
+            "{name}[{iteration}]: pc diverged, row {:?}",
+            instance.row
+        );
+        for register in 0..REGS {
+            assert_eq!(
+                native.regs[register], reference.regs[register],
+                "{name}[{iteration}]: x{register} diverged, row {:?}",
+                instance.row
+            );
+        }
+        assert_eq!(
+            native.scratch, reference.scratch,
+            "{name}[{iteration}]: scratch memory diverged, row {:?}",
+            instance.row
+        );
+        assert_eq!(
+            native.advice_tape, reference.advice_tape,
+            "{name}[{iteration}]: advice tape diverged, row {:?}",
+            instance.row
+        );
+    }
+}
+
+macro_rules! difftests {
+    ($($test:ident => $gen:expr;)*) => {
+        $(
+            #[test]
+            fn $test() {
+                run_difftest(stringify!($test), $gen);
+            }
+        )*
+    };
+}
+
+use JoltInstructionKind as K;
+
+/// For kinds whose associated-const name collides with the enum variant name
+/// (the variant constructor wins path resolution), resolve by name instead.
+fn kind_by_name(name: &str) -> JoltInstructionKind {
+    JoltInstructionKind::from_name(name).expect("unknown kind name")
+}
+
+difftests! {
+    diff_add => |r| alu_rr(r, K::ADD);
+    diff_sub => |r| alu_rr(r, K::SUB);
+    diff_and => |r| alu_rr(r, K::AND);
+    diff_or => |r| alu_rr(r, K::OR);
+    diff_xor => |r| alu_rr(r, K::XOR);
+    diff_mul => |r| alu_rr(r, K::MUL);
+    diff_mulhu => |r| alu_rr(r, K::MULHU);
+    diff_sltu => |r| alu_rr(r, K::SLTU);
+    diff_addi => |r| alu_ri(r, K::ADDI, false);
+    diff_andi => |r| alu_ri(r, K::ANDI, false);
+    diff_ori => |r| alu_ri(r, K::ORI, false);
+    diff_xori => |r| alu_ri(r, K::XORI, false);
+    diff_slti => |r| alu_ri(r, K::SLTI, false);
+    diff_sltiu => |r| alu_ri(r, K::SLTIU, false);
+    diff_muli => |r| alu_ri(r, K::VirtualMULI, true);
+    diff_lui => |r| upper_imm(r, K::LUI);
+    diff_auipc => |r| upper_imm(r, K::AUIPC);
+    diff_pow2 => |r| unary(r, K::VirtualPow2);
+    diff_shift_right_bitmask => |r| unary(r, kind_by_name("VirtualShiftRightBitmask"));
+    diff_sign_extend_word => |r| unary(r, kind_by_name("VirtualSignExtendWord"));
+    diff_zero_extend_word => |r| unary(r, kind_by_name("VirtualZeroExtendWord"));
+    diff_srai => |r| shift_imm(r, K::VirtualSRAI);
+    diff_srli => |r| shift_imm(r, K::VirtualSRLI);
+    diff_srl => |r| shift_reg(r, K::VirtualSRL);
+    diff_beq => |r| branch(r, K::BEQ);
+    diff_bne => |r| branch(r, K::BNE);
+    diff_blt => |r| branch(r, K::BLT);
+    diff_bge => |r| branch(r, K::BGE);
+    diff_bltu => |r| branch(r, K::BLTU);
+    diff_bgeu => |r| branch(r, K::BGEU);
+    diff_jal => jal;
+    diff_jalr => jalr;
+    diff_ld => load;
+    diff_sd => store;
+    diff_assert_halfword_alignment => |r| assert_align(r, K::VirtualAssertHalfwordAlignment, 2);
+    diff_assert_word_alignment => |r| assert_align(r, K::VirtualAssertWordAlignment, 4);
+    diff_assert_lte => assert_lte;
+    diff_fence => fence;
+    diff_host_io => host_io;
+}
+
+/// Every supported kind has a differential test above (one test per kind,
+/// 39 of each); this pins the count so growing SUPPORTED without adding a
+/// test fails.
+#[test]
+fn supported_kinds_all_have_difftests() {
+    assert_eq!(SUPPORTED.len(), 39);
+}

--- a/crates/jolt-tracer-x86/tests/per_instruction_diff.rs
+++ b/crates/jolt-tracer-x86/tests/per_instruction_diff.rs
@@ -34,6 +34,10 @@ const REGS: usize = REGISTER_COUNT as usize;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum Class {
     Supported,
+    /// Implemented, but only legal inside a source group that computes
+    /// advice; a bare row must be a compile-time error (never a stale
+    /// advice-slot read), so the single-row harness cannot drive it.
+    RequiresAdviceGroup,
     NotYetSupported,
 }
 
@@ -106,14 +110,15 @@ const SUPPORTED: &[&str] = &[
     "VirtualChangeDivisorW",
     "VirtualAdviceLen",
     "VirtualAdviceLoad",
-    // Slice 3b: value comes from the group's advice slots, so the
-    // single-row harness cannot drive it; whole-guest gates cover it
-    // (muldiv's DIV/REM groups).
-    "VirtualAdvice",
 ];
 
 fn class_by_marker(marker: &str) -> Class {
-    if SUPPORTED.contains(&marker) {
+    // Slice 3b: VirtualAdvice reads the group's advice slots, filled by the
+    // group's advice computation; whole-guest gates cover it (muldiv's
+    // DIV/REM groups, the inline guests).
+    if marker == "VirtualAdvice" {
+        Class::RequiresAdviceGroup
+    } else if SUPPORTED.contains(&marker) {
         Class::Supported
     } else {
         Class::NotYetSupported
@@ -156,7 +161,8 @@ fn default_row(kind: JoltInstructionKind) -> JoltInstructionRow {
 }
 
 /// The classification must agree with what the transpiler accepts: every
-/// supported kind compiles, every unsupported kind fails fast.
+/// supported kind compiles as a bare row, everything else fails fast
+/// (unimplemented kinds and advice-group-only kinds alike).
 #[test]
 fn classification_matches_compiler() {
     for &kind in JoltInstructionKind::ALL {
@@ -171,6 +177,23 @@ fn classification_matches_compiler() {
             kind
         );
     }
+}
+
+/// Regression: a `VirtualAdvice` row in a group without an advice
+/// computation must be refused at compile time with the advice-specific
+/// error, not compiled into a stale-slot read (and not rejected as merely
+/// unsupported).
+#[test]
+fn bare_virtual_advice_is_a_compile_error() {
+    let mut row = default_row(kind_by_name("VirtualAdvice"));
+    row.operands.rd = Some(5);
+    let error = harness::compile_only(&single_row_program(row))
+        .expect_err("bare VirtualAdvice must not compile");
+    let message = format!("{error:?}");
+    assert!(
+        message.contains("without an advice computation"),
+        "expected the advice-group error, got: {message}"
+    );
 }
 
 // ── Random row/state generation ─────────────────────────────────────
@@ -692,10 +715,11 @@ difftests! {
     diff_advice_load => advice_load;
 }
 
-/// Every supported kind has a differential test above (one test per kind,
-/// 39 of each); this pins the count so growing SUPPORTED without adding a
-/// test fails.
+/// Every supported kind has a differential test above; this pins the count
+/// so growing SUPPORTED without adding a test fails. (`VirtualAdvice` is
+/// classified `RequiresAdviceGroup`, not listed here: a bare row is a
+/// compile error, and the whole-guest gates cover its semantics.)
 #[test]
 fn supported_kinds_all_have_difftests() {
-    assert_eq!(SUPPORTED.len(), 67);
+    assert_eq!(SUPPORTED.len(), 66);
 }

--- a/crates/jolt-tracer-x86/tests/phase3_baseline.rs
+++ b/crates/jolt-tracer-x86/tests/phase3_baseline.rs
@@ -12,12 +12,7 @@
 //! real linux-x86_64 workstation.
 
 #![cfg(all(target_arch = "x86_64", target_os = "linux"))]
-#![expect(
-    clippy::unwrap_used,
-    clippy::expect_used,
-    clippy::panic,
-    clippy::print_stdout
-)]
+#![expect(clippy::unwrap_used, clippy::expect_used, clippy::print_stdout)]
 
 use jolt_program::execution::{
     ChunkedExecutionBackend, ExecutionBackend, JoltProgram, TraceInputs,
@@ -29,51 +24,8 @@ use tracer::TracerBackend;
 // Link the SHA2 inline registration for the sha2-chain guest.
 use jolt_inlines_sha2 as _;
 
-fn build_guest_elf(package: &str, func: &str) -> Vec<u8> {
-    let target_dir = format!("/tmp/jolt-guest-targets/{package}-{func}");
-    let output = std::process::Command::new("jolt")
-        .args([
-            "build",
-            "-p",
-            package,
-            "--stack-size",
-            &common::constants::DEFAULT_STACK_SIZE.to_string(),
-            "--heap-size",
-            &common::constants::DEFAULT_HEAP_SIZE.to_string(),
-            "--",
-            "--release",
-            "--target-dir",
-            &target_dir,
-            "--features",
-            "guest",
-        ])
-        .env("JOLT_FUNC_NAME", func)
-        .output()
-        .expect("failed to run jolt CLI");
-    assert!(output.status.success(), "guest build failed");
-    let elf_path = format!("{target_dir}/riscv64imac-unknown-none-elf/release/{package}");
-    std::fs::read(&elf_path).unwrap_or_else(|e| panic!("failed to read ELF at {elf_path}: {e}"))
-}
-
-fn setup(package: &str, func: &str, input: Vec<u8>) -> (JoltProgram, TraceInputs) {
-    let elf = build_guest_elf(package, func);
-    // Inline-bearing guests (sha2-chain) need the tracer's inline provider.
-    let mut provider = tracer::TracerInlineExpansionProvider::new();
-    let program = jolt_program::build_jolt_program_with_inline_provider(
-        &elf,
-        &mut provider,
-        jolt_riscv::RV64IMAC_JOLT_ALL_INLINES,
-    )
-    .expect("failed to build Jolt program");
-    let memory_config = common::jolt_device::MemoryConfig {
-        program_size: Some(program.program_end - common::constants::RAM_START_ADDRESS),
-        ..Default::default()
-    };
-    (
-        program,
-        TraceInputs::new(input, Vec::new(), Vec::new(), memory_config),
-    )
-}
+mod common;
+use common::setup;
 
 fn median3(mut f: impl FnMut() -> f64) -> f64 {
     let mut times = [f(), f(), f()];
@@ -165,15 +117,19 @@ fn phase3_baseline() {
     );
     println!("|---|---:|---:|---:|---:|---:|");
 
-    let (program, inputs) = setup(
+    let Some((program, inputs)) = setup(
         "fibonacci-guest",
         "fib",
         postcard::to_stdvec(&400_000_u32).unwrap(),
-    );
+    ) else {
+        return;
+    };
     report("fibonacci_400000", &program, &inputs, true);
 
     let mut chain_input = postcard::to_stdvec(&[5u8; 32]).unwrap();
     chain_input.append(&mut postcard::to_stdvec(&4_446u32).unwrap());
-    let (program, inputs) = setup("sha2-chain-guest", "sha2_chain", chain_input);
+    let Some((program, inputs)) = setup("sha2-chain-guest", "sha2_chain", chain_input) else {
+        return;
+    };
     report("sha2_chain_4446", &program, &inputs, true);
 }

--- a/crates/jolt-tracer-x86/tests/phase3_baseline.rs
+++ b/crates/jolt-tracer-x86/tests/phase3_baseline.rs
@@ -157,5 +157,5 @@ fn phase3_baseline() {
     let mut chain_input = postcard::to_stdvec(&[5u8; 32]).unwrap();
     chain_input.append(&mut postcard::to_stdvec(&4_446u32).unwrap());
     let (program, inputs) = setup("sha2-chain-guest", "sha2_chain", chain_input);
-    report("sha2_chain_4446", &program, &inputs, false);
+    report("sha2_chain_4446", &program, &inputs, true);
 }

--- a/crates/jolt-tracer-x86/tests/phase3_baseline.rs
+++ b/crates/jolt-tracer-x86/tests/phase3_baseline.rs
@@ -109,6 +109,18 @@ fn report(guest: &str, program: &JoltProgram, inputs: &TraceInputs, x86: bool) {
     });
 
     // AOT x86 fast pass (supported guests only).
+    // One-time AOT compile cost, reported separately: the spec tracks it
+    // as an amortized number rather than a gated one, since every
+    // re-trace and chunk replay reuses the cached artifact.
+    let compile_seconds = x86.then(|| {
+        let mut backend = X86TracerBackend::new();
+        let start = Instant::now();
+        let _ = backend
+            .fast_run(program, inputs.clone())
+            .expect("fast_run failed");
+        start.elapsed().as_secs_f64()
+    });
+
     let x86_fast = x86.then(|| {
         let mut backend = X86TracerBackend::new();
         // Warm the compile cache so steady-state is measured.
@@ -127,14 +139,20 @@ fn report(guest: &str, program: &JoltProgram, inputs: &TraceInputs, x86: bool) {
 
     let mhz = |seconds: f64| rows as f64 / seconds / 1e6;
     println!(
-        "| {guest} | {rows} | {:.3} ({:.1} MHz) | {:.3} ({:.1} MHz) | {} |",
+        "| {guest} | {rows} | {:.3} ({:.1} MHz) | {:.3} ({:.1} MHz) | {} | {} |",
         serial,
         mhz(serial),
         fast,
         mhz(fast),
         match x86_fast {
             Some(t) => format!("{:.3} ({:.1} MHz)", t, mhz(t)),
-            None => "n/a (inline kinds, slice 3)".to_string(),
+            None => "n/a".to_string(),
+        },
+        match (compile_seconds, x86_fast) {
+            // The first run pays compilation; subtracting the steady-state
+            // pass leaves the one-time AOT cost.
+            (Some(first), Some(steady)) => format!("{:.3}", (first - steady).max(0.0)),
+            _ => "n/a".to_string(),
         }
     );
 }
@@ -143,9 +161,9 @@ fn report(guest: &str, program: &JoltProgram, inputs: &TraceInputs, x86: bool) {
 #[ignore = "phase-3 baseline measurement; run explicitly"]
 fn phase3_baseline() {
     println!(
-        "| guest | rows | ref serial s (MHz) | ref fast pass s (MHz) | x86 fast pass s (MHz) |"
+        "| guest | rows | ref serial s (MHz) | ref fast pass s (MHz) | x86 fast pass s (MHz) | AOT compile s |"
     );
-    println!("|---|---:|---:|---:|---:|");
+    println!("|---|---:|---:|---:|---:|---:|");
 
     let (program, inputs) = setup(
         "fibonacci-guest",

--- a/crates/jolt-tracer-x86/tests/phase3_baseline.rs
+++ b/crates/jolt-tracer-x86/tests/phase3_baseline.rs
@@ -1,0 +1,161 @@
+//! Phase-3 baseline: both engines, one platform, one harness.
+//! Measures, per guest (median of 3, in-process):
+//! - reference serial `ExecutionBackend::trace` (modular seam, includes the
+//!   Cycle to TraceRow conversion),
+//! - reference fast pass `ChunkedExecutionBackend::execute` at 2^18 rows
+//!   (post-#1717 this runs the parallel machinery's PassOne, execute mode),
+//! - the AOT x86 fast pass (`fast_run`), where the guest's kinds are
+//!   supported (fibonacci yes; sha2-chain uses the SHA2 inline and
+//!   fail-fasts by design until slice 3).
+//!
+//! Numbers from a Rosetta container are PROVISIONAL; the gate platform is a
+//! real linux-x86_64 workstation.
+
+#![cfg(all(target_arch = "x86_64", target_os = "linux"))]
+#![expect(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::print_stdout
+)]
+
+use jolt_program::execution::{
+    ChunkedExecutionBackend, ExecutionBackend, JoltProgram, TraceInputs,
+};
+use jolt_tracer_x86::X86TracerBackend;
+use std::time::Instant;
+use tracer::TracerBackend;
+
+// Link the SHA2 inline registration for the sha2-chain guest.
+use jolt_inlines_sha2 as _;
+
+fn build_guest_elf(package: &str, func: &str) -> Vec<u8> {
+    let target_dir = format!("/tmp/jolt-guest-targets/{package}-{func}");
+    let output = std::process::Command::new("jolt")
+        .args([
+            "build",
+            "-p",
+            package,
+            "--stack-size",
+            &common::constants::DEFAULT_STACK_SIZE.to_string(),
+            "--heap-size",
+            &common::constants::DEFAULT_HEAP_SIZE.to_string(),
+            "--",
+            "--release",
+            "--target-dir",
+            &target_dir,
+            "--features",
+            "guest",
+        ])
+        .env("JOLT_FUNC_NAME", func)
+        .output()
+        .expect("failed to run jolt CLI");
+    assert!(output.status.success(), "guest build failed");
+    let elf_path = format!("{target_dir}/riscv64imac-unknown-none-elf/release/{package}");
+    std::fs::read(&elf_path).unwrap_or_else(|e| panic!("failed to read ELF at {elf_path}: {e}"))
+}
+
+fn setup(package: &str, func: &str, input: Vec<u8>) -> (JoltProgram, TraceInputs) {
+    let elf = build_guest_elf(package, func);
+    // Inline-bearing guests (sha2-chain) need the tracer's inline provider.
+    let mut provider = tracer::TracerInlineExpansionProvider::new();
+    let program = jolt_program::build_jolt_program_with_inline_provider(
+        &elf,
+        &mut provider,
+        jolt_riscv::RV64IMAC_JOLT_ALL_INLINES,
+    )
+    .expect("failed to build Jolt program");
+    let memory_config = common::jolt_device::MemoryConfig {
+        program_size: Some(program.program_end - common::constants::RAM_START_ADDRESS),
+        ..Default::default()
+    };
+    (
+        program,
+        TraceInputs::new(input, Vec::new(), Vec::new(), memory_config),
+    )
+}
+
+fn median3(mut f: impl FnMut() -> f64) -> f64 {
+    let mut times = [f(), f(), f()];
+    times.sort_by(f64::total_cmp);
+    times[1]
+}
+
+fn report(guest: &str, program: &JoltProgram, inputs: &TraceInputs, x86: bool) {
+    std::env::remove_var("TRACER_PARALLEL");
+
+    // Reference serial (modular seam).
+    let mut rows = 0usize;
+    let serial = median3(|| {
+        let mut backend = TracerBackend::new();
+        let start = Instant::now();
+        let out = backend
+            .trace(program, inputs.clone())
+            .expect("trace failed");
+        let elapsed = start.elapsed().as_secs_f64();
+        rows = out.trace.rows().len();
+        elapsed
+    });
+
+    // Reference fast pass (execute mode + per-chunk checkpoints).
+    let fast = median3(|| {
+        let mut backend = TracerBackend::new();
+        let start = Instant::now();
+        let summary = backend
+            .execute(program, inputs.clone(), 1 << 18)
+            .expect("execute failed");
+        assert_eq!(summary.trace_len, rows);
+        start.elapsed().as_secs_f64()
+    });
+
+    // AOT x86 fast pass (supported guests only).
+    let x86_fast = x86.then(|| {
+        let mut backend = X86TracerBackend::new();
+        // Warm the compile cache so steady-state is measured.
+        let _ = backend
+            .fast_run(program, inputs.clone())
+            .expect("fast_run failed");
+        median3(|| {
+            let start = Instant::now();
+            let out = backend
+                .fast_run(program, inputs.clone())
+                .expect("fast_run failed");
+            assert_eq!(out.trace_len, rows);
+            start.elapsed().as_secs_f64()
+        })
+    });
+
+    let mhz = |seconds: f64| rows as f64 / seconds / 1e6;
+    println!(
+        "| {guest} | {rows} | {:.3} ({:.1} MHz) | {:.3} ({:.1} MHz) | {} |",
+        serial,
+        mhz(serial),
+        fast,
+        mhz(fast),
+        match x86_fast {
+            Some(t) => format!("{:.3} ({:.1} MHz)", t, mhz(t)),
+            None => "n/a (inline kinds, slice 3)".to_string(),
+        }
+    );
+}
+
+#[test]
+#[ignore = "phase-3 baseline measurement; run explicitly"]
+fn phase3_baseline() {
+    println!(
+        "| guest | rows | ref serial s (MHz) | ref fast pass s (MHz) | x86 fast pass s (MHz) |"
+    );
+    println!("|---|---:|---:|---:|---:|");
+
+    let (program, inputs) = setup(
+        "fibonacci-guest",
+        "fib",
+        postcard::to_stdvec(&400000u32).unwrap(),
+    );
+    report("fibonacci_400000", &program, &inputs, true);
+
+    let mut chain_input = postcard::to_stdvec(&[5u8; 32]).unwrap();
+    chain_input.append(&mut postcard::to_stdvec(&4446u32).unwrap());
+    let (program, inputs) = setup("sha2-chain-guest", "sha2_chain", chain_input);
+    report("sha2_chain_4446", &program, &inputs, false);
+}

--- a/crates/jolt-tracer-x86/tests/phase3_baseline.rs
+++ b/crates/jolt-tracer-x86/tests/phase3_baseline.rs
@@ -150,12 +150,12 @@ fn phase3_baseline() {
     let (program, inputs) = setup(
         "fibonacci-guest",
         "fib",
-        postcard::to_stdvec(&400000u32).unwrap(),
+        postcard::to_stdvec(&400_000_u32).unwrap(),
     );
     report("fibonacci_400000", &program, &inputs, true);
 
     let mut chain_input = postcard::to_stdvec(&[5u8; 32]).unwrap();
-    chain_input.append(&mut postcard::to_stdvec(&4446u32).unwrap());
+    chain_input.append(&mut postcard::to_stdvec(&4_446u32).unwrap());
     let (program, inputs) = setup("sha2-chain-guest", "sha2_chain", chain_input);
     report("sha2_chain_4446", &program, &inputs, false);
 }

--- a/crates/jolt-tracer-x86/tests/safety.rs
+++ b/crates/jolt-tracer-x86/tests/safety.rs
@@ -1,0 +1,123 @@
+//! Safety properties of the generated code (spec AC11 / invariant 6).
+//!
+//! Two claims that must hold for a backend that executes guest-controlled
+//! data in-process:
+//! 1. the finalized code mapping is never writable and executable at once;
+//! 2. a guest access outside the memory plane surfaces as a defined error,
+//!    not as undefined behaviour.
+
+#![cfg(all(target_arch = "x86_64", target_os = "linux"))]
+#![expect(clippy::expect_used, clippy::panic)]
+
+use jolt_riscv::{JoltInstructionKind, JoltInstructionRow, NormalizedOperands};
+use jolt_tracer_x86::harness::{compile_program, run_program, single_row_program, TEST_ADDR};
+
+const REGS: usize = common::constants::REGISTER_COUNT as usize;
+
+fn row(
+    kind: JoltInstructionKind,
+    rs1: Option<u8>,
+    rd: Option<u8>,
+    imm: i128,
+) -> JoltInstructionRow {
+    JoltInstructionRow {
+        instruction_kind: kind,
+        address: TEST_ADDR as usize,
+        operands: NormalizedOperands {
+            rs1,
+            rs2: None,
+            rd,
+            imm,
+        },
+        virtual_sequence_remaining: None,
+        is_first_in_sequence: true,
+        is_compressed: false,
+    }
+}
+
+/// The mapping holding generated code must be executable and not writable.
+/// dynasm-rs assembles into a read-write mapping and flips it to read-execute
+/// on finalize; this asserts the flip actually happened in the running
+/// process rather than trusting the library.
+#[test]
+fn generated_code_mapping_is_not_writable() {
+    let program = single_row_program(row(JoltInstructionKind::ADDI, Some(1), Some(2), 7));
+    // The artifact must stay alive: dropping it unmaps the very region whose
+    // permissions we are asserting.
+    let compiled = compile_program(&program).expect("compile failed");
+    let address = compiled.code_address();
+
+    let maps = std::fs::read_to_string("/proc/self/maps").expect("cannot read /proc/self/maps");
+    let mut found = None;
+    for line in maps.lines() {
+        let mut fields = line.split_whitespace();
+        let Some(range) = fields.next() else { continue };
+        let Some(perms) = fields.next() else { continue };
+        let Some((start, end)) = range.split_once('-') else {
+            continue;
+        };
+        let (Ok(start), Ok(end)) = (
+            usize::from_str_radix(start, 16),
+            usize::from_str_radix(end, 16),
+        ) else {
+            continue;
+        };
+        if (start..end).contains(&address) {
+            found = Some(perms.to_string());
+            break;
+        }
+    }
+
+    let perms = found.unwrap_or_else(|| {
+        panic!("no /proc/self/maps entry contains the generated code at {address:#x}")
+    });
+    assert!(
+        perms.contains('x'),
+        "generated code mapping is not executable: {perms}"
+    );
+    assert!(
+        !perms.contains('w'),
+        "generated code mapping is writable and executable (W^X violated): {perms}"
+    );
+}
+
+/// A load whose effective address lies outside the guest memory plane must
+/// produce the defined out-of-bounds exit, not a host segfault.
+#[test]
+fn out_of_bounds_load_reports_a_fault() {
+    let program = single_row_program(row(JoltInstructionKind::LD, Some(1), Some(2), 0));
+    let mut pre = [0u64; REGS];
+    // Far past the plane, but still in the RAM region so it is not routed to
+    // the device helpers: the bounds check is what must catch it.
+    pre[1] = common::constants::RAM_START_ADDRESS + (1u64 << 40);
+
+    let outcome = run_program(&program, &pre, &[], &[]).expect("run should not error");
+    assert_eq!(
+        outcome.exit, 2,
+        "expected the out-of-bounds exit reason, got {} ({:?})",
+        outcome.exit, outcome.helper_error
+    );
+    assert_eq!(
+        outcome.fault_addr, pre[1],
+        "the faulting guest address should be reported"
+    );
+}
+
+/// A store outside the plane must likewise be caught rather than corrupting
+/// host memory.
+#[test]
+fn out_of_bounds_store_reports_a_fault() {
+    let mut store = row(JoltInstructionKind::SD, Some(1), None, 0);
+    store.operands.rs2 = Some(3);
+    let program = single_row_program(store);
+    let mut pre = [0u64; REGS];
+    pre[1] = common::constants::RAM_START_ADDRESS + (1u64 << 40);
+    pre[3] = 0xdead_beef;
+
+    let outcome = run_program(&program, &pre, &[], &[]).expect("run should not error");
+    assert_eq!(
+        outcome.exit, 2,
+        "expected the out-of-bounds exit reason, got {} ({:?})",
+        outcome.exit, outcome.helper_error
+    );
+}

--- a/crates/jolt-tracer-x86/tests/safety.rs
+++ b/crates/jolt-tracer-x86/tests/safety.rs
@@ -121,3 +121,20 @@ fn out_of_bounds_store_reports_a_fault() {
         outcome.exit, outcome.helper_error
     );
 }
+
+/// An aligned address inside the text span but between compiled group starts
+/// must take the jump-table filler path and report the bad target.
+#[test]
+fn in_range_unmapped_jump_reports_bad_target() {
+    let program = single_row_program(row(JoltInstructionKind::JALR, Some(1), None, 0));
+    let mut pre = [0u64; REGS];
+    pre[1] = TEST_ADDR + 2;
+
+    let outcome = run_program(&program, &pre, &[], &[]).expect("run should not error");
+    assert_eq!(
+        outcome.exit, 3,
+        "expected the bad-jump exit reason, got {} ({:?})",
+        outcome.exit, outcome.helper_error
+    );
+    assert_eq!(outcome.fault_addr, TEST_ADDR + 2);
+}

--- a/jolt-eval/Cargo.toml
+++ b/jolt-eval/Cargo.toml
@@ -9,6 +9,7 @@ jolt-verifier = { workspace = true }
 jolt-dory = { workspace = true }
 jolt-crypto = { workspace = true }
 jolt-program = { workspace = true, features = ["serialization"] }
+jolt-tracer-x86 = { workspace = true }
 jolt-riscv = { workspace = true, features = ["serialization"] }
 jolt-field = { workspace = true }
 jolt-transcript = { workspace = true, features = [

--- a/jolt-eval/benches/trace_gen_fibonacci.rs
+++ b/jolt-eval/benches/trace_gen_fibonacci.rs
@@ -8,7 +8,7 @@ use jolt_eval::Objective as _;
 // Setup (guest build, ELF decode + expansion, one un-timed trace for the row
 // count) runs once outside the measurement; each iteration re-traces from the
 // shared `JoltProgram`. Backend variants (`x86`, `x86_fast`) join as
-// additional bench ids in this group.
+// additional bench ids in this group (present below on x86_64 Linux).
 fn bench(c: &mut Criterion) {
     // The tracer env-dispatches to parallel mode; pin serial so
     // measurements are environment-independent.
@@ -21,19 +21,32 @@ fn bench(c: &mut Criterion) {
     group.measurement_time(std::time::Duration::from_secs(60));
     group.throughput(Throughput::Elements(setup.trace_len as u64));
     // Assert the row count rather than discard it: `Throughput::Elements` is
-    // fixed at `setup.trace_len`, so a backend id in this group that produced a
-    // different number of rows would report MHz against the wrong denominator.
-    // Row equality is AC5's job; this only keeps the units honest.
+    // fixed at `setup.trace_len`, so any id in this group that produced a
+    // different number of rows would report MHz against the wrong
+    // denominator. Row equality is AC5's job; this only keeps the units
+    // honest — and it applies most to the backend ids below.
     group.bench_function("reference", |b| {
         b.iter(|| assert_eq!(objective.run_reference(&setup), setup.trace_len))
     });
     // Same group and throughput so the pair decomposes the seam: `reference`
     // is raw tracing plus the Cycle to TraceRow conversion, `reference_raw` is
-    // raw tracing alone. A backend emitting TraceRow directly skips the
-    // difference, so AC8/AC9 ratios need both to be attributable.
+    // raw tracing alone. The AOT backend emits TraceRow directly and so skips
+    // the difference; AC8/AC9 ratios need both to be attributable.
     group.bench_function("reference_raw", |b| {
         b.iter(|| assert_eq!(objective.run_reference_raw(&setup), setup.trace_len))
     });
+    // The AOT backend's arms exist only where it has native codegen;
+    // elsewhere NativeBackend is the interpreter and these would duplicate
+    // the reference id.
+    #[cfg(all(target_arch = "x86_64", target_os = "linux"))]
+    {
+        group.bench_function("x86", |b| {
+            b.iter(|| assert_eq!(objective.run_x86(&setup), setup.trace_len))
+        });
+        group.bench_function("x86_fast", |b| {
+            b.iter(|| assert_eq!(objective.run_x86_fast(&setup), setup.trace_len))
+        });
+    }
     group.finish();
 }
 

--- a/jolt-eval/benches/trace_gen_fibonacci.rs
+++ b/jolt-eval/benches/trace_gen_fibonacci.rs
@@ -37,14 +37,26 @@ fn bench(c: &mut Criterion) {
     });
     // The AOT backend's arms exist only where it has native codegen;
     // elsewhere NativeBackend is the interpreter and these would duplicate
-    // the reference id.
+    // the reference id. One backend outside the measured region, warmed with
+    // an un-timed run: iterations must reuse the compile cache, not pay the
+    // one-time AOT compile per iteration.
     #[cfg(all(target_arch = "x86_64", target_os = "linux"))]
     {
+        let mut backend = jolt_tracer_x86::X86TracerBackend::new();
+        assert_eq!(
+            objective.run_x86_fast(&mut backend, &setup),
+            setup.trace_len
+        );
         group.bench_function("x86", |b| {
-            b.iter(|| assert_eq!(objective.run_x86(&setup), setup.trace_len))
+            b.iter(|| assert_eq!(objective.run_x86(&mut backend, &setup), setup.trace_len))
         });
         group.bench_function("x86_fast", |b| {
-            b.iter(|| assert_eq!(objective.run_x86_fast(&setup), setup.trace_len))
+            b.iter(|| {
+                assert_eq!(
+                    objective.run_x86_fast(&mut backend, &setup),
+                    setup.trace_len
+                );
+            })
         });
     }
     group.finish();

--- a/jolt-eval/benches/trace_gen_sha2_chain.rs
+++ b/jolt-eval/benches/trace_gen_sha2_chain.rs
@@ -40,14 +40,26 @@ fn bench(c: &mut Criterion) {
     });
     // The AOT backend's arms exist only where it has native codegen;
     // elsewhere NativeBackend is the interpreter and these would duplicate
-    // the reference id.
+    // the reference id. One backend outside the measured region, warmed with
+    // an un-timed run: iterations must reuse the compile cache, not pay the
+    // one-time AOT compile per iteration.
     #[cfg(all(target_arch = "x86_64", target_os = "linux"))]
     {
+        let mut backend = jolt_tracer_x86::X86TracerBackend::new();
+        assert_eq!(
+            objective.run_x86_fast(&mut backend, &setup),
+            setup.trace_len
+        );
         group.bench_function("x86", |b| {
-            b.iter(|| assert_eq!(objective.run_x86(&setup), setup.trace_len))
+            b.iter(|| assert_eq!(objective.run_x86(&mut backend, &setup), setup.trace_len))
         });
         group.bench_function("x86_fast", |b| {
-            b.iter(|| assert_eq!(objective.run_x86_fast(&setup), setup.trace_len))
+            b.iter(|| {
+                assert_eq!(
+                    objective.run_x86_fast(&mut backend, &setup),
+                    setup.trace_len
+                );
+            })
         });
     }
     group.finish();

--- a/jolt-eval/benches/trace_gen_sha2_chain.rs
+++ b/jolt-eval/benches/trace_gen_sha2_chain.rs
@@ -11,7 +11,7 @@ use jolt_inlines_sha2 as _;
 // Setup (guest build, ELF decode + expansion, one un-timed trace for the row
 // count) runs once outside the measurement; each iteration re-traces from the
 // shared `JoltProgram`. Backend variants (`x86`, `x86_fast`) join as
-// additional bench ids in this group.
+// additional bench ids in this group (present below on x86_64 Linux).
 fn bench(c: &mut Criterion) {
     // The tracer env-dispatches to parallel mode; pin serial so
     // measurements are environment-independent.
@@ -24,19 +24,32 @@ fn bench(c: &mut Criterion) {
     group.measurement_time(std::time::Duration::from_secs(120));
     group.throughput(Throughput::Elements(setup.trace_len as u64));
     // Assert the row count rather than discard it: `Throughput::Elements` is
-    // fixed at `setup.trace_len`, so a backend id in this group that produced a
-    // different number of rows would report MHz against the wrong denominator.
-    // Row equality is AC5's job; this only keeps the units honest.
+    // fixed at `setup.trace_len`, so any id in this group that produced a
+    // different number of rows would report MHz against the wrong
+    // denominator. Row equality is AC5's job; this only keeps the units
+    // honest — and it applies most to the backend ids below.
     group.bench_function("reference", |b| {
         b.iter(|| assert_eq!(objective.run_reference(&setup), setup.trace_len))
     });
     // Same group and throughput so the pair decomposes the seam: `reference`
     // is raw tracing plus the Cycle to TraceRow conversion, `reference_raw` is
-    // raw tracing alone. A backend emitting TraceRow directly skips the
-    // difference, so AC8/AC9 ratios need both to be attributable.
+    // raw tracing alone. The AOT backend emits TraceRow directly and so skips
+    // the difference; AC8/AC9 ratios need both to be attributable.
     group.bench_function("reference_raw", |b| {
         b.iter(|| assert_eq!(objective.run_reference_raw(&setup), setup.trace_len))
     });
+    // The AOT backend's arms exist only where it has native codegen;
+    // elsewhere NativeBackend is the interpreter and these would duplicate
+    // the reference id.
+    #[cfg(all(target_arch = "x86_64", target_os = "linux"))]
+    {
+        group.bench_function("x86", |b| {
+            b.iter(|| assert_eq!(objective.run_x86(&setup), setup.trace_len))
+        });
+        group.bench_function("x86_fast", |b| {
+            b.iter(|| assert_eq!(objective.run_x86_fast(&setup), setup.trace_len))
+        });
+    }
     group.finish();
 }
 

--- a/jolt-eval/fuzz/Cargo.toml
+++ b/jolt-eval/fuzz/Cargo.toml
@@ -71,4 +71,3 @@ path = "fuzz_targets/transcript_consistency_poseidon.rs"
 test = false
 doc = false
 bench = false
-

--- a/jolt-eval/fuzz/Cargo.toml
+++ b/jolt-eval/fuzz/Cargo.toml
@@ -45,6 +45,13 @@ doc = false
 bench = false
 
 [[bin]]
+name = "tracer_backend_equivalence"
+path = "fuzz_targets/tracer_backend_equivalence.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
 name = "transcript_consistency_blake2b"
 path = "fuzz_targets/transcript_consistency_blake2b.rs"
 test = false
@@ -64,3 +71,4 @@ path = "fuzz_targets/transcript_consistency_poseidon.rs"
 test = false
 doc = false
 bench = false
+

--- a/jolt-eval/fuzz/fuzz_targets/tracer_backend_equivalence.rs
+++ b/jolt-eval/fuzz/fuzz_targets/tracer_backend_equivalence.rs
@@ -1,0 +1,3 @@
+#![no_main]
+use jolt_eval::invariant::tracer_backend_equivalence::TracerBackendEquivalenceInvariant;
+jolt_eval::fuzz_invariant!(TracerBackendEquivalenceInvariant::default());

--- a/jolt-eval/src/invariant/mod.rs
+++ b/jolt-eval/src/invariant/mod.rs
@@ -5,6 +5,7 @@ pub mod soundness;
 pub mod source_to_jolt_expansion_equivalence;
 pub mod split_eq_bind;
 pub mod synthesis;
+pub mod tracer_backend_equivalence;
 pub mod transcript_symmetry;
 
 use std::fmt;
@@ -144,6 +145,7 @@ pub enum JoltInvariants {
     SourceToJoltExpansionEquivalence(
         source_to_jolt_expansion_equivalence::SourceToJoltExpansionEquivalenceInvariant,
     ),
+    TracerBackendEquivalence(tracer_backend_equivalence::TracerBackendEquivalenceInvariant),
 }
 
 macro_rules! dispatch {
@@ -157,6 +159,7 @@ macro_rules! dispatch {
             JoltInvariants::TranscriptConsistencyKeccak($inv) => $body,
             JoltInvariants::TranscriptConsistencyPoseidon($inv) => $body,
             JoltInvariants::SourceToJoltExpansionEquivalence($inv) => $body,
+            JoltInvariants::TracerBackendEquivalence($inv) => $body,
         }
     };
 }
@@ -179,6 +182,9 @@ impl JoltInvariants {
             ),
             Self::SourceToJoltExpansionEquivalence(
                 source_to_jolt_expansion_equivalence::SourceToJoltExpansionEquivalenceInvariant,
+            ),
+            Self::TracerBackendEquivalence(
+                tracer_backend_equivalence::TracerBackendEquivalenceInvariant,
             ),
         ]
     }

--- a/jolt-eval/src/invariant/tracer_backend_equivalence.rs
+++ b/jolt-eval/src/invariant/tracer_backend_equivalence.rs
@@ -1,0 +1,294 @@
+//! Execution backends must agree.
+//!
+//! `specs/x86-tracer-backend.md` invariants 1-2: a non-reference backend's
+//! output must be indistinguishable from the reference interpreter's for the
+//! same program and inputs.
+//!
+//! Scope today is the **fast pass**, which is what the AOT backend
+//! implements: total row count, `JoltDevice` (outputs and panic flag), final
+//! memory, and the captured advice tape. Full `TraceRow`-stream equality
+//! joins when the backend grows record mode (spec slice 3's record half);
+//! the row *count* already catches control-flow divergence, and final memory
+//! catches value divergence that reaches RAM.
+//!
+//! Two comparisons run, so the invariant is meaningful on every platform:
+//! - the reference backend's eager trace vs its own chunked fast pass
+//!   (backend-generic; the fast pass must not observe a different execution
+//!   from the recording one), and
+//! - on x86-64 Linux, additionally the AOT backend's fast pass against the
+//!   same reference. Elsewhere `NativeBackend` *is* the interpreter, so that
+//!   second comparison would be vacuous and is skipped rather than faked.
+
+use common::constants::RAM_START_ADDRESS;
+use common::jolt_device::MemoryConfig;
+use jolt_program::execution::{
+    ChunkedExecutionBackend, ExecutionBackend, JoltProgram, MemoryImage, TraceInputs,
+};
+use jolt_prover_legacy::host::Program;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use tracer::TracerBackend;
+
+use crate::invariant::{CheckError, Invariant, InvariantViolation};
+
+/// Guests in the equivalence corpus. Each is a distinct execution shape:
+/// a tight arithmetic loop, an inline-heavy hash chain, allocator and
+/// pointer-chasing traffic, and the division/remainder advice groups.
+const CORPUS: &[Guest] = &[
+    Guest {
+        package: "fibonacci-guest",
+        func: "fib",
+        kind: GuestInput::U32 { min: 1, max: 2000 },
+    },
+    Guest {
+        package: "sha2-chain-guest",
+        func: "sha2_chain",
+        kind: GuestInput::Chain { min: 1, max: 16 },
+    },
+    Guest {
+        package: "sha3-chain-guest",
+        func: "sha3_chain",
+        kind: GuestInput::Chain { min: 1, max: 8 },
+    },
+    Guest {
+        package: "btreemap-guest",
+        func: "btreemap",
+        kind: GuestInput::U32 { min: 1, max: 64 },
+    },
+    Guest {
+        package: "muldiv-guest",
+        func: "muldiv",
+        kind: GuestInput::MulDiv,
+    },
+];
+
+struct Guest {
+    package: &'static str,
+    func: &'static str,
+    kind: GuestInput,
+}
+
+/// How a fuzzed parameter becomes this guest's serialized input. Inputs stay
+/// well-formed by construction: a guest that fails to deserialize its input
+/// panics identically under both backends and would test nothing.
+enum GuestInput {
+    U32 {
+        min: u32,
+        max: u32,
+    },
+    Chain {
+        min: u32,
+        max: u32,
+    },
+    /// `muldiv(a, b, c)` — three u32s; `c` is forced nonzero so the DIV
+    /// group actually executes instead of the guest panicking on a
+    /// divide-by-zero (both backends agree on the panic, but it ends the
+    /// run before the interesting rows).
+    MulDiv,
+}
+
+impl Guest {
+    fn encode(&self, parameter: u32) -> Vec<u8> {
+        match self.kind {
+            GuestInput::U32 { min, max } => {
+                let n = min + parameter % (max - min + 1);
+                postcard::to_stdvec(&n).unwrap_or_default()
+            }
+            GuestInput::Chain { min, max } => {
+                let iterations = min + parameter % (max - min + 1);
+                let mut bytes = postcard::to_stdvec(&[5u8; 32]).unwrap_or_default();
+                bytes.extend(postcard::to_stdvec(&iterations).unwrap_or_default());
+                bytes
+            }
+            GuestInput::MulDiv => {
+                let a = parameter | 1;
+                let b = parameter.rotate_left(7) | 1;
+                let c = parameter.rotate_left(17) | 1;
+                postcard::to_stdvec(&(a, b, c)).unwrap_or_default()
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, arbitrary::Arbitrary)]
+pub struct TracerBackendEquivalenceInput {
+    /// Selects a corpus guest (taken modulo the corpus size).
+    pub guest: u8,
+    /// Guest parameter (loop count, chain length, operand seed).
+    pub parameter: u32,
+}
+
+/// What a fast pass observes, for equality comparison.
+#[derive(PartialEq, Eq)]
+struct Observation {
+    rows: usize,
+    outputs: Vec<u8>,
+    panic: bool,
+    final_memory: Option<MemoryImage>,
+    advice_tape: Option<Vec<u8>>,
+}
+
+impl Observation {
+    fn diff(&self, other: &Self) -> Option<String> {
+        if self.rows != other.rows {
+            return Some(format!("row count: {} vs {}", self.rows, other.rows));
+        }
+        if self.outputs != other.outputs {
+            return Some(format!(
+                "device outputs: {} bytes vs {} bytes",
+                self.outputs.len(),
+                other.outputs.len()
+            ));
+        }
+        if self.panic != other.panic {
+            return Some(format!("panic flag: {} vs {}", self.panic, other.panic));
+        }
+        if self.final_memory != other.final_memory {
+            return Some("final memory differs".to_string());
+        }
+        if self.advice_tape != other.advice_tape {
+            return Some("advice tape differs".to_string());
+        }
+        None
+    }
+}
+
+pub struct CorpusProgram {
+    program: JoltProgram,
+    memory_config: MemoryConfig,
+}
+
+#[jolt_eval_macros::invariant(Test, Fuzz, RedTeam)]
+#[derive(Default)]
+pub struct TracerBackendEquivalenceInvariant;
+
+impl Invariant for TracerBackendEquivalenceInvariant {
+    type Setup = Vec<CorpusProgram>;
+    type Input = TracerBackendEquivalenceInput;
+
+    fn name(&self) -> &str {
+        "tracer_backend_equivalence"
+    }
+
+    fn description(&self) -> String {
+        "Execution backends must be indistinguishable: for the same program \
+         and inputs, a fast pass must report the same row count, JoltDevice \
+         outputs and panic flag, final memory, and advice tape as the \
+         reference interpreter's eager trace. Checked for the reference \
+         backend's own chunked fast pass everywhere, and additionally for \
+         the AOT x86-64 backend on x86_64 Linux."
+            .to_string()
+    }
+
+    fn setup(&self) -> Vec<CorpusProgram> {
+        CORPUS
+            .iter()
+            .map(|guest| {
+                let mut host = Program::new(guest.package);
+                host.set_func(guest.func);
+                let program = host
+                    .jolt_program()
+                    .expect("failed to build corpus guest program");
+                let memory_config = MemoryConfig {
+                    program_size: Some(program.program_end - RAM_START_ADDRESS),
+                    ..Default::default()
+                };
+                CorpusProgram {
+                    program,
+                    memory_config,
+                }
+            })
+            .collect()
+    }
+
+    fn check(
+        &self,
+        setup: &Vec<CorpusProgram>,
+        input: TracerBackendEquivalenceInput,
+    ) -> Result<(), CheckError> {
+        if setup.is_empty() {
+            return Err(CheckError::InvalidInput("empty corpus".into()));
+        }
+        let index = usize::from(input.guest) % setup.len();
+        let guest = &CORPUS[index];
+        let entry = &setup[index];
+        let inputs = TraceInputs::new(
+            guest.encode(input.parameter),
+            Vec::new(),
+            Vec::new(),
+            entry.memory_config,
+        );
+
+        // The reference eager trace is the oracle.
+        let mut reference = TracerBackend::new();
+        let eager = reference
+            .trace(&entry.program, inputs.clone())
+            .map_err(|e| CheckError::InvalidInput(format!("reference trace failed: {e:?}")))?;
+        let oracle = Observation {
+            rows: eager.trace.rows().len(),
+            outputs: eager.device.outputs.clone(),
+            panic: eager.device.panic,
+            final_memory: eager.final_memory.clone(),
+            advice_tape: eager.advice_tape.clone(),
+        };
+
+        // The reference backend's own fast pass must observe the same
+        // execution as its recording pass.
+        let summary = reference
+            .execute(&entry.program, inputs.clone(), 1 << 18)
+            .map_err(|e| CheckError::InvalidInput(format!("reference fast pass failed: {e:?}")))?;
+        let reference_fast = Observation {
+            rows: summary.trace_len,
+            outputs: summary.device.outputs.clone(),
+            panic: summary.device.panic,
+            final_memory: summary.final_memory.clone(),
+            advice_tape: summary.advice_tape.clone(),
+        };
+        if let Some(diff) = oracle.diff(&reference_fast) {
+            return Err(CheckError::Violation(InvariantViolation::with_details(
+                "reference fast pass diverged from the eager trace",
+                format!(
+                    "guest={}, parameter={}: {diff}",
+                    guest.package, input.parameter
+                ),
+            )));
+        }
+
+        // Where the AOT backend exists, it faces the same oracle.
+        #[cfg(all(target_arch = "x86_64", target_os = "linux"))]
+        {
+            let mut native = jolt_tracer_x86::X86TracerBackend::new();
+            let fast = native
+                .fast_run(&entry.program, inputs)
+                .map_err(|e| CheckError::InvalidInput(format!("x86 fast run failed: {e:?}")))?;
+            let native_fast = Observation {
+                rows: fast.trace_len,
+                outputs: fast.device.outputs.clone(),
+                panic: fast.device.panic,
+                final_memory: Some(fast.final_memory.clone()),
+                advice_tape: Some(fast.advice_tape.clone()),
+            };
+            if let Some(diff) = oracle.diff(&native_fast) {
+                return Err(CheckError::Violation(InvariantViolation::with_details(
+                    "x86 backend diverged from the reference",
+                    format!(
+                        "guest={}, parameter={}: {diff}",
+                        guest.package, input.parameter
+                    ),
+                )));
+            }
+        }
+
+        Ok(())
+    }
+
+    fn seed_corpus(&self) -> Vec<TracerBackendEquivalenceInput> {
+        (0..CORPUS.len() as u8)
+            .flat_map(|guest| {
+                [1u32, 7, 64]
+                    .into_iter()
+                    .map(move |parameter| TracerBackendEquivalenceInput { guest, parameter })
+            })
+            .collect()
+    }
+}

--- a/jolt-eval/src/lib.rs
+++ b/jolt-eval/src/lib.rs
@@ -6,6 +6,7 @@ extern crate self as jolt_eval;
 // Force the linker to keep inline instruction registrations from these
 // crates. Without this, inventory::submit! symbols get dead-stripped
 // and the tracer panics with "No inline registered for opcode=...".
+extern crate jolt_inlines_keccak256;
 extern crate jolt_inlines_secp256k1;
 extern crate jolt_inlines_sha2;
 

--- a/jolt-eval/src/objective/performance/trace_gen.rs
+++ b/jolt-eval/src/objective/performance/trace_gen.rs
@@ -49,6 +49,30 @@ impl<G: GuestConfig> TraceGenObjective<G> {
         Self { guest, name }
     }
 
+    /// One eager trace with the AOT x86-64 backend (record mode).
+    ///
+    /// Only present on x86_64 Linux; elsewhere `NativeBackend` is the
+    /// interpreter and this arm would duplicate `run_reference`.
+    #[cfg(all(target_arch = "x86_64", target_os = "linux"))]
+    pub fn run_x86(&self, setup: &TraceGenSetup) -> usize {
+        let mut backend = jolt_tracer_x86::X86TracerBackend::new();
+        let output = setup
+            .program
+            .trace_with(&mut backend, setup.inputs.clone())
+            .expect("x86 trace failed");
+        std::hint::black_box(output.trace.rows().len())
+    }
+
+    /// One fast (non-recording) pass with the AOT x86-64 backend.
+    #[cfg(all(target_arch = "x86_64", target_os = "linux"))]
+    pub fn run_x86_fast(&self, setup: &TraceGenSetup) -> usize {
+        let mut backend = jolt_tracer_x86::X86TracerBackend::new();
+        let output = backend
+            .fast_run(&setup.program, setup.inputs.clone())
+            .expect("x86 fast run failed");
+        std::hint::black_box(output.trace_len)
+    }
+
     /// One eager trace with the reference interpreter backend.
     pub fn run_reference(&self, setup: &TraceGenSetup) -> usize {
         let mut backend = TracerBackend::new();

--- a/jolt-eval/src/objective/performance/trace_gen.rs
+++ b/jolt-eval/src/objective/performance/trace_gen.rs
@@ -53,20 +53,33 @@ impl<G: GuestConfig> TraceGenObjective<G> {
     ///
     /// Only present on x86_64 Linux; elsewhere `NativeBackend` is the
     /// interpreter and this arm would duplicate `run_reference`.
+    ///
+    /// The backend is a parameter (not constructed here) so its compile
+    /// cache survives across bench iterations: a fresh backend would pay
+    /// the one-time AOT compile inside the measured region, which for the
+    /// small guests is on the order of the fast pass itself. Callers warm
+    /// the cache with one un-timed run (the phase3_baseline pattern).
     #[cfg(all(target_arch = "x86_64", target_os = "linux"))]
-    pub fn run_x86(&self, setup: &TraceGenSetup) -> usize {
-        let mut backend = jolt_tracer_x86::X86TracerBackend::new();
+    pub fn run_x86(
+        &self,
+        backend: &mut jolt_tracer_x86::X86TracerBackend,
+        setup: &TraceGenSetup,
+    ) -> usize {
         let output = setup
             .program
-            .trace_with(&mut backend, setup.inputs.clone())
+            .trace_with(backend, setup.inputs.clone())
             .expect("x86 trace failed");
         std::hint::black_box(output.trace.rows().len())
     }
 
-    /// One fast (non-recording) pass with the AOT x86-64 backend.
+    /// One fast (non-recording) pass with the AOT x86-64 backend. See
+    /// [`Self::run_x86`] for why the backend is a parameter.
     #[cfg(all(target_arch = "x86_64", target_os = "linux"))]
-    pub fn run_x86_fast(&self, setup: &TraceGenSetup) -> usize {
-        let mut backend = jolt_tracer_x86::X86TracerBackend::new();
+    pub fn run_x86_fast(
+        &self,
+        backend: &mut jolt_tracer_x86::X86TracerBackend,
+        setup: &TraceGenSetup,
+    ) -> usize {
         let output = backend
             .fast_run(&setup.program, setup.inputs.clone())
             .expect("x86 fast run failed");

--- a/tracer/src/instruction/inline.rs
+++ b/tracer/src/instruction/inline.rs
@@ -139,6 +139,20 @@ pub fn list_registered_inlines() -> Vec<((u32, u32, u32), String)> {
         .collect()
 }
 
+/// Look up a linked inline registration by its encoded key.
+///
+/// Execution backends need the registration itself (not just its existence)
+/// to run `build_advice` over their own state.
+pub fn find_inline_registration(
+    opcode: u32,
+    funct3: u32,
+    funct7: u32,
+) -> Option<&'static InlineRegistration> {
+    inventory::iter::<InlineRegistration>
+        .into_iter()
+        .find(|r| r.opcode == opcode && r.funct3 == funct3 && r.funct7 == funct7)
+}
+
 /// Check whether a linked inline registration exists for the encoded key.
 pub fn is_inline_registered(opcode: u32, funct3: u32, funct7: u32) -> bool {
     inventory::iter::<InlineRegistration>


### PR DESCRIPTION
## Summary

Slices 2 to 5 of `specs/x86-tracer-backend.md` (#1713), **experimental**: `crates/jolt-tracer-x86`, an AOT x86-64 transpiling execution backend with fast and record modes over every final-bytecode kind, plus the differential-test infrastructure the spec puts before optimization.

- Whole-program AOT via dynasm-rs: one straight-line template per expanded-bytecode row, halfword-granular jump table (JALR dispatch + branch label source), PC-stall termination, explicit in-process bounds checks (deliberate departure from sp1-jit's no-checks/child-process model), sysv64 helpers for device I/O, host IO, and faults; fail-fast `TraceError` on unsupported kinds.
- `NativeBackend` alias: the AOT backend on x86_64-linux, the reference interpreter everywhere else; the crate compiles on all targets.
- **Fast-pass coverage of every final-bytecode kind.** Most of what looks missing from a base-ISA backend is source-only: shifts, W-arithmetic, the M and A extensions, CSR ops, ECALL and the advice-load kinds all expand into final rows the backend already emits (finality per `expand/grammar.rs` `is_source_only`). What remained was 28 templates: `Slt`, `Andn`, the Pow2 family, `MovSign`, `VirtualRev8W`, `Rotri`/`Rotriw`, `ShiftRightBitmaskI`, `VirtualSra`, the eight XOR-rotates, four asserts, both `ChangeDivisor` variants, the two advice-tape kinds, and `VirtualAdvice`. clippy independently confirms the coverage: the fail-fast match arm now reaches only `Noop`.
- **Per-group runtime advice.** The expanded bytecode erases source kind and inline key, so source instructions are recovered by re-decoding the ELF and keying by address; each group needing advice resolves at compile time into a job table, and one helper call at the group's entry fills the advice slots before any of its rows execute (matching the interpreter, which computes advice from the same pre-group state). DIV/REM mirrors the tracer's four variant formulas; **inline advice reuses the registered `build_advice` functions unchanged** through `InlineAdviceContext` implemented over the guest state — the seam introduced in the slice-1 PR, now with its second implementor. A `VirtualAdvice` row in a group without an advice computation is a compile-time error rather than a stale slot read.
- Per-instruction differential tests: 66 kinds x 1000 random operand/state instances against the reference `Cpu` (full register file, PC, memory, advice tape), with compile-time-exhaustive kind classification (`for_each_jolt_instruction_kind!`, no wildcard) pinned to what the transpiler accepts — 68/68 green. Whole-guest fast-pass equivalence across five guests (fibonacci, sha2-chain, sha3-chain, btreemap, muldiv — the last exercising the DIV/REM advice groups) against the post-#1717 interpreter: rows, device outputs, panic flag, final memory and advice tape all bit-exact.
- **`RowEmitter` seam** (`compile/emitter.rs`, per the updated spec): emission sits behind a trait whose production implementor is the dynasm templates. Emitters report `Unsupported` rather than erroring, so an ordered `EmitterSet` falls through and a hybrid (stencils for some kinds, templates for the rest) needs no extra plumbing; the fail-fast invariant-7 error moves to the set, keeping the authoritative supported-kind list in the emitter's own match. `compile_with(program, &EmitterSet)` plus the seam types are re-exported through the harness module, so the Alternative 11 stencil spike can live outside the crate. Prologue, dispatch stubs, jump table and chunk accounting stay in the driver — execution-model properties, not row encoding.
- **`jolt-emu-x86`** (AC4): the ACT4 runner. Arch tests halt by storing to `tohost` then spinning in `j .`, which the backend's PC-stall termination already ends, so the result word and signature region come out of final memory — no mid-execution HTIF hook. Matches `run.sh`'s contract and `jolt-emu`'s signature format; pipeline/transpiler rejection gets its own exit code so the x86 skip list can be regenerated mechanically ("skipped and listed").
- **`tracer_backend_equivalence`** (AC5): registered in `JoltInvariants` (Test, Fuzz, RedTeam) over a five-guest corpus with bounded fuzzable parameters. Scoped to what the fast pass observes — row count, device outputs and panic flag, final memory, advice tape — since full `TraceRow`-stream equality needs record mode; row count already catches control-flow divergence and final memory catches value divergence reaching RAM. The reference backend's eager trace is also compared against its own chunked fast pass on every platform, so the invariant is not vacuous where `NativeBackend` is the interpreter.
- **Record mode**: the backend produces `TraceRow`s, not just execution. Generated code writes a fixed 64-byte `Observation` per row (row index plus dynamic values) rather than constructing `TraceRow` directly, since its `Option` fields have no guaranteed layout; a Rust pass joins each observation with `expanded_bytecode[row_index]` for the static half. Two bodies are compiled from the same templates as separate assemblies (branch labels are per guest address and cannot be shared). `trace()` runs the fast pass first to size the observation buffer exactly, which also cross-checks the two bodies' row counts against each other.
- **Row-stream equality**: every `TraceRow` field-for-field against the reference on fibonacci, muldiv (DIV/REM advice) and sha2-chain (inlines), plus scale tests at 4.4M and ~800k rows. Since a proof is a deterministic function of the trace, byte-identical rows imply byte-identical proofs; literal AC7 additionally wants two proofs compared, which needs `byte_diff.rs`'s helpers extracted into a shared module (proposed, not done here).
- **Chunked execution** (`ChunkedExecutionBackend`, slice 4), so this can serve as an alternative fast first pass feeding per-chunk replay. Pausing is the crux: generated code does not maintain PC in straight-line rows, so it can only stop where a resumable PC is statically known, i.e. a group boundary — a row limit plus a two-instruction check per group start, with the group's address published as the resume PC. A boundary may precede the requested mark, which is what `skip_rows` covers and what makes chunk size 1 work. Checkpoints carry a memory image rather than an access-value log (the same tradeoff #1717's parallel machinery makes); the `Checkpoint` type is opaque, so switching to logs later is invisible to consumers. Gate: composition over chunk sizes 1, 7, 100, 2^18 and 1, 13, 1000, replayed in reverse order, row-for-row equal to the eager trace.
- **Safety** (AC11): the generated code mapping is asserted executable-and-not-writable by locating it in `/proc/self/maps` in the running process, and out-of-bounds loads and stores each surface the defined fault exit with the faulting address rather than a host segfault.
- **Slice 5, partial**: ALU rows take their second operand straight from the state plane rather than via a scratch register (one fewer instruction and register on the most common row shape); the chunk-boundary pause check is confined to chunk-capable bodies so eager traces do not pay for it (pausability is its own compile axis, four bodies at ~13ms each); AOT compile cost is reported as a tracked column. Register pinning into XMM lanes and fused fast-mode groups are implementable but deliberately deferred: they cannot be evaluated in this environment, and unmeasurable micro-optimization is not progress.
- Per-kind iai-callgrind microbenchmarks behind an `iai` feature, and `x86`/`x86_fast` Criterion ids in the jolt-eval `trace_gen` targets.
- Cross-engine baseline harness (`phase3_baseline`, ignored test). Provisional numbers, x86-64 Linux container under Rosetta, median of 3:

| guest | rows | ref serial (seam) | ref fast pass (execute mode) | AOT fast pass | ratio | AOT compile |
|---|---:|---:|---:|---:|---:|---:|
| fibonacci_400000 | 4.40M | 11.0 MHz | 77.3 MHz | **346.3 MHz** | 4.5x | 13ms |
| sha2_chain_4446 | 13.6M | 12.3 MHz | 131.8 MHz | **799.9 MHz** | 6.1x | 13ms |

**Treat these as indicative only.** Run-to-run variance on an unchanged binary reaches 30% here (the reference fast pass reads 60 to 79 MHz across runs), because the container translates x86 through Rosetta. The ratios are stable across runs; the absolute numbers are not. AC8/AC9 need a bare-metal measurement.

The untuned AOT fast pass is 5.4-6.1x the optimized interpreter's execute mode on the same platform: the two-pass pipeline's pass-1 ceiling is where AOT pays. Note the inline-heavy guest is AOT's *better* case, not its worse one — inline expansions are long straight-line runs of exactly the arithmetic rows the transpiler emits without dispatch. Gate-platform numbers (bare-metal linux-x86_64, where Rosetta translation no longer taxes the generated code) to follow; AC8/AC9 renegotiation is proposed on #1713.

Stacked on #1728 (slice 1); base is `perf/tracer-100mhz` for the cross-repo reason noted there. Review from commit `02c76a2ff` onward. Still to come: the remainder of slice 5 (register pinning, fused groups) and the AC8/AC9 gate measurements, both of which want native hardware; the x86 arch-test Makefile lane and skip list (needs generated ACT4 ELFs); literal AC7 (needs `byte_diff.rs`'s helpers extracted into a shared module). The blocker that dominates all of them: **nothing here has executed on real x86-64 silicon** — every result comes from a Rosetta-translated container. Record mode is deliberately de-emphasized per the measurements above — the fast pass is where AOT pays.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
