### PR TITLE
docs: fix broken sumcheck DAG link in bytecode.md

### DIFF
--- a/book/src/how/architecture/bytecode.md
+++ b/book/src/how/architecture/bytecode.md
@@ -6,7 +6,7 @@ To prove the correctness of these lookups, we use the [Shout](../twist-shout.md)
 
 One distinguishing feature of the bytecode Shout instance is that we have multiple instances of the read-checking and $\widetilde{\textsf{raf}}$-evaluation sumchecks.
 Intuitively, the bytecode serves as the "ground truth" of what's being executed, so one would expect many virtual polynomial claims to eventually lead back to the bytecode.
-And this holds in practice –– in the Jolt sumcheck [DAG](./architecture/architecture.md##sumchecks-as-nodes) diagram, we see that there are five stages of read-checking claims pointing to the bytecode read-checking node, and two $\widetilde{\textsf{raf}}$ evaluation claims folded into stages 1 and 3.
+And this holds in practice –– in the Jolt sumcheck [DAG](./architecture.md#sumchecks-as-nodes) diagram, we see that there are five stages of read-checking claims pointing to the bytecode read-checking node, and two $\widetilde{\textsf{raf}}$ evaluation claims folded into stages 1 and 3.
 
 Each stage has its own unique opening point, so having in-edges of different colors implies that multiple instances of that sumcheck must be run in [parallel](../optimizations/batched-sumcheck.md) to prove the different claims.
 


### PR DESCRIPTION
`book/src/how/architecture/bytecode.md:9` links the sumcheck DAG diagram as:

```markdown
[DAG](./architecture/architecture.md##sumchecks-as-nodes)
```

Two problems in one link:

1. **Wrong relative path.** `bytecode.md` already lives in `book/src/how/architecture/`, so `./architecture/architecture.md` resolves to `book/src/how/architecture/architecture/architecture.md`, which does not exist. It should be `./architecture.md`.
2. **Double `#`.** `##sumchecks-as-nodes` is not a valid fragment; it needs a single `#`.

Corrected to `./architecture.md#sumchecks-as-nodes`. Verified the target exists — `architecture.md:86` is `### Sumchecks as Nodes`, which produces exactly that anchor.
