### PR TITLE
feat(field): expose canonical storage capabilities

### DIFF
--- a/crates/jolt-field/src/algebra.rs
+++ b/crates/jolt-field/src/algebra.rs
@@ -328,6 +328,16 @@ pub trait CanonicalEncoding:
         None
     }
 
+    /// Borrows canonical `u64` representatives without per-element conversion.
+    ///
+    /// Fields whose in-memory representation is exactly one canonical `u64`
+    /// may override this capability. Narrower or encoded fields return `None`.
+    #[inline]
+    fn canonical_u64_slice(values: &[Self]) -> Option<&[u64]> {
+        let _ = values;
+        None
+    }
+
     /// Number of significant bits in this element's canonical representative.
     ///
     /// Zero is considered to have zero significant bits.

--- a/crates/jolt-field/src/solinas/fp128.rs
+++ b/crates/jolt-field/src/solinas/fp128.rs
@@ -634,7 +634,7 @@ impl<const P: u128> Fp128<P> {
     /// `x` must be less than `P`. Violating this condition breaks the private
     /// canonical representation invariant used by the arithmetic kernels.
     #[inline]
-    pub unsafe fn from_canonical_u128(x: u128) -> Self {
+    pub const unsafe fn from_canonical_u128(x: u128) -> Self {
         debug_assert!(x < P);
         Self(split(x))
     }

--- a/crates/jolt-field/src/solinas/word.rs
+++ b/crates/jolt-field/src/solinas/word.rs
@@ -341,6 +341,11 @@ macro_rules! define_solinas_prime {
             }
 
             #[inline]
+            fn canonical_u64_slice(values: &[Self]) -> Option<&[u64]> {
+                canonical_u64_slice!($word, values)
+            }
+
+            #[inline]
             fn num_bits(&self) -> u32 {
                 <$word>::BITS - self.0.leading_zeros()
             }
@@ -365,6 +370,18 @@ macro_rules! define_solinas_prime {
 macro_rules! canonical_u32_slice {
     (u32, $values:ident) => {{
         // SAFETY: `Fp32` is transparent over one `u32`, and every constructor
+        // and arithmetic operation maintains a canonical representative.
+        Some(unsafe { std::slice::from_raw_parts($values.as_ptr().cast(), $values.len()) })
+    }};
+    ($word:ident, $values:ident) => {{
+        let _ = $values;
+        None
+    }};
+}
+
+macro_rules! canonical_u64_slice {
+    (u64, $values:ident) => {{
+        // SAFETY: `Fp64` is transparent over one `u64`, and every constructor
         // and arithmetic operation maintains a canonical representative.
         Some(unsafe { std::slice::from_raw_parts($values.as_ptr().cast(), $values.len()) })
     }};

--- a/crates/jolt-field/tests/solinas_fp128_differential.rs
+++ b/crates/jolt-field/tests/solinas_fp128_differential.rs
@@ -426,3 +426,10 @@ fn jolt_field_blanket_covers_fp128() {
     check::<two::Prime128Offset275>();
     check::<two::Prime128OffsetA7F7>();
 }
+
+#[test]
+fn fp128_canonical_constructor_is_const_usable() {
+    // SAFETY: one is below every supported prime modulus.
+    const ONE: two::Prime128OffsetA7F7 = unsafe { two::Prime128OffsetA7F7::from_canonical_u128(1) };
+    assert_eq!(ONE.to_u128_checked(), Some(1));
+}

--- a/crates/jolt-field/tests/solinas_words_differential.rs
+++ b/crates/jolt-field/tests/solinas_words_differential.rs
@@ -323,3 +323,12 @@ fn fp32_exposes_canonical_storage_slice_only_for_u32_fields() {
     assert_eq!(F32::canonical_u32_slice(&values), Some(&[1, 7, 42][..]));
     assert!(F64::canonical_u32_slice(&[F64::from_u64(1)]).is_none());
 }
+
+#[test]
+fn fp64_exposes_canonical_storage_slice_only_for_u64_fields() {
+    type F32 = two::Prime32Offset99;
+    type F64 = two::Prime64Offset59;
+    let values = [F64::from_u64(1), F64::from_u64(7), F64::from_u64(42)];
+    assert_eq!(F64::canonical_u64_slice(&values), Some(&[1, 7, 42][..]));
+    assert!(F32::canonical_u64_slice(&[F32::from_u64(1)]).is_none());
+}


### PR DESCRIPTION
## Summary

This is the minimal Jolt foundation for the refreshed shared-field cutover stack. It adds a zero-copy canonical-`u64` slice capability for Solinas `Fp64` fields and makes the raw canonical Fp128 constructor usable in const contexts while preserving its explicit unsafe precondition.

Akita needs the borrowed `u64` storage to retain its optimized native carry/decomposition path after deleting its duplicate field trait. Its const field adapters also need to construct known canonical identities without introducing a second wrapper implementation.

### Diff metadata

- Base: `53ed6c31977d463e1e9061fd4b5569825d04e4e6` (`main`)
- Head: `ba36f6d53a51d6fb724d5c27fb4b48604975f1a4`
- Commits: 2
- Files changed: 5
- Diff: 44 insertions, 1 deletion

## Changes

- Add `CanonicalEncoding::canonical_u64_slice`, defaulting to `None` like the existing `canonical_u32_slice` capability.
- Implement the capability for `Fp64<P>` as a borrowed one-word slice.
- Keep narrower, wider, extension, and encoded fields on the conservative `None` default.
- Change `Fp128::from_canonical_u128` from `unsafe fn` to `const unsafe fn`; the caller must still prove `x < P`.
- Add positive/negative storage-capability tests and a compile-time Fp128 constructor test.

## Safety boundary

The `Fp64` slice implementation mirrors the existing Fp32 implementation. It reinterprets a slice of a `#[repr(transparent)]` field element as its single storage word. This is exposed only for `Fp64`, whose constructors and arithmetic maintain a canonical representative.

Making the Fp128 constructor `const` does not weaken its contract: arbitrary runtime or serialized inputs must use `CanonicalEncoding::from_u128_checked` or `from_u128_reduced`. The unsafe constructor is for callers that already establish canonicality, including compile-time field constants.

## Stack

1. This PR provides the two minimal shared capabilities.
2. [LayerZero-Labs/akita#443](https://github.com/LayerZero-Labs/akita/pull/443) consumes them in the current-main Akita field cutover and supersedes LayerZero-Labs/akita#429.
3. [a16z/jolt#1796](https://github.com/a16z/jolt/pull/1796) is based on this branch, pins the Akita replacement, and removes the temporary reverse adapter.

## Validation

- [x] `cargo fmt --all --check`
- [x] `cargo nextest run -p jolt-field --test solinas_words_differential --no-default-features --features solinas --cargo-quiet` — 7 passed
- [x] focused const-constructor test — 1 passed
- [x] `cargo clippy -p jolt-field --all-targets --no-default-features --features solinas -- -D warnings`
- [x] `git diff --check`
- [x] all GitHub checks on the two-commit head, including field portability, assembly differential fuzzing, HOL Light proofs, Akita fixtures, and the workspace test matrix

## Reviewer map

1. `crates/jolt-field/src/algebra.rs` — conservative capability default.
2. `crates/jolt-field/src/solinas/word.rs` — Fp64 transparent-storage specialization.
3. `crates/jolt-field/src/solinas/fp128.rs` — const/unsafe constructor boundary.
4. `crates/jolt-field/tests/solinas_words_differential.rs` — storage capability behavior.
5. `crates/jolt-field/tests/solinas_fp128_differential.rs` — const construction.
