### PR TITLE
chore(deps): bump dory-pcs to 0.4.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1731,7 +1731,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2258,9 +2258,9 @@ dependencies = [
 
 [[package]]
 name = "dory-pcs"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c6a5b6aa708db35ced06eeef3d2b4408004c76279091e0bc387f8fd42796555"
+checksum = "bc655754c8ddb6b75f528efcfcddf2cd8db59bdea777de157400d642048bd2f4"
 dependencies = [
  "ark-bn254 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ark-ec 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -281,7 +281,7 @@ spongefish = { git = "https://github.com/arkworks-rs/spongefish", rev = "d2d190b
   "sha3",
 ] }
 jolt-optimizations = { git = "https://github.com/a16z/arkworks-algebra", branch = "dev/twist-shout" }
-dory = { package = "dory-pcs", version = "0.4.0", features = [
+dory = { package = "dory-pcs", version = "0.4.1", features = [
   "backends",
   "cache",
   "disk-persistence",


### PR DESCRIPTION
Picks up [dory v0.4.1](https://github.com/a16z/dory/releases/tag/v0.4.1): batch-normalized MSM affine conversion and `parallel`-gated `DoryRoutines` vector ops in the stock arkworks backend (a16z/dory#27). No API changes; proofs are byte-identical, so this is perf-only for the default backend.