### PR TITLE
docs: weekly freshness pass (2026-08-17)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,7 +83,7 @@ The span taxonomy (versioned, normative) lives in `crates/jolt-profiling/src/tax
 
 ### Crate Structure
 
-The workspace is mid-decomposition: `crates/` holds the modular stack (jolt-verifier, jolt-prover, jolt-sumcheck, jolt-poly, jolt-blindfold, jolt-witness, jolt-openings, jolt-r1cs, jolt-dory, jolt-transcript, jolt-utils, …26 crates), while **crates/jolt-prover-legacy** is the legacy monolith mapped below. Top-level crates: `tracer`, `jolt-sdk`, `jolt-inlines`, `common`.
+The workspace is mid-decomposition: `crates/` holds the modular stack (jolt-verifier, jolt-prover, jolt-sumcheck, jolt-poly, jolt-blindfold, jolt-witness, jolt-openings, jolt-r1cs, jolt-dory, jolt-transcript, jolt-utils, …27 crates), while **crates/jolt-prover-legacy** is the legacy monolith mapped below. Top-level crates: `tracer`, `jolt-sdk`, `jolt-inlines`, `common`.
 
 Arkworks dependencies use a fork: `a16z/arkworks-algebra` branch `dev/twist-shout`, pinned in the root `Cargo.toml`.
 

--- a/book/src/how/formal-verification/z3-verifier.md
+++ b/book/src/how/formal-verification/z3-verifier.md
@@ -102,7 +102,11 @@ The verifier searches for non-deterministic transitions. We verify that the tran
 
 ## Interpreting Results
 
-When the test suite runs (`cargo test -p z3-verifier -- --nocapture`), it outputs `SAT` or `UNSAT`. A `SAT` result indicates a failure in verification.
+When the test suite runs (`cargo nextest run -p z3-verifier`), it outputs `SAT` or `UNSAT`. A `SAT` result indicates a failure in verification. Each `Solver::check` call carries a fixed timeout and random seed (`Z3_TIMEOUT_MS`, `Z3_RANDOM_SEED` in `lib.rs`); a call that times out fails its test with "Solver failed/timed out, result inconclusive" rather than hanging the run.
+
+## Nightly CI
+
+A scheduled workflow (`.github/workflows/z3-nightly.yml`) runs a subset of the suite nightly against a hermetic Z3 built from pinned vendored source (the crate's `vendored-z3` feature), and files a GitHub issue on failure. Its scope is narrower than the full suite: the non-`#[ignore]`d virtual-sequence proofs plus the per-instruction R1CS determinism checks; the div/rem/mulh sequences (non-terminating under the 64-bit model), memory/atomic/CSR expansions, and registered inlines are not covered. It can also be run on demand via `workflow_dispatch` after changes to `tracer/`, `crates/jolt-program/`, or `z3-verifier/`.
 
 ## Bit-Width Scaling (Virtual Sequences)
 
@@ -111,7 +115,7 @@ Some virtual sequences (notably those involving division/remainder or high-half 
 Set `Z3_VERIFIER_BV_BITS` to a power of two in `[8, 64]` (default: `64`):
 
 ```bash
-Z3_VERIFIER_BV_BITS=8 cargo test -p z3-verifier virtual_sequences -- --nocapture
+Z3_VERIFIER_BV_BITS=8 cargo nextest run -p z3-verifier virtual_sequences
 ```
 
 ### 1. Correctness Failures (Logic Bugs)


### PR DESCRIPTION
Weekly docs-freshness pass over the last 7 days of main (16 commits, notably #1729 x86 AOT tracer crate, #1758 nightly Z3 workflow, #1750 word-op fusion, #1770 RoundScheduler, #1765 diff classifier).

Drift found and fixed:

- **CLAUDE.md**: modular-stack crate count `…26 crates` → `…27` — `crates/jolt-tracer-x86` landed in #1729 (verified against `ls crates/`: 28 dirs incl. legacy).
- **book/src/how/formal-verification/z3-verifier.md**:
  - New "Nightly CI" section documenting `.github/workflows/z3-nightly.yml` (#1758): hermetic `vendored-z3` build, failure-issue filing, scope/NOT-covered list taken verbatim from the workflow header.
  - Documented the new per-`Solver::check` timeout + fixed seed (`Z3_TIMEOUT_MS`/`Z3_RANDOM_SEED` in `z3-verifier/src/lib.rs`) and the "Solver failed/timed out" failure mode.
  - Run commands switched from `cargo test` to `cargo nextest run` per repo convention.

Checked, no drift: README, skills (`.claude/skills/*`, `agent-skills/jolt/SKILL.md`), book architecture pages (no per-word-op sequence claims, no `prove_round`/RoundScheduler references), profiling docs (already updated by #1760). Skill file's hash-inline cycle table may shift with #1750's shorter word-op sequences but I could not verify without running guests, so left untouched.

All edited claims verified against the repo (workflow file, `z3-verifier` sources, workspace `Cargo.toml`).