### PR TITLE
ci: nightly Z3 formal-verification workflow

### DIFF
--- a/.github/workflows/z3-nightly.yml
+++ b/.github/workflows/z3-nightly.yml
@@ -1,13 +1,24 @@
-# Nightly Z3 formal verification of the tracer/jolt-program virtual-sequence
-# expansions (z3-verifier). Runs the full symbolic_exec suite against a
-# hermetic, vendored Z3 (`z3/bundled` — built from source, no system libz3),
-# so results don't depend on runner packages.
+# Nightly Z3 verification of the jolt-program virtual-sequence expansions and
+# the Jolt CPU R1CS constraints (z3-verifier), against a hermetic Z3 built from
+# pinned vendored source (`vendored-z3`), so results don't depend on runner
+# packages or on whatever z3-src happens to be current.
 #
-# Nightly-only by design: the bundled Z3 build is too slow for the PR-blocking
-# path, and the suite proves ∀-input properties that only change when
-# expansions or the z3 model change. `workflow_dispatch` allows on-demand runs
-# (e.g. after landing a PR that touches tracer/, crates/jolt-program/, or
-# z3-verifier/).
+# SCOPE — this suite is narrower than "the expansion pipeline". It runs 83 of
+# the crate's 103 tests:
+#   * 32 virtual-sequence proofs (16 mnemonics x correctness+consistency):
+#     ADDIW ADDW MULW SUBW and the twelve shifts. Exhaustive over register
+#     values, but at one fixed operand assignment (rd=x1, rs1=x2, rs2=x3,
+#     imm=1234), so immediate-form sequences are proved at a single shift
+#     amount and the rd=x0 expansion path is never taken.
+#   * 51 per-instruction R1CS/product-constraint determinism checks.
+# NOT covered: the 10 #[ignore]d div/rem/mulh sequences (non-terminating under
+# the 64-bit model), all memory/atomic/LR-SC/CSR/trap expansions, and the
+# registered inlines.
+#
+# Nightly-only by design: the vendored Z3 build is too slow for the PR-blocking
+# path, and the obligations only move when expansions or the z3 model change.
+# `workflow_dispatch` allows on-demand runs (e.g. after landing a PR that
+# touches tracer/, crates/jolt-program/, or z3-verifier/).
 name: Z3 Formal Verification
 
 on:
@@ -23,7 +34,10 @@ permissions:
 jobs:
   z3-formal-verification:
     runs-on: ubuntu-latest
-    timeout-minutes: 90
+    # Backstop only. The real bound is the step-level timeout below: a job-level
+    # timeout CANCELS the job, which skips the `if: failure()` reporting step, so
+    # a hang would go unreported. Keep this comfortably above the step budget.
+    timeout-minutes: 100
     steps:
       - uses: actions/checkout@v7.0.1
       - uses: actions-rust-lang/setup-rust-toolchain@v1
@@ -33,10 +47,14 @@ jobs:
           tool: nextest
       - uses: Swatinem/rust-cache@v2
         with:
-          # Cache the expensive bundled-Z3 CMake build across nightly runs.
+          # Cache the expensive vendored-Z3 CMake build across nightly runs.
           shared-key: z3-nightly
       - name: Run Z3 formal verification suite
-        run: cargo nextest run -p z3-verifier --features z3/bundled --cargo-quiet --no-fail-fast
+        # Step-level (not job-level) so an obligation that stops terminating
+        # fails this step and the reporting step below still runs.
+        timeout-minutes: 75
+        # --locked so the pinned z3-src in Cargo.lock is what actually gets built.
+        run: cargo nextest run -p z3-verifier --features vendored-z3 --locked --cargo-quiet --no-fail-fast
       - name: File failure issue
         if: failure()
         env:
@@ -46,9 +64,10 @@ jobs:
             --state open --search "in:title \"Nightly Z3 formal verification failed\"" \
             --json number --jq 'length')
           if [ "$existing" -eq 0 ]; then
-            body=$(printf '%s\n\n%s' \
+            body=$(printf '%s\n\n%s\n\n%s' \
               "The scheduled z3-verifier run failed: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" \
-              "A symbolic_exec obligation regressed (or the z3 model drifted from an expansion change). The suite proves every virtual-sequence expansion against its architectural semantics for all inputs — treat failures as potential soundness signals, not flakes.")
+              "A z3-verifier obligation regressed, or the hand-written z3 model drifted from an expansion change. Within its scope (see the header comment in .github/workflows/z3-nightly.yml) the suite quantifies over all register values, so treat failures as potential soundness signals, not flakes." \
+              "Two non-soundness causes worth ruling out first: a test reporting 'Solver failed/timed out, result inconclusive' hit the per-solver-call budget rather than finding a counterexample; and a step timeout means an obligation stopped terminating altogether.")
             gh issue create --repo "$GITHUB_REPOSITORY" \
               --title "Nightly Z3 formal verification failed" \
               --body "$body"

