### PR TITLE
feat(isa): implicit-carry ISA layer — ADDC and MULC instructions

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -155,6 +155,20 @@ jobs:
           --features field-inline,implicit-carry
           --
           -D warnings
+      # jolt-tracer-x86's native module is cfg-gated to x86_64-linux; pin the
+      # target so the implicit-carry lane covers it even if the runner
+      # architecture changes.
+      - name: cargo clippy -p jolt-tracer-x86 --features implicit-carry
+        run: >
+          cargo clippy
+          -q
+          --message-format=short
+          -p jolt-tracer-x86
+          --all-targets
+          --features implicit-carry
+          --target x86_64-unknown-linux-gnu
+          --
+          -D warnings
 
   machete:
     runs-on: ubuntu-latest

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -116,6 +116,45 @@ jobs:
           --features host,field-inline
           --
           -D warnings
+      # Same for implicit-carry: lint every crate that defines the feature lane.
+      - name: cargo clippy --features implicit-carry
+        run: >
+          cargo clippy
+          -q
+          --message-format=short
+          -p tracer
+          -p jolt-program
+          -p jolt-riscv
+          -p jolt-lookup-tables
+          --all-targets
+          --features implicit-carry
+          --
+          -D warnings
+      - name: cargo clippy -p jolt-prover-legacy -p jolt-sdk --features host,implicit-carry
+        run: >
+          cargo clippy
+          -q
+          --message-format=short
+          -p jolt-prover-legacy
+          -p jolt-sdk
+          --all-targets
+          --features host,implicit-carry
+          --
+          -D warnings
+      # Composition coverage: both additive feature lanes must coexist.
+      - name: cargo clippy --features field-inline,implicit-carry
+        run: >
+          cargo clippy
+          -q
+          --message-format=short
+          -p tracer
+          -p jolt-program
+          -p jolt-riscv
+          -p jolt-lookup-tables
+          --all-targets
+          --features field-inline,implicit-carry
+          --
+          -D warnings
 
   machete:
     runs-on: ubuntu-latest
@@ -545,6 +584,13 @@ jobs:
           cargo nextest run -p jolt-claims -p jolt-r1cs \
             -p jolt-program -p jolt-riscv -p jolt-lookup-tables \
             --features field-inline --no-tests=pass --cargo-quiet
+      - name: Test crates with implicit-carry
+        if: matrix.shard == 1
+        shell: bash
+        run: |
+          set -euo pipefail
+          cargo nextest run -p jolt-program -p jolt-riscv -p jolt-lookup-tables \
+            --features implicit-carry --no-tests=pass --cargo-quiet
 
   # Join gate so the check name "Test modular crates" is stable regardless of
   # shard count.
@@ -699,6 +745,8 @@ jobs:
         run: cargo nextest run --cargo-profile ci -p tracer --features test-utils --cargo-quiet
       - name: Run tracer tests with field-inline
         run: cargo nextest run --cargo-profile ci -p tracer --features test-utils,field-inline --cargo-quiet
+      - name: Run tracer tests with implicit-carry
+        run: cargo nextest run --cargo-profile ci -p tracer --features test-utils,implicit-carry --cargo-quiet
 
   zklean-extractor-tests:
     name: ZkLean extractor tests

--- a/crates/jolt-lookup-tables/Cargo.toml
+++ b/crates/jolt-lookup-tables/Cargo.toml
@@ -18,6 +18,11 @@ field-inline = [
   "jolt-riscv/field-inline",
   "tracer/field-inline",
 ]
+implicit-carry = [
+  "jolt-prover-legacy/implicit-carry",
+  "jolt-riscv/implicit-carry",
+  "tracer/implicit-carry",
+]
 
 [dependencies]
 jolt-field = { workspace = true }

--- a/crates/jolt-lookup-tables/src/instructions/implicit_carry/addc.rs
+++ b/crates/jolt-lookup-tables/src/instructions/implicit_carry/addc.rs
@@ -1,0 +1,56 @@
+use crate::traits::impl_lookup_table;
+use crate::traits::LookupQuery;
+use jolt_riscv::instructions::AddC;
+use jolt_riscv::JoltCycle;
+
+impl_lookup_table!(AddC, Some(RangeCheck));
+
+impl<const XLEN: usize, C: JoltCycle> LookupQuery<XLEN> for AddC<C> {
+    fn to_lookup_operands(&self) -> (u64, u128) {
+        let (x, y) = LookupQuery::<XLEN>::to_instruction_inputs(self);
+        // rs1 + rs2 + carry < 3 * 2^64, well inside the 128-bit lookup domain.
+        (0, x as u128 + y as u64 as u128 + self.0.carry() as u128)
+    }
+
+    fn to_lookup_index(&self) -> u128 {
+        LookupQuery::<XLEN>::to_lookup_operands(self).1
+    }
+
+    fn to_instruction_inputs(&self) -> (u64, i128) {
+        let mask = (1u128 << XLEN).wrapping_sub(1) as u64;
+        (
+            self.0.rs1_val().unwrap_or(0) & mask,
+            (self.0.rs2_val().unwrap_or(0) & mask) as i128,
+        )
+    }
+
+    fn to_lookup_output(&self) -> u64 {
+        let (x, y) = LookupQuery::<XLEN>::to_instruction_inputs(self);
+        let mask = (1u128 << XLEN).wrapping_sub(1) as u64;
+        x.wrapping_add(y as u64).wrapping_add(self.0.carry()) & mask
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        instruction_inputs_match_constraint_test, lookup_output_matches_trace_test,
+        materialize_entry_test,
+    };
+
+    #[test]
+    fn materialize_entry_addc() {
+        materialize_entry_test!(AddC, tracer::instruction::addc::ADDC);
+    }
+
+    #[test]
+    fn instruction_inputs_match_constraint_addc() {
+        instruction_inputs_match_constraint_test!(AddC, tracer::instruction::addc::ADDC);
+    }
+
+    #[test]
+    fn lookup_output_matches_trace_addc() {
+        lookup_output_matches_trace_test!(AddC, tracer::instruction::addc::ADDC);
+    }
+}

--- a/crates/jolt-lookup-tables/src/instructions/implicit_carry/mod.rs
+++ b/crates/jolt-lookup-tables/src/instructions/implicit_carry/mod.rs
@@ -1,0 +1,4 @@
+//! Per-instruction impls for the implicit-carry custom instructions.
+
+pub mod addc;
+pub mod mulc;

--- a/crates/jolt-lookup-tables/src/instructions/implicit_carry/mulc.rs
+++ b/crates/jolt-lookup-tables/src/instructions/implicit_carry/mulc.rs
@@ -1,0 +1,56 @@
+use crate::traits::impl_lookup_table;
+use crate::traits::LookupQuery;
+use jolt_riscv::instructions::MulC;
+use jolt_riscv::JoltCycle;
+
+impl_lookup_table!(MulC, Some(RangeCheck));
+
+impl<const XLEN: usize, C: JoltCycle> LookupQuery<XLEN> for MulC<C> {
+    fn to_lookup_operands(&self) -> (u64, u128) {
+        let (x, y) = LookupQuery::<XLEN>::to_instruction_inputs(self);
+        // rs1 * rs2 + carry <= (2^64-1)^2 + (2^64-1) < 2^128: no overflow.
+        (0, x as u128 * (y as u64 as u128) + self.0.carry() as u128)
+    }
+
+    fn to_lookup_index(&self) -> u128 {
+        LookupQuery::<XLEN>::to_lookup_operands(self).1
+    }
+
+    fn to_instruction_inputs(&self) -> (u64, i128) {
+        let mask = (1u128 << XLEN).wrapping_sub(1) as u64;
+        (
+            self.0.rs1_val().unwrap_or(0) & mask,
+            (self.0.rs2_val().unwrap_or(0) & mask) as i128,
+        )
+    }
+
+    fn to_lookup_output(&self) -> u64 {
+        let (x, y) = LookupQuery::<XLEN>::to_instruction_inputs(self);
+        let mask = (1u128 << XLEN).wrapping_sub(1) as u64;
+        x.wrapping_mul(y as u64).wrapping_add(self.0.carry()) & mask
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        instruction_inputs_match_constraint_test, lookup_output_matches_trace_test,
+        materialize_entry_test,
+    };
+
+    #[test]
+    fn materialize_entry_mulc() {
+        materialize_entry_test!(MulC, tracer::instruction::mulc::MULC);
+    }
+
+    #[test]
+    fn instruction_inputs_match_constraint_mulc() {
+        instruction_inputs_match_constraint_test!(MulC, tracer::instruction::mulc::MULC);
+    }
+
+    #[test]
+    fn lookup_output_matches_trace_mulc() {
+        lookup_output_matches_trace_test!(MulC, tracer::instruction::mulc::MULC);
+    }
+}

--- a/crates/jolt-lookup-tables/src/instructions/mod.rs
+++ b/crates/jolt-lookup-tables/src/instructions/mod.rs
@@ -3,7 +3,10 @@
 //! Split into:
 //! - [`riscv`]: RV64I/M base ISA + RV64 W-suffix instructions
 //! - [`virt`]: virtual (synthesized) instructions used by the proving system
+//! - [`implicit_carry`]: Jolt custom carry-consuming arithmetic (`ADDC`, `MULC`)
 
+#[cfg(feature = "implicit-carry")]
+pub mod implicit_carry;
 pub mod riscv;
 pub mod virt;
 

--- a/crates/jolt-lookup-tables/src/instructions/test.rs
+++ b/crates/jolt-lookup-tables/src/instructions/test.rs
@@ -31,6 +31,8 @@ where
             instruction,
             register_state,
             ram_access: T::RAMAccess::default(),
+            #[cfg(feature = "implicit-carry")]
+            carry: rand::RngCore::next_u64(rng),
         }
     }
 }
@@ -162,6 +164,11 @@ where
         }
         if let Some(rs2_val) = raw.rs2_val() {
             cpu.write_register(rs2_idx.unwrap() as usize, rs2_val as i64);
+        }
+        // The incoming implicit carry is pre-state, same as rs1/rs2.
+        #[cfg(feature = "implicit-carry")]
+        {
+            cpu.carry = raw.carry();
         }
 
         instr.trace(&mut cpu, None);

--- a/crates/jolt-program/Cargo.toml
+++ b/crates/jolt-program/Cargo.toml
@@ -17,6 +17,7 @@ serialization = ["dep:ark-serialize", "dep:serde", "jolt-riscv/serialization"]
 std = ["common/std"]
 image = ["dep:object"]
 field-inline = ["jolt-riscv/field-inline"]
+implicit-carry = ["jolt-riscv/implicit-carry"]
 
 [dependencies]
 ark-serialize = { workspace = true, optional = true }

--- a/crates/jolt-program/src/execution/trace.rs
+++ b/crates/jolt-program/src/execution/trace.rs
@@ -251,6 +251,28 @@ pub struct TraceRow {
     pub carry: u64,
 }
 
+impl TraceRow {
+    /// Builds a row from the always-present fields, defaulting the cfg-gated
+    /// extensions. Downstream constructors stay immune to future cfg-gated
+    /// fields, and unlike `..Default::default()` at fully-specified sites this
+    /// stays clean under clippy's `needless_update` with `-D warnings`.
+    pub fn new(
+        instruction: JoltInstructionRow,
+        registers: RegisterState,
+        ram_access: RamAccess,
+    ) -> Self {
+        Self {
+            instruction,
+            registers,
+            ram_access,
+            #[cfg(feature = "field-inline")]
+            field_inline: None,
+            #[cfg(feature = "implicit-carry")]
+            carry: 0,
+        }
+    }
+}
+
 impl JoltCycle for TraceRow {
     type Instruction = JoltInstructionRow;
 

--- a/crates/jolt-program/src/execution/trace.rs
+++ b/crates/jolt-program/src/execution/trace.rs
@@ -245,6 +245,10 @@ pub struct TraceRow {
     pub ram_access: RamAccess,
     #[cfg(feature = "field-inline")]
     pub field_inline: Option<Arc<FieldInlineTraceData>>,
+    /// The row's incoming implicit carry (the previous row's carry-out).
+    /// Zero on padding rows.
+    #[cfg(feature = "implicit-carry")]
+    pub carry: u64,
 }
 
 impl JoltCycle for TraceRow {
@@ -296,6 +300,12 @@ impl JoltCycle for TraceRow {
             RamAccess::Write(write) => Some(write.post_value),
             RamAccess::Read(_) | RamAccess::NoOp => None,
         }
+    }
+
+    #[cfg(feature = "implicit-carry")]
+    #[inline]
+    fn carry(&self) -> u64 {
+        self.carry
     }
 }
 

