### PR TITLE
fix: issue 1780 findings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1754,6 +1754,7 @@ version = "0.2.0"
 dependencies = [
  "allocative",
  "ark-serialize 0.5.0 (git+https://github.com/a16z/arkworks-algebra?branch=dev%2Ftwist-shout)",
+ "bincode 2.0.1",
  "serde",
  "syn 2.0.119",
 ]

--- a/book/src/usage/guests_hosts/guests.md
+++ b/book/src/usage/guests_hosts/guests.md
@@ -219,3 +219,13 @@ By default, the guest program is compiled with optimization level 3 to attempt t
 To change this optimization level, set the `JOLT_GUEST_OPT` environment variable to one of the allowed values: `0`, `1`, `2`, `3`, `s`, or `z`.
 
 A common choice is `z` which optimizes for code size, at the cost of a larger number of instructions executed.
+
+## Foreign guest toolchains
+
+Guests do not have to be Rust: any toolchain that produces a bare-metal `riscv64imac-unknown-none-elf` binary can target Jolt (for example, [jolt-go](https://github.com/sputn1ck/jolt-go) proves guests written in Go). The guest environment is plain RV64IMAC with memory-mapped I/O and a PC-stall exit; the contract a foreign toolchain must satisfy is mostly in the linker script and a few ELF conventions.
+
+- **Memory layout.** The program image is loaded at `0x8000_0000` (`RAM_START_ADDRESS`). The host computes `program_end` as the maximum `sh_addr + sh_size` over all ELF sections at or above that address — `.bss` included — and uses `program_size = program_end - RAM_START_ADDRESS` in `MemoryLayout::new` (`common/src/jolt_device.rs`) with no alignment or rounding. The 128-byte stack canary, the stack, and the heap are placed immediately after `program_end`, so a foreign linker script must derive its stack and heap symbols from the same section-end arithmetic or the guest and host will disagree about where those regions live. The canonical layout is the linker script `jolt build` links guests with (template: `src/linker.ld.template` in the Jolt repo); mirror it, keeping `.bss` as the last allocated section. Do not mirror the output of `jolt generate linker` — that command emits a different, zeroos-oriented layout that places the stack at the top of RAM and even defines a `tohost` symbol.
+
+- **Atomics.** The A extension is fully implemented as virtual instruction sequences, so `lr`/`sc` and the AMO instructions work unmodified. Execution is single-hart and deterministic, which makes cooperative (green-thread) runtimes work as-is.
+
+- **Do not define a `tohost` symbol.** The tracer recognizes [riscv-tests](https://github.com/riscv-software-src/riscv-tests) binaries by the presence of a `tohost` symbol and switches into test mode: the binary is treated as a riscv-tests program rather than a Jolt guest, and emulator memory is sized to a fixed test capacity instead of the program + canary + stack + heap total from `MemoryLayout::new`, so a larger guest's stack and heap may not fit. The tracer logs a warning when an ELF with a configured `JoltDevice` triggers this, but the fix is to not emit the symbol in the first place.

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -22,3 +22,6 @@ allocative = { workspace = true, optional = true }
 ark-serialize = { workspace = true, default-features = false, optional = true }
 serde = { workspace = true, default-features = false, features = ["alloc"] }
 syn = { workspace = true, optional = true }
+
+[dev-dependencies]
+bincode = { workspace = true }

--- a/common/src/jolt_device.rs
+++ b/common/src/jolt_device.rs
@@ -44,18 +44,66 @@ impl core::fmt::Display for MemoryLayoutError {
 /// all reads from the reserved memory address space for program inputs and all writes
 /// to the reserved memory address space for program outputs.
 /// The inputs and outputs are part of the public inputs to the proof.
+///
+/// The advice fields are *not* public: they hold the prover's private inputs,
+/// populated so the emulator can service loads from the advice memory regions.
+/// The verifier never reads them (advice is bound through polynomial
+/// commitments), so both serialization impls emit them as empty to keep
+/// private bytes out of any serialized device (e.g. a host publishing
+/// `program_io` alongside a proof). Deserialization still accepts populated
+/// advice fields, so pre-existing blobs decode unchanged.
 #[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
-#[cfg_attr(
-    feature = "std",
-    derive(Allocative, CanonicalSerialize, CanonicalDeserialize)
-)]
+#[cfg_attr(feature = "std", derive(Allocative, CanonicalDeserialize))]
 pub struct JoltDevice {
     pub inputs: Vec<u8>,
+    /// Private prover input; serialized as empty (see struct docs).
+    #[serde(serialize_with = "serialize_advice_stripped")]
     pub trusted_advice: Vec<u8>,
+    /// Private prover input; serialized as empty (see struct docs).
+    #[serde(serialize_with = "serialize_advice_stripped")]
     pub untrusted_advice: Vec<u8>,
     pub outputs: Vec<u8>,
     pub panic: bool,
     pub memory_layout: MemoryLayout,
+}
+
+/// Serializes an advice field as an empty byte vector, byte-compatible with
+/// the derived impl for a device whose advice is empty.
+fn serialize_advice_stripped<S: serde::Serializer>(
+    _advice: &[u8],
+    serializer: S,
+) -> Result<S::Ok, S::Error> {
+    Vec::<u8>::new().serialize(serializer)
+}
+
+/// Mirrors the derived impl except that the advice fields are written as
+/// empty vectors — advice bytes are private inputs and must not leave the
+/// host in a serialized device.
+#[cfg(feature = "std")]
+impl CanonicalSerialize for JoltDevice {
+    fn serialize_with_mode<W: ark_serialize::Write>(
+        &self,
+        mut writer: W,
+        compress: ark_serialize::Compress,
+    ) -> Result<(), ark_serialize::SerializationError> {
+        let empty_advice = Vec::<u8>::new();
+        self.inputs.serialize_with_mode(&mut writer, compress)?;
+        empty_advice.serialize_with_mode(&mut writer, compress)?;
+        empty_advice.serialize_with_mode(&mut writer, compress)?;
+        self.outputs.serialize_with_mode(&mut writer, compress)?;
+        self.panic.serialize_with_mode(&mut writer, compress)?;
+        self.memory_layout
+            .serialize_with_mode(&mut writer, compress)
+    }
+
+    fn serialized_size(&self, compress: ark_serialize::Compress) -> usize {
+        let empty_advice = Vec::<u8>::new();
+        self.inputs.serialized_size(compress)
+            + 2 * empty_advice.serialized_size(compress)
+            + self.outputs.serialized_size(compress)
+            + self.panic.serialized_size(compress)
+            + self.memory_layout.serialized_size(compress)
+    }
 }
 
 impl JoltDevice {
@@ -473,6 +521,7 @@ impl MemoryLayout {
 }
 
 #[cfg(test)]
+#[expect(clippy::unwrap_used)]
 mod tests {
     use super::*;
 
@@ -502,6 +551,60 @@ mod tests {
 
         assert_eq!(device.input_words_le(), vec![0x0807_0605_0403_0201, 9]);
         assert_eq!(device.output_words_le(), vec![0xbbaa]);
+    }
+
+    fn device_with_advice() -> JoltDevice {
+        let mut device = JoltDevice::new(&MemoryConfig {
+            program_size: Some(1024),
+            ..Default::default()
+        });
+        device.inputs = vec![1, 2, 3];
+        device.trusted_advice = vec![0xde, 0xad];
+        device.untrusted_advice = vec![0xbe, 0xef, 0x42];
+        device.outputs = vec![7, 8];
+        device.panic = true;
+        device
+    }
+
+    #[cfg(feature = "std")]
+    #[test]
+    fn canonical_serialization_strips_advice() {
+        use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
+
+        let device = device_with_advice();
+        let mut public_device = device.clone();
+        public_device.trusted_advice.clear();
+        public_device.untrusted_advice.clear();
+
+        let mut bytes = Vec::new();
+        device.serialize_compressed(&mut bytes).unwrap();
+        assert_eq!(bytes.len(), device.compressed_size());
+
+        let mut public_bytes = Vec::new();
+        public_device
+            .serialize_compressed(&mut public_bytes)
+            .unwrap();
+        assert_eq!(bytes, public_bytes);
+
+        let roundtrip = JoltDevice::deserialize_compressed(bytes.as_slice()).unwrap();
+        assert_eq!(roundtrip, public_device);
+    }
+
+    #[test]
+    fn serde_serialization_strips_advice() {
+        let device = device_with_advice();
+        let mut public_device = device.clone();
+        public_device.trusted_advice.clear();
+        public_device.untrusted_advice.clear();
+
+        let bytes = bincode::serde::encode_to_vec(&device, bincode::config::standard()).unwrap();
+        let public_bytes =
+            bincode::serde::encode_to_vec(&public_device, bincode::config::standard()).unwrap();
+        assert_eq!(bytes, public_bytes);
+
+        let (roundtrip, _): (JoltDevice, usize) =
+            bincode::serde::decode_from_slice(&bytes, bincode::config::standard()).unwrap();
+        assert_eq!(roundtrip, public_device);
     }
 
     #[test]

--- a/crates/jolt-prover-legacy/benches/e2e_profiling.rs
+++ b/crates/jolt-prover-legacy/benches/e2e_profiling.rs
@@ -244,7 +244,8 @@ fn prove_example(
             None,
             None,
             None,
-        );
+        )
+        .unwrap();
         let program_io = prover.program_io.clone();
         let (jolt_proof, _) = prover
             .prove()
@@ -318,7 +319,8 @@ fn prove_example_with_trace(
         None,
         None,
         None,
-    );
+    )
+    .unwrap();
     let now = Instant::now();
     let (proof, _) = prover
         .prove()

--- a/crates/jolt-prover-legacy/src/guest/prover.rs
+++ b/crates/jolt-prover-legacy/src/guest/prover.rs
@@ -81,7 +81,7 @@ pub fn prove<
         trusted_advice_commitment,
         trusted_advice_hint,
         None,
-    );
+    )?;
     let io_device = prover.program_io.clone();
     let (proof, debug_info) = prover.prove()?;
     output_bytes[..io_device.outputs.len()].copy_from_slice(&io_device.outputs);