--- a/.github/workflows/z3-nightly.yml
+++ b/.github/workflows/z3-nightly.yml
@@ -1,0 +1,57 @@
+# Nightly Z3 formal verification of the tracer/jolt-program virtual-sequence
+# expansions (z3-verifier). Runs the full symbolic_exec suite against a
+# hermetic, vendored Z3 (`z3/bundled` — built from source, no system libz3),
+# so results don't depend on runner packages.
+#
+# Nightly-only by design: the bundled Z3 build is too slow for the PR-blocking
+# path, and the suite proves ∀-input properties that only change when
+# expansions or the z3 model change. `workflow_dispatch` allows on-demand runs
+# (e.g. after landing a PR that touches tracer/, crates/jolt-program/, or
+# z3-verifier/).
+name: Z3 Formal Verification
+
+on:
+  schedule:
+    # 07:13 UTC nightly (off the top of the hour to dodge scheduler congestion)
+    - cron: "13 7 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  z3-formal-verification:
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@v7.0.1
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - name: Install nextest
+        uses: taiki-e/install-action@v2
+        with:
+          tool: nextest
+      - uses: Swatinem/rust-cache@v2
+        with:
+          # Cache the expensive bundled-Z3 CMake build across nightly runs.
+          shared-key: z3-nightly
+      - name: Run Z3 formal verification suite
+        run: cargo nextest run -p z3-verifier --features z3/bundled --cargo-quiet --no-fail-fast
+      - name: File failure issue
+        if: failure()
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          existing=$(gh issue list --repo "$GITHUB_REPOSITORY" \
+            --state open --search "in:title \"Nightly Z3 formal verification failed\"" \
+            --json number --jq 'length')
+          if [ "$existing" -eq 0 ]; then
+            body=$(printf '%s\n\n%s' \
+              "The scheduled z3-verifier run failed: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" \
+              "A symbolic_exec obligation regressed (or the z3 model drifted from an expansion change). The suite proves every virtual-sequence expansion against its architectural semantics for all inputs — treat failures as potential soundness signals, not flakes.")
+            gh issue create --repo "$GITHUB_REPOSITORY" \
+              --title "Nightly Z3 formal verification failed" \
+              --body "$body"
+          else
+            echo "Open failure issue already exists; not filing a duplicate."
+          fi

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1688,6 +1688,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
 
 [[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "cmov"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7807,12 +7816,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "z3-src"
+version = "416.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2af0c6527de39877cf55cb87f233016573eeeb7cf77afdc1469e4b32faef832"
+dependencies = [
+ "cmake",
+]
+
+[[package]]
 name = "z3-sys"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c18b0a91a13522d21b3414847667de2b2056a721a3edcb5b6ee6858352d58db4"
 dependencies = [
  "pkg-config",
+ "z3-src",
 ]
 
 [[package]]
@@ -7824,6 +7843,7 @@ dependencies = [
  "paste",
  "tracer",
  "z3",
+ "z3-src",
 ]
 
 [[package]]

--- a/z3-verifier/Cargo.toml
+++ b/z3-verifier/Cargo.toml
@@ -9,3 +9,18 @@ jolt-prover-legacy = { path = "../crates/jolt-prover-legacy" }
 common = { path = "../common" }
 tracer = { path = "../tracer" }
 z3 = "0.20.0"
+# Never used from Rust — declared only to pin the Z3 that `vendored-z3` builds.
+# z3-sys asks for `z3-src = "416"`, which would let the solver change under the
+# nightly between runs and surface as a spurious soundness signal. 416.0.2 is
+# Z3 release 4.16.0. A future `z3` bump that needs a different z3-src major
+# fails resolution here rather than drifting silently.
+z3-src = { version = "=416.0.2", optional = true }
+
+[features]
+# Build Z3 from pinned vendored source instead of linking the runner's libz3.
+# Used by .github/workflows/z3-nightly.yml so nightly results depend only on
+# this repo, not on runner packages.
+vendored-z3 = ["z3/vendored", "dep:z3-src"]
+
+[package.metadata.cargo-machete]
+ignored = ["z3-src"]

--- a/z3-verifier/src/cpu_constraints.rs
+++ b/z3-verifier/src/cpu_constraints.rs
@@ -1,6 +1,7 @@
 #![cfg(test)]
 #![allow(non_upper_case_globals)]
 
+use crate::{Z3_RANDOM_SEED, Z3_TIMEOUT_MS};
 use jolt_prover_legacy::zkvm::{
     instruction::{
         CircuitFlags, Flags, InstructionFlags, NUM_CIRCUIT_FLAGS, NUM_INSTRUCTION_FLAGS,
@@ -74,7 +75,7 @@ use tracer::instruction::{
     virtual_srli::VirtualSRLI,
     Instruction,
 };
-use z3::{ast::Int, SatResult, Solver};
+use z3::{ast::Int, Params, SatResult, Solver};
 
 #[derive(Clone, Debug)]
 struct JoltState<T = Int> {
@@ -420,7 +421,12 @@ impl JoltState<i64> {
 }
 
 fn do_test(name: &str, instr: &Instruction) {
+    let mut solver_params = Params::default();
+    solver_params.set_u32("timeout", Z3_TIMEOUT_MS);
+    solver_params.set_u32("random_seed", Z3_RANDOM_SEED);
+
     let mut solver = Solver::new();
+    solver.set_params(&solver_params);
 
     let r1 = JoltState::new("r1".to_string());
     r1.add_constraints(&mut solver);
@@ -459,7 +465,7 @@ fn do_test(name: &str, instr: &Instruction) {
             panic!("{}", msg.trim());
         }
         SatResult::Unsat => (),
-        SatResult::Unknown => panic!("Solver failed"),
+        SatResult::Unknown => panic!("Solver failed/timed out, result inconclusive"),
     }
 }
 

--- a/z3-verifier/src/lib.rs
+++ b/z3-verifier/src/lib.rs
@@ -1,6 +1,18 @@
 mod cpu_constraints;
 mod virtual_sequences;
 
+/// Bounds a single `Solver::check`. Every obligation in this crate discharges in
+/// milliseconds, so a call that hits this is a blowup rather than a slow proof.
+/// Surfacing it as `SatResult::Unknown` keeps the failure attributable to a named
+/// test instead of hanging the run.
+#[cfg(test)]
+pub(crate) const Z3_TIMEOUT_MS: u32 = 30_000;
+
+/// Fixed so a counterexample search is reproducible. Has no bearing on validity:
+/// `Unsat` is the only passing verdict and does not depend on the seed.
+#[cfg(test)]
+pub(crate) const Z3_RANDOM_SEED: u32 = 42;
+
 #[macro_export]
 macro_rules! template_format {
     (FormatR) => {

--- a/z3-verifier/src/virtual_sequences.rs
+++ b/z3-verifier/src/virtual_sequences.rs
@@ -74,8 +74,8 @@ use z3::{
     Params, SatResult, Solver,
 };
 
-const _Z3_TIMEOUT_MS: u32 = 30_000;
-const Z3_RANDOM_SEED: u32 = 42;
+use crate::{Z3_RANDOM_SEED, Z3_TIMEOUT_MS};
+
 const DEFAULT_BV_BITS: u32 = 64;
 const BV_BITS_ENV: &str = "Z3_VERIFIER_BV_BITS";
 
@@ -454,7 +454,7 @@ fn test_correctness<I: RISCVInstruction + RISCVTrace>(
     RISCVCycle<I>: Into<Cycle>,
 {
     let mut solver_params = Params::default();
-    //solver_params.set_u32("timeout", Z3_TIMEOUT_MS);
+    solver_params.set_u32("timeout", Z3_TIMEOUT_MS);
     solver_params.set_u32("random_seed", Z3_RANDOM_SEED);
 
     let mut solver = Solver::new();
@@ -519,7 +519,7 @@ fn test_correctness<I: RISCVInstruction + RISCVTrace>(
 
 fn test_consistency(instr: &Instruction) {
     let mut solver_params = Params::default();
-    //solver_params.set_u32("timeout", Z3_TIMEOUT_MS);
+    solver_params.set_u32("timeout", Z3_TIMEOUT_MS);
     solver_params.set_u32("random_seed", Z3_RANDOM_SEED);
 
     let mut solver = Solver::new();


### PR DESCRIPTION
## What

Adds a scheduled workflow running the full `z3-verifier` suite — the symbolic-execution harness that formally proves every virtual-sequence expansion against its architectural semantics for **all** inputs (the suite #1750's review round repaired and extended).

- **Nightly** (`cron: 13 7 * * *`) + **`workflow_dispatch`** for on-demand runs after landing expansion-touching PRs
- **Hermetic Z3**: `--features z3/bundled` builds Z3 from source — no dependence on runner packages; `Swatinem/rust-cache` with a dedicated shared-key caches the expensive CMake build across runs
- **Off the PR-blocking path by design**: the bundled build is too slow for per-PR CI, and the obligations only move when expansions or the z3 model change
- **Failure visibility**: files a `Nightly Z3 formal verification failed` issue with the run link (deduplicated — no issue spam on consecutive failures); body notes failures are potential soundness signals, not flakes
- `timeout-minutes: 90`, `--no-fail-fast` so one regressed obligation doesn't hide others

## Why

The z3 harness had rotted on main (missing `symbolic_exec` arms surfaced during #1750's audit — 8 tests panicking) precisely because nothing runs it. This gives the formal suite a heartbeat. Follow-up proposed in the #1750 review discussion.

## Testing

`actionlint` clean. The exact cargo command (`cargo nextest run -p z3-verifier --features z3/bundled`) is what the recent PR gates ran locally (83–84/84 green, incl. the bundled-Z3 build path on a clean target).