--- a/crates/jolt-program/src/expand/mod.rs
+++ b/crates/jolt-program/src/expand/mod.rs
@@ -158,6 +158,7 @@ fn expand_source_instruction_with_provider<P: InlineExpansionProvider + ?Sized>(
         let mut state = ExpansionState::new(owned_allocator, profile);
         let result = state
             .expand_source_recursive(instruction)
+            .and_then(|rows| clobber_trailing_carry(instruction, rows, profile))
             .and_then(|rows| final_rows_to_instructions(rows, profile));
         *allocator = state.into_allocator();
         result
@@ -166,6 +167,61 @@ fn expand_source_instruction_with_provider<P: InlineExpansionProvider + ?Sized>(
         allocator.release(register)?;
     }
     result
+}
+
+/// Feature-on, a guest instruction that is not a carry producer must leave
+/// carry = 0. Recipes may legitimately end in ADD/MUL rows (MULH, SLL) and may
+/// nest producer-ending helpers like SLL mid-sequence, so the guarantee is
+/// enforced once at the source-instruction boundary: append a non-producing
+/// noop and re-stamp the sequence metadata. Inline sequences are exempt — the
+/// carry contract of an inline is owned by its provider.
+#[cfg(feature = "implicit-carry")]
+fn clobber_trailing_carry(
+    source: &SourceInstruction,
+    mut rows: Vec<JoltInstructionRow>,
+    profile: JoltInstructionProfile,
+) -> Result<Vec<JoltInstructionRow>, ExpansionError> {
+    fn produces_carry(kind: JoltInstructionKind) -> bool {
+        kind == JoltInstructionKind::ADD
+            || kind == JoltInstructionKind::MUL
+            || kind == JoltInstructionKind::ADDC
+            || kind == JoltInstructionKind::MULC
+    }
+    let source_kind = source.kind();
+    let source_produces = source_kind == SourceInstructionKind::ADD
+        || source_kind == SourceInstructionKind::MUL
+        || source_kind == SourceInstructionKind::ADDC
+        || source_kind == SourceInstructionKind::MULC;
+    if source_produces
+        || !rows
+            .last()
+            .is_some_and(|row| produces_carry(row.instruction_kind))
+    {
+        return Ok(rows);
+    }
+    rows.push(JoltInstructionRow {
+        instruction_kind: JoltInstructionKind::ADDI,
+        address: source.row().address,
+        operands: NormalizedOperands {
+            rd: Some(0),
+            rs1: Some(0),
+            rs2: None,
+            imm: 0,
+        },
+        virtual_sequence_remaining: None,
+        is_first_in_sequence: false,
+        is_compressed: false,
+    });
+    metadata::stamp_instruction_sequence(rows, source.row().is_compressed, profile)
+}
+
+#[cfg(not(feature = "implicit-carry"))]
+fn clobber_trailing_carry(
+    _source: &SourceInstruction,
+    rows: Vec<JoltInstructionRow>,
+    _profile: JoltInstructionProfile,
+) -> Result<Vec<JoltInstructionRow>, ExpansionError> {
+    Ok(rows)
 }
 
 fn final_rows_to_instructions(

--- a/crates/jolt-program/src/expand/tests.rs
+++ b/crates/jolt-program/src/expand/tests.rs
@@ -61,9 +61,11 @@ fn rows(instructions: Vec<JoltInstruction>) -> Vec<JoltInstructionRow> {
 
 #[test]
 fn side_effect_free_rd_zero_becomes_noop_addi() -> Result<(), ExpansionError> {
+    // XOR is side-effect-free in every configuration; ADD is only
+    // feature-off (feature-on its carry-out is an observable side effect).
     let mut allocator = ExpansionAllocator::new();
     let expanded = rows(expand_instruction(
-        &instruction(SourceInstructionKind::ADD, Some(0), true),
+        &instruction(SourceInstructionKind::XOR, Some(0), true),
         &mut allocator,
         RV64IMAC_JOLT,
     )?);
@@ -75,6 +77,29 @@ fn side_effect_free_rd_zero_becomes_noop_addi() -> Result<(), ExpansionError> {
     assert_eq!(expanded[0].operands.rs2, None);
     assert_eq!(expanded[0].operands.imm, 0);
     assert!(expanded[0].is_compressed);
+    Ok(())
+}
+
+#[cfg(feature = "implicit-carry")]
+#[test]
+fn carry_producing_rd_zero_keeps_its_row() -> Result<(), ExpansionError> {
+    // ADD/MUL rd=x0 must stay real rows feature-on: their carry-out is
+    // consumable by a following ADDC/MULC, like AddC/MulC themselves.
+    for (source_kind, jolt_kind) in [
+        (SourceInstructionKind::ADD, JoltInstructionKind::ADD),
+        (SourceInstructionKind::MUL, JoltInstructionKind::MUL),
+    ] {
+        let mut allocator = ExpansionAllocator::new();
+        let expanded = rows(expand_instruction(
+            &instruction(source_kind, Some(0), false),
+            &mut allocator,
+            RV64IMAC_JOLT,
+        )?);
+
+        assert_eq!(expanded.len(), 1);
+        assert_eq!(expanded[0].instruction_kind, jolt_kind);
+        assert_eq!(expanded[0].operands.rd, Some(40));
+    }
     Ok(())
 }
 
@@ -456,6 +481,21 @@ fn expansion_matches_main_golden_fixture() -> Result<(), Box<dyn std::error::Err
         serde_json::from_str(include_str!("fixtures/main_expand_parity_hashes.json"))?;
 
     for case in cases {
+        // Feature-on, MULH/MULHSU/SLL gain a trailing carry-clobbering noop
+        // row, so their hashes are main-parity only in the base
+        // configuration. Their rd=x0 forms still lower to the same noop and
+        // stay covered.
+        #[cfg(feature = "implicit-carry")]
+        if matches!(
+            case.input.kind(),
+            SourceInstructionKind::MULH
+                | SourceInstructionKind::MULHSU
+                | SourceInstructionKind::SLL
+        ) && case.input.row().operands.rd != Some(0)
+        {
+            continue;
+        }
+
         let mut allocator = ExpansionAllocator::new();
         let expanded = rows(expand_instruction(
             &case.input,

--- a/crates/jolt-program/src/image/decode.rs
+++ b/crates/jolt-program/src/image/decode.rs
@@ -193,6 +193,10 @@ fn decode_custom(word: u32) -> Result<SourceInstructionKind, ProgramError> {
         (0b000, 0x05) => Ok(SourceInstructionKind::VirtualRev8W(
             jolt_riscv::instructions::VirtualRev8W(()),
         )),
+        #[cfg(feature = "implicit-carry")]
+        (0b000, 0x06) => Ok(SourceInstructionKind::ADDC),
+        #[cfg(feature = "implicit-carry")]
+        (0b000, 0x07) => Ok(SourceInstructionKind::MULC),
         (0b001, _) => Ok(SourceInstructionKind::VirtualAssertEQ),
         (0b010, _) => Ok(SourceInstructionKind::VirtualHostIO(
             jolt_riscv::instructions::VirtualHostIO(()),
@@ -286,6 +290,8 @@ fn operands(instruction_kind: SourceInstructionKind, word: u32) -> NormalizedOpe
         SourceInstructionKind::VirtualRev8W(jolt_riscv::instructions::VirtualRev8W(())) => {
             format_t_operands(word)
         }
+        #[cfg(feature = "implicit-carry")]
+        SourceInstructionKind::ADDC | SourceInstructionKind::MULC => format_r_operands(word),
         #[cfg(feature = "field-inline")]
         SourceInstructionKind::FIELD_ADD
         | SourceInstructionKind::FIELD_SUB

--- a/crates/jolt-prover-legacy/Cargo.toml
+++ b/crates/jolt-prover-legacy/Cargo.toml
@@ -76,6 +76,12 @@ field-inline = [
   "jolt-riscv/field-inline",
   "tracer/field-inline",
 ]
+implicit-carry = [
+  "jolt-lookup-tables/implicit-carry",
+  "jolt-program/implicit-carry",
+  "jolt-riscv/implicit-carry",
+  "tracer/implicit-carry",
+]
 transcript-poseidon = ["dep:light-poseidon", "challenge-254-bit"]
 transcript-keccak = []
 transcript-blake2b = []

--- a/crates/jolt-prover-legacy/src/zkvm/claim_reductions/bytecode_reconstruction.rs
+++ b/crates/jolt-prover-legacy/src/zkvm/claim_reductions/bytecode_reconstruction.rs
@@ -48,15 +48,19 @@ use crate::utils::math::Math;
 #[cfg(feature = "prover")]
 use crate::zkvm::bytecode::chunks::BYTECODE_LANE_LAYOUT;
 use crate::zkvm::bytecode::chunks::COMMITTED_BYTECODE_LANE_CAPACITY;
+// The flag counts must come from the legacy prover's own enums: the lane layout
+// authority is zkvm/bytecode/chunks.rs's BYTECODE_LANE_LAYOUT, which is sized by
+// these counts. jolt_riscv's counts are feature-dependent (implicit-carry grows
+// them to 16) and would alias lanes here.
 #[cfg(feature = "prover")]
-use crate::zkvm::instruction::{Flags, InstructionLookup, InterleavedBitsMarker};
+use crate::zkvm::instruction::{
+    Flags, InstructionLookup, InterleavedBitsMarker, NUM_CIRCUIT_FLAGS, NUM_INSTRUCTION_FLAGS,
+};
 #[cfg(feature = "prover")]
 use crate::zkvm::lookup_table::LookupTables;
 use crate::zkvm::witness::CommittedPolynomial;
 #[cfg(feature = "prover")]
 use common::constants::XLEN;
-#[cfg(feature = "prover")]
-use jolt_riscv::{NUM_CIRCUIT_FLAGS, NUM_INSTRUCTION_FLAGS};
 
 const DEGREE_BOUND: usize = 2;
 

--- a/crates/jolt-prover-legacy/src/zkvm/instruction/mod.rs
+++ b/crates/jolt-prover-legacy/src/zkvm/instruction/mod.rs
@@ -416,6 +416,15 @@ impl<const XLEN: usize> LookupQuery<XLEN> for JoltTraceCycle<'_> {
 }
 
 fn circuit_flags_from_riscv(flags: RiscvCircuitFlagSet) -> [bool; NUM_CIRCUIT_FLAGS] {
+    // jolt_riscv's flag set can be wider than the legacy layout (implicit-carry
+    // adds UsesCarry/ProducesCarry); silently truncating a set carry flag would
+    // prove wrong semantics. This runs at preprocessing time, not per cycle.
+    assert!(
+        flags.bits() >> NUM_CIRCUIT_FLAGS == 0,
+        "circuit flags {:#018b} exceed the legacy prover's {NUM_CIRCUIT_FLAGS} flags; \
+         ADDC/MULC are not supported by the legacy prover",
+        flags.bits()
+    );
     let mut converted = [false; NUM_CIRCUIT_FLAGS];
     for (index, value) in converted.iter_mut().enumerate() {
         *value = flags.bits() & (1 << index) != 0;
@@ -424,6 +433,7 @@ fn circuit_flags_from_riscv(flags: RiscvCircuitFlagSet) -> [bool; NUM_CIRCUIT_FL
 }
 
 fn instruction_flags_from_riscv(flags: RiscvInstructionFlagSet) -> [bool; NUM_INSTRUCTION_FLAGS] {
+    assert!(flags.bits() >> NUM_INSTRUCTION_FLAGS == 0);
     let mut converted = [false; NUM_INSTRUCTION_FLAGS];
     for (index, value) in converted.iter_mut().enumerate() {
         *value = flags.bits() & (1 << index) != 0;

--- a/crates/jolt-prover-legacy/src/zkvm/instruction/mod.rs
+++ b/crates/jolt-prover-legacy/src/zkvm/instruction/mod.rs
@@ -358,6 +358,13 @@ impl<const XLEN: usize> InstructionLookup<XLEN> for JoltInstructionRow {
             | JoltInstruction::FieldLoadFromX(_)
             | JoltInstruction::FieldStoreToX(_)
             | JoltInstruction::FieldLoadImm(_) => return None,
+            // Same combined-operand range-check lookup as ADD/MUL; the legacy
+            // prover has no implicit-carry constraint support yet, so proving
+            // a trace containing these is unsupported until then.
+            #[cfg(feature = "implicit-carry")]
+            JoltInstruction::AddC(_) | JoltInstruction::MulC(_) => {
+                LookupTables::RangeCheck(Default::default())
+            }
             JoltInstructionKind::NoOp
             | JoltInstructionKind::LD
             | JoltInstructionKind::SD

--- a/crates/jolt-prover-legacy/src/zkvm/preprocessing.rs
+++ b/crates/jolt-prover-legacy/src/zkvm/preprocessing.rs
@@ -110,6 +110,13 @@ where
         self.program.check()?;
         self.program_meta.check()?;
         self.memory_layout.check()?;
+        // Deserialization bypasses FullProgramPreprocessing::preprocess, so the
+        // implicit-carry rejection must be repeated here or ADDC/MULC bytecode
+        // smuggled in via a serialized preprocessing would reach the prover.
+        if let ProgramPreprocessing::Full(full) = &self.program {
+            crate::zkvm::program::reject_implicit_carry_instructions(&full.bytecode.bytecode)
+                .map_err(|_| ark_serialize::SerializationError::InvalidData)?;
+        }
         if self.program.is_committed()
             && !is_valid_committed_bytecode_chunking_for_len(
                 self.program.bytecode_len(),

--- a/crates/jolt-prover-legacy/src/zkvm/program.rs
+++ b/crates/jolt-prover-legacy/src/zkvm/program.rs
@@ -17,8 +17,39 @@ use crate::zkvm::bytecode::{
 };
 use crate::zkvm::ram::RAMPreprocessing;
 use common::jolt_device::MemoryLayout;
+#[cfg(feature = "implicit-carry")]
+use jolt_riscv::JoltInstruction;
 use jolt_riscv::{JoltInstructionRow, RV64IMAC_JOLT};
 use tracer::instruction::Cycle;
+
+/// The legacy prover has no implicit-carry constraint support: its circuit-flag
+/// layout is 14 lanes wide, so ADDC/MULC rows (whose UsesCarry/ProducesCarry
+/// flags sit at bits 14/15) would be silently truncated. Reject them up front
+/// rather than prove wrong semantics.
+#[cfg(feature = "implicit-carry")]
+pub fn reject_implicit_carry_instructions(
+    instructions: &[JoltInstructionRow],
+) -> Result<(), PreprocessingError> {
+    for instruction in instructions {
+        if matches!(
+            instruction.instruction_kind,
+            JoltInstruction::AddC(_) | JoltInstruction::MulC(_)
+        ) {
+            return Err(PreprocessingError::IllegalTargetInstruction(
+                instruction.instruction_kind,
+            ));
+        }
+    }
+    Ok(())
+}
+
+/// Feature-off the ADDC/MULC kinds do not exist, so there is nothing to reject.
+#[cfg(not(feature = "implicit-carry"))]
+pub fn reject_implicit_carry_instructions(
+    _instructions: &[JoltInstructionRow],
+) -> Result<(), PreprocessingError> {
+    Ok(())
+}
 
 #[derive(Debug, Clone, CanonicalSerialize, CanonicalDeserialize)]
 pub struct FullProgramPreprocessing {
@@ -45,6 +76,7 @@ impl FullProgramPreprocessing {
         memory_init: Vec<(u64, u8)>,
         entry_address: u64,
     ) -> Result<Self, PreprocessingError> {
+        reject_implicit_carry_instructions(&instructions)?;
         Ok(Self {
             bytecode: Arc::new(BytecodePreprocessing::preprocess(
                 instructions,

--- a/crates/jolt-riscv/Cargo.toml
+++ b/crates/jolt-riscv/Cargo.toml
@@ -15,6 +15,7 @@ workspace = true
 default = ["serialization"]
 serialization = ["dep:ark-serialize", "dep:serde"]
 field-inline = []
+implicit-carry = []
 
 [dependencies]
 ark-serialize = { workspace = true, optional = true }

--- a/crates/jolt-riscv/src/flags.rs
+++ b/crates/jolt-riscv/src/flags.rs
@@ -50,6 +50,13 @@ pub enum CircuitFlags {
     IsFirstInSequence,
     /// Last instruction in a virtual sequence.
     IsLastInSequence,
+    /// Instruction consumes the implicit carry from the previous row (`ADDC`, `MULC`).
+    #[cfg(feature = "implicit-carry")]
+    UsesCarry,
+    /// Instruction's arithmetic result splits into a low-64-bit `rd` and a
+    /// high-64-bit carry-out (`ADD`, `MUL`, `ADDC`, `MULC`).
+    #[cfg(feature = "implicit-carry")]
+    ProducesCarry,
 }
 
 /// Number of circuit flags.
@@ -70,6 +77,10 @@ pub const CIRCUIT_FLAGS: [CircuitFlags; NUM_CIRCUIT_FLAGS] = [
     CircuitFlags::IsCompressed,
     CircuitFlags::IsFirstInSequence,
     CircuitFlags::IsLastInSequence,
+    #[cfg(feature = "implicit-carry")]
+    CircuitFlags::UsesCarry,
+    #[cfg(feature = "implicit-carry")]
+    CircuitFlags::ProducesCarry,
 ];
 
 /// Boolean flags that are NOT part of Jolt's R1CS constraints.
@@ -100,8 +111,13 @@ pub enum InstructionFlags {
 pub const NUM_INSTRUCTION_FLAGS: usize = InstructionFlags::COUNT;
 
 /// Packed bitfield of [`CircuitFlags`].
+///
+/// WARNING: `JoltTraceRow::meta` parks [`InstructionFlags`] at bit 16, so a
+/// 17th circuit flag would silently collide rather than fail to build.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
 pub struct CircuitFlagSet(u16);
+
+const _: () = assert!(NUM_CIRCUIT_FLAGS <= 16, "CircuitFlagSet(u16) is full");
 
 impl CircuitFlagSet {
     #[inline]

--- a/crates/jolt-riscv/src/instructions/i/add.rs
+++ b/crates/jolt-riscv/src/instructions/i/add.rs
@@ -3,6 +3,11 @@ use crate::jolt_instruction;
 jolt_instruction!(
     /// RV64I ADD: `rd = rs1 + rs2` (wrapping).
     Add,
-    circuit flags: [AddOperands, WriteLookupOutputToRD],
+    circuit flags: [
+        AddOperands,
+        WriteLookupOutputToRD,
+        #[cfg(feature = "implicit-carry")]
+        ProducesCarry,
+    ],
     instruction flags: [LeftOperandIsRs1Value, RightOperandIsRs2Value]
 );

--- a/crates/jolt-riscv/src/instructions/implicit_carry.rs
+++ b/crates/jolt-riscv/src/instructions/implicit_carry.rs
@@ -4,7 +4,7 @@
 //! `Carry` column) and, like `ADD` and `MUL`, export the high 64 bits of the
 //! true arithmetic result as the next row's carry. The carry is
 //! non-architectural: it is not part of the memory-checked register file.
-//! See `specs/implicit-carry-handling.md`.
+//! See the implicit-carry spec in <https://github.com/a16z/jolt/issues/1710>.
 
 use crate::jolt_instruction;
 

--- a/crates/jolt-riscv/src/instructions/implicit_carry.rs
+++ b/crates/jolt-riscv/src/instructions/implicit_carry.rs
@@ -1,0 +1,34 @@
+//! Implicit-carry arithmetic instructions.
+//!
+//! `ADDC` and `MULC` consume the previous row's implicit carry (the committed
+//! `Carry` column) and, like `ADD` and `MUL`, export the high 64 bits of the
+//! true arithmetic result as the next row's carry. The carry is
+//! non-architectural: it is not part of the memory-checked register file.
+//! See `specs/implicit-carry-handling.md`.
+
+use crate::jolt_instruction;
+
+jolt_instruction!(
+    /// Jolt ADDC: `rd = low_64(rs1 + rs2 + carry)`, carry-out = `high_64(rs1 + rs2 + carry)`.
+    AddC,
+    circuit flags: [
+        AddOperands,
+        WriteLookupOutputToRD,
+        UsesCarry,
+        ProducesCarry,
+    ],
+    instruction flags: [LeftOperandIsRs1Value, RightOperandIsRs2Value]
+);
+
+jolt_instruction!(
+    /// Jolt MULC: `rd = low_64(rs1 * rs2 + carry)`, carry-out = `high_64(rs1 * rs2 + carry)`,
+    /// over the unsigned 128-bit widening of the raw 64-bit words.
+    MulC,
+    circuit flags: [
+        MultiplyOperands,
+        WriteLookupOutputToRD,
+        UsesCarry,
+        ProducesCarry,
+    ],
+    instruction flags: [LeftOperandIsRs1Value, RightOperandIsRs2Value]
+);

--- a/crates/jolt-riscv/src/instructions/m/mul.rs
+++ b/crates/jolt-riscv/src/instructions/m/mul.rs
@@ -3,6 +3,11 @@ use crate::jolt_instruction;
 jolt_instruction!(
     /// RV64M MUL: signed multiply, lower 64 bits of the 128-bit product.
     Mul,
-    circuit flags: [MultiplyOperands, WriteLookupOutputToRD],
+    circuit flags: [
+        MultiplyOperands,
+        WriteLookupOutputToRD,
+        #[cfg(feature = "implicit-carry")]
+        ProducesCarry,
+    ],
     instruction flags: [LeftOperandIsRs1Value, RightOperandIsRs2Value]
 );

--- a/crates/jolt-riscv/src/instructions/mod.rs
+++ b/crates/jolt-riscv/src/instructions/mod.rs
@@ -20,6 +20,8 @@ pub mod assert;
 #[cfg(feature = "field-inline")]
 pub mod field_inline;
 pub mod i;
+#[cfg(feature = "implicit-carry")]
+pub mod implicit_carry;
 pub mod m;
 pub mod virt;
 
@@ -93,6 +95,8 @@ pub use i::SubW;
 pub use i::Sw;
 pub use i::Xor;
 pub use i::XorI;
+#[cfg(feature = "implicit-carry")]
+pub use implicit_carry::{AddC, MulC};
 pub use m::Div;
 pub use m::DivU;
 pub use m::DivUW;
@@ -418,6 +422,10 @@ pub enum JoltInstruction<T = JoltInstructionRow> {
     FieldStoreToX(FieldStoreToX<T>),
     #[cfg(feature = "field-inline")]
     FieldLoadImm(FieldLoadImm<T>),
+    #[cfg(feature = "implicit-carry")]
+    AddC(AddC<T>),
+    #[cfg(feature = "implicit-carry")]
+    MulC(MulC<T>),
 }
 
 macro_rules! impl_jolt_instruction_try_from_row {
@@ -620,6 +628,10 @@ impl_jolt_instructions_flags! {
     FieldStoreToX => FIELD_STORE_TO_X,
     #[cfg(feature = "field-inline")]
     FieldLoadImm => FIELD_LOAD_IMM,
+    #[cfg(feature = "implicit-carry")]
+    AddC => ADDC,
+    #[cfg(feature = "implicit-carry")]
+    MulC => MULC,
 }
 #[cfg(test)]
 mod tests {

--- a/crates/jolt-riscv/src/kind.rs
+++ b/crates/jolt-riscv/src/kind.rs
@@ -632,7 +632,10 @@ macro_rules! source_side_effects_for_marker {
         true
     };
     (Add) => {
-        false
+        // Feature-on, the carry-out is observable state: rd=x0 ADD must stay
+        // a real row (like AddC/MulC) rather than be noop-rewritten, which
+        // would clobber the carry it produces.
+        cfg!(feature = "implicit-carry")
     };
     (Addi) => {
         false
@@ -674,7 +677,8 @@ macro_rules! source_side_effects_for_marker {
         false
     };
     (Mul) => {
-        false
+        // See the Add arm: carry-out makes rd=x0 MUL observable feature-on.
+        cfg!(feature = "implicit-carry")
     };
     (MulH) => {
         false
@@ -1211,7 +1215,10 @@ macro_rules! jolt_side_effects_for_marker {
         true
     };
     (Add) => {
-        false
+        // Feature-on, the carry-out is observable state: rd=x0 ADD must stay
+        // a real row (like AddC/MulC) rather than be noop-rewritten, which
+        // would clobber the carry it produces.
+        cfg!(feature = "implicit-carry")
     };
     (Addi) => {
         false
@@ -1232,7 +1239,8 @@ macro_rules! jolt_side_effects_for_marker {
         false
     };
     (Mul) => {
-        false
+        // See the Add arm: carry-out makes rd=x0 MUL observable feature-on.
+        cfg!(feature = "implicit-carry")
     };
     (MulHU) => {
         false

--- a/crates/jolt-riscv/src/kind.rs
+++ b/crates/jolt-riscv/src/kind.rs
@@ -463,6 +463,12 @@ macro_rules! source_extension_for_marker {
     (FieldLoadImm) => {
         Some(SourceExtension::FieldInline)
     };
+    (AddC) => {
+        Some(SourceExtension::ImplicitCarry)
+    };
+    (MulC) => {
+        Some(SourceExtension::ImplicitCarry)
+    };
 }
 
 macro_rules! source_side_effects_for_marker {
@@ -892,6 +898,12 @@ macro_rules! source_side_effects_for_marker {
     (FieldLoadImm) => {
         true
     };
+    (AddC) => {
+        true
+    };
+    (MulC) => {
+        true
+    };
 }
 
 macro_rules! jolt_target_extension_for_marker {
@@ -1120,6 +1132,12 @@ macro_rules! jolt_target_extension_for_marker {
     (FieldLoadImm) => {
         Some(JoltTargetExtension::FieldInline)
     };
+    (AddC) => {
+        Some(JoltTargetExtension::ImplicitCarry)
+    };
+    (MulC) => {
+        Some(JoltTargetExtension::ImplicitCarry)
+    };
 }
 
 macro_rules! jolt_side_effects_for_marker {
@@ -1184,6 +1202,12 @@ macro_rules! jolt_side_effects_for_marker {
         true
     };
     (FieldLoadImm) => {
+        true
+    };
+    (AddC) => {
+        true
+    };
+    (MulC) => {
         true
     };
     (Add) => {

--- a/crates/jolt-riscv/src/lib.rs
+++ b/crates/jolt-riscv/src/lib.rs
@@ -172,6 +172,10 @@ macro_rules! for_each_instruction_kind {
                 FIELD_STORE_TO_X => FieldStoreToX => "field.store_to_x",
                 #[cfg(feature = "field-inline")]
                 FIELD_LOAD_IMM => FieldLoadImm => "field.load_imm",
+                #[cfg(feature = "implicit-carry")]
+                ADDC => AddC => "jolt.addc",
+                #[cfg(feature = "implicit-carry")]
+                MULC => MulC => "jolt.mulc",
             ]
         }
     };
@@ -265,6 +269,10 @@ macro_rules! for_each_jolt_instruction_kind {
                 FIELD_STORE_TO_X => FieldStoreToX => (0x0106, "field.store_to_x"),
                 #[cfg(feature = "field-inline")]
                 FIELD_LOAD_IMM => FieldLoadImm => (0x0107, "field.load_imm"),
+                #[cfg(feature = "implicit-carry")]
+                ADDC => AddC => (0x0110, "jolt.addc"),
+                #[cfg(feature = "implicit-carry")]
+                MULC => MulC => (0x0111, "jolt.mulc"),
             ]
         }
     };
@@ -288,6 +296,8 @@ pub use kind::{
 };
 #[cfg(feature = "field-inline")]
 pub use profile::RV64IMAC_JOLT_FIELD_INLINE;
+#[cfg(feature = "implicit-carry")]
+pub use profile::RV64IMAC_JOLT_IMPLICIT_CARRY;
 pub use profile::{
     jolt_target_extension, source_extension, InlineExtension, JoltInstructionProfile,
     JoltTargetExtension, ProfileInstructionIndex, SourceExtension, RV64IMAC_JOLT,
@@ -325,7 +335,7 @@ macro_rules! jolt_instruction {
     (
         $(#[$attr:meta])*
         $name:ident,
-        circuit flags: [$($circuit:ident),* $(,)?],
+        circuit flags: [$($(#[$cmeta:meta])* $circuit:ident),* $(,)?],
         instruction flags: [$($instruction:ident),* $(,)?] $(,)?
     ) => {
         $crate::jolt_instruction!(@struct $(#[$attr])* $name);
@@ -334,8 +344,13 @@ macro_rules! jolt_instruction {
             #[inline]
             fn circuit_flags(&self) -> $crate::CircuitFlagSet {
                 let instruction: $crate::JoltInstructionRow = self.0.into();
-                let mut flags = $crate::CircuitFlagSet::default()
-                    $(.set($crate::CircuitFlags::$circuit))*;
+                let mut flags = $crate::CircuitFlagSet::default();
+                $(
+                    $(#[$cmeta])*
+                    {
+                        flags = flags.set($crate::CircuitFlags::$circuit);
+                    }
+                )*
                 if let Some(virtual_sequence_remaining) = instruction.virtual_sequence_remaining {
                     flags = flags.set($crate::CircuitFlags::VirtualInstruction);
                     if virtual_sequence_remaining == 0 {

--- a/crates/jolt-riscv/src/profile.rs
+++ b/crates/jolt-riscv/src/profile.rs
@@ -12,6 +12,8 @@ pub enum SourceExtension {
     JoltInline,
     #[cfg(feature = "field-inline")]
     FieldInline,
+    #[cfg(feature = "implicit-carry")]
+    ImplicitCarry,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
@@ -28,6 +30,8 @@ pub enum JoltTargetExtension {
     BitManipulation,
     #[cfg(feature = "field-inline")]
     FieldInline,
+    #[cfg(feature = "implicit-carry")]
+    ImplicitCarry,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
@@ -107,6 +111,22 @@ pub const RV64IMAC_JOLT_FIELD_INLINE: JoltInstructionProfile = JoltInstructionPr
     inline_extensions: RV64IMAC_JOLT_ALL_INLINES.inline_extensions,
 };
 
+#[cfg(feature = "implicit-carry")]
+pub const RV64IMAC_JOLT_IMPLICIT_CARRY: JoltInstructionProfile = JoltInstructionProfile {
+    source_extensions: &[
+        SourceExtension::Rv64I,
+        SourceExtension::Rv64M,
+        SourceExtension::Rv64A,
+        SourceExtension::Rv64C,
+        SourceExtension::Zicsr,
+        SourceExtension::RvPrivileged,
+        SourceExtension::JoltCustom,
+        SourceExtension::JoltInline,
+        SourceExtension::ImplicitCarry,
+    ],
+    inline_extensions: RV64IMAC_JOLT_ALL_INLINES.inline_extensions,
+};
+
 impl JoltInstructionProfile {
     pub fn supports_source(self, kind: SourceInstructionKind) -> bool {
         match source_extension(kind) {
@@ -130,6 +150,12 @@ impl JoltInstructionProfile {
     pub fn supports_field_inline(self) -> bool {
         self.source_extensions
             .contains(&SourceExtension::FieldInline)
+    }
+
+    #[cfg(feature = "implicit-carry")]
+    pub fn supports_implicit_carry(self) -> bool {
+        self.source_extensions
+            .contains(&SourceExtension::ImplicitCarry)
     }
 
     pub fn source_dense_index(
@@ -205,6 +231,8 @@ impl JoltInstructionProfile {
             }
             #[cfg(feature = "field-inline")]
             JoltTargetExtension::FieldInline => self.supports_field_inline(),
+            #[cfg(feature = "implicit-carry")]
+            JoltTargetExtension::ImplicitCarry => self.supports_implicit_carry(),
         }
     }
 }
@@ -271,6 +299,8 @@ const fn source_extension_code(extension: SourceExtension) -> u8 {
         SourceExtension::JoltInline => 7,
         #[cfg(feature = "field-inline")]
         SourceExtension::FieldInline => 8,
+        #[cfg(feature = "implicit-carry")]
+        SourceExtension::ImplicitCarry => 9,
     }
 }
 

--- a/crates/jolt-riscv/src/trace.rs
+++ b/crates/jolt-riscv/src/trace.rs
@@ -31,6 +31,13 @@ pub trait JoltCycle {
 
     /// RAM write value (post-access value). `None` if no RAM access.
     fn ram_write_value(&self) -> Option<u64>;
+
+    /// The row's incoming implicit carry (the previous row's carry-out).
+    /// Defaults to zero for cycle views that do not track carry.
+    #[cfg(feature = "implicit-carry")]
+    fn carry(&self) -> u64 {
+        0
+    }
 }
 
 impl<T: JoltCycle> JoltCycle for &T {
@@ -69,5 +76,11 @@ impl<T: JoltCycle> JoltCycle for &T {
     #[inline]
     fn ram_write_value(&self) -> Option<u64> {
         (**self).ram_write_value()
+    }
+
+    #[cfg(feature = "implicit-carry")]
+    #[inline]
+    fn carry(&self) -> u64 {
+        (**self).carry()
     }
 }

--- a/crates/jolt-tracer-x86/Cargo.toml
+++ b/crates/jolt-tracer-x86/Cargo.toml
@@ -16,6 +16,13 @@ field-inline = [
   "jolt-riscv/field-inline",
   "tracer/field-inline",
 ]
+# Passthrough only: the AOT backend has no carry register; the feature exists
+# so `for_each_jolt_instruction_kind!` expansions resolve their cfg entries.
+implicit-carry = [
+  "jolt-program/implicit-carry",
+  "jolt-riscv/implicit-carry",
+  "tracer/implicit-carry",
+]
 
 [dependencies]
 common = { workspace = true, features = ["std"] }

--- a/crates/jolt-tracer-x86/src/native/compile/emit.rs
+++ b/crates/jolt-tracer-x86/src/native/compile/emit.rs
@@ -572,6 +572,14 @@ impl DynasmEmitter {
         if matches!(row.instruction_kind, K::Noop(_)) {
             return Ok(EmitOutcome::Unsupported);
         }
+        // The AOT backend has no carry register (the `implicit-carry` feature
+        // is passthrough only), so the carry consumers cannot be compiled;
+        // declining makes `EmitterSet` fail fast rather than execute wrong
+        // semantics.
+        #[cfg(feature = "implicit-carry")]
+        if matches!(row.instruction_kind, K::AddC(_) | K::MulC(_)) {
+            return Ok(EmitOutcome::Unsupported);
+        }
 
         // Every row is one trace row.
         dynasm!(e.ops ; .arch x64 ; inc r14);
@@ -978,6 +986,11 @@ impl DynasmEmitter {
             // in executable bytecode and was declined before any emission (the
             // early return above), so this arm only completes the match.
             K::Noop(_) => return Ok(EmitOutcome::Unsupported),
+
+            // Declined before any emission (the early return above); these
+            // arms only complete the match.
+            #[cfg(feature = "implicit-carry")]
+            K::AddC(_) | K::MulC(_) => return Ok(EmitOutcome::Unsupported),
         }
         if record && !transfers_control {
             e.obs_rd_post(row);

--- a/crates/jolt-tracer-x86/src/native/mod.rs
+++ b/crates/jolt-tracer-x86/src/native/mod.rs
@@ -275,7 +275,8 @@ impl ExecutionBackend for X86TracerBackend {
                 "record pass emitted a different row count than the fast pass",
             ));
         }
-        let rows = Observation::reassemble_rows(&program.expanded_bytecode, &record.observations)?;
+        let rows =
+            Observation::reassemble_rows(&program.expanded_bytecode, &record.observations, 0)?;
         Ok(TraceOutput::new(
             OwnedTrace::new(rows),
             record.device,
@@ -298,37 +299,89 @@ impl Observation {
     /// values. Generated code cannot construct `TraceRow` directly (its
     /// `Option` fields have no guaranteed layout), so this is the seam between
     /// the two.
+    ///
+    /// The first `skip_rows` observations produce no rows (chunk replay
+    /// resumes from a boundary at or before its window) but are still walked:
+    /// the implicit carry is cross-row state, and the first kept row's
+    /// incoming carry is the carry-out of the last skipped observation.
     fn reassemble_rows(
         bytecode: &[JoltInstructionRow],
         observations: &[Self],
+        skip_rows: usize,
     ) -> Result<Vec<TraceRow>, TraceError> {
-        let mut rows = Vec::with_capacity(observations.len());
-        for observation in observations {
+        let mut rows = Vec::with_capacity(observations.len().saturating_sub(skip_rows));
+        // Seeding the walk with carry = 0 mirrors the interpreter at the
+        // program's initial boundary, and is immaterial at any other:
+        // checkpoint selection guarantees `skip_rows >= 1` there (feature-on),
+        // so the seed never reaches a kept row.
+        #[cfg(feature = "implicit-carry")]
+        let mut carry = 0u64;
+        for (index, observation) in observations.iter().enumerate() {
             let row = bytecode
                 .get(observation.row_index as usize)
                 .ok_or(TraceError::Backend("observation row index out of range"))?;
-            rows.push(TraceRow {
-                instruction: *row,
-                registers: RegisterState {
-                    rs1: Self::register_read(row.operands.rs1, observation.rs1),
-                    rs2: Self::register_read(row.operands.rs2, observation.rs2),
-                    rd: row.operands.rd.map(|register| RegisterWrite {
-                        register,
-                        // x0 reads as zero on both sides of a write.
-                        pre_value: if register == 0 { 0 } else { observation.rd_pre },
-                        post_value: if register == 0 {
-                            0
-                        } else {
-                            observation.rd_post
-                        },
-                    }),
-                },
-                ram_access: observation.ram_access(row.instruction_kind),
-                #[cfg(feature = "field-inline")]
-                field_inline: None,
-            });
+            if index >= skip_rows {
+                rows.push(TraceRow {
+                    instruction: *row,
+                    registers: RegisterState {
+                        rs1: Self::register_read(row.operands.rs1, observation.rs1),
+                        rs2: Self::register_read(row.operands.rs2, observation.rs2),
+                        rd: row.operands.rd.map(|register| RegisterWrite {
+                            register,
+                            // x0 reads as zero on both sides of a write.
+                            pre_value: if register == 0 { 0 } else { observation.rd_pre },
+                            post_value: if register == 0 {
+                                0
+                            } else {
+                                observation.rd_post
+                            },
+                        }),
+                    },
+                    ram_access: observation.ram_access(row.instruction_kind),
+                    #[cfg(feature = "field-inline")]
+                    field_inline: None,
+                    // The row's incoming carry: the previous row's carry-out,
+                    // matching the interpreter's pre-execute `cpu.carry` read.
+                    #[cfg(feature = "implicit-carry")]
+                    carry,
+                });
+            }
+            #[cfg(feature = "implicit-carry")]
+            {
+                carry = observation.carry_out(row);
+            }
         }
         Ok(rows)
+    }
+
+    /// This row's carry-out, mirroring the interpreter's `cpu.carry` updates:
+    /// `Add` and `Mul` write the high 64 bits of their true 128-bit result
+    /// (computed from the recorded pre-execute reads); every other kind
+    /// clobbers the carry to zero. The carry consumers (`AddC`/`MulC`) never
+    /// reach reassembly — the emitter declines them, so programs containing
+    /// them fail to compile — hence carry consumption needs no modeling here.
+    #[cfg(feature = "implicit-carry")]
+    fn carry_out(&self, row: &JoltInstructionRow) -> u64 {
+        // x0 reads as zero, as in `register_read`.
+        let source = |register: Option<u8>, value: u64| -> u128 {
+            match register {
+                Some(0) | None => 0,
+                Some(_) => u128::from(value),
+            }
+        };
+        match row.instruction_kind {
+            JoltInstructionKind::ADD => {
+                let rs1 = source(row.operands.rs1, self.rs1);
+                let rs2 = source(row.operands.rs2, self.rs2);
+                ((rs1 + rs2) >> 64) as u64
+            }
+            JoltInstructionKind::MUL => {
+                let rs1 = source(row.operands.rs1, self.rs1);
+                let rs2 = source(row.operands.rs2, self.rs2);
+                ((rs1 * rs2) >> 64) as u64
+            }
+            _ => 0,
+        }
     }
 
     fn register_read(register: Option<u8>, value: u64) -> Option<RegisterRead> {
@@ -562,7 +615,19 @@ impl ChunkedExecutionBackend for X86TracerBackend {
         let mut index = 0usize;
         for chunk in 0..trace_len.div_ceil(chunk_size) {
             let mark = chunk * chunk_size;
-            while index + 1 < boundaries.len() && boundaries[index + 1].0 <= mark {
+            // Feature-on, a mid-trace chunk must resume from a boundary
+            // strictly before its mark: the implicit carry is cross-row state
+            // no boundary snapshot holds (the AOT machine has no carry
+            // register), and reassembly derives the first kept row's incoming
+            // carry from the replayed-then-discarded predecessor, so at least
+            // one row must be skipped. The initial boundary is exempt — the
+            // machine starts with carry = 0.
+            let latest = if cfg!(feature = "implicit-carry") {
+                mark.saturating_sub(1)
+            } else {
+                mark
+            };
+            while index + 1 < boundaries.len() && boundaries[index + 1].0 <= latest {
                 index += 1;
             }
             let (rows_before, boundary) = &boundaries[index];
@@ -643,7 +708,8 @@ impl ChunkedExecutionBackend for X86TracerBackend {
         observations.truncate(needed);
         let rows = Observation::reassemble_rows(
             &checkpoint.bytecode,
-            &observations[checkpoint.skip_rows..],
+            &observations,
+            checkpoint.skip_rows,
         )?;
         Ok(OwnedTrace::new(rows))
     }

--- a/crates/jolt-witness/src/backend/trace/tests.rs
+++ b/crates/jolt-witness/src/backend/trace/tests.rs
@@ -277,9 +277,9 @@ fn virtual_oracle_views_materialize_stage1_r1cs_inputs() -> Result<(), String> {
     let preprocessing = preprocessing_with_bytecode(bytecode);
     let program = Arc::new(JoltProgram::default());
     let rows = vec![
-        TraceRow {
-            instruction: instruction_row,
-            registers: RegisterState {
+        TraceRow::new(
+            instruction_row,
+            RegisterState {
                 rs1: Some(RegisterRead {
                     register: 2,
                     value: 5,
@@ -291,13 +291,11 @@ fn virtual_oracle_views_materialize_stage1_r1cs_inputs() -> Result<(), String> {
                 }),
                 ..Default::default()
             },
-            ram_access: RamAccess::Read(RamRead {
+            RamAccess::Read(RamRead {
                 address: RAM_START_ADDRESS,
                 value: 7,
             }),
-            #[cfg(feature = "field-inline")]
-            field_inline: None,
-        },
+        ),
         TraceRow::default(),
     ];
     let inputs = JoltVmWitnessInputs::new(&program, &preprocessing, trace_output_with_rows(rows));
@@ -502,9 +500,9 @@ fn atomic_extractors_derive_named_witnesses() -> Result<(), String> {
     )
     .map_err(|error| error.to_string())?;
     let preprocessing = preprocessing_with_bytecode(bytecode);
-    let row = TraceRow {
-        instruction: instruction_row,
-        registers: RegisterState {
+    let row = TraceRow::new(
+        instruction_row,
+        RegisterState {
             rs1: Some(RegisterRead {
                 register: 2,
                 value: 5,
@@ -516,13 +514,11 @@ fn atomic_extractors_derive_named_witnesses() -> Result<(), String> {
             }),
             ..Default::default()
         },
-        ram_access: RamAccess::Read(RamRead {
+        RamAccess::Read(RamRead {
             address: RAM_START_ADDRESS,
             value: 7,
         }),
-        #[cfg(feature = "field-inline")]
-        field_inline: None,
-    };
+    );
     let next = TraceRow::default();
     let env = WitnessEnv {
         preprocessing: &preprocessing,
@@ -958,9 +954,9 @@ fn slice_fast_paths_match_the_sequential_fallback() {
     let preprocessing = preprocessing_with_bytecode(bytecode);
     let program = Arc::new(JoltProgram::default());
     let rows = vec![
-        TraceRow {
-            instruction: instruction_row,
-            registers: RegisterState {
+        TraceRow::new(
+            instruction_row,
+            RegisterState {
                 rs1: Some(RegisterRead {
                     register: 2,
                     value: 5,
@@ -972,13 +968,11 @@ fn slice_fast_paths_match_the_sequential_fallback() {
                 }),
                 ..Default::default()
             },
-            ram_access: RamAccess::Read(RamRead {
+            RamAccess::Read(RamRead {
                 address: RAM_START_ADDRESS,
                 value: 7,
             }),
-            #[cfg(feature = "field-inline")]
-            field_inline: None,
-        },
+        ),
         TraceRow::default(),
         TraceRow {
             instruction: instruction_row,

--- a/crates/jolt-witness/src/testing.rs
+++ b/crates/jolt-witness/src/testing.rs
@@ -45,9 +45,9 @@ pub fn with_sample_backend<R>(f: impl FnOnce(&TraceBackend<OwnedTrace>) -> R) ->
     });
     let program = Arc::new(JoltProgram::default());
     let rows = vec![
-        TraceRow {
+        TraceRow::new(
             instruction,
-            registers: RegisterState {
+            RegisterState {
                 rs1: Some(RegisterRead {
                     register: 2,
                     value: 5,
@@ -59,13 +59,11 @@ pub fn with_sample_backend<R>(f: impl FnOnce(&TraceBackend<OwnedTrace>) -> R) ->
                 }),
                 ..Default::default()
             },
-            ram_access: RamAccess::Read(RamRead {
+            RamAccess::Read(RamRead {
                 address: 0x8000_1000,
                 value: 7,
             }),
-            #[cfg(feature = "field-inline")]
-            field_inline: None,
-        },
+        ),
         TraceRow {
             ram_access: RamAccess::Write(RamWrite {
                 address: 0x8000_1008,

--- a/jolt-sdk/Cargo.toml
+++ b/jolt-sdk/Cargo.toml
@@ -23,6 +23,11 @@ field-inline = [
   "jolt-program?/field-inline",
   "tracer?/field-inline",
 ]
+implicit-carry = [
+  "jolt-prover-legacy?/implicit-carry",
+  "jolt-program?/implicit-carry",
+  "tracer?/implicit-carry",
+]
 
 host = [
   "jolt-prover-legacy/default",

--- a/tracer/Cargo.toml
+++ b/tracer/Cargo.toml
@@ -38,6 +38,7 @@ field-inline = [
   "jolt-riscv/field-inline",
   "dep:jolt-field",
 ]
+implicit-carry = ["jolt-program/implicit-carry", "jolt-riscv/implicit-carry"]
 
 [dependencies]
 thiserror.workspace = true

--- a/tracer/src/emulator/cpu.rs
+++ b/tracer/src/emulator/cpu.rs
@@ -255,6 +255,8 @@ pub(crate) struct ChunkCpuState {
     advice_suffix: Vec<u8>,
     #[cfg(feature = "field-inline")]
     field_registers: FieldRegisterFile,
+    #[cfg(feature = "implicit-carry")]
+    carry: u64,
 }
 
 impl ChunkCpuState {
@@ -325,6 +327,10 @@ impl ChunkCpuState {
                 self.executed_instrs, cpu.executed_instrs
             ));
         }
+        #[cfg(feature = "implicit-carry")]
+        if self.carry != cpu.carry {
+            return Some(format!("carry: {:#x} vs {:#x}", self.carry, cpu.carry));
+        }
         let cpu_suffix = &cpu.advice_tape.data[cpu.advice_tape.read_position..];
         if self.advice_suffix != cpu_suffix {
             return Some(format!(
@@ -370,6 +376,12 @@ pub struct Cpu {
     host_io: HostIo,
     #[cfg(feature = "field-inline")]
     pub field_registers: FieldRegisterFile,
+    /// Emulator-local implicit carry: the carry-out of the most recently
+    /// executed instruction (zero unless it was `ADD`, `MUL`, `ADDC`, or
+    /// `MULC`). Non-architectural: not part of the memory-checked register
+    /// file; committed separately as the `Carry` column.
+    #[cfg(feature = "implicit-carry")]
+    pub carry: u64,
 }
 
 /// Width of an LR/SC reservation set. Ordered `Word < Doubleword` so
@@ -541,6 +553,8 @@ impl Cpu {
             host_io: HostIo::Live,
             #[cfg(feature = "field-inline")]
             field_registers: FieldRegisterFile::default(),
+            #[cfg(feature = "implicit-carry")]
+            carry: 0,
         };
         // cpu.x[0xb] = 0x1020; // I don't know why but Linux boot seems to require this initialization
         cpu.write_csr_raw(CSR_MISA_ADDRESS, 0x800000008014312f);
@@ -1384,6 +1398,8 @@ impl Cpu {
             host_io: self.host_io,
             #[cfg(feature = "field-inline")]
             field_registers: self.field_registers.clone(),
+            #[cfg(feature = "implicit-carry")]
+            carry: self.carry,
         }
     }
 
@@ -1425,6 +1441,8 @@ impl Cpu {
             host_io: _,
             #[cfg(feature = "field-inline")]
             field_registers,
+            #[cfg(feature = "implicit-carry")]
+            carry,
         } = self;
         debug_assert!(
             vr_allocator.is_quiescent(),
@@ -1446,6 +1464,8 @@ impl Cpu {
             advice_suffix: advice_tape.data[advice_tape.read_position..].to_vec(),
             #[cfg(feature = "field-inline")]
             field_registers: field_registers.clone(),
+            #[cfg(feature = "implicit-carry")]
+            carry: *carry,
         }
     }
 
@@ -1475,6 +1495,10 @@ impl Cpu {
         #[cfg(feature = "field-inline")]
         {
             self.field_registers = state.field_registers.clone();
+        }
+        #[cfg(feature = "implicit-carry")]
+        {
+            self.carry = state.carry;
         }
     }
 
@@ -1562,6 +1586,10 @@ impl Cpu {
                 "executed_instrs: {} vs {}",
                 self.executed_instrs, other.executed_instrs
             ));
+        }
+        #[cfg(feature = "implicit-carry")]
+        if self.carry != other.carry {
+            return Some(format!("carry: {:#x} vs {:#x}", self.carry, other.carry));
         }
         match (&self.mmu.jolt_device, &other.mmu.jolt_device) {
             (Some(a), Some(b)) => {

--- a/tracer/src/execution_backend.rs
+++ b/tracer/src/execution_backend.rs
@@ -264,6 +264,8 @@ fn trace_row_from_cycle(cycle: Cycle) -> Result<TraceRow, TraceError> {
         ram_access: cycle.ram_access().into(),
         #[cfg(feature = "field-inline")]
         field_inline: cycle.field_inline_trace().map(Into::into),
+        #[cfg(feature = "implicit-carry")]
+        carry: cycle.carry(),
     })
 }
 

--- a/tracer/src/instruction/add.rs
+++ b/tracer/src/instruction/add.rs
@@ -9,17 +9,23 @@ declare_riscv_instr!(
     mask   = 0xfe00707f,
     match  = 0x00000033,
     format = FormatR,
-    ram    = ()
+    ram    = (),
+    produces_carry = true,
 );
 
 impl ADD {
     fn exec(&self, cpu: &mut Cpu, _: &mut <ADD as RISCVInstruction>::RAMAccess) {
+        let rs1 = cpu.x[self.operands.rs1 as usize];
+        let rs2 = cpu.x[self.operands.rs2 as usize];
         cpu.write_register(
             self.operands.rd as usize,
-            cpu.sign_extend(
-                cpu.x[self.operands.rs1 as usize].wrapping_add(cpu.x[self.operands.rs2 as usize]),
-            ),
+            cpu.sign_extend(rs1.wrapping_add(rs2)),
         );
+        // Carry-out: the high 64 bits of the unsigned widening sum of the raw words.
+        #[cfg(feature = "implicit-carry")]
+        {
+            cpu.carry = ((rs1 as u64 as u128 + rs2 as u64 as u128) >> 64) as u64;
+        }
     }
 }
 

--- a/tracer/src/instruction/addc.rs
+++ b/tracer/src/instruction/addc.rs
@@ -1,0 +1,29 @@
+use serde::{Deserialize, Serialize};
+
+use crate::{declare_riscv_instr, emulator::cpu::Cpu};
+
+use super::{format::format_r::FormatR, RISCVInstruction, RISCVTrace};
+
+declare_riscv_instr!(
+    name   = ADDC,
+    mask   = 0,
+    match  = 0,
+    format = FormatR,
+    ram    = (),
+    produces_carry = true,
+);
+
+impl ADDC {
+    fn exec(&self, cpu: &mut Cpu, _: &mut <ADDC as RISCVInstruction>::RAMAccess) {
+        let sum = cpu.x[self.operands.rs1 as usize] as u64 as u128
+            + cpu.x[self.operands.rs2 as usize] as u64 as u128
+            + cpu.carry as u128;
+        cpu.write_register(
+            self.operands.rd as usize,
+            cpu.sign_extend(sum as u64 as i64),
+        );
+        cpu.carry = (sum >> 64) as u64;
+    }
+}
+
+impl RISCVTrace for ADDC {}

--- a/tracer/src/instruction/field_inline.rs
+++ b/tracer/src/instruction/field_inline.rs
@@ -66,6 +66,10 @@ macro_rules! field_instruction {
 
             fn execute(&self, cpu: &mut Cpu, ram_access: &mut Self::RAMAccess) {
                 ram_access.trace = Some(execute_field_inline($op, self.operands, cpu));
+                #[cfg(feature = "implicit-carry")]
+                {
+                    cpu.carry = 0;
+                }
             }
         }
 

--- a/tracer/src/instruction/field_inline.rs
+++ b/tracer/src/instruction/field_inline.rs
@@ -66,10 +66,6 @@ macro_rules! field_instruction {
 
             fn execute(&self, cpu: &mut Cpu, ram_access: &mut Self::RAMAccess) {
                 ram_access.trace = Some(execute_field_inline($op, self.operands, cpu));
-                #[cfg(feature = "implicit-carry")]
-                {
-                    cpu.carry = 0;
-                }
             }
         }
 

--- a/tracer/src/instruction/mod.rs
+++ b/tracer/src/instruction/mod.rs
@@ -16,9 +16,9 @@ pub const FUNCT7_ADVICE_LW: u32 = 0x02; // Load word from advice tape
 pub const FUNCT7_ADVICE_LD: u32 = 0x03; // Load doubleword from advice tape
 pub const FUNCT7_ADVICE_LEN: u32 = 0x04; // Get remaining bytes in advice tape
 pub const FUNCT7_VIRTUAL_REV8W: u32 = 0x05; // Reverse bytes in a word
-#[cfg(feature = "implicit-carry")]
+                                            // The ADDC/MULC funct7 slots are allocated even when the `implicit-carry`
+                                            // feature (which compiles the instructions) is off.
 pub const FUNCT7_ADDC: u32 = 0x06; // Add with implicit carry-in
-#[cfg(feature = "implicit-carry")]
 pub const FUNCT7_MULC: u32 = 0x07; // Multiply with implicit carry-in
 
 use add::ADD;
@@ -422,8 +422,9 @@ pub trait RISCVInstruction: std::fmt::Debug + Sized + Copy + Into<Instruction> {
 
     /// Whether this instruction writes the implicit carry (`ADD`, `MUL`,
     /// `ADDC`, `MULC`). Every other instruction clobbers the carry to zero;
-    /// see `declare_riscv_instr!`'s generated `execute`. Only consulted under
-    /// the `implicit-carry` feature.
+    /// enforced once for all impls in `RISCVTrace::trace`, the single point
+    /// every executed row passes through. Only consulted under the
+    /// `implicit-carry` feature.
     const PRODUCES_CARRY: bool = false;
 
     fn execute(&self, cpu: &mut Cpu, ram_access: &mut Self::RAMAccess);
@@ -450,6 +451,14 @@ where
         self.operands()
             .capture_pre_execution_state(&mut cycle.register_state, cpu);
         self.execute(cpu, &mut cycle.ram_access);
+        // Non-producers clobber the implicit carry to zero; producers set
+        // `cpu.carry` inside `execute`. Clobbering here (rather than in each
+        // `execute` impl) covers manual `RISCVInstruction` impls too — both
+        // trace and execute-only modes dispatch through this method.
+        #[cfg(feature = "implicit-carry")]
+        if !Self::PRODUCES_CARRY {
+            cpu.carry = 0;
+        }
         self.operands()
             .capture_post_execution_state(&mut cycle.register_state, cpu);
         match trace {
@@ -2061,11 +2070,25 @@ mod tests {
             | (funct7 << 25)
     }
 
+    /// Operand bits on top of an instruction's `MATCH` constant, like
+    /// `MULHSU::with_regs`.
+    #[cfg(feature = "implicit-carry")]
+    fn r_word_from_match(match_: u32, rd: u8, rs1: u8, rs2: u8) -> u32 {
+        match_ | (u32::from(rd) << 7) | (u32::from(rs1) << 15) | (u32::from(rs2) << 20)
+    }
+
     #[cfg(not(feature = "implicit-carry"))]
     #[test]
     fn addc_mulc_opcodes_are_unknown_without_feature() {
-        for funct7 in [0x06, 0x07] {
-            let word = r_type_word(0x5b, 0b000, funct7, 5, 6, 7);
+        for funct7 in [FUNCT7_ADDC, FUNCT7_MULC] {
+            let word = r_type_word(
+                u32::from(CUSTOM_OPCODE),
+                u32::from(FUNCT3_VIRTUAL_R),
+                funct7,
+                5,
+                6,
+                7,
+            );
             assert!(Instruction::decode(word, 0x8000_0000, false).is_err());
         }
     }
@@ -2076,13 +2099,32 @@ mod tests {
         use crate::emulator::default_terminal::DefaultTerminal;
 
         const ADD_WORD: fn(u8, u8, u8) -> u32 =
-            |rd, rs1, rs2| super::r_type_word(0x33, 0b000, 0x00, rd, rs1, rs2);
+            |rd, rs1, rs2| super::r_word_from_match(ADD::MATCH, rd, rs1, rs2);
         const MUL_WORD: fn(u8, u8, u8) -> u32 =
-            |rd, rs1, rs2| super::r_type_word(0x33, 0b000, 0x01, rd, rs1, rs2);
-        const ADDC_WORD: fn(u8, u8, u8) -> u32 =
-            |rd, rs1, rs2| super::r_type_word(0x5b, 0b000, 0x06, rd, rs1, rs2);
-        const MULC_WORD: fn(u8, u8, u8) -> u32 =
-            |rd, rs1, rs2| super::r_type_word(0x5b, 0b000, 0x07, rd, rs1, rs2);
+            |rd, rs1, rs2| super::r_word_from_match(MUL::MATCH, rd, rs1, rs2);
+        // ADDC/MULC have `mask = match = 0` (decoded via the custom-opcode
+        // switch), so their words are built from the named encoding constants
+        // rather than `MATCH`.
+        const ADDC_WORD: fn(u8, u8, u8) -> u32 = |rd, rs1, rs2| {
+            super::r_type_word(
+                u32::from(CUSTOM_OPCODE),
+                u32::from(FUNCT3_VIRTUAL_R),
+                FUNCT7_ADDC,
+                rd,
+                rs1,
+                rs2,
+            )
+        };
+        const MULC_WORD: fn(u8, u8, u8) -> u32 = |rd, rs1, rs2| {
+            super::r_type_word(
+                u32::from(CUSTOM_OPCODE),
+                u32::from(FUNCT3_VIRTUAL_R),
+                FUNCT7_MULC,
+                rd,
+                rs1,
+                rs2,
+            )
+        };
 
         fn trace_one(cpu: &mut Cpu, word: u32) -> Cycle {
             let instruction = Instruction::decode(word, 0x8000_0000, false).unwrap();
@@ -2178,7 +2220,7 @@ mod tests {
             assert_eq!(cpu.carry, 1);
 
             // XOR is not carry-producing: clobbers carry to 0.
-            trace_one(&mut cpu, super::r_type_word(0x33, 0b100, 0x00, 12, 5, 6));
+            trace_one(&mut cpu, super::r_word_from_match(XOR::MATCH, 12, 5, 6));
             assert_eq!(cpu.carry, 0);
 
             // ADDC after the clobber consumes 0.
@@ -2196,6 +2238,38 @@ mod tests {
             assert_eq!(cycle.carry(), 0);
             assert_eq!(cpu.x[10], 7);
             assert_eq!(cpu.carry, 0);
+        }
+
+        #[test]
+        fn expanding_non_producers_clobber_carry_to_zero() {
+            // MULH and SLL lower to virtual sequences whose interiors use
+            // ADD/MUL; at the guest level they are still non-producers, so
+            // their expansions must leave carry = 0 (the expansion boundary
+            // appends a non-producing noop row when needed).
+            for word in [
+                super::r_word_from_match(MULH::MATCH, 12, 5, 6),
+                super::r_word_from_match(SLL::MATCH, 12, 5, 6),
+            ] {
+                let mut cpu = fresh_cpu();
+                cpu.write_register(5, u64::MAX as i64);
+                cpu.write_register(6, 2);
+                cpu.write_register(7, 1);
+
+                // Seed a nonzero carry: u64::MAX * 2 has carry-out 1.
+                trace_one(&mut cpu, MUL_WORD(10, 5, 6));
+                assert_eq!(cpu.carry, 1);
+
+                let instruction = Instruction::decode(word, 0x8000_0000, false).unwrap();
+                let mut rows = Vec::new();
+                instruction.trace(&mut cpu, Some(&mut rows));
+                assert!(rows.len() > 1, "expected a virtual expansion");
+                assert_eq!(cpu.carry, 0, "expansion leaked a nonzero carry");
+
+                // A following ADDC consumes 0, not expansion-internal state.
+                let cycle = trace_one(&mut cpu, ADDC_WORD(11, 5, 7));
+                assert_eq!(cycle.carry(), 0);
+                assert_eq!(cpu.x[11] as u64, u64::MAX.wrapping_add(1));
+            }
         }
 
         #[test]

--- a/tracer/src/instruction/mod.rs
+++ b/tracer/src/instruction/mod.rs
@@ -16,6 +16,10 @@ pub const FUNCT7_ADVICE_LW: u32 = 0x02; // Load word from advice tape
 pub const FUNCT7_ADVICE_LD: u32 = 0x03; // Load doubleword from advice tape
 pub const FUNCT7_ADVICE_LEN: u32 = 0x04; // Get remaining bytes in advice tape
 pub const FUNCT7_VIRTUAL_REV8W: u32 = 0x05; // Reverse bytes in a word
+#[cfg(feature = "implicit-carry")]
+pub const FUNCT7_ADDC: u32 = 0x06; // Add with implicit carry-in
+#[cfg(feature = "implicit-carry")]
+pub const FUNCT7_MULC: u32 = 0x07; // Multiply with implicit carry-in
 
 use add::ADD;
 use addi::ADDI;
@@ -155,6 +159,8 @@ use virtual_srli::VirtualSRLI;
 use virtual_xor_rot::{VirtualXORROT16, VirtualXORROT24, VirtualXORROT32, VirtualXORROT63};
 use virtual_xor_rotw::{VirtualXORROTW12, VirtualXORROTW16, VirtualXORROTW7, VirtualXORROTW8};
 use virtual_zero_extend_word::VirtualZeroExtendWord;
+#[cfg(feature = "implicit-carry")]
+use {addc::ADDC, mulc::MULC};
 
 use self::inline::INLINE;
 
@@ -214,6 +220,8 @@ pub(crate) fn trace_inline_sequence_with_advice(
 }
 
 pub mod add;
+#[cfg(feature = "implicit-carry")]
+pub mod addc;
 pub mod addi;
 pub mod addiw;
 pub mod addw;
@@ -275,6 +283,8 @@ pub mod lw;
 pub mod lwu;
 pub mod mret;
 pub mod mul;
+#[cfg(feature = "implicit-carry")]
+pub mod mulc;
 pub mod mulh;
 pub mod mulhsu;
 pub mod mulhu;
@@ -410,6 +420,12 @@ pub trait RISCVInstruction: std::fmt::Debug + Sized + Copy + Into<Instruction> {
         Self::new(rng.next_u32(), rng.next_u64(), false, false)
     }
 
+    /// Whether this instruction writes the implicit carry (`ADD`, `MUL`,
+    /// `ADDC`, `MULC`). Every other instruction clobbers the carry to zero;
+    /// see `declare_riscv_instr!`'s generated `execute`. Only consulted under
+    /// the `implicit-carry` feature.
+    const PRODUCES_CARRY: bool = false;
+
     fn execute(&self, cpu: &mut Cpu, ram_access: &mut Self::RAMAccess);
 
     fn has_side_effects(&self) -> bool {
@@ -426,6 +442,10 @@ where
             instruction: *self,
             register_state: Default::default(),
             ram_access: Default::default(),
+            // The row's incoming carry: `cpu.carry` is read before `execute`
+            // below updates it to this row's carry-out.
+            #[cfg(feature = "implicit-carry")]
+            carry: cpu.carry,
         };
         self.operands()
             .capture_pre_execution_state(&mut cycle.register_state, cpu);
@@ -597,6 +617,19 @@ macro_rules! define_rv64imac_enums {
                     Cycle::FIELD_STORE_TO_X(cycle) => cycle.ram_access.trace,
                     Cycle::FIELD_LOAD_IMM(cycle) => cycle.ram_access.trace,
                     _ => None,
+                }
+            }
+
+            /// The row's incoming implicit carry (the previous row's carry-out).
+            #[cfg(feature = "implicit-carry")]
+            pub fn carry(&self) -> u64 {
+                match self {
+                    Cycle::NoOp => 0,
+                    $(
+                        $(#[$meta])*
+                        Cycle::$instr(cycle) => cycle.carry,
+                    )*
+                    Cycle::INLINE(cycle) => cycle.carry,
                 }
             }
 
@@ -1360,6 +1393,10 @@ impl Instruction {
                         FUNCT7_VIRTUAL_REV8W => {
                             Ok(VirtualRev8W::new(instr, address, true, compressed).into())
                         }
+                        #[cfg(feature = "implicit-carry")]
+                        FUNCT7_ADDC => Ok(ADDC::new(instr, address, true, compressed).into()),
+                        #[cfg(feature = "implicit-carry")]
+                        FUNCT7_MULC => Ok(MULC::new(instr, address, true, compressed).into()),
                         _ => Err("Invalid funct7 for virtual R-type instruction"),
                     }
                 } else if funct3 == FUNCT3_VIRTUAL_ASSERT_EQ {
@@ -1952,6 +1989,9 @@ pub struct RISCVCycle<T: RISCVInstruction> {
     pub instruction: T,
     pub register_state: <T::Format as InstructionFormat>::RegisterState,
     pub ram_access: T::RAMAccess,
+    /// Incoming implicit carry for this row (the previous row's carry-out).
+    #[cfg(feature = "implicit-carry")]
+    pub carry: u64,
 }
 
 impl<T: RISCVInstruction> RISCVCycle<T> {
@@ -1969,6 +2009,8 @@ impl<T: RISCVInstruction> RISCVCycle<T> {
             instruction,
             ram_access: Default::default(),
             register_state,
+            #[cfg(feature = "implicit-carry")]
+            carry: rand::RngCore::next_u64(rng),
         }
     }
 }
@@ -2008,6 +2050,176 @@ mod tests {
     fn field_inline_opcode_is_unknown_without_feature() {
         let word = 0x7b | (2 << 12) | (1 << 7) | (2 << 15) | (3 << 20);
         assert!(Instruction::decode(word, 0x8000_0000, false).is_err());
+    }
+
+    fn r_type_word(opcode: u32, funct3: u32, funct7: u32, rd: u8, rs1: u8, rs2: u8) -> u32 {
+        opcode
+            | (u32::from(rd) << 7)
+            | (funct3 << 12)
+            | (u32::from(rs1) << 15)
+            | (u32::from(rs2) << 20)
+            | (funct7 << 25)
+    }
+
+    #[cfg(not(feature = "implicit-carry"))]
+    #[test]
+    fn addc_mulc_opcodes_are_unknown_without_feature() {
+        for funct7 in [0x06, 0x07] {
+            let word = r_type_word(0x5b, 0b000, funct7, 5, 6, 7);
+            assert!(Instruction::decode(word, 0x8000_0000, false).is_err());
+        }
+    }
+
+    #[cfg(feature = "implicit-carry")]
+    mod implicit_carry {
+        use super::super::*;
+        use crate::emulator::default_terminal::DefaultTerminal;
+
+        const ADD_WORD: fn(u8, u8, u8) -> u32 =
+            |rd, rs1, rs2| super::r_type_word(0x33, 0b000, 0x00, rd, rs1, rs2);
+        const MUL_WORD: fn(u8, u8, u8) -> u32 =
+            |rd, rs1, rs2| super::r_type_word(0x33, 0b000, 0x01, rd, rs1, rs2);
+        const ADDC_WORD: fn(u8, u8, u8) -> u32 =
+            |rd, rs1, rs2| super::r_type_word(0x5b, 0b000, 0x06, rd, rs1, rs2);
+        const MULC_WORD: fn(u8, u8, u8) -> u32 =
+            |rd, rs1, rs2| super::r_type_word(0x5b, 0b000, 0x07, rd, rs1, rs2);
+
+        fn trace_one(cpu: &mut Cpu, word: u32) -> Cycle {
+            let instruction = Instruction::decode(word, 0x8000_0000, false).unwrap();
+            let mut trace = Vec::new();
+            instruction.trace(cpu, Some(&mut trace));
+            assert_eq!(trace.len(), 1);
+            trace.remove(0)
+        }
+
+        fn fresh_cpu() -> Cpu {
+            Cpu::new(Box::new(DefaultTerminal::default()))
+        }
+
+        /// Edge-case operand corpus: zero, one, max, and values with large
+        /// high halves.
+        const OPERANDS: [u64; 6] = [
+            0,
+            1,
+            u64::MAX,
+            u64::MAX - 1,
+            0x8000_0000_0000_0000,
+            0xdead_beef_cafe_f00d,
+        ];
+
+        #[test]
+        fn producer_consumer_pairs_propagate_carry() {
+            type Encoder = fn(u8, u8, u8) -> u32;
+            type Producer = (fn(u64, u64) -> u128, Encoder);
+            type Consumer = (fn(u64, u64, u64) -> u128, Encoder);
+            let producers: [Producer; 2] = [
+                (|a, b| a as u128 + b as u128, ADD_WORD),
+                (|a, b| a as u128 * b as u128, MUL_WORD),
+            ];
+            let consumers: [Consumer; 2] = [
+                (|a, b, c| a as u128 + b as u128 + c as u128, ADDC_WORD),
+                (|a, b, c| a as u128 * b as u128 + c as u128, MULC_WORD),
+            ];
+            for (produce, producer_word) in producers {
+                for (consume, consumer_word) in consumers {
+                    for &a in &OPERANDS {
+                        for &b in &OPERANDS {
+                            for &c in &OPERANDS {
+                                let mut cpu = fresh_cpu();
+                                cpu.write_register(5, a as i64);
+                                cpu.write_register(6, b as i64);
+                                cpu.write_register(7, c as i64);
+
+                                let expected_p = produce(a, b);
+                                let first = trace_one(&mut cpu, producer_word(10, 5, 6));
+                                assert_eq!(first.carry(), 0, "row 0 consumes carry 0");
+                                assert_eq!(
+                                    cpu.x[10] as u64, expected_p as u64,
+                                    "producer rd = low 64 bits"
+                                );
+                                assert_eq!(
+                                    cpu.carry,
+                                    (expected_p >> 64) as u64,
+                                    "producer carry-out = high 64 bits"
+                                );
+
+                                let expected_c = consume(cpu.x[10] as u64, c, cpu.carry);
+                                let second = trace_one(&mut cpu, consumer_word(11, 10, 7));
+                                assert_eq!(
+                                    second.carry(),
+                                    (expected_p >> 64) as u64,
+                                    "consumer row records producer's carry-out as incoming"
+                                );
+                                assert_eq!(
+                                    cpu.x[11] as u64, expected_c as u64,
+                                    "consumer rd = low 64 bits with carry-in"
+                                );
+                                assert_eq!(
+                                    cpu.carry,
+                                    (expected_c >> 64) as u64,
+                                    "consumer carry-out = high 64 bits"
+                                );
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        #[test]
+        fn intervening_instruction_clobbers_carry_to_zero() {
+            let mut cpu = fresh_cpu();
+            cpu.write_register(5, u64::MAX as i64);
+            cpu.write_register(6, 2);
+            cpu.write_register(7, 0);
+
+            // ADD overflows: carry-out = 1.
+            trace_one(&mut cpu, ADD_WORD(10, 5, 6));
+            assert_eq!(cpu.carry, 1);
+
+            // XOR is not carry-producing: clobbers carry to 0.
+            trace_one(&mut cpu, super::r_type_word(0x33, 0b100, 0x00, 12, 5, 6));
+            assert_eq!(cpu.carry, 0);
+
+            // ADDC after the clobber consumes 0.
+            let cycle = trace_one(&mut cpu, ADDC_WORD(11, 10, 7));
+            assert_eq!(cycle.carry(), 0);
+            assert_eq!(cpu.x[11] as u64, (u64::MAX).wrapping_add(2));
+        }
+
+        #[test]
+        fn addc_on_fresh_cpu_consumes_zero() {
+            let mut cpu = fresh_cpu();
+            cpu.write_register(5, 3);
+            cpu.write_register(6, 4);
+            let cycle = trace_one(&mut cpu, ADDC_WORD(10, 5, 6));
+            assert_eq!(cycle.carry(), 0);
+            assert_eq!(cpu.x[10], 7);
+            assert_eq!(cpu.carry, 0);
+        }
+
+        #[test]
+        fn execute_only_mode_maintains_carry_like_trace_mode() {
+            let mut traced = fresh_cpu();
+            let mut executed = fresh_cpu();
+            for cpu in [&mut traced, &mut executed] {
+                cpu.write_register(5, u64::MAX as i64);
+                cpu.write_register(6, u64::MAX as i64);
+                cpu.write_register(7, 1);
+            }
+            let program = [
+                MUL_WORD(10, 5, 6),
+                MULC_WORD(11, 6, 7),
+                ADDC_WORD(12, 10, 11),
+            ];
+            for word in program {
+                trace_one(&mut traced, word);
+                let instruction = Instruction::decode(word, 0x8000_0000, false).unwrap();
+                instruction.trace(&mut executed, None);
+                assert_eq!(traced.carry, executed.carry);
+            }
+            assert_eq!(traced.x, executed.x);
+        }
     }
 
     #[cfg(feature = "field-inline")]

--- a/tracer/src/instruction/mul.rs
+++ b/tracer/src/instruction/mul.rs
@@ -9,17 +9,24 @@ declare_riscv_instr!(
     mask   = 0xfe00707f,
     match  = 0x02000033,
     format = FormatR,
-    ram    = ()
+    ram    = (),
+    produces_carry = true,
 );
 
 impl MUL {
     fn exec(&self, cpu: &mut Cpu, _: &mut <MUL as RISCVInstruction>::RAMAccess) {
+        let rs1 = cpu.x[self.operands.rs1 as usize];
+        let rs2 = cpu.x[self.operands.rs2 as usize];
         cpu.write_register(
             self.operands.rd as usize,
-            cpu.sign_extend(
-                cpu.x[self.operands.rs1 as usize].wrapping_mul(cpu.x[self.operands.rs2 as usize]),
-            ),
+            cpu.sign_extend(rs1.wrapping_mul(rs2)),
         );
+        // Carry-out: the high 64 bits of the unsigned 64x64 widening product
+        // of the raw words (equals `MULHU rs1, rs2`).
+        #[cfg(feature = "implicit-carry")]
+        {
+            cpu.carry = ((rs1 as u64 as u128 * rs2 as u64 as u128) >> 64) as u64;
+        }
     }
 }
 

--- a/tracer/src/instruction/mulc.rs
+++ b/tracer/src/instruction/mulc.rs
@@ -1,0 +1,31 @@
+use serde::{Deserialize, Serialize};
+
+use crate::{declare_riscv_instr, emulator::cpu::Cpu};
+
+use super::{format::format_r::FormatR, RISCVInstruction, RISCVTrace};
+
+declare_riscv_instr!(
+    name   = MULC,
+    mask   = 0,
+    match  = 0,
+    format = FormatR,
+    ram    = (),
+    produces_carry = true,
+);
+
+impl MULC {
+    fn exec(&self, cpu: &mut Cpu, _: &mut <MULC as RISCVInstruction>::RAMAccess) {
+        // Unsigned 64x64 widening product plus carry-in; cannot overflow 128
+        // bits: (2^64-1)^2 + (2^64-1) < 2^128.
+        let product = cpu.x[self.operands.rs1 as usize] as u64 as u128
+            * (cpu.x[self.operands.rs2 as usize] as u64 as u128)
+            + cpu.carry as u128;
+        cpu.write_register(
+            self.operands.rd as usize,
+            cpu.sign_extend(product as u64 as i64),
+        );
+        cpu.carry = (product >> 64) as u64;
+    }
+}
+
+impl RISCVTrace for MULC {}

--- a/tracer/src/instruction/virtual_advice.rs
+++ b/tracer/src/instruction/virtual_advice.rs
@@ -60,6 +60,10 @@ impl RISCVInstruction for VirtualAdvice {
 
     fn execute(&self, cpu: &mut Cpu, _: &mut Self::RAMAccess) {
         cpu.write_register(self.operands.rd as usize, self.advice as i64);
+        #[cfg(feature = "implicit-carry")]
+        {
+            cpu.carry = 0;
+        }
     }
 }
 

--- a/tracer/src/instruction/virtual_advice.rs
+++ b/tracer/src/instruction/virtual_advice.rs
@@ -60,10 +60,6 @@ impl RISCVInstruction for VirtualAdvice {
 
     fn execute(&self, cpu: &mut Cpu, _: &mut Self::RAMAccess) {
         cpu.write_register(self.operands.rd as usize, self.advice as i64);
-        #[cfg(feature = "implicit-carry")]
-        {
-            cpu.carry = 0;
-        }
     }
 }
 

--- a/tracer/src/jolt_cycle_adapter.rs
+++ b/tracer/src/jolt_cycle_adapter.rs
@@ -49,4 +49,9 @@ impl<T: RISCVInstruction + JoltInstructionRowData> JoltCycle for RISCVCycle<T> {
             RAMAccess::NoOp => None,
         }
     }
+
+    #[cfg(feature = "implicit-carry")]
+    fn carry(&self) -> u64 {
+        self.carry
+    }
 }

--- a/tracer/src/utils/instruction_macros.rs
+++ b/tracer/src/utils/instruction_macros.rs
@@ -5,19 +5,10 @@ macro_rules! declare_riscv_instr {
       mask    = $mask:expr,
       match   = $match_:expr,
       format  = $format:ty,
-      ram     = $ram:ty $(,)?
+      ram     = $ram:ty
+      $(, produces_carry = $produces_carry:literal)? $(,)?
   ) => {
-        declare_riscv_instr!(@inner $name, $mask, $match_, $format, $ram, false);
-    };
-    (
-      name    = $name:ident,
-      mask    = $mask:expr,
-      match   = $match_:expr,
-      format  = $format:ty,
-      ram     = $ram:ty,
-      produces_carry = true $(,)?
-  ) => {
-        declare_riscv_instr!(@inner $name, $mask, $match_, $format, $ram, true);
+        declare_riscv_instr!(@inner $name, $mask, $match_, $format, $ram, (false $(|| $produces_carry)?));
     };
     (@inner $name:ident, $mask:expr, $match_:expr, $format:ty, $ram:ty, $produces_carry:expr) => {
         #[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq)]
@@ -88,14 +79,6 @@ macro_rules! declare_riscv_instr {
 
             fn execute(&self, cpu: &mut $crate::emulator::cpu::Cpu, ram: &mut Self::RAMAccess) {
                 self.exec(cpu, ram);
-                // Non-carry-producing instructions clobber the implicit carry
-                // to zero; producers set `cpu.carry` inside `exec`. Living in
-                // `execute` (not `RISCVTrace::trace`) keeps trace and
-                // execute-only modes in lockstep for chunked replay.
-                #[cfg(feature = "implicit-carry")]
-                if !Self::PRODUCES_CARRY {
-                    cpu.carry = 0;
-                }
             }
         }
 

--- a/tracer/src/utils/instruction_macros.rs
+++ b/tracer/src/utils/instruction_macros.rs
@@ -7,9 +7,19 @@ macro_rules! declare_riscv_instr {
       format  = $format:ty,
       ram     = $ram:ty $(,)?
   ) => {
-        declare_riscv_instr!(@inner $name, $mask, $match_, $format, $ram);
+        declare_riscv_instr!(@inner $name, $mask, $match_, $format, $ram, false);
     };
-    (@inner $name:ident, $mask:expr, $match_:expr, $format:ty, $ram:ty) => {
+    (
+      name    = $name:ident,
+      mask    = $mask:expr,
+      match   = $match_:expr,
+      format  = $format:ty,
+      ram     = $ram:ty,
+      produces_carry = true $(,)?
+  ) => {
+        declare_riscv_instr!(@inner $name, $mask, $match_, $format, $ram, true);
+    };
+    (@inner $name:ident, $mask:expr, $match_:expr, $format:ty, $ram:ty, $produces_carry:expr) => {
         #[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq)]
         pub struct $name {
             pub address: u64,
@@ -74,8 +84,18 @@ macro_rules! declare_riscv_instr {
                 }
             }
 
+            const PRODUCES_CARRY: bool = $produces_carry;
+
             fn execute(&self, cpu: &mut $crate::emulator::cpu::Cpu, ram: &mut Self::RAMAccess) {
-                self.exec(cpu, ram)
+                self.exec(cpu, ram);
+                // Non-carry-producing instructions clobber the implicit carry
+                // to zero; producers set `cpu.carry` inside `exec`. Living in
+                // `execute` (not `RISCVTrace::trace`) keeps trace and
+                // execute-only modes in lockstep for chunked replay.
+                #[cfg(feature = "implicit-carry")]
+                if !Self::PRODUCES_CARRY {
+                    cpu.carry = 0;
+                }
             }
         }
 


### PR DESCRIPTION
## Summary

First of three PRs implementing the implicit-carry spec (#1710, `specs/implicit-carry-handling.md`): the ISA layer only. Adds `ADDC` and `MULC` as guest-emittable final Jolt instructions and the emulator/trace plumbing that records each row's incoming carry, behind a new `implicit-carry` cargo feature mirroring the `field-inline` lane. No protocol changes: with the feature off, builds and proof geometry are unchanged (the `muldiv` e2e passes in both standard and ZK modes); with it on, traces containing `ADDC`/`MULC` are not yet provable — constraint support lands in the follow-up.

## What's included

- **Instructions**: `ADDC` (`rd = low64(rs1 + rs2 + carry)`) and `MULC` (`rd = low64(rs1 * rs2 + carry)`), custom opcode `0x5B`, funct3 `0`, funct7 `0x06`/`0x07`, Jolt tags `0x0110`/`0x0111`. Decoded by both the tracer and `jolt-program` decoders; rejected when the feature is off. Gated behind a new `SourceExtension::ImplicitCarry` and the `RV64IMAC_JOLT_IMPLICIT_CARRY` profile.
- **Circuit flags**: `UsesCarry` and `ProducesCarry` (14 → 16, exactly filling `CircuitFlagSet(u16)`; a new const assert makes a 17th flag a build error instead of a silent bit collision). `ADD`/`MUL` gain `ProducesCarry` under the feature via `jolt_instruction!` support for per-flag cfg attributes.
- **Emulator semantics**: `cpu.carry` holds the last instruction's carry-out; producers set it in `exec`, everything else clobbers it to zero in the macro-generated `execute`, so trace mode and execute-only mode stay in lockstep for chunked parallel replay. Carry is captured in `ChunkCpuState` and both replay-divergence checks.
- **Trace**: `RISCVCycle.carry` / `TraceRow.carry` record the row's incoming carry (zero on padding rows).
- **Lookups**: both instructions reuse the `RangeCheck` table with combined operands `rs1 + rs2 + carry` (< 3·2^64) and `rs1·rs2 + carry` (< 2^128), matching the spec's soundness argument that `NextCarry` inherits its range check from the 128-bit lookup domain.
- **CI**: clippy + nextest lanes for `implicit-carry` and the `field-inline,implicit-carry` composition, mirroring the existing `field-inline` jobs.

## Semantics worth reviewing

- `ADDC`/`MULC` declare `HAS_SIDE_EFFECTS = true`: an `rd = x0` occurrence is rewritten to a virtual register during expansion rather than noop-eliminated, which would silently break a carry chain. `ADD`/`MUL` remain side-effect-free, so `add x0, a, b` does **not** produce a usable carry.
- The legacy prover compiles with the feature on but ignores the two new flag bits (`circuit_flags_from_riscv` reads only the low 14) and maps `ADDC`/`MULC` to `RangeCheck`. Fail-closed protocol-config rejection arrives with the constraint PR.

## Testing

- Randomized `{ADD, MUL} → {ADDC, MULC}` pair tests over edge-case operands (0, 1, `u64::MAX`, large high halves; 864 cases), carry-clobber by intervening instructions, row-0 zero carry, and a trace-vs-execute lockstep check (`tracer/src/instruction/mod.rs`).
- Standard lookup-table macro tests for both instructions; the shared trace-match harness now seeds `cpu.carry` from the cycle, so future carry-aware instructions get correct coverage for free.
- Full matrix locally: workspace clippy (`host`, `host,zk`), per-crate clippy/nextest with the feature off, on, and composed with `field-inline`; `muldiv` e2e in both modes.

## Out of scope (per spec §Non-Goals)

Committed `Carry` column, `CarryUsed` product term, uniform R1CS rows, shift-relation extension, `carry_init` opening, BlindFold sync, modular-stack geometry, jolt-eval invariant, inline (`BigintMul256`) rewrites, guest-crate feature forwards, z3-verifier/lean-gen updates.
