### PR TITLE
fix(zk): bind committed sumcheck round degree into the Fiat-Shamir transcript

### DIFF
--- a/crates/jolt-prover-legacy/src/subprotocols/sumcheck.rs
+++ b/crates/jolt-prover-legacy/src/subprotocols/sumcheck.rs
@@ -284,8 +284,13 @@ impl BatchedSumcheck {
 
             let blinding = F::random(rng);
             let commitment = pedersen_gens.commit(&batched_univariate_poly.coeffs, &blinding);
+            let poly_degree = batched_univariate_poly.coeffs.len() - 1;
 
-            transcript.append_commitment(b"sumcheck_commitment", &commitment);
+            transcript.append_commitment_with_count(
+                b"sumcheck_commitment",
+                poly_degree as u64,
+                &commitment,
+            );
 
             let r_j = transcript.challenge_scalar_optimized::<F>();
             r_sumcheck.push(r_j);
@@ -305,7 +310,7 @@ impl BatchedSumcheck {
             }
 
             round_commitments_g1.push(commitment);
-            poly_degrees.push(batched_univariate_poly.coeffs.len() - 1);
+            poly_degrees.push(poly_degree);
             poly_coeffs.push(batched_univariate_poly.coeffs.clone());
             blinding_factors.push(blinding);
         }
@@ -725,8 +730,12 @@ impl<F: JoltField, C: JoltCurve<F = F>, ProofTranscript: Transcript>
         }
 
         let mut r: Vec<F::Challenge> = Vec::new();
-        for commitment in &self.round_commitments {
-            transcript.append_commitment(b"sumcheck_commitment", commitment);
+        for (commitment, &degree) in self.round_commitments.iter().zip(&self.poly_degrees) {
+            transcript.append_commitment_with_count(
+                b"sumcheck_commitment",
+                degree as u64,
+                commitment,
+            );
             let r_i: F::Challenge = transcript.challenge_scalar_optimized::<F>();
             r.push(r_i);
         }

--- a/crates/jolt-prover-legacy/src/subprotocols/univariate_skip.rs
+++ b/crates/jolt-prover-legacy/src/subprotocols/univariate_skip.rs
@@ -174,7 +174,11 @@ pub fn prove_uniskip_round_zk<
     let blinding = F::random(rng);
     let commitment = pedersen_gens.commit(&uni_poly.coeffs, &blinding);
 
-    transcript.append_commitment(b"sumcheck_commitment", &commitment);
+    transcript.append_commitment_with_count(
+        b"sumcheck_commitment",
+        poly_degree as u64,
+        &commitment,
+    );
 
     let r0: F::Challenge = transcript.challenge_scalar_optimized::<F>();
     instance.cache_openings(opening_accumulator, &[r0]);
@@ -325,7 +329,11 @@ impl<F: JoltField, C: JoltCurve<F = F>, T: Transcript> ZkUniSkipFirstRoundProof<
             ));
         }
 
-        transcript.append_commitment(b"sumcheck_commitment", &self.commitment);
+        transcript.append_commitment_with_count(
+            b"sumcheck_commitment",
+            self.poly_degree as u64,
+            &self.commitment,
+        );
 
         let r0: F::Challenge = transcript.challenge_scalar_optimized::<F>();
         sumcheck_instance.cache_openings(opening_accumulator, &[r0]);

--- a/crates/jolt-prover-legacy/src/transcripts/transcript.rs
+++ b/crates/jolt-prover-legacy/src/transcripts/transcript.rs
@@ -84,6 +84,24 @@ pub trait Transcript: Default + Clone + Sync + Send + 'static {
         self.raw_append_bytes(&bytes);
     }
 