--- a/crates/jolt-prover-legacy/src/zkvm/packed.rs
+++ b/crates/jolt-prover-legacy/src/zkvm/packed.rs
@@ -1813,7 +1813,8 @@ mod tests {
             None,
             None,
             None,
-        );
+        )
+        .unwrap();
         let io_device = prover.program_io.clone();
         let setup_params = prover.one_hot_trace_setup_params();
         assert_eq!(setup_params.one_hot_k(), 16);
@@ -1905,7 +1906,8 @@ mod tests {
             None,
             None,
             None,
-        );
+        )
+        .unwrap();
         let forced = crate::zkvm::config::OneHotConfig {
             log_k_chunk: 8,
             lookups_ra_virtual_log_k_chunk: 32,
@@ -1990,7 +1992,8 @@ mod advice_tests {
             None,
             None,
             None,
-        );
+        )
+        .unwrap();
         let io_device = prover.program_io.clone();
 
         let (object_setup, verifier_setup) =
@@ -2095,7 +2098,8 @@ mod advice_tests {
             None,
             None,
             None,
-        );
+        )
+        .unwrap();
         let io_device = prover.program_io.clone();
 
         let (object_setup, verifier_setup) =
@@ -2158,7 +2162,8 @@ mod committed_tests {
             None,
             None,
             None,
-        );
+        )
+        .unwrap();
         let io_device = prover.program_io.clone();
 
         let (object_setup, verifier_setup) =
