### PR TITLE
docs: weekly freshness pass (Aug 24)

### DIFF
--- a/agent-skills/jolt/SKILL.md
+++ b/agent-skills/jolt/SKILL.md
@@ -114,10 +114,10 @@ For `PrivateInput<T>`, enable `zk` on the host only (see Step 7). The macro enfo
 
 | Hash | Cycles | vs SHA-256 | Max input |
 |------|--------|-----------|-----------|
-| BLAKE3 | 863 | 8.2x faster | 64 bytes (single block only) |
-| Blake2b | 1,264 | 5.6x faster | unlimited |
+| BLAKE3 | 781 | 9.1x faster | 64 bytes (single block only) |
+| Blake2b | 1,235 | 5.8x faster | unlimited |
 | Keccak-256 | 3,680 | 1.9x faster | unlimited |
-| SHA-256 | 7,134 | baseline | unlimited |
+| SHA-256 | 7,140 | baseline | unlimited |
 
 BLAKE3 is fastest but capped at 64 bytes. For variable-length hashing, Blake2b is the best choice. SHA-256 must be used when the hash is dictated by an external protocol (e.g., JWT RSA-SHA256 signatures).
 


### PR DESCRIPTION
## Week's changes reviewed (Aug 17–24, 19 commits)

#1792 shared field stack, #1791 dory-pcs 0.4.2, #1754 read-raf hygiene, #1737 parallel preprocessing, #1761 fused sub-word LW, #1718 Akita port to modular prover, #1777 WASM verifier fix, #1731 Akita prefix-packed commitments, #1778 inline-alias facade removal + jolt_asm!, #1757 SHA-256 ingest polish, #1756 BLAKE3/BLAKE2/bigint polish, dep bumps.

## Drift found and fixed

- **agent-skills/jolt/SKILL.md** hash inline cycle table was stale after #1756/#1757. Updated to the current 64B aligned numbers from `examples/hash-bench/README.md` (refreshed by those PRs): BLAKE3 863→781 (9.1x), Blake2b 1,264→1,235 (5.8x), SHA-256 baseline 7,134→7,140. Keccak-256 unchanged (3,680).

## Claims verified against code (no drift)

- CLAUDE.md `akita`/`zk` mutual exclusion — `compile_error!` still present in `crates/jolt-prover/src/lib.rs:37`; feature wiring in `crates/jolt-prover/Cargo.toml` matches.
- CLAUDE.md legacy `field/` module description — `crates/jolt-prover-legacy/src/field/mod.rs` still defines `JoltField` post-#1792 (the shared stack landed in `crates/jolt-field` alongside it).
- CLAUDE.md modular-stack crate count (27 excl. legacy) — still matches `crates/` (28 dirs incl. legacy).
- CLAUDE.md `Kind`-alias emit style — post-#1778 call sites still use `Kind::MUL` via the SDK aliases (`jolt-inlines/sdk/src/host.rs`).
- book `ram.md` sub-word claim — post-#1761 LW still expands to an LD-based inline sequence (now 6 cycles via WindowMaskW/PextSigned), so "expanded into inline sequences that use LD/SD" remains accurate.
- book `inlines.md` benchmarks + registers 48–127 and `examples/hash-bench/README.md` — already refreshed by #1756/#1757/#1778 themselves.
- book `testing-gates.md` Akita matrix note — still accurate post-#1718 (Akita ZK remains compile-probed).

No other doc surfaces (README.md, book/, .claude/skills/) drifted this week.