+    /// Append a curve point with a label and a count packed into one 32-byte
+    /// word (same layout as the variable-length methods). Used to bind
+    /// per-commitment metadata — e.g. a committed sumcheck round's polynomial
+    /// degree — into the transcript alongside the commitment.
+    fn append_commitment_with_count<G: JoltGroupElement>(
+        &mut self,
+        label: &'static [u8],
+        count: u64,
+        point: &G,
+    ) {
+        self.raw_append_label_with_len(label, count);
+        let mut bytes = Vec::new();
+        point
+            .serialize_compressed(&mut bytes)
+            .expect("JoltGroupElement serialization should not fail");
+        self.raw_append_bytes(&bytes);
+    }
+
     /// Append a serializable value with a label.
     /// Variable-length: label and length packed into single 32-byte word.
     fn append_serializable<T: CanonicalSerialize>(&mut self, label: &'static [u8], data: &T) {

--- a/crates/jolt-prover-legacy/src/zkvm/prover.rs
+++ b/crates/jolt-prover-legacy/src/zkvm/prover.rs
@@ -3815,10 +3815,13 @@ mod tests {
                     let mut rounds = Vec::with_capacity(num_rounds);
 
                     for (round_idx, commitment) in zk_proof.round_commitments.iter().enumerate() {
-                        transcript.append_commitment(b"sumcheck_commitment", commitment);
-                        let challenge: Fr = transcript.challenge_scalar_optimized::<Fr>().into();
-
                         let degree = zk_proof.poly_degrees[round_idx];
+                        transcript.append_commitment_with_count(
+                            b"sumcheck_commitment",
+                            degree as u64,
+                            commitment,
+                        );
+                        let challenge: Fr = transcript.challenge_scalar_optimized::<Fr>().into();
 
                         // Create synthetic coefficients that satisfy sumcheck relation
                         // g(x) = c0 + c1*x + c2*x^2 + ... has degree+1 coefficients

--- a/crates/jolt-sumcheck/src/committed.rs
+++ b/crates/jolt-sumcheck/src/committed.rs
@@ -3,7 +3,7 @@
 use jolt_crypto::VectorCommitment;
 use jolt_field::Field;
 use jolt_poly::UnivariatePoly;
-use jolt_transcript::{AppendToTranscript, Label, LabelWithCount, Transcript};
+use jolt_transcript::{AppendToTranscript, LabelWithCount, Transcript};
 use rand_core::RngCore;
 use serde::{Deserialize, Serialize};
 
@@ -26,7 +26,13 @@ impl<C: AppendToTranscript> RoundMessage for CommittedRound<C> {
     }
 
     fn append_to_transcript<T: Transcript>(&self, transcript: &mut T) {
-        transcript.append(&Label(SUMCHECK_COMMITMENT_LABEL));
+        // The degree is packed into the label word so the round's degree —
+        // which fixes the BlindFold R1CS coefficient layout — is
+        // Fiat-Shamir-bound, not free prover-chosen wire data.
+        transcript.append(&LabelWithCount(
+            SUMCHECK_COMMITMENT_LABEL,
+            self.degree as u64,
+        ));
         self.commitment.append_to_transcript(transcript);
     }
 }

--- a/crates/jolt-sumcheck/src/tests.rs
+++ b/crates/jolt-sumcheck/src/tests.rs
@@ -9,7 +9,7 @@
 use jolt_crypto::{Bn254, Bn254G1, JoltGroup, Pedersen, PedersenSetup, VectorCommitment};
 use jolt_field::{Fr, FromPrimitiveInt};
 use jolt_poly::{CompressedPoly, UnivariatePoly};
-use jolt_transcript::{AppendToTranscript, Blake2bTranscript, Label, LabelWithCount, Transcript};
+use jolt_transcript::{AppendToTranscript, Blake2bTranscript, LabelWithCount, Transcript};
 
 use crate::claim::{EvaluationClaim, SumcheckClaim, SumcheckStatement};
 use crate::committed::{
@@ -786,7 +786,7 @@ fn committed_rounds_check_transcript_and_return_public_data() {
     let mut manual = Blake2bTranscript::<F>::new(b"committed-sumcheck");
     let mut expected_challenges = Vec::new();
     for round in &rounds {
-        manual.append(&Label(b"sumcheck_commitment"));
+        manual.append(&LabelWithCount(b"sumcheck_commitment", round.degree as u64));
         round.commitment.append_to_transcript(&mut manual);
         expected_challenges.push(manual.challenge());
     }
@@ -896,7 +896,7 @@ fn committed_proof_checks_rounds_then_output_claims() {
     let mut manual = Blake2bTranscript::<F>::new(b"committed-proof");
     let mut expected_challenges = Vec::new();
     for round in &proof.rounds {
-        manual.append(&Label(b"sumcheck_commitment"));
+        manual.append(&LabelWithCount(b"sumcheck_commitment", round.degree as u64));
         round.commitment.append_to_transcript(&mut manual);
         expected_challenges.push(manual.challenge());
     }

--- a/crates/jolt-verifier/tests/support/verifier_fixtures.rs
+++ b/crates/jolt-verifier/tests/support/verifier_fixtures.rs
@@ -354,10 +354,13 @@ impl VerifierFixtureKind {
             Self::AdviceConsumer => "standard-advice-consumer",
             #[cfg(not(feature = "zk"))]
             Self::CommittedMulDivSmall => "standard-committed-muldiv-small",
+            // ZK names carry a transcript-scheme suffix: they key the temp-dir
+            // cache, so a ZK transcript change must rename them or stale cached
+            // proofs fail verification instead of regenerating.
             #[cfg(feature = "zk")]
-            Self::ZkMulDivSmall => "zk-muldiv-small-continued-transcript",
+            Self::ZkMulDivSmall => "zk-muldiv-small-degree-bound",
             #[cfg(feature = "zk")]
-            Self::ZkCommittedMulDivSmall => "zk-committed-muldiv-small",
+            Self::ZkCommittedMulDivSmall => "zk-committed-muldiv-small-degree-bound",
         }
     }
 }


### PR DESCRIPTION
## Summary

`CommittedRound::append_to_transcript` absorbed only the round commitment, leaving the `degree` field unabsorbed — flagged in the #1669 security review as out-of-scope-but-adjacent, and carried in `PLAN_OF_PRS.md` as a BlindFold-wiring follow-up. The degree is prover-chosen wire data: a Pedersen vector commitment doesn't bind its length (a shorter coefficient vector commits identically to its zero-padded extension), and the degree fixes both the verifier's per-round degree-bound checks and the BlindFold R1CS coefficient layout. It belongs under Fiat-Shamir.

## Changes

- **`jolt-sumcheck`** — `CommittedRound::append_to_transcript` now packs the degree into the label word (`LabelWithCount(b"sumcheck_commitment", degree)`), matching the clear-round convention (`LabeledRoundPoly` / `CompressedLabeledRoundPoly` already bind their coefficient counts). Single site: modular prover (`CommittedSumcheckBuilder::commit_round`, `prove_uniskip_committed`) and verifier (`verify_committed_round_consistency`) share it.
- **`jolt-prover-legacy`** — new `Transcript::append_commitment_with_count` (label+count packed via `raw_append_label_with_len`, byte-compatible with `LabelWithCount`); the five inline `b"sumcheck_commitment"` absorb sites (batched `prove_zk`/`verify_transcript_only`, uniskip prove/verify, `blindfold_r1cs_satisfaction` replay) move in lockstep — legacy ZK proofs convert into the shared proof type, so both stacks must agree byte-for-byte.
- **`jolt-verifier` fixtures** — ZK fixture cache names bumped (`…-degree-bound`): they key the temp-dir cache, and a stale cached proof from the old transcript would fail verification instead of regenerating. Repo-pinned standard fixtures are untouched.

## Wire impact

ZK transcript break only (challenges derive differently); proof serialization format is unchanged and **clear-mode proof bytes are unchanged**.

## Verification

- `cargo clippy --all --features host` and `host,zk` — clean
- `jolt-sumcheck` suite 68/68 (manual-transcript twins updated)
- Legacy ZK e2e: `muldiv` ×3 + `blindfold_r1cs_satisfaction` — pass
- Modular ZK e2e (`prover-fixtures,zk`): accept / tamper-reject / advice / committed program — 12/12
- Clear-mode byte-diff ratchets (`prover-fixtures`): 18/18, zero fixture regeneration
- `jolt-verifier` ZK completeness (legacy-prove → shared-verify seam): 2/2, fixtures regenerated under new names