@@ -2280,7 +2285,8 @@ mod committed_tests {
             None,
             None,
             None,
-        );
+        )
+        .unwrap();
         let io_device = prover.program_io.clone();
         eprintln!("trace length: {}", prover.trace.len());
         let setup_params = prover.one_hot_trace_setup_params();

--- a/crates/jolt-prover-legacy/src/zkvm/prover.rs
+++ b/crates/jolt-prover-legacy/src/zkvm/prover.rs
@@ -237,6 +237,8 @@ impl<
         ProofTranscript: Transcript,
     > JoltCpuProver<'a, F, C, PCS, ProofTranscript>
 {
+    /// Traces the guest and constructs a prover; see [`Self::gen_from_trace`]
+    /// for the error condition.
     #[expect(
         clippy::too_many_arguments,
         reason = "prover construction mirrors public inputs and advice channels"
@@ -250,7 +252,7 @@ impl<
         trusted_advice_commitment: Option<PCS::Commitment>,
         trusted_advice_hint: Option<PCS::OpeningProofHint>,
         advice_tape: Option<tracer::AdviceTape>,
-    ) -> Self {
+    ) -> Result<Self, jolt_verifier::VerifierError> {
         let memory_config = MemoryConfig {
             max_untrusted_advice_size: preprocessing.shared.memory_layout.max_untrusted_advice_size,
             max_trusted_advice_size: preprocessing.shared.memory_layout.max_trusted_advice_size,
@@ -324,6 +326,12 @@ impl<
         )
     }
 
