### PR TITLE
docs: document the optimized prover backend selector (--backend)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,6 +54,8 @@ cargo install --path . --locked
 cargo run --release -p jolt-prover --features profiling -- profile --name fibonacci --format chrome
 # --name options (default scale): fibonacci (16), sha2-chain (22), sha3-chain (22), btreemap (20)
 # --scale <log2 trace length> overrides; --format none = no-subscriber Instant baseline
+# --backend reference (default, naive test oracle) | optimized (performance tier, legacy-parity);
+# optimized artifacts get an _optimized suffix on the run dir and latest_ symlink
 
 # Canonical summary queries (no Perfetto UI needed) — see book/src/usage/profiling/zkvm_profiling.md
 jq '.stages | map({label, s: (.wall_time_ns/1e9)})' benchmark-runs/latest_modular_fibonacci_16/summary.json

--- a/book/src/usage/profiling/zkvm_profiling.md
+++ b/book/src/usage/profiling/zkvm_profiling.md
@@ -20,10 +20,17 @@ Workloads and default scales (`--scale <log2 trace length>` overrides):
 | `sha3-chain` | 2^22 |
 | `btreemap` | 2^20 |
 
+`--backend` selects the prover backend (both subcommands): `reference`
+(default) is the naive test oracle — absolute numbers are provisional,
+attribution is meaningful relatively — while `optimized` is the performance
+tier (legacy-parity prover performance), slotting into the same
+instrumented seams.
+
 Artifacts are grouped by run: each invocation writes into
 `benchmark-runs/{timestamp}_{trace_name}/` (with `{trace_name}` =
 `modular_{workload}_{scale}`, hyphens in the workload mapped to
-underscores), and `benchmark-runs/latest_{trace_name}` is symlinked to the
+underscores; optimized runs append `_optimized`, keeping their artifact set
+next to the reference one), and `benchmark-runs/latest_{trace_name}` is symlinked to the
 newest successful run — the stable path every example below reads. All
 paths are under the current working directory. The directory name carries
 the run identity, so the files inside use fixed names:
@@ -61,8 +68,8 @@ python3 scripts/plot_memory_usage.py     # peak memory per run (from summary.jso
 ```
 
 Mind the machine: the reference backend retains ~18 GiB regardless of scale
-and grows steeply with it — large-scale sweeps are for big-memory hosts
-until an optimized backend lands.
+and grows steeply with it — large-scale sweeps on the reference backend are
+for big-memory hosts; use `--backend optimized` above small scales.
 
 The span labels are a versioned public schema — taxonomy v1 lives in the
 `jolt-profiling` crate docs (`crates/jolt-profiling/src/taxonomy.rs`), the


### PR DESCRIPTION
Weekly docs-freshness pass over the last 7 days of main (15 commits reviewed).

**Drift found:** PR #1714 landed the optimized kernel backend with a `--backend reference|optimized` selector on the modular prover's `profile` and `benchmark` subcommands (optimized runs write artifacts under an `_optimized` suffix), but the profiling docs still describe a reference-only CLI and say large-scale sweeps must wait "until an optimized backend lands".

**Changes:**
- `book/src/usage/profiling/zkvm_profiling.md`: document `--backend` (default `reference` = naive test oracle; `optimized` = legacy-parity performance tier), the `_optimized` artifact/`latest_` symlink suffix, and fix the stale sweep caveat.
- `CLAUDE.md`: add the `--backend` flag and artifact-suffix note to the profiling block.

Verified against `crates/jolt-prover/src/profile.rs` at head (flag defaults, `trace_suffix()`, resume-link naming). Other doc surfaces (README, skills, emulation/tracer book pages) checked against the week's diff — no other drift (removed VirtualLW/VirtualSW were undocumented; FS-soundness PR #1702 and kernels PR #1714 carried their own doc updates).