### PR TITLE
perf(field): port subword Fp64 kernels

### DIFF
--- a/.github/workflows/field-portability.yml
+++ b/.github/workflows/field-portability.yml
@@ -34,12 +34,14 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - name: Install nextest
+        uses: taiki-e/install-action@nextest
       - name: Require AVX2
         run: grep -Eq '(^|[[:space:]])avx2([[:space:]]|$)' /proc/cpuinfo
       - name: Run packed field tests
         env:
           RUSTFLAGS: -D warnings -C target-feature=+avx2
-        run: cargo test --release -p jolt-field --no-default-features --features solinas --test solinas_packed_differential
+        run: cargo nextest run --release -p jolt-field --no-default-features --features solinas --test solinas_packed_differential
 
   aarch64-neon:
     name: AArch64 NEON field kernels
@@ -47,6 +49,8 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - name: Install nextest
+        uses: taiki-e/install-action@nextest
       - name: Require native AArch64 NEON
         run: |
           test "$(uname -m)" = "aarch64"
@@ -54,7 +58,7 @@ jobs:
       - name: Run packed field tests
         env:
           RUSTFLAGS: -D warnings -C target-cpu=native
-        run: cargo test --release -p jolt-field --no-default-features --features solinas --test solinas_packed_differential
+        run: cargo nextest run --release -p jolt-field --no-default-features --features solinas --test solinas_packed_differential
 
   avx512:
     name: AVX-512 field kernels (emulated)
@@ -62,6 +66,8 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - name: Install nextest
+        uses: taiki-e/install-action@nextest
       - name: Install Intel Software Development Emulator
         run: |
           curl --fail --location --silent --show-error --output /tmp/intel-sde.tar.xz https://downloadmirror.intel.com/924984/sde-external-10.13.1-2026-07-28-lin.tar.xz
@@ -73,4 +79,4 @@ jobs:
         env:
           CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUNNER: /opt/intel-sde/sde64 -icx --
           RUSTFLAGS: -D warnings -C target-feature=+avx2,+avx512f,+avx512dq
-        run: cargo test --release --target x86_64-unknown-linux-gnu -p jolt-field --no-default-features --features solinas --test solinas_packed_differential
+        run: cargo nextest run --release --target x86_64-unknown-linux-gnu -p jolt-field --no-default-features --features solinas --test solinas_packed_differential

--- a/.github/workflows/field-portability.yml
+++ b/.github/workflows/field-portability.yml
@@ -1,0 +1,76 @@
+name: Field portability
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/field-portability.yml"
+      - "crates/jolt-field/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
+  pull_request:
+    branches: [main]
+    paths:
+      - ".github/workflows/field-portability.yml"
+      - "crates/jolt-field/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+  RUSTFLAGS: -D warnings
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  avx2:
+    name: AVX2 field kernels
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - name: Require AVX2
+        run: grep -Eq '(^|[[:space:]])avx2([[:space:]]|$)' /proc/cpuinfo
+      - name: Run packed field tests
+        env:
+          RUSTFLAGS: -D warnings -C target-feature=+avx2
+        run: cargo test --release -p jolt-field --no-default-features --features solinas --test solinas_packed_differential
+
+  aarch64-neon:
+    name: AArch64 NEON field kernels
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - name: Require native AArch64 NEON
+        run: |
+          test "$(uname -m)" = "aarch64"
+          grep -Eq '(^|[[:space:]])(asimd|neon)([[:space:]]|$)' /proc/cpuinfo
+      - name: Run packed field tests
+        env:
+          RUSTFLAGS: -D warnings -C target-cpu=native
+        run: cargo test --release -p jolt-field --no-default-features --features solinas --test solinas_packed_differential
+
+  avx512:
+    name: AVX-512 field kernels (emulated)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - name: Install Intel Software Development Emulator
+        run: |
+          curl --fail --location --silent --show-error --output /tmp/intel-sde.tar.xz https://downloadmirror.intel.com/924984/sde-external-10.13.1-2026-07-28-lin.tar.xz
+          echo '94e97d623fec54385686e1e7ba65ebc9941748c05ee451423948334892bf2b50  /tmp/intel-sde.tar.xz' | sha256sum --check
+          sudo mkdir --parents /opt/intel-sde
+          sudo tar --extract --xz --file /tmp/intel-sde.tar.xz --strip-components=1 --directory /opt/intel-sde
+          sudo sysctl --write kernel.yama.ptrace_scope=0
+      - name: Run packed field tests under emulation
+        env:
+          CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUNNER: /opt/intel-sde/sde64 -icx --
+          RUSTFLAGS: -D warnings -C target-feature=+avx2,+avx512f,+avx512dq
+        run: cargo test --release --target x86_64-unknown-linux-gnu -p jolt-field --no-default-features --features solinas --test solinas_packed_differential

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -741,9 +741,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7.0.1
+      - name: Install nextest
+        uses: taiki-e/install-action@nextest
       - name: Run extractor tests
         working-directory: ./zklean-extractor