+    /// Constructs a prover from an execution trace.
+    ///
+    /// Returns [`VerifierError::InvalidTraceLength`] when the padded trace
+    /// exceeds the preprocessing's `max_padded_trace_length` — a
+    /// `Result` rather than a panic so FFI hosts (where unwinding across the
+    /// boundary is undefined behavior) can reject oversized traces cleanly.
     pub fn gen_from_trace(
         preprocessing: &'a JoltProverPreprocessing<F, C, PCS>,
         lazy_trace: LazyTraceIterator,
@@ -332,7 +340,7 @@ impl<
         trusted_advice_commitment: Option<PCS::Commitment>,
         trusted_advice_hint: Option<PCS::OpeningProofHint>,
         final_memory_state: Memory,
-    ) -> Self {
+    ) -> Result<Self, jolt_verifier::VerifierError> {
         // Truncate trailing zero bytes from outputs. Both prover and verifier
         // apply the same truncation so the proof is internally consistent.
         // See the corresponding comment in JoltVerifier::new().
@@ -352,11 +360,15 @@ impl<
         };
         let max_padded_trace_length = preprocessing.shared.max_padded_trace_length;
         if padded_trace_len > max_padded_trace_length {
-            panic!(
+            tracing::error!(
                 "Execution trace length ({unpadded_trace_len} cycles, padded to {padded_trace_len}) \
                 exceeds max_trace_length ({max_padded_trace_length}) configured in MemoryConfig. \
                 Increase max_trace_length to at least {padded_trace_len}."
             );
+            return Err(jolt_verifier::VerifierError::InvalidTraceLength {
+                got: padded_trace_len,
+                max: max_padded_trace_length,
+            });
         }
 
         trace.resize(padded_trace_len, Cycle::NoOp);
@@ -406,7 +418,7 @@ impl<
             preprocessing.pedersen_generators(MAX_BLINDFOLD_GENERATORS)
         };
 
-        Self {
+        Ok(Self {
             preprocessing,
             program_io,
             lazy_trace,
@@ -437,7 +449,7 @@ impl<
             blindfold_accumulator: crate::subprotocols::blindfold::BlindFoldAccumulator::new(),
             #[cfg(not(feature = "zk"))]
             _curve: std::marker::PhantomData,
-        }
+        })
     }
 
     #[cfg(not(feature = "akita"))]
@@ -2946,12 +2958,48 @@ mod tests {
             None,
             None,
             None,
-        );
+        )
+        .unwrap();
         let io_device = prover.program_io.clone();
         let (jolt_proof, _debug_info) = prover
             .prove()
             .expect("prover should produce verifier-native proof");
         verify_verifier_proof(&prover_preprocessing, jolt_proof, io_device, None);
+    }
+
+    #[test]
+    #[serial]
+    fn oversized_trace_returns_error() {
+        DoryGlobals::reset();
+        let mut program = host::Program::new("fibonacci-guest");
+        let inputs = postcard::to_stdvec(&100u32).unwrap();
+        let (bytecode, init_memory_state, _, e_entry) = program.decode();
+        let (_, _, _, io_device) = program.trace(&inputs, &[], &[]);
+        let (shared_preprocessing, _program_data) = test_shared_preprocessing(
+            bytecode,
+            init_memory_state,
+            e_entry,
+            io_device.memory_layout.clone(),
+            256,
+        )
+        .unwrap();
+        let prover_preprocessing = JoltProverPreprocessing::new(shared_preprocessing);
+        let elf_contents_opt = program.get_elf_contents();
+        let elf_contents = elf_contents_opt.as_deref().expect("elf contents is None");
+        let result = RV64IMACProver::gen_from_elf(
+            &prover_preprocessing,
+            elf_contents,
+            &inputs,
+            &[],
+            &[],
+            None,
+            None,
+            None,
+        );
+        assert!(matches!(
+            result,
+            Err(jolt_verifier::VerifierError::InvalidTraceLength { .. })
+        ));
     }
 
     #[test]
