### PR TITLE
test(jolt-prover): add inline-bearing guest to the modular acceptance suite

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3722,6 +3722,7 @@ dependencies = [
  "jolt-profiling",
  "jolt-program",
  "jolt-prover-legacy",
+ "jolt-riscv",
  "jolt-sumcheck",
  "jolt-transcript",
  "jolt-verifier",

--- a/crates/jolt-prover/Cargo.toml
+++ b/crates/jolt-prover/Cargo.toml
@@ -103,6 +103,7 @@ clap.workspace = true
 jolt-dory.workspace = true
 jolt-inlines-keccak256 = { workspace = true, features = ["host"] }
 jolt-inlines-sha2 = { workspace = true, features = ["host"] }
+jolt-riscv.workspace = true
 # Subscriber stack for tests; the profiling smoke test's summary usage
 # arrives via the `profiling` feature's `jolt-profiling/summary`.
 jolt-profiling = { workspace = true, default-features = false }

--- a/crates/jolt-prover/tests/byte_diff.rs
+++ b/crates/jolt-prover/tests/byte_diff.rs
@@ -17,6 +17,7 @@
 //! (`advice_consumer`, `committed_muldiv`, `address_major`,
 //! `advice_committed`) are whole-proof ratchets over the mode ×
 //! trace-order matrix, sharing the `support` scaffolding.
+//! `inline_sha3` adds a minimal inline-bearing whole-proof ratchet.
 //! `chunk_boundary` is the scale arm: a real 2^17-cycle trace, one power
 //! past the optimized backend's 2^16-row streaming chunk, proved both
 //! slice-backed and behind a re-emulating source (the forced chunk walk).
@@ -1705,6 +1706,117 @@ mod advice_committed {
                 Some(&trusted.converted),
             );
         }
+    }
+}
+
+#[cfg(all(feature = "prover-fixtures", not(feature = "zk")))]
+#[expect(clippy::expect_used)]
+mod inline_sha3 {
+    // Anchor the Keccak inline registration into this test binary.
+    extern crate jolt_inlines_keccak256;
+
+    use std::sync::Arc;
+
+    use jolt_claims::protocols::jolt::TracePolynomialOrder;
+    use jolt_crypto::{Bn254G1, Pedersen};
+    use jolt_dory::DoryScheme;
+    use jolt_field::Fr;
+    use jolt_program::execution::JoltProgram;
+    use jolt_prover::{JoltBackend, JoltProverPreprocessing};
+    use jolt_prover_legacy::host;
+    use jolt_prover_legacy::zkvm::preprocessing::JoltSharedPreprocessing;
+    use jolt_prover_legacy::zkvm::proof::verifier_preprocessing_from_prover;
+    use jolt_prover_legacy::zkvm::prover::JoltProverPreprocessing as LegacyProverPreprocessing;
+    use jolt_prover_legacy::zkvm::RV64IMACProver;
+    use jolt_riscv::JoltInstructionKind;
+    use jolt_transcript::LegacyBlake2bTranscript as Blake2bTranscript;
+    use jolt_witness::{JoltVmWitnessInputs, TraceBackend};
+
+    use super::support;
+
+    const KECCAK_ROTRI_ROWS: usize = 696;
+
+    #[test]
+    fn prover_matches_legacy_on_sha3_inline() {
+        let mut program = host::Program::new("sha3-guest");
+        let inputs = postcard::to_stdvec(&[5u8; 32]).expect("serialize input");
+
+        let guest = support::legacy_guest(&mut program, &inputs, &[], &[]);
+        let shared = JoltSharedPreprocessing::new(
+            guest.program,
+            guest.io_device.memory_layout.clone(),
+            support::MAX_PADDED_TRACE_LENGTH,
+        );
+        let legacy_preprocessing = LegacyProverPreprocessing::new(shared);
+        let legacy_prover = RV64IMACProver::gen_from_elf(
+            &legacy_preprocessing,
+            &guest.elf_contents,
+            &inputs,
+            &[],
+            &[],
+            None,
+            None,
+            None,
+        );
+        let public_io = legacy_prover.program_io.clone();
+        let (legacy_proof, _) = legacy_prover.prove().expect("legacy prove");
+        let verifier_preprocessing = verifier_preprocessing_from_prover(&legacy_preprocessing);
+
+        let jolt_program = Arc::new(JoltProgram::from_elf_bytes(guest.elf_contents));
+        let memory_layout = &public_io.memory_layout;
+        let trace_output = support::trace_modular(&jolt_program, memory_layout, &inputs, &[], &[]);
+        assert_eq!(
+            trace_output
+                .trace
+                .rows()
+                .iter()
+                .filter(|row| {
+                    row.instruction.instruction_kind == JoltInstructionKind::VirtualROTRI
+                })
+                .count(),
+            KECCAK_ROTRI_ROWS,
+            "one Keccak permutation must be expanded into the modular trace",
+        );
+        let program_preprocessing = verifier_preprocessing
+            .program
+            .as_full_arc()
+            .expect("full program preprocessing");
+        let config = support::derive_config_pinned(
+            &trace_output,
+            memory_layout,
+            &verifier_preprocessing,
+            TracePolynomialOrder::CycleMajor,
+            None,
+            &legacy_proof,
+            support::MAX_PADDED_TRACE_LENGTH,
+        );
+        let padded_output = support::pad_trace(trace_output, config.trace_length);
+        let witness = Arc::new(TraceBackend::new(
+            support::witness_config(&config),
+            JoltVmWitnessInputs::new(&jolt_program, &program_preprocessing, padded_output),
+        ));
+        let prover_preprocessing = JoltProverPreprocessing::<DoryScheme, Pedersen<Bn254G1>> {
+            verifier: verifier_preprocessing,
+            pcs_setup: DoryScheme::setup_prover(support::setup_total_vars(
+                memory_layout,
+                &[],
+                support::MAX_PADDED_TRACE_LENGTH,
+            )),
+            committed_program: None,
+        };
+
+        let backend = JoltBackend::<Fr, DoryScheme>::optimized();
+        let proof = jolt_prover::prove::<Fr, DoryScheme, Pedersen<Bn254G1>, Blake2bTranscript, _>(
+            &backend,
+            &prover_preprocessing,
+            &config,
+            None,
+            witness,
+            &public_io,
+        )
+        .expect("modular prove");
+        assert_eq!(proof, legacy_proof, "assembled proof diverged from legacy");
+        support::verify_modular(&prover_preprocessing.verifier, &public_io, &proof, None);
     }
 }
 