-        run: cargo test
+        run: cargo nextest run --cargo-quiet
 
   compile-extracted-lean:
     name: Compile extracted Lean

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3425,6 +3425,7 @@ dependencies = [
  "ark-ff 0.5.0 (git+https://github.com/a16z/arkworks-algebra?branch=dev%2Ftwist-shout)",
  "ark-serialize 0.5.0 (git+https://github.com/a16z/arkworks-algebra?branch=dev%2Ftwist-shout)",
  "bincode 2.0.1",
+ "criterion",
  "num-bigint",
  "num-traits",
  "rand 0.8.7",

--- a/crates/jolt-field/Cargo.toml
+++ b/crates/jolt-field/Cargo.toml
@@ -36,10 +36,15 @@ allocative = ["dep:allocative"]
 
 [dev-dependencies]
 bincode = { workspace = true }
+criterion = { workspace = true }
 num-bigint = { workspace = true }
 rand = { workspace = true }
 rand_chacha = { workspace = true }
 
 [[bench]]
 name = "ext4_kernels"
+harness = false
+
+[[bench]]
+name = "fp64_kernels"
 harness = false

--- a/crates/jolt-field/benches/fp64_kernels.rs
+++ b/crates/jolt-field/benches/fp64_kernels.rs
@@ -1,0 +1,54 @@
+//! Arithmetic benchmark coverage for the 63-bit carry-preserving scalar and
+//! packed kernels introduced by the Akita #427 port.
+//!
+//! Run with:
+//! `cargo bench -p jolt-field --no-default-features --features solinas --bench fp64_kernels`
+
+#[cfg(feature = "solinas")]
+mod harness {
+    use criterion::Criterion;
+    use jolt_field::{Ext2, Field, Packed, WithPacking};
+    use rand::SeedableRng;
+    use rand_chacha::ChaCha20Rng;
+    use std::hint::black_box;
+
+    type F63 = jolt_field::Fp64<{ (1u64 << 63) - 259 }>;
+    type PF63 = <F63 as WithPacking>::Packing;
+    type E63 = Ext2<F63>;
+    type PE63 = <E63 as WithPacking>::Packing;
+
+    pub(crate) fn bench(c: &mut Criterion) {
+        let mut rng = ChaCha20Rng::seed_from_u64(0xA427_0063);
+        let a = F63::random(&mut rng);
+        let b = F63::random(&mut rng);
+        let pa = PF63::from_fn(|_| F63::random(&mut rng));
+        let pb = PF63::from_fn(|_| F63::random(&mut rng));
+        let ea = E63::random(&mut rng);
+        let eb = E63::random(&mut rng);
+        let pea = PE63::from_fn(|_| E63::random(&mut rng));
+        let peb = PE63::from_fn(|_| E63::random(&mut rng));
+
+        let mut group = c.benchmark_group("fp64_prime63_offset259");
+        let _ = group.bench_function("scalar_mul", |bencher| {
+            bencher.iter(|| black_box(a) * black_box(b));
+        });
+        let _ = group.bench_function("packed_mul", |bencher| {
+            bencher.iter(|| black_box(pa) * black_box(pb));
+        });
+        let _ = group.bench_function("ext2_scalar_mul", |bencher| {
+            bencher.iter(|| black_box(ea) * black_box(eb));
+        });
+        let _ = group.bench_function("ext2_packed_mul", |bencher| {
+            bencher.iter(|| black_box(pea) * black_box(peb));
+        });
+        group.finish();
+    }
+}
+
+#[cfg(feature = "solinas")]
+criterion::criterion_group!(benches, harness::bench);
+#[cfg(feature = "solinas")]
+criterion::criterion_main!(benches);
+
+#[cfg(not(feature = "solinas"))]
+fn main() {}

--- a/crates/jolt-field/src/extension.rs
+++ b/crates/jolt-field/src/extension.rs
@@ -69,14 +69,31 @@ pub trait MulBaseUnreduced<F: Field>: ExtField<F> + Unreduced {
 /// A base field is its own degree-1 extension; the default body is exact.
 impl<F: PseudoMersenne + Unreduced + ExtField<F>> MulBaseUnreduced<F> for F {}
 
+/// Arithmetic form of an [`Ext2Config`] non-residue.
+///
+/// Configurations must use [`Self::Generic`] unless [`Ext2Config::non_residue`]
+/// returns exactly `-1` or `2`. Packed and delayed-reduction kernels use this
+/// value to select formulas that are valid only for those two constants.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Ext2NonResidueKind {
+    /// Any non-residue without a dedicated arithmetic formula.
+    Generic,
+    /// The non-residue is exactly `-1`.
+    NegOne,
+    /// The non-residue is exactly `2`.
+    Two,
+}
+
 /// Parameters for a quadratic extension `F[u]/(u^2 − NR)` over `F`.
 ///
 /// Implemented by zero-sized config types so the non-residue choice is a
 /// compile-time property of the extension type.
 pub trait Ext2Config<F: Ring> {
-    /// Whether the non-residue is −1: multiplication by `NR` is then a free
-    /// negation and the Karatsuba/squaring routines save a base multiply.
-    const IS_NEG_ONE: bool = false;
+    /// Arithmetic form of the non-residue.
+    ///
+    /// The default keeps the generic formula. Implementations may select a
+    /// specialized kind only when [`Self::non_residue`] returns that value.
+    const NON_RESIDUE_KIND: Ext2NonResidueKind = Ext2NonResidueKind::Generic;
 
     /// The quadratic non-residue `NR` with `u^2 = NR`.
     fn non_residue() -> F;
@@ -90,7 +107,7 @@ pub trait Ext2Config<F: Ring> {
         A: Copy + Add<Output = A> + Sub<Output = A> + Mul<Output = A>,
         B: FnOnce(F) -> A,
     {
-        if Self::IS_NEG_ONE {
+        if Self::NON_RESIDUE_KIND == Ext2NonResidueKind::NegOne {
             from_base(F::zero()) - x
         } else {
             from_base(Self::non_residue()) * x
@@ -102,7 +119,7 @@ pub trait Ext2Config<F: Ring> {
 pub struct NegOneNr;
 
 impl<F: Ring> Ext2Config<F> for NegOneNr {
-    const IS_NEG_ONE: bool = true;
+    const NON_RESIDUE_KIND: Ext2NonResidueKind = Ext2NonResidueKind::NegOne;
 
     #[inline]
     fn non_residue() -> F {
@@ -115,6 +132,8 @@ impl<F: Ring> Ext2Config<F> for NegOneNr {
 pub struct TwoNr;
 
 impl<F: Ring> Ext2Config<F> for TwoNr {
+    const NON_RESIDUE_KIND: Ext2NonResidueKind = Ext2NonResidueKind::Two;
+
     #[inline]
     fn non_residue() -> F {
         F::from_u64(2)

--- a/crates/jolt-field/src/lib.rs
+++ b/crates/jolt-field/src/lib.rs
@@ -108,7 +108,7 @@ pub use algebra::{
 };
 #[cfg(feature = "bn254")]
 pub use bn254::{Fq, Fr, FrSignedProductAccumulator, FrSmallScalarAccumulator, WideAccumulator};
-pub use extension::{Ext2Config, ExtField, MulBaseUnreduced, NegOneNr, TwoNr};
+pub use extension::{Ext2Config, Ext2NonResidueKind, ExtField, MulBaseUnreduced, NegOneNr, TwoNr};
 pub use limbs::Limbs;
 pub use num_traits::{One, Zero};
 pub use packed::{NoPacking, Packed, WithPacking};

--- a/crates/jolt-field/src/solinas/ext.rs
+++ b/crates/jolt-field/src/solinas/ext.rs
@@ -65,7 +65,7 @@ impl<F: Field, C: Ext2Config<F>> FpExt2<F, C> {
     }
 
     /// Multiplies a base-field element by the non-residue (a free negation
-    /// when `C::IS_NEG_ONE`).
+    /// when `C` declares a non-residue of `-1`).
     #[inline(always)]
     fn mul_nr(x: F) -> F {
         C::mul_non_residue(x, |base| base)

--- a/crates/jolt-field/src/solinas/packed/engine.rs
+++ b/crates/jolt-field/src/solinas/packed/engine.rs
@@ -17,7 +17,7 @@
 
 use super::simd::SimdWord;
 use crate::solinas::{Fp32, Fp64};
-use crate::Packed;
+use crate::{Ext2NonResidueKind, Packed};
 
 pub(crate) use super::fp128::PackedFp128;
 
@@ -266,12 +266,20 @@ impl<const P: u64, I: SimdWord> PackedFp64<P, I> {
         (1u64 << Self::BITS) - 1
     };
 
+    /// Adds lane-wise 128-bit values represented as `[lo, hi]`.
+    #[inline(always)]
+    fn add128(a: [I::V64; 2], b: [I::V64; 2]) -> [I::V64; 2] {
+        let lo = I::add64(a[0], b[0]);
+        let carry = I::select64(I::lt_u64(lo, a[0]), I::splat64(1), I::splat64(0));
+        [lo, I::add64(I::add64(a[1], b[1]), carry)]
+    }
+
     #[inline(always)]
     fn add_raw(a: Self, b: Self) -> Self {
         let p = I::splat64(P);
         let s = I::add64(a.0, b.0);
-        if Self::BITS <= 62 {
-            // a + b < 2P < 2^63: no wrap possible.
+        if Self::BITS < 64 {
+            // a + b < 2P < 2^64: no wrap possible.
             Self(I::select64(I::lt_u64(s, p), s, I::sub64(s, p)))
         } else {
             let no_wrap = I::select64(I::lt_u64(s, p), s, I::sub64(s, p));
@@ -301,7 +309,14 @@ impl<const P: u64, I: SimdWord> PackedFp64<P, I> {
     fn mul_raw(a: Self, b: Self) -> Self {
         if I::FP64_MUL_BY_LANES {
             Self(I::v64_from_fn(|i| {
-                (Fp64::<P>(I::v64_lane(a.0, i)) * Fp64::<P>(I::v64_lane(b.0, i))).0
+                let x = I::v64_lane(a.0, i);
+                let y = I::v64_lane(b.0, i);
+                if Self::BITS == 63 {
+                    if let Some(reduced) = I::mul_pm63(x, y, P, Self::C) {
+                        return reduced;
+                    }
+                }
+                (Fp64::<P>(x) * Fp64::<P>(y)).0
             }))
         } else {
             let [lo, hi] = I::mul64_wide(a.0, b.0);
@@ -313,11 +328,7 @@ impl<const P: u64, I: SimdWord> PackedFp64<P, I> {
     #[inline(always)]
     fn reduce128(lo: I::V64, hi: I::V64) -> I::V64 {
         let p = I::splat64(P);
-        if Self::BITS < 64 {
-            // Both folds stay in u64 whenever C < 2^(64−BITS) — true for
-            // every registered sub-64-bit prime (the scalar field switches
-            // to its u128 path in exactly the same regime).
-            debug_assert!(u128::from(Self::C) < 1u128 << (64 - Self::BITS));
+        if Self::BITS < 64 && Fp64::<P>::FOLD_IN_U64 {
             let mask = I::splat64(Self::MASK);
             let hi_k = I::add64(I::shr64(lo, Self::BITS), I::shl64(hi, 64 - Self::BITS));
             let f1 = I::add64(I::and64(lo, mask), mul_by_offset::<I>(hi_k, Self::C));
@@ -326,6 +337,8 @@ impl<const P: u64, I: SimdWord> PackedFp64<P, I> {
                 mul_by_offset::<I>(I::shr64(f1, Self::BITS), Self::C),
             );
             I::select64(I::lt_u64(f2, p), f2, I::sub64(f2, p))
+        } else if Self::BITS < 64 {
+            Self::reduce128_sub_word_wide(lo, hi)
         } else {
             // BITS == 64: hi·2^64 ≡ C·hi, a 96-bit product. Fold its carry
             // limb once more; the final +C correction cannot cascade
@@ -339,6 +352,30 @@ impl<const P: u64, I: SimdWord> PackedFp64<P, I> {
             let r = I::select64(I::lt_u64(r, s), I::add64(r, I::splat64(Self::C)), r);
             I::select64(I::lt_u64(r, p), r, I::sub64(r, p))
         }
+    }
+
+    /// Two-fold sub-word reduction that retains the carry out of the first
+    /// `C * (product >> BITS)` fold. It also accepts sums of up to three
+    /// products when [`Fp64::EXT2_TWO_FUSION_SAFE`] holds.
+    #[inline(always)]
+    fn reduce128_sub_word_wide(lo: I::V64, hi: I::V64) -> I::V64 {
+        let mask = I::splat64(Self::MASK);
+        let high = I::or64(I::shr64(lo, Self::BITS), I::shl64(hi, 64 - Self::BITS));
+        let high_overflow = I::shr64(hi, Self::BITS);
+        let [c_high_lo, c_high_hi] = I::mul_small_wide(high, Self::C);
+        let c_high_hi = I::add64(c_high_hi, I::mul_small(high_overflow, Self::C));
+
+        let low_bits = I::and64(lo, mask);
+        let fold1_lo = I::add64(low_bits, c_high_lo);
+        let carry = I::select64(I::lt_u64(fold1_lo, low_bits), I::splat64(1), I::splat64(0));
+        let fold1_hi = I::add64(c_high_hi, carry);
+        let fold1_high = I::or64(
+            I::shr64(fold1_lo, Self::BITS),
+            I::shl64(fold1_hi, 64 - Self::BITS),
+        );
+        let fold2 = I::add64(I::and64(fold1_lo, mask), I::mul_small(fold1_high, Self::C));
+        let p = I::splat64(P);
+        I::select64(I::lt_u64(fold2, p), fold2, I::sub64(fold2, p))
     }
 }
 
@@ -362,5 +399,54 @@ impl<const P: u64, I: SimdWord> Packed for PackedFp64<P, I> {
     #[inline]
     fn broadcast(value: Fp64<P>) -> Self {
         Self(I::splat64(value.0))
+    }
+
+    #[inline(always)]
+    fn ext2_mul<C: crate::Ext2Config<Self::Scalar>>(
+        a0: Self,
+        a1: Self,
+        b0: Self,
+        b1: Self,
+    ) -> (Self, Self) {
+        if C::NON_RESIDUE_KIND == Ext2NonResidueKind::Two && Fp64::<P>::EXT2_TWO_FUSION_SAFE {
+            if I::FP64_MUL_BY_LANES {
+                let c0 = I::v64_from_fn(|lane| {
+                    let a0 = I::v64_lane(a0.0, lane) as u128;
+                    let a1 = I::v64_lane(a1.0, lane) as u128;
+                    let b0 = I::v64_lane(b0.0, lane) as u128;
+                    let b1 = I::v64_lane(b1.0, lane) as u128;
+                    let z = a0 * b0 + 2 * a1 * b1;
+                    Fp64::<P>::reduce_three_product_sum(z as u64, (z >> 64) as u64)
+                });
+                let c1 = I::v64_from_fn(|lane| {
+                    let a0 = I::v64_lane(a0.0, lane) as u128;
+                    let a1 = I::v64_lane(a1.0, lane) as u128;
+                    let b0 = I::v64_lane(b0.0, lane) as u128;
+                    let b1 = I::v64_lane(b1.0, lane) as u128;
+                    let z = a0 * b1 + a1 * b0;
+                    Fp64::<P>::reduce_three_product_sum(z as u64, (z >> 64) as u64)
+                });
+                return (Self(c0), Self(c1));
+            }
+
+            let p00 = I::mul64_wide(a0.0, b0.0);
+            let p11 = I::mul64_wide(a1.0, b1.0);
+            let p01 = I::mul64_wide(a0.0, b1.0);
+            let p10 = I::mul64_wide(a1.0, b0.0);
+            let z0 = Self::add128(Self::add128(p00, p11), p11);
+            let z1 = Self::add128(p01, p10);
+            return (
+                Self(Self::reduce128_sub_word_wide(z0[0], z0[1])),
+                Self(Self::reduce128_sub_word_wide(z1[0], z1[1])),
+            );
+        }
+
+        let v0 = a0 * b0;
+        let v1 = a1 * b1;
+        let cross = (a0 + a1) * (b0 + b1);
+        (
+            v0 + C::mul_non_residue(v1, Self::broadcast),
+            cross - v0 - v1,
+        )
     }
 }

--- a/crates/jolt-field/src/solinas/packed/engine.rs
+++ b/crates/jolt-field/src/solinas/packed/engine.rs
@@ -265,6 +265,16 @@ impl<const P: u64, I: SimdWord> PackedFp64<P, I> {
     } else {
         (1u64 << Self::BITS) - 1
     };
+    /// Whether two folds and one subtraction reduce a sum of three products.
+    const EXT2_TWO_FUSION_SAFE: bool =
+        Self::BITS < 64 && 3 * (Self::C as u128) * (Self::C as u128 + 1) < P as u128;
+
+    /// Reduces a scalar sum of up to three products for lane-wise backends.
+    #[inline(always)]
+    fn reduce_three_product_sum(lo: u64, hi: u64) -> u64 {
+        debug_assert!(Self::EXT2_TWO_FUSION_SAFE);
+        Fp64::<P>::reduce_sub_word_wide(lo, hi, hi >> Self::BITS)
+    }
 
     /// Adds lane-wise 128-bit values represented as `[lo, hi]`.
     #[inline(always)]
@@ -356,7 +366,7 @@ impl<const P: u64, I: SimdWord> PackedFp64<P, I> {
 
     /// Two-fold sub-word reduction that retains the carry out of the first
     /// `C * (product >> BITS)` fold. It also accepts sums of up to three
-    /// products when [`Fp64::EXT2_TWO_FUSION_SAFE`] holds.
+    /// products when [`Self::EXT2_TWO_FUSION_SAFE`] holds.
     #[inline(always)]
     fn reduce128_sub_word_wide(lo: I::V64, hi: I::V64) -> I::V64 {
         let mask = I::splat64(Self::MASK);
@@ -408,7 +418,7 @@ impl<const P: u64, I: SimdWord> Packed for PackedFp64<P, I> {
         b0: Self,
         b1: Self,
     ) -> (Self, Self) {
-        if C::NON_RESIDUE_KIND == Ext2NonResidueKind::Two && Fp64::<P>::EXT2_TWO_FUSION_SAFE {
+        if C::NON_RESIDUE_KIND == Ext2NonResidueKind::Two && Self::EXT2_TWO_FUSION_SAFE {
             if I::FP64_MUL_BY_LANES {
                 let c0 = I::v64_from_fn(|lane| {
                     let a0 = I::v64_lane(a0.0, lane) as u128;
@@ -416,7 +426,7 @@ impl<const P: u64, I: SimdWord> Packed for PackedFp64<P, I> {
                     let b0 = I::v64_lane(b0.0, lane) as u128;
                     let b1 = I::v64_lane(b1.0, lane) as u128;
                     let z = a0 * b0 + 2 * a1 * b1;
-                    Fp64::<P>::reduce_three_product_sum(z as u64, (z >> 64) as u64)
+                    Self::reduce_three_product_sum(z as u64, (z >> 64) as u64)
                 });
                 let c1 = I::v64_from_fn(|lane| {
                     let a0 = I::v64_lane(a0.0, lane) as u128;
@@ -424,7 +434,7 @@ impl<const P: u64, I: SimdWord> Packed for PackedFp64<P, I> {
                     let b0 = I::v64_lane(b0.0, lane) as u128;
                     let b1 = I::v64_lane(b1.0, lane) as u128;
                     let z = a0 * b1 + a1 * b0;
-                    Fp64::<P>::reduce_three_product_sum(z as u64, (z >> 64) as u64)
+                    Self::reduce_three_product_sum(z as u64, (z >> 64) as u64)
                 });
                 return (Self(c0), Self(c1));
             }

--- a/crates/jolt-field/src/solinas/packed/simd.rs
+++ b/crates/jolt-field/src/solinas/packed/simd.rs
@@ -75,6 +75,13 @@ pub trait SimdWord: 'static {
     fn mul_pm31(_a: Self::V32, _b: Self::V32, _p: u32, _c: u32) -> Option<Self::V32> {
         None
     }
+
+    /// Scalar-lane multiply for 63-bit pseudo-Mersenne primes when the ISA
+    /// has a dedicated carry-preserving sequence.
+    #[inline(always)]
+    fn mul_pm63(_a: u64, _b: u64, _p: u64, _c: u64) -> Option<u64> {
+        None
+    }
 }
 
 /// Stamps vocabulary methods whose body is a single (possibly block)
@@ -220,6 +227,45 @@ mod neon {
                 let tprime = vaddq_u32(vmulq_u32(hp, cvec), lo31p);
                 Some(vminq_u32(tprime, vsubq_u32(tprime, pvec)))
             }
+        }
+
+        /// Carry-preserving two-fold reducer for `p = 2^63 - c`.
+        #[inline(always)]
+        fn mul_pm63(lhs: u64, rhs: u64, _p: u64, c: u64) -> Option<u64> {
+            let result: u64;
+            let reduction_bias = (1u64 << 63) + c;
+
+            // SAFETY: the assembly has no memory or stack effects and all
+            // temporaries are declared outputs. The caller dispatches here
+            // only for a 63-bit modulus satisfying the field invariant.
+            unsafe {
+                core::arch::asm!(
+                    "umulh {high}, {lhs}, {rhs}",
+                    "mul {result}, {lhs}, {rhs}",
+                    "extr {quotient}, {high}, {result}, #63",
+                    "and {result}, {result}, #0x7fffffffffffffff",
+                    "umulh {product_hi}, {quotient}, {c}",
+                    "mul {product_lo}, {quotient}, {c}",
+                    "adds {result}, {result}, {product_lo}",
+                    "adc {high}, {product_hi}, xzr",
+                    "extr {quotient}, {high}, {result}, #63",
+                    "and {result}, {result}, #0x7fffffffffffffff",
+                    "madd {result}, {quotient}, {c}, {result}",
+                    "adds {high}, {result}, {reduction_bias}",
+                    "csel {result}, {high}, {result}, hs",
+                    lhs = in(reg) lhs,
+                    rhs = in(reg) rhs,
+                    c = in(reg) c,
+                    reduction_bias = in(reg) reduction_bias,
+                    result = out(reg) result,
+                    high = out(reg) _,
+                    quotient = out(reg) _,
+                    product_lo = out(reg) _,
+                    product_hi = out(reg) _,
+                    options(pure, nomem, nostack),
+                );
+            }
+            Some(result)
         }
     }
 }

--- a/crates/jolt-field/src/solinas/unreduced.rs
+++ b/crates/jolt-field/src/solinas/unreduced.rs
@@ -517,24 +517,27 @@ fn fp64_accum_limbs(lo128: u128, hi_carry: u128) -> [u128; 2] {
 /// - `NR = 2`: `c0 = p00 + 2·p11 < 3P² < 2^130`, carry ∈ {0, 1, 2}.
 /// - `c1 = p01 + p10 < 2P² < 2^129`, carry ∈ {0, 1}.
 ///
-/// Only these two non-residues are supported (debug-asserted); a third
-/// `Ext2Config` would need its own carry analysis. (The baseline compiled
-/// the same two-case body for arbitrary configs without checking.)
+/// The specialized carry analysis applies to these two non-residues. Other
+/// configurations reduce each product first and lift its canonical
+/// coordinates into the same exact accumulator representation.
 #[inline(always)]
 fn fp_ext2_mul_to_accum_fp64<const P: u64, C: Ext2Config<Fp64<P>>>(
     a: [Fp64<P>; 2],
     b: [Fp64<P>; 2],
 ) -> FpExt2Fp64ProductAccum {
-    debug_assert!(
-        C::IS_NEG_ONE || C::non_residue() == Fp64::<P>::from_u64(2),
-        "fp_ext2_mul_to_accum_fp64 supports NR ∈ {{−1, 2}} only"
-    );
+    let subtract_p11 = match C::NON_RESIDUE_KIND {
+        crate::Ext2NonResidueKind::Generic => {
+            return fp_ext2_reduced_product_accum::<P, C>(a, b);
+        }
+        crate::Ext2NonResidueKind::NegOne => true,
+        crate::Ext2NonResidueKind::Two => false,
+    };
     let p00 = a[0].mul_wide(b[0]);
     let p11 = a[1].mul_wide(b[1]);
     let p01 = a[0].mul_wide(b[1]);
     let p10 = a[1].mul_wide(b[0]);
 
-    let [c0_lo, c0_hi] = if C::IS_NEG_ONE {
+    let [c0_lo, c0_hi] = if subtract_p11 {
         // c0 = p00 + P² − p11 (the P² bias keeps it non-negative and is
         // invisible mod p).
         let modulus_sq = (P as u128) * (P as u128);
@@ -552,6 +555,23 @@ fn fp_ext2_mul_to_accum_fp64<const P: u64, C: Ext2Config<Fp64<P>>>(
     let [c1_lo, c1_hi] = fp64_accum_limbs(c1_sum, c1_carry as u128);
 
     FpExt2Fp64ProductAccum([c0_lo, c0_hi, c1_lo, c1_hi])
+}
+
+#[inline(always)]
+fn fp_ext2_reduced_product_accum<const P: u64, C: Ext2Config<Fp64<P>>>(
+    a: [Fp64<P>; 2],
+    b: [Fp64<P>; 2],
+) -> FpExt2Fp64ProductAccum {
+    // An arbitrary non-residue can make NR*p11 wider than the two-limb
+    // coefficient accumulator. Reduce this uncommon configuration first,
+    // then lift the canonical coordinates into the exact split-limb sum.
+    let product = FpExt2::<Fp64<P>, C>::new(a[0], a[1]) * FpExt2::new(b[0], b[1]);
+    FpExt2Fp64ProductAccum([
+        product.coeffs[0].0 as u128,
+        0,
+        product.coeffs[1].0 as u128,
+        0,
+    ])
 }
 
 impl<const P: u64, C: Ext2Config<Fp64<P>>> Unreduced for FpExt2<Fp64<P>, C> {

--- a/crates/jolt-field/src/solinas/word.rs
+++ b/crates/jolt-field/src/solinas/word.rs
@@ -139,13 +139,12 @@ macro_rules! define_solinas_prime {
 
             #[inline(always)]
             fn sub_raw(a: $word, b: $word) -> $word {
-                if Self::BITS < <$word>::BITS {
-                    let d = a.wrapping_sub(b);
-                    d.min(d.wrapping_add(P))
-                } else {
-                    let (d, underflow) = a.overflowing_sub(b);
-                    d.wrapping_sub((underflow as $word).wrapping_neg() & Self::C)
-                }
+                let (d, underflow) = a.overflowing_sub(b);
+                // If subtraction borrowed, subtracting -P modulo the word
+                // adds P. At full width, -P is the small Solinas offset C.
+                d.wrapping_sub(
+                    (underflow as $word).wrapping_neg() & P.wrapping_neg()
+                )
             }
 
             #[inline(always)]
@@ -417,11 +416,8 @@ define_solinas_prime!(
     double: u128,
     mul_wide_raw: mul_wide_u64(u64),
     mul(a, b): {
-        if fp64_folds_in_word(P) {
-            fp64_mul_fast::<P>(a, b)
-        } else {
-            Self::reduce_product((a as u128) * (b as u128))
-        }
+        let (lo, hi) = mul64_wide(a, b);
+        Self::reduce_product_wide(lo, hi)
     },
     random(rng): Self(super::sample_uniform_below(rng, P as u128, Self::BITS) as u64),
 );
@@ -430,12 +426,59 @@ impl<const P: u64> PseudoMersenne for Fp64<P> {
     const OFFSET: u128 = Self::C as u128;
 }
 
-/// Whether the two-fold product reduction stays entirely in `u64` for the
-/// modulus `p`: sub-word prime with `C · 2^BITS < 2^64`.
-#[inline(always)]
-const fn fp64_folds_in_word(p: u64) -> bool {
-    let bits = 64 - p.leading_zeros();
-    bits < 64 && (((1u64 << bits) - p) as u128) < (1u128 << (64 - bits))
+impl<const P: u64> Fp64<P> {
+    /// Mask for the low `BITS` bits in a word.
+    pub(crate) const MASK64: u64 = if Self::BITS < 64 {
+        (1u64 << Self::BITS) - 1
+    } else {
+        u64::MAX
+    };
+
+    /// Whether both product folds stay in a single word.
+    pub(crate) const FOLD_IN_U64: bool =
+        Self::BITS < 64 && (Self::C as u128) < (1u128 << (64 - Self::BITS));
+
+    /// Whether two folds and one subtraction reduce a sum of three products.
+    pub(crate) const EXT2_TWO_FUSION_SAFE: bool =
+        Self::BITS < 64 && 3 * (Self::C as u128) * (Self::C as u128 + 1) < P as u128;
+
+    /// Reduces a product supplied as exact low and high words.
+    #[inline(always)]
+    pub(crate) fn reduce_product_wide(lo: u64, hi: u64) -> u64 {
+        if Self::FOLD_IN_U64 {
+            let high = (lo >> Self::BITS) | (hi << (64 - Self::BITS));
+            let f1 = (lo & Self::MASK64) + mul_c_narrow(Self::C, high);
+            let f2 = (f1 & Self::MASK64) + mul_c_narrow(Self::C, f1 >> Self::BITS);
+            let reduced = f2.wrapping_sub(P);
+            reduced.wrapping_add((reduced >> 63).wrapping_neg() & P)
+        } else if Self::BITS < 64 {
+            Self::reduce_sub_word_wide(lo, hi, 0)
+        } else {
+            Self::reduce_product((lo as u128) | ((hi as u128) << 64))
+        }
+    }
+
+    /// Reduces a sum of up to three products for the fused quadratic kernel.
+    #[inline(always)]
+    pub(crate) fn reduce_three_product_sum(lo: u64, hi: u64) -> u64 {
+        debug_assert!(Self::EXT2_TWO_FUSION_SAFE);
+        Self::reduce_sub_word_wide(lo, hi, hi >> Self::BITS)
+    }
+
+    /// Two-fold sub-word reduction. `high_overflow` is the portion of
+    /// `x >> BITS` above one word, which can be nonzero for three products.
+    #[inline(always)]
+    fn reduce_sub_word_wide(lo: u64, hi: u64, high_overflow: u64) -> u64 {
+        let high = (lo >> Self::BITS) | (hi << (64 - Self::BITS));
+        let c_high = (Self::C as u128) * (high as u128)
+            + (((Self::C as u128) * (high_overflow as u128)) << 64);
+        let (fold1_lo, carry) = (lo & Self::MASK64).overflowing_add(c_high as u64);
+        let fold1_hi = ((c_high >> 64) as u64) + u64::from(carry);
+        let fold1_high = (fold1_lo >> Self::BITS) | (fold1_hi << (64 - Self::BITS));
+        let fold2 = (fold1_lo & Self::MASK64) + mul_c_narrow(Self::C, fold1_high);
+        let reduced = fold2.wrapping_sub(P);
+        reduced.wrapping_add(u64::from(fold2 < P).wrapping_neg() & P)
+    }
 }
 
 /// `a * b` widening to 128 bits; returns `(lo, hi)`. Shared with the
@@ -470,20 +513,4 @@ fn mul_c_narrow(c: u64, x: u64) -> u64 {
         let (c, x_lo, x_hi) = (c as u32 as u64, x as u32 as u64, x >> 32);
         (c * x_lo).wrapping_add((c * x_hi) << 32)
     }
-}
-
-/// Two-fold product reduction entirely in `u64` (requires
-/// [`fp64_folds_in_word`]): avoids u128 mask/shift on sub-word primes.
-#[inline(always)]
-fn fp64_mul_fast<const P: u64>(a: u64, b: u64) -> u64 {
-    let bits = 64 - P.leading_zeros();
-    let c = (1u64 << bits).wrapping_sub(P);
-    let mask = (1u64 << bits) - 1;
-    let (lo, hi) = mul64_wide(a, b);
-    let high = (lo >> bits) | (hi << (64 - bits));
-    let f1 = (lo & mask) + mul_c_narrow(c, high);
-    let f2 = (f1 & mask) + mul_c_narrow(c, f1 >> bits);
-    let reduced = f2.wrapping_sub(P);
-    let borrow = reduced >> 63;
-    reduced.wrapping_add(borrow.wrapping_neg() & P)
 }

--- a/crates/jolt-field/src/solinas/word.rs
+++ b/crates/jolt-field/src/solinas/word.rs
@@ -438,10 +438,6 @@ impl<const P: u64> Fp64<P> {
     pub(crate) const FOLD_IN_U64: bool =
         Self::BITS < 64 && (Self::C as u128) < (1u128 << (64 - Self::BITS));
 
-    /// Whether two folds and one subtraction reduce a sum of three products.
-    pub(crate) const EXT2_TWO_FUSION_SAFE: bool =
-        Self::BITS < 64 && 3 * (Self::C as u128) * (Self::C as u128 + 1) < P as u128;
-
     /// Reduces a product supplied as exact low and high words.
     #[inline(always)]
     pub(crate) fn reduce_product_wide(lo: u64, hi: u64) -> u64 {
@@ -458,17 +454,10 @@ impl<const P: u64> Fp64<P> {
         }
     }
 
-    /// Reduces a sum of up to three products for the fused quadratic kernel.
-    #[inline(always)]
-    pub(crate) fn reduce_three_product_sum(lo: u64, hi: u64) -> u64 {
-        debug_assert!(Self::EXT2_TWO_FUSION_SAFE);
-        Self::reduce_sub_word_wide(lo, hi, hi >> Self::BITS)
-    }
-
     /// Two-fold sub-word reduction. `high_overflow` is the portion of
     /// `x >> BITS` above one word, which can be nonzero for three products.
     #[inline(always)]
-    fn reduce_sub_word_wide(lo: u64, hi: u64, high_overflow: u64) -> u64 {
+    pub(super) fn reduce_sub_word_wide(lo: u64, hi: u64, high_overflow: u64) -> u64 {
         let high = (lo >> Self::BITS) | (hi << (64 - Self::BITS));
         let c_high = (Self::C as u128) * (high as u128)
             + (((Self::C as u128) * (high_overflow as u128)) << 64);

--- a/crates/jolt-field/tests/solinas_packed_differential.rs
+++ b/crates/jolt-field/tests/solinas_packed_differential.rs
@@ -14,7 +14,7 @@
 
 use jolt_field as two;
 
-use rand::SeedableRng;
+use rand::{Rng, SeedableRng};
 use rand_chacha::ChaCha20Rng;
 use two::{
     pseudo_mersenne_modulus, CanonicalEncoding, ExtField, Field, NoPacking, Packed, WithPacking,
@@ -84,6 +84,53 @@ where
     check_boundary_patterns::<PF>(p);
 }
 
+/// Packed Fp64 arithmetic checked directly against integer modular
+/// arithmetic, without routing the expectation through the scalar kernel.
+fn check_fp64_integer_oracle<const P: u64, PF>(lhs: &[u64], rhs: &[u64])
+where
+    PF: Packed<Scalar = two::Fp64<P>>,
+{
+    assert_eq!(lhs.len(), PF::WIDTH);
+    assert_eq!(rhs.len(), PF::WIDTH);
+    let a = PF::from_fn(|i| two::Fp64::<P>::from_u128_checked(lhs[i] as u128).unwrap());
+    let b = PF::from_fn(|i| two::Fp64::<P>::from_u128_checked(rhs[i] as u128).unwrap());
+    let (sum, diff, product) = (a + b, a - b, a * b);
+    for lane in 0..PF::WIDTH {
+        let x = lhs[lane] as u128;
+        let y = rhs[lane] as u128;
+        let p = P as u128;
+        assert_eq!(sum.extract(lane).to_u128_checked(), Some((x + y) % p));
+        assert_eq!(diff.extract(lane).to_u128_checked(), Some((x + p - y) % p));
+        assert_eq!(product.extract(lane).to_u128_checked(), Some((x * y) % p));
+    }
+}
+
+fn check_fp64_wide_sub_word<const P: u64>(seed: u64)
+where
+    two::Fp64<P>: WithPacking,
+{
+    type F<const Q: u64> = two::Fp64<Q>;
+    let boundary = [0, 1, 2, (P - 1) / 2, P - 2, P - 1];
+    for &x in &boundary {
+        for &y in &boundary {
+            check_fp64_integer_oracle::<P, <F<P> as WithPacking>::Packing>(
+                &vec![x; <F<P> as WithPacking>::Packing::WIDTH],
+                &vec![y; <F<P> as WithPacking>::Packing::WIDTH],
+            );
+        }
+    }
+    let mut rng = ChaCha20Rng::seed_from_u64(seed);
+    for _ in 0..1024 {
+        let lhs: Vec<u64> = (0..<F<P> as WithPacking>::Packing::WIDTH)
+            .map(|_| rng.gen::<u64>() % P)
+            .collect();
+        let rhs: Vec<u64> = (0..<F<P> as WithPacking>::Packing::WIDTH)
+            .map(|_| rng.gen::<u64>() % P)
+            .collect();
+        check_fp64_integer_oracle::<P, <F<P> as WithPacking>::Packing>(&lhs, &rhs);
+    }
+}
+
 /// `from_fn`/`extract`/`broadcast` and the slice-helper laws.
 fn check_lane_laws<PF: Packed>(vals: &[PF::Scalar]) {
     let w = PF::WIDTH;
@@ -139,6 +186,12 @@ fn packed_fp64_matches_scalar() {
     check_prime_field::<<two::Prime48Offset59 as WithPacking>::Packing>(pm(48, 59), 0x4801);
     check_prime_field::<<two::Prime56Offset27 as WithPacking>::Packing>(pm(56, 27), 0x5601);
     check_prime_field::<<two::Prime64Offset59 as WithPacking>::Packing>(pm(64, 59), 0x6401);
+}
+
+#[test]
+fn packed_fp64_wide_sub_word_matches_integer_reference() {
+    check_fp64_wide_sub_word::<{ (1u64 << 63) - 259 }>(0xAA63_0259);
+    check_fp64_wide_sub_word::<{ (1u64 << 63) - 25 }>(0xAA63_0025);
 }
 
 #[test]
@@ -205,6 +258,22 @@ fn packed_ext2_matches_scalar() {
     check_ext_field::<<two::Ext2<F64> as WithPacking>::Packing, F64>(pm(64, 59), 0xE203);
     type F128 = two::Prime128Offset275;
     check_ext_field::<<two::Ext2<F128> as WithPacking>::Packing, F128>(pm(128, 275), 0xE204);
+
+    // Fused NR=2 paths: a wide 63-bit base product, a narrow base reducer
+    // whose three-product coefficient needs the wide fold, and a large
+    // offset that exercises the full-low-word SIMD correction multiply.
+    type Wide = two::Fp64<{ (1u64 << 63) - 259 }>;
+    check_ext_field::<<two::Ext2<Wide> as WithPacking>::Packing, Wide>((1u128 << 63) - 259, 0xE205);
+    type NarrowBase = two::Fp64<{ (1u64 << 58) - 27 }>;
+    check_ext_field::<<two::Ext2<NarrowBase> as WithPacking>::Packing, NarrowBase>(
+        (1u128 << 58) - 27,
+        0xE206,
+    );
+    type LargeOffset = two::Fp64<{ (1u64 << 63) - 1_500_000_051 }>;
+    check_ext_field::<<two::Ext2<LargeOffset> as WithPacking>::Packing, LargeOffset>(
+        (1u128 << 63) - 1_500_000_051,
+        0xE207,
+    );
 }
 
 #[test]

--- a/crates/jolt-field/tests/solinas_unreduced_differential.rs
+++ b/crates/jolt-field/tests/solinas_unreduced_differential.rs
@@ -30,6 +30,15 @@ use two::{
 };
 
 const M61: u64 = (1 << 61) - 1;
+const P62: u64 = (1 << 62) - 143;
+
+struct ThreeNr;
+
+impl two::Ext2Config<two::Fp64<P62>> for ThreeNr {
+    fn non_residue() -> two::Fp64<P62> {
+        <two::Fp64<P62> as Ring>::from_u64(3)
+    }
+}
 
 #[test]
 fn commitment_accumulation_limit_is_the_exact_i32_lane_bound() {
@@ -497,6 +506,15 @@ ext2_fp64_suite!(
     two::NegOneNr,
     M61 as u128,
     0x0E22_0003
+);
+// A custom non-residue must use the generic reduced-product fallback rather
+// than silently taking the NR=2 carry formula.
+ext2_fp64_suite!(
+    ext2_fp64_generic_non_residue_accum,
+    two::Fp64<P62>,
+    ThreeNr,
+    P62 as u128,
+    0x0E22_0004
 );
 
 /// Fold semantics for one instantiation: `fold_one(precompute(r), e, o)`

--- a/crates/jolt-field/tests/solinas_words_differential.rs
+++ b/crates/jolt-field/tests/solinas_words_differential.rs
@@ -228,6 +228,10 @@ fn fp64_offsets_match() {
     check_prime!(two::Prime64Offset59, (1 << 64) - 59, 8, &mut rng);
     // Mersenne61: sub-word u64 prime exercising C = 1.
     check_prime!(two::Fp64<{ (1 << 61) - 1 }>, (1 << 61) - 1, 8, &mut rng);
+    // Test-only 63-bit primes exercise the carry-preserving wide sub-word
+    // reducer with two distinct offsets.
+    check_prime!(two::Fp64<{ (1 << 63) - 259 }>, (1 << 63) - 259, 8, &mut rng);
+    check_prime!(two::Fp64<{ (1 << 63) - 25 }>, (1 << 63) - 25, 8, &mut rng);
 }
 
 /// The registered prime-offset table, pinned as data. Generated from

--- a/z3-verifier/README.md
+++ b/z3-verifier/README.md
@@ -6,7 +6,7 @@ This is structured as tests, but note that all tests are not expected to succeed
 
 Consistency refers to a virtual sequence only allowing a single result for a given input, i.e it not being underconstrained. Correctness is a stronger statement which says that it only allows the correct computation, this may be harder to solve for which is why they are separated.
 
-To see the found examples of contradictions run using `cargo test -- --nocapture`.
+To see the found examples of contradictions, run `cargo nextest run --no-capture`.
 
 To run you will need z3 installed on your system.
 ```

--- a/zklean-extractor/README.md
+++ b/zklean-extractor/README.md
@@ -27,10 +27,10 @@ Testing
 
 You can run tests on the internal representation produced by the `zklean-extractor` executable by running the following from the root of the Jolt repo:
 ```sh
-cargo test -p zklean-extractor
+cargo nextest run -p zklean-extractor
 ```
 
 These tests use the [`proptest`](https://docs.rs/proptest/latest/proptest/index.html) library to ensure that extracting a representation of each constraint and MLE and executing it produces the same result as computing the constraint or MLE on its own. By default we run proptest for 256 iterations, however this can be changed on the command line. For example, to run 512 iterations instead, you can run
 ```sh
-PROPTEST_CASES=512 cargo test -p zklean-extractor
+PROPTEST_CASES=512 cargo nextest run -p zklean-extractor
 ```


### PR DESCRIPTION
## Summary

This ports the field arithmetic kernel work from [Akita #427](https://github.com/LayerZero-Labs/akita/pull/427) into the canonical `jolt-field` implementation landed by #1792.

It fixes carry handling for valid generic subword `Fp64<P>` moduli, adds the fused packed `FpExt2<TwoNr>` path, preserves optimized NEON, AVX2, and AVX-512 execution, and adds independent regression coverage. This is the Jolt-side prerequisite for refreshing and merging [Akita #429](https://github.com/LayerZero-Labs/akita/pull/429).

## What changed

### Scalar Fp64 arithmetic

* Keep the first Solinas fold as an exact two-word value when `C * (product >> BITS)` does not fit in one `u64`.
* Use the carry-preserving reducer for generic 63-bit moduli such as `2^63 - 259` and `2^63 - 25`.
* Simplify subword addition and subtraction using the fact that `2P < 2^64` for every subword modulus.
* Retain a dedicated AArch64 63-bit multiply and reduction sequence.

### Extension and packed arithmetic

* Replace the boolean `Ext2Config::IS_NEG_ONE` marker with `Ext2NonResidueKind::{Generic, NegOne, Two}` so specialized formulas are selected explicitly.
* Use a correct reduced-product fallback for custom non-residues in delayed `FpExt2<Fp64>` accumulation.
* Fuse the four raw base products and two final reductions for packed `FpExt2<TwoNr>` when the exact accumulation bound holds.
* Share the carry-preserving reduction through the existing `SimdWord` engine across NEON, AVX2, and AVX-512.
* Keep Jolt's full-low-word SIMD correction multiply. This removes an Akita-specific AVX fallback that was only required by its older low-32-bit implementation.

### Evidence and portability

* Add independent integer-oracle tests for two generic 63-bit moduli.
* Add fused extension regressions for wide subword products, first-fold carry, and large offsets.
* Add a custom non-residue delayed-accumulation regression.
* Add a reproducible scalar, packed, and extension benchmark for `2^63 - 259`.
* Add dedicated CI execution on AVX2, AArch64 NEON, and emulated AVX-512.

No public Fp31 or Fp63 preset is added in this PR.

## Validation

* `cargo fmt --all --check`
* `taplo fmt --check crates/jolt-field/Cargo.toml`
* `cargo clippy -p jolt-field --all-targets --no-default-features --features solinas -- -D warnings`
* `cargo nextest run -p jolt-field --no-default-features --features solinas --release`: 119 passed
* Native AArch64 NEON packed differential suite: 9 passed
* Native AVX2 packed differential suite: 9 passed
* Native AVX-512 packed differential suite: 9 passed
* AVX2 and AVX-512 cross-compilation with `-D warnings`

A short Apple M4 smoke run measured approximately 1.11 ns for scalar Fp64 multiply, 2.64 ns for a two-lane packed multiply, 7.21 ns for scalar Ext2 multiply, and 8.27 ns for a two-lane packed Ext2 multiply. These numbers confirm the benchmark and optimized paths execute. They are not a stable baseline comparison.

Repository-wide `taplo fmt --check` still reports three pre-existing vendored Lean package TOML files under `zklean-extractor/package-template/.lake/packages`. This PR does not touch those files.