@@ -2983,7 +3031,8 @@ mod tests {
             None,
             None,
             None,
-        );
+        )
+        .unwrap();
 
         assert!(
             prover.padded_trace_len <= (1 << log_chunk),
@@ -3029,7 +3078,8 @@ mod tests {
             None,
             None,
             None,
-        );
+        )
+        .unwrap();
         let io_device = prover.program_io.clone();
         let (jolt_proof, _debug_info) = prover
             .prove()
@@ -3078,7 +3128,8 @@ mod tests {
             None,
             None,
             None,
-        );
+        )
+        .unwrap();
         let io_device = prover.program_io.clone();
         let (jolt_proof, _debug_info) = prover
             .prove()
@@ -3136,7 +3187,8 @@ mod tests {
             Some(trusted_commitment),
             Some(trusted_hint),
             None,
-        );
+        )
+        .unwrap();
         let io_device = prover.program_io.clone();
         let (jolt_proof, _debug_info) = prover
             .prove()
@@ -3198,7 +3250,8 @@ mod tests {
             Some(trusted_commitment),
             Some(trusted_hint),
             final_memory_state,
-        );
+        )
+        .unwrap();
 
         // Trace is tiny but advice is max-sized
         assert!(prover.unpadded_trace_len < 8192);
@@ -3255,7 +3308,8 @@ mod tests {
             Some(trusted_commitment),
             Some(trusted_hint),
             None,
-        );
+        )
+        .unwrap();
         let io_device = prover.program_io.clone();
         let (jolt_proof, _debug_info) = prover
             .prove()
@@ -3314,7 +3368,8 @@ mod tests {
             Some(trusted_commitment),
             Some(trusted_hint),
             final_memory_state,
-        );
+        )
+        .unwrap();
 
         assert!(prover.padded_trace_len <= 1024, "test expects small trace");
 
@@ -3402,7 +3457,8 @@ mod tests {
             None,
             None,
             None,
-        );
+        )
+        .unwrap();
         let io_device = prover.program_io.clone();
         let (jolt_proof, _debug_info) = prover
             .prove()
@@ -3439,7 +3495,8 @@ mod tests {
             None,
             None,
             None,
-        );
+        )
+        .unwrap();
         let io_device = prover.program_io.clone();
         let (jolt_proof, _debug_info) = prover
             .prove()
@@ -3527,7 +3584,8 @@ mod tests {
             None,
             None,
             None,
-        );
+        )
+        .unwrap();
         eprintln!(
             "trace length: {} (padded 2^{})",
             prover.trace.len(),
@@ -3587,7 +3645,8 @@ mod tests {
             None,
             None,
             None,
-        );
+        )
+        .unwrap();
         let io_device = prover.program_io.clone();
         let (jolt_proof, _debug_info) = prover
             .prove()
@@ -3629,7 +3688,8 @@ mod tests {
             None,
             None,
             None,
-        );
+        )
+        .unwrap();
         let io_device = prover.program_io.clone();
         let (jolt_proof, _debug_info) = prover
             .prove()
@@ -3687,7 +3747,8 @@ mod tests {
             None,
             None,
             None,
-        );
+        )
+        .unwrap();
         let io_device = prover.program_io.clone();
         let (jolt_proof, _debug_info) = prover
             .prove()
@@ -3728,7 +3789,8 @@ mod tests {
             None,
             None,
             None,
-        );
+        )
+        .unwrap();
         let io_device = prover.program_io.clone();
         let (jolt_proof, _debug_info) = prover
             .prove()
@@ -3875,7 +3937,8 @@ mod tests {
             None,
             None,
             None,
-        );
+        )
+        .unwrap();
         let (jolt_proof, _) = prover.prove_parts();
 
         println!("\n=== BlindFold R1CS Satisfaction Test (All 7 Stages) ===\n");
@@ -3997,7 +4060,8 @@ mod tests {
             None,
             None,
             final_memory_state,
-        );
+        )
+        .unwrap();
 
         let (proof, _) = prover
             .prove()
