### PR TITLE
docs: weekly freshness pass — modular BlindFold ZK drift in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,6 +28,11 @@ cargo nextest run -p [package_name] [test_name] --cargo-quiet
 cargo nextest run -p jolt-prover-legacy muldiv --cargo-quiet --features host
 cargo nextest run -p jolt-prover-legacy muldiv --cargo-quiet --features host,zk
 
+# Modular prover acceptance suites (mirror CI): clear-mode byte-diff ratchets
+# vs the legacy prover, and the modular ZK e2e (muldiv accept, tamper reject,
+# advice, committed program)
+cargo nextest run -p jolt-prover --features prover-fixtures --cargo-quiet
+cargo nextest run -p jolt-prover --features prover-fixtures,zk --cargo-quiet
 ```
 
 ### Building
@@ -171,7 +176,7 @@ In ZK mode, `input_claim()` is never called so verifier params can use partial v
 
 ### BlindFold Zero-Knowledge Protocol (subprotocols/blindfold/)
 
-BlindFold makes all sumcheck proofs zero-knowledge without SNARK composition. Instead of revealing sumcheck round polynomial coefficients, the prover sends Pedersen commitments. Sumcheck verifier checks are encoded into a small verifier R1CS, proved via Nova folding + Spartan. (A modular port lives in `crates/jolt-blindfold`; the module map below is the legacy implementation.)
+BlindFold makes all sumcheck proofs zero-knowledge without SNARK composition. Instead of revealing sumcheck round polynomial coefficients, the prover sends Pedersen commitments. Sumcheck verifier checks are encoded into a small verifier R1CS, proved via Nova folding + Spartan. (The modular prover has full ZK support: `crates/jolt-blindfold` plus `crates/jolt-prover/src/blindfold.rs` and `recorder.rs`, behind jolt-prover's compile-time `zk` feature — see `specs/jolt-prover-blindfold.md`. The module map below is the legacy implementation.)
 
 **Module structure:**
 - `mod.rs`: `StageConfig`, `BakedPublicInputs`, `HyraxParams`, R1CS primitives (`Variable`, `LinearCombination`, `Constraint`)


### PR DESCRIPTION
Weekly docs-freshness pass (11 commits on main since 2026-07-27 reviewed).

## Week's doc-relevant changes
- **#1690** — BlindFold ZK support in the modular prover (`jolt-prover` `zk` feature, `blindfold.rs`/`recorder.rs`, `zk_e2e` suite, CI acceptance steps). **Did not update docs.**
- **#1686** — generated stage drivers / `jolt-kernels-derive`. No doc surface references these internals; crate-count phrasing in CLAUDE.md ("…25 crates") remains accurate (26 dirs in `crates/` incl. legacy).
- **#1712** — modular profiling: updated CLAUDE.md + `book/src/usage/profiling/zkvm_profiling.md` itself; verified commands match the `jolt-prover` `profile`/`benchmark` bins.
- **#1704** — already fixed README/CLAUDE.md Akita drift (incl. `sha3-chain` in README `--name` list).

## Drift fixed (CLAUDE.md only)
1. BlindFold section still said the modular side was just "a modular port … in `crates/jolt-blindfold`" — now notes full modular ZK support (`crates/jolt-prover/src/blindfold.rs` + `recorder.rs`, compile-time `zk` feature, `specs/jolt-prover-blindfold.md`).
2. Testing section lacked the modular acceptance suites CI now runs — added `cargo nextest run -p jolt-prover --features prover-fixtures[,zk]`.

## Verification
Claims checked against the repo at `fa303e27f6`: `jolt-prover` `[features] zk` (pulls `dep:jolt-blindfold`, no runtime mode flag), `byte_diff.rs` gated `prover-fixtures ∧ ¬zk`, `zk_e2e.rs` gated `prover-fixtures ∧ zk`, CI steps in `.github/workflows/rust.yml`, `JOLT_VERIFIER_CONFIG` still in `crates/jolt-verifier/src/config.rs`, spec file exists. book/ and skills surfaces reviewed — no drift.