--- a/crates/jolt-prover/tests/zk_e2e.rs
+++ b/crates/jolt-prover/tests/zk_e2e.rs
@@ -306,17 +306,21 @@ mod support {
     reason = "integration tests should fail loudly"
 )]
 mod zk {
+    // Anchor the Keccak inline registration into this test binary.
+    extern crate jolt_inlines_keccak256;
+
     use std::sync::Arc;
 
     use jolt_crypto::{Bn254G1, Pedersen};
     use jolt_dory::DoryScheme;
     use jolt_field::Fr;
-    use jolt_program::execution::JoltProgram;
+    use jolt_program::execution::{JoltProgram, TraceRow};
     use jolt_prover::{CommittedProgramProverData, JoltBackend, JoltProverPreprocessing};
     use jolt_prover_legacy::host;
     use jolt_prover_legacy::zkvm::preprocessing::JoltSharedPreprocessing;
     use jolt_prover_legacy::zkvm::proof::verifier_preprocessing_from_prover;
     use jolt_prover_legacy::zkvm::prover::JoltProverPreprocessing as LegacyProverPreprocessing;
+    use jolt_riscv::JoltInstructionKind;
     use jolt_transcript::LegacyBlake2bTranscript as Blake2bTranscript;
     use jolt_verifier::preprocessing::ProgramPreprocessing;
     use jolt_verifier::proof::JoltProofClaims;
@@ -324,15 +328,19 @@ mod zk {
 
     use super::support;
 
-    fn prove_muldiv_zk(
+    const KECCAK_ROTRI_ROWS: usize = 696;
+
+    fn prove_guest_zk(
+        guest_name: &str,
+        inputs: Vec<u8>,
         backend: JoltBackend<Fr, DoryScheme>,
+        inspect_trace: impl FnOnce(&[TraceRow]),
     ) -> (
         support::VerifierPreprocessing,
         common::jolt_device::JoltDevice,
         support::Proof,
     ) {
-        let mut program = host::Program::new("muldiv-guest");
-        let inputs = postcard::to_stdvec(&[9u32, 5u32, 3u32]).expect("serialize inputs");
+        let mut program = host::Program::new(guest_name);
 
         // Legacy host preprocessing carries the program metadata and — under
         // the zk feature — the BlindFold vector-commitment setup.
@@ -354,6 +362,7 @@ mod zk {
         let jolt_program = Arc::new(JoltProgram::from_elf_bytes(guest.elf_contents));
         let memory_layout = io_device.memory_layout.clone();
         let trace_output = support::trace_modular(&jolt_program, &memory_layout, &inputs, &[], &[]);
+        inspect_trace(trace_output.trace.rows());
         let public_io = trace_output.device.clone();
         let program_preprocessing = verifier_preprocessing
             .program
@@ -383,6 +392,21 @@ mod zk {
         (prover_preprocessing.verifier, public_io, proof)
     }
 
+    fn prove_muldiv_zk(
+        backend: JoltBackend<Fr, DoryScheme>,
+    ) -> (
+        support::VerifierPreprocessing,
+        common::jolt_device::JoltDevice,
+        support::Proof,
+    ) {
+        prove_guest_zk(
+            "muldiv-guest",
+            postcard::to_stdvec(&[9u32, 5u32, 3u32]).expect("serialize inputs"),
+            backend,
+            |_| {},
+        )
+    }
+
     #[test]
     fn zk_muldiv_modular_proof_is_accepted() {
         support::with_zk_stack(|| {
@@ -408,6 +432,33 @@ mod zk {
             assert!(matches!(proof.claims, JoltProofClaims::Zk { .. }));
             support::verify_modular(&preprocessing, &public_io, &proof, None)
                 .expect("optimized-backend ZK proof must verify");
+        });
+    }
+
+    #[test]
+    fn zk_sha3_inline_modular_proof_is_accepted() {
+        support::with_zk_stack(|| {
+            let inputs = postcard::to_stdvec(&[5u8; 32]).expect("serialize input");
+            let (preprocessing, public_io, proof) = prove_guest_zk(
+                "sha3-guest",
+                inputs,
+                JoltBackend::<Fr, DoryScheme>::optimized(),
+                |rows| {
+                    assert_eq!(
+                        rows.iter()
+                            .filter(|row| {
+                                row.instruction.instruction_kind
+                                    == JoltInstructionKind::VirtualROTRI
+                            })
+                            .count(),
+                        KECCAK_ROTRI_ROWS,
+                        "one Keccak permutation must be expanded into the modular trace",
+                    );
+                },
+            );
+            assert!(matches!(proof.claims, JoltProofClaims::Zk { .. }));
+            support::verify_modular(&preprocessing, &public_io, &proof, None)
+                .expect("modular SHA3 ZK proof must verify");
         });
     }
 


### PR DESCRIPTION
## What

The modular acceptance suite (`crates/jolt-prover/tests/`) proved only the muldiv guest — no inline-bearing guest (sha2/sha3/blake/…) has ever been proven end-to-end through the modular prover in CI, so inline lookup-table changes were gated only by per-table unit suites plus the *legacy* e2e. This adds:

- **`byte_diff.rs` arm**: `sha3-guest` (32-byte input, one Keccak permutation) proven through both provers, byte-identical proof assertion — same structure as the muldiv module.
- **`zk_e2e.rs` arm**: modular ZK prove+verify on the same guest.
- **Inline-footprint pin**: both arms assert the trace contains exactly **696 `VirtualROTRI` rows** (one permutation's rotation footprint) — proving the inline sequence is actually in-trace, not silently absent. PRs that change the Keccak inline sequence will move this pin; that's its job.

The test module carries an `extern crate jolt_inlines_keccak256;` anchor so the inline registration isn't dead-stripped from the test binary.

## Runtime

Standalone: clear 27.5s, ZK 51.1s. Under full-suite parallel contention: 43.5s / 89.6s — on par with the existing optimized-muldiv arm (89.2s), well inside the suite's slowest pre-existing arms (>5 min).

## Testing

Full clear acceptance 21/21; full ZK 14/14; workspace clippy `host` + `host,zk` with `-D warnings`; fmt.