@@ -4041,7 +4105,8 @@ mod tests {
             None,
             None,
             final_memory_state,
-        );
+        )
+        .unwrap();
         let (proof, _) = prover
             .prove()
             .expect("prover should produce verifier-native proof");
@@ -4080,7 +4145,8 @@ mod tests {
             None,
             None,
             final_memory_state,
-        );
+        )
+        .unwrap();
         let (proof, _) = prover
             .prove()
             .expect("prover should produce verifier-native proof");
@@ -4261,7 +4327,8 @@ mod tests {
             None,
             None,
             None,
-        );
+        )
+        .unwrap();
         let io_device = prover.program_io.clone();
         let (proof, _debug_info) = prover
             .prove()
@@ -4309,7 +4376,8 @@ mod tests {
             Some(trusted_commitment),
             Some(trusted_hint),
             None,
-        );
+        )
+        .unwrap();
         let io_device = prover.program_io.clone();
         let (jolt_proof, _debug_info) = prover
             .prove()

--- a/crates/jolt-prover/tests/akita_byte_diff.rs
+++ b/crates/jolt-prover/tests/akita_byte_diff.rs
@@ -308,7 +308,8 @@ mod muldiv {
             None,
             None,
             None,
-        );
+        )
+        .expect("legacy prover construction");
         let public_io = legacy_prover.program_io.clone();
         let (object_setup, verifier_setup) = <AkitaScheme as VerifierCommitmentScheme>::setup(
             legacy_prover.one_hot_trace_setup_params(),
@@ -424,7 +425,8 @@ mod advice_consumer {
             None,
             None,
             None,
-        );
+        )
+        .expect("legacy prover construction");
         let public_io = legacy_prover.program_io.clone();
         let (object_setup, verifier_setup) = <AkitaScheme as VerifierCommitmentScheme>::setup(
             legacy_prover.one_hot_trace_setup_params(),
@@ -561,7 +563,8 @@ mod committed_muldiv {
             None,
             None,
             None,
-        );
+        )
+        .expect("legacy prover construction");
         let public_io = legacy_prover.program_io.clone();
         let (object_setup, verifier_setup) = <AkitaScheme as VerifierCommitmentScheme>::setup(
             legacy_prover.one_hot_trace_setup_params(),

--- a/crates/jolt-prover/tests/akita_e2e.rs
+++ b/crates/jolt-prover/tests/akita_e2e.rs
@@ -212,7 +212,8 @@ mod muldiv {
             None,
             None,
             None,
-        );
+        )
+        .expect("legacy prover construction");
         let public_io = legacy_prover.program_io.clone();
         let setup_params = legacy_prover.one_hot_trace_setup_params();
         assert_eq!(setup_params.one_hot_k(), 16);
@@ -329,7 +330,8 @@ mod muldiv {
             None,
             None,
             None,
-        );
+        )
+        .expect("legacy prover construction");
         // The forced K = 256 regime; the setup params must be derived AFTER
         // the override (they carry K and the layout digest).
         let forced = LegacyOneHotConfig {
@@ -463,7 +465,8 @@ mod advice {
             None,
             None,
             None,
-        );
+        )
+        .expect("legacy prover construction");
         let public_io = legacy_prover.program_io.clone();
         let (object_setup, verifier_setup) = <AkitaScheme as VerifierCommitmentScheme>::setup(
             legacy_prover.one_hot_trace_setup_params(),
@@ -608,7 +611,8 @@ mod advice {
             None,
             None,
             None,
-        );
+        )
+        .expect("legacy prover construction");
         let public_io = legacy_prover.program_io.clone();
         let (object_setup, verifier_setup) = <AkitaScheme as VerifierCommitmentScheme>::setup(
             legacy_prover.one_hot_trace_setup_params(),
@@ -715,7 +719,8 @@ mod committed {
             None,
             None,
             None,
-        );
+        )
+        .expect("legacy prover construction");
         let public_io = legacy_prover.program_io.clone();
         let (object_setup, verifier_setup) = <AkitaScheme as VerifierCommitmentScheme>::setup(
             legacy_prover.one_hot_trace_setup_params(),

--- a/crates/jolt-prover/tests/dory_byte_diff.rs
+++ b/crates/jolt-prover/tests/dory_byte_diff.rs
@@ -534,7 +534,8 @@ mod muldiv {
             None,
             None,
             None,
-        );
+        )
+        .expect("legacy prover construction");
         let public_io = legacy_prover.program_io.clone();
         let (legacy_proof, _) = legacy_prover.prove().expect("legacy prove");
         let verifier_preprocessing = verifier_preprocessing_from_prover(&legacy_preprocessing);
