### PR TITLE
chore(deps): bump dory-pcs to 0.4.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2272,9 +2272,9 @@ dependencies = [
 
 [[package]]
 name = "dory-pcs"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc655754c8ddb6b75f528efcfcddf2cd8db59bdea777de157400d642048bd2f4"
+checksum = "065945e9fff3c7dac5d6f72f8260eac82ad577e7c7009b6290847d1252d14d78"
 dependencies = [
  "ark-bn254 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ark-ec 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -280,7 +280,7 @@ spongefish = { git = "https://github.com/arkworks-rs/spongefish", rev = "d2d190b
   "sha3",
 ] }
 jolt-optimizations = { git = "https://github.com/a16z/arkworks-algebra", branch = "dev/twist-shout" }
-dory = { package = "dory-pcs", version = "0.4.1", features = [
+dory = { package = "dory-pcs", version = "0.4.2", features = [
   "backends",
   "cache",
   "disk-persistence",


### PR DESCRIPTION
Picks up [dory v0.4.2](https://github.com/a16z/dory/releases/tag/v0.4.2): parallel G1/G2 prepared-point cache initialization and building replacements outside the global cache write lock (a16z/dory#30). No API changes; this is perf-only for the default backend.