@@ -1160,7 +1161,8 @@ mod advice_consumer {
             Some(trusted.commitment),
             Some(trusted.hint.clone()),
             None,
-        );
+        )
+        .expect("legacy prover construction");
         let public_io = legacy_prover.program_io.clone();
         let (legacy_proof, _) = legacy_prover.prove().expect("legacy prove");
         let verifier_preprocessing = verifier_preprocessing_from_prover(&legacy_preprocessing);
@@ -1374,7 +1376,8 @@ mod committed_muldiv {
             None,
             None,
             None,
-        );
+        )
+        .expect("legacy prover construction");
         let public_io = legacy_prover.program_io.clone();
         let (legacy_proof, _) = legacy_prover.prove().expect("legacy prove");
         let verifier_preprocessing = verifier_preprocessing_from_prover(&legacy_preprocessing);
@@ -1539,7 +1542,8 @@ mod address_major {
             None,
             None,
             None,
-        );
+        )
+        .expect("legacy prover construction");
         let public_io = legacy_prover.program_io.clone();
         let (legacy_proof, _) = legacy_prover.prove().expect("legacy prove");
         let verifier_preprocessing = verifier_preprocessing_from_prover(&legacy_preprocessing);
@@ -1706,7 +1710,8 @@ mod advice_committed {
             Some(trusted.commitment),
             Some(trusted.hint.clone()),
             None,
-        );
+        )
+        .expect("legacy prover construction");
         let public_io = legacy_prover.program_io.clone();
         let (legacy_proof, _) = legacy_prover.prove().expect("legacy prove");
         let verifier_preprocessing = verifier_preprocessing_from_prover(&legacy_preprocessing);
@@ -1889,7 +1894,8 @@ mod inline_sha3 {
             None,
             None,
             None,
-        );
+        )
+        .expect("legacy prover construction");
         let public_io = legacy_prover.program_io.clone();
         let (legacy_proof, _) = legacy_prover.prove().expect("legacy prove");
         let verifier_preprocessing = verifier_preprocessing_from_prover(&legacy_preprocessing);
@@ -2024,7 +2030,8 @@ mod chunk_boundary {
             None,
             None,
             None,
-        );
+        )
+        .expect("legacy prover construction");
         let public_io = legacy_prover.program_io.clone();
         let (legacy_proof, _) = legacy_prover.prove().expect("legacy prove");
         let verifier_preprocessing = verifier_preprocessing_from_prover(&legacy_preprocessing);
@@ -2238,7 +2245,8 @@ mod wide_one_hot {
             None,
             None,
             None,
-        );
+        )
+        .expect("legacy prover construction");
         legacy_prover.one_hot_params = LegacyOneHotParams::from_config(
             &LegacyOneHotConfig {
                 log_k_chunk: WIDE_LOG_K_CHUNK,

--- a/crates/jolt-verifier/tests/support/akita_fixtures.rs
+++ b/crates/jolt-verifier/tests/support/akita_fixtures.rs
@@ -91,7 +91,8 @@ fn generate_muldiv() -> AkitaFixtureCase {
         None,
         None,
         None,
-    );
+    )
+    .expect("legacy prover construction");
     let public_io = prover.program_io.clone();
     let (object_setup, verifier_setup) =
         <AkitaScheme as VerifierCommitmentScheme>::setup(prover.one_hot_trace_setup_params())
@@ -139,7 +140,8 @@ fn generate_advice() -> AkitaFixtureCase {
         None,
         None,
         None,
-    );
+    )
+    .expect("legacy prover construction");
     let public_io = prover.program_io.clone();
     let (object_setup, verifier_setup) =
         <AkitaScheme as VerifierCommitmentScheme>::setup(prover.one_hot_trace_setup_params())
@@ -184,7 +186,8 @@ fn generate_committed_muldiv() -> AkitaFixtureCase {
         None,
         None,
         None,
-    );
+    )
+    .expect("legacy prover construction");
     let public_io = prover.program_io.clone();
     let (object_setup, verifier_setup) =
         <AkitaScheme as VerifierCommitmentScheme>::setup(prover.one_hot_trace_setup_params())

--- a/crates/jolt-verifier/tests/support/verifier_fixtures.rs
+++ b/crates/jolt-verifier/tests/support/verifier_fixtures.rs
@@ -616,7 +616,8 @@ fn generate_committed_muldiv() -> GeneratedVerifierFixture {
         None,
         None,
         None,
-    );
+    )
+    .expect("legacy prover construction");
     let public_io = prover.program_io.clone();
     let (proof, _) = prover.prove().expect("prove verifier object fixture");
     let preprocessing = verifier_preprocessing_from_prover(&prover_preprocessing);
@@ -670,7 +671,8 @@ fn generate_verifier_fixture(
         trusted_advice_commitment,
         trusted_advice_hint,
         None,
-    );
+    )
+    .expect("legacy prover construction");
     let public_io = prover.program_io.clone();
     let (proof, _) = prover.prove().expect("prove verifier object fixture");
     let preprocessing = verifier_preprocessing_from_prover(&prover_preprocessing);

--- a/jolt-sdk/macros/src/lib.rs
+++ b/jolt-sdk/macros/src/lib.rs
@@ -939,7 +939,7 @@ impl MacroBuilder {
                     &trusted_advice_bytes,
                     #commitment_arg,
                     advice_tape,
-                );
+                ).expect("execution trace exceeds the max_trace_length configured in #[jolt::provable]");
                 let io_device = prover.program_io.clone();
                 let (jolt_proof, _) = prover.prove()
                     .expect("prover should produce verifier-native proof");

--- a/tracer/src/emulator/mod.rs
+++ b/tracer/src/emulator/mod.rs
@@ -269,6 +269,18 @@ impl Emulator {
         assert_eq!(header.e_width, 64, "tracer only supports RV64 ELF inputs");
 
         if self.tohost_addr != 0 {
+            // WARNING: a `tohost` symbol is how riscv-tests ELFs are
+            // recognized; a Jolt guest built by a foreign toolchain that
+            // defines one silently loses the layout-derived memory sizing
+            // configured below.
+            #[cfg(feature = "std")]
+            if self.cpu.get_mut_mmu().jolt_device.is_some() {
+                tracing::warn!(
+                    "ELF defines a `tohost` symbol, so the tracer is entering riscv-tests mode: \
+                    emulator memory is sized to the riscv-tests test capacity instead of the \
+                    Jolt memory layout. If this is a Jolt guest, do not emit a `tohost` symbol."
+                );
+            }
             self.is_test = true;
             self.cpu.get_mut_mmu().init_memory(TEST_MEMORY_CAPACITY);
         } else {


### PR DESCRIPTION
Addresses issues flagged in #1780:

> 1. **`JoltDevice` serialization includes the advice fields.** The tracer populates `trusted_advice`/`untrusted_advice` so the MMU can service loads, and they ride along in serialization. An FFI/host integration that naively serializes `prover.program_io` as its public io blob **leaks the private input bytes** — the verifier never reads those fields (it binds advice via `proof.untrusted_advice_commitment` only). I clear both fields before serializing, mirroring what the `#[jolt::provable]` verifier closure does implicitly. Maybe worth clearing in `JoltDevice`'s serialize impl, or a doc note for integrators.
> 2. **The trace-length check panics (`prover.rs:355`)**, which is awkward for FFI hosts: on Linux, that panic unwinding across a cgo-created thread segfaults even under `catch_unwind`. I pre-validate the trace length before constructing the prover. A `Result`-returning prove path would remove the sharp edge for all FFI consumers.
> 3. Small confirmations that might help other porters: `MemoryLayout::new` uses `program_size` raw (no alignment) with `program_end = max(sh_addr + sh_size)`, so a foreign toolchain's `.bss`-last layout must match exactly; the A extension being fully implemented as virtual sequences is what makes an off-the-shelf green-threads runtime viable; and the `tohost` symbol silently flipping the tracer into riscv-tests mode is a fun trap for foreign ELFs.
