### PR TITLE
perf(prover): fix two Akita field-op hotspots (-4.3% prove Ir)

### DIFF
--- a/crates/jolt-field/src/algebra.rs
+++ b/crates/jolt-field/src/algebra.rs
@@ -396,6 +396,12 @@ pub trait Accumulator: Default + Copy + Send + Sync {
         self.fmadd(a, Self::Element::from_u64(b));
     }
 
+    /// Fused multiply-add with a `u128` scalar: `self += a * F::from(b)`.
+    #[inline]
+    fn fmadd_u128(&mut self, a: Self::Element, b: u128) {
+        self.fmadd(a, Self::Element::from_u128(b));
+    }
+
     /// Fused multiply-add with an `i64` scalar: `self += a * F::from(b)`.
     #[inline]
     fn fmadd_i64(&mut self, a: Self::Element, b: i64) {

--- a/crates/jolt-field/src/bn254/mont.rs
+++ b/crates/jolt-field/src/bn254/mont.rs
@@ -609,6 +609,18 @@ impl Accumulator for WideAccumulator {
             }
         }
     }
+
+    /// One Barrett round beats the default's `from_u64` conversion plus a
+    /// full 4×4 limb product.
+    #[inline(always)]
+    fn fmadd_u64(&mut self, value: Fr, scalar: u64) {
+        self.add(Fr(mul_u64(value.0, scalar)));
+    }
+
+    #[inline(always)]
+    fn fmadd_u128(&mut self, value: Fr, scalar: u128) {
+        self.add(Fr(mul_u128(value.0, scalar)));
+    }
 }
 
 #[cfg(test)]

--- a/crates/jolt-kernels/src/optimized/instruction_read_raf.rs
+++ b/crates/jolt-kernels/src/optimized/instruction_read_raf.rs
@@ -836,16 +836,16 @@ impl<F: JoltField> OptimizedInstructionReadRafKernel<F> {
                         let (left, right) = LookupBits::new(suffix_bits, suffix_len).uninterleave();
                         let left = u64::from(left);
                         if left != 0 {
-                            scan.left[chunk].add(u.mul_u64(left));
+                            scan.left[chunk].fmadd_u64(u, left);
                         }
                         let right = u64::from(right);
                         if right != 0 {
-                            scan.right[chunk].add(u.mul_u64(right));
+                            scan.right[chunk].fmadd_u64(u, right);
                         }
                     } else {
                         scan.shift_full[chunk].add(u);
                         if suffix_bits != 0 {
-                            scan.identity[chunk].add(u.mul_u128(suffix_bits));
+                            scan.identity[chunk].fmadd_u128(u, suffix_bits);
                         }
                     }
                 }
@@ -984,7 +984,7 @@ impl<F: JoltField> OptimizedInstructionReadRafKernel<F> {
                             } else {
                                 let value = suffix.suffix_mle(suffix_bits);
                                 if value != 0 {
-                                    slot.add(u.mul_u64(value));
+                                    slot.fmadd_u64(u, value);
                                 }
                             }
                         }

--- a/crates/jolt-witness/src/witnesses/increments.rs
+++ b/crates/jolt-witness/src/witnesses/increments.rs
@@ -65,10 +65,26 @@ impl Extract for RamInc {
 pub struct FusedInc(pub i128);
 
 impl FusedInc {
+    /// `(radix/2) · (2^FUSED_INC_BITS − 1)/(radix − 1)` per digit width
+    /// dividing [`FUSED_INC_BITS`] (0 elsewhere). Precomputed because the
+    /// closed form's i128 division lowers to a `__udivti3` libcall, and
+    /// [`Self::selected_row`] reads the bias per cycle per balanced column.
+    const BALANCED_BIASES: [i128; FUSED_INC_BITS + 1] = {
+        let mut table = [0i128; FUSED_INC_BITS + 1];
+        let mut width = 1;
+        while width <= FUSED_INC_BITS {
+            if FUSED_INC_BITS.is_multiple_of(width) {
+                let radix = 1i128 << width;
+                table[width] = (radix / 2) * (((1i128 << FUSED_INC_BITS) - 1) / (radix - 1));
+            }
+            width += 1;
+        }
+        table
+    };
+
     fn balanced_bias(width: usize) -> i128 {
         debug_assert!(width > 0 && FUSED_INC_BITS.is_multiple_of(width));
-        let radix = 1i128 << width;
-        (radix / 2) * (((1i128 << FUSED_INC_BITS) - 1) / (radix - 1))
+        Self::BALANCED_BIASES[width]
     }
 
     fn biased_for_balanced_digits(self, width: usize) -> i128 {


### PR DESCRIPTION
Two value-preserving hotspot fixes found by callgrind-profiling the optimized Akita prove (`profile --name fibonacci --scale 18 --backend optimized`, aarch64). Proofs are byte-identical: accumulated values are unchanged mod p, and the byte-diff ratchet suites pass untouched.

## Commit 1 — read-raf primitive-scalar multiplies through accumulator fmadds

The fused RAF scan and suffix-table scan in `optimized/instruction_read_raf.rs` multiplied the eq mass via the `Ring::mul_u64`/`mul_u128` default bodies (`from_u64` + full 128×128 multiply + reduction per call) before adding into a deferred-reduction accumulator. They now use `Accumulator::fmadd_u64` and a new defaulted `Accumulator::fmadd_u128`:

- Akita lands in the upstream 128×64 unreduced kernel — two widening multiplies, no per-term reduction.
- BN254 gets `WideAccumulator::fmadd_u64`/`fmadd_u128` overrides doing exactly what the call sites did before (one Barrett round + slot add), so the Dory lane is unchanged bit for bit.

Isolated impact: −112M Ir (−0.19%) at 2^18. Modest here, but it is the right API for these loops and worth more on x86-64, where fp128 has no multiply asm.

## Commit 2 — precompute `FusedInc::balanced_bias`

`balanced_bias` divides by `radix − 1`, a non-power-of-two i128 division that lowers to a `__udivti3` libcall, and `selected_row` recomputes it per cycle per balanced-inc column (`fill_trace_row`, the booleanity chunk index source, the lazy-RA gathers) — 26.7M calls at 2^18. The bias depends only on the digit width, so it is now a const table indexed by width.

Isolated impact: −2.52B Ir (−4.2%); all `__udivti3` calls gone.

## Measurements (fibonacci 2^18, optimized Akita backend, aarch64)

| | Ir (callgrind, deterministic) | wall (median of 3, 12 threads) |
|---|---|---|
| baseline `b7aa1ac` | 60.708B | 1.11s |
| + commit 1 | 60.596B | 1.06s |
| + commit 2 | **58.077B (−4.3%)** | **1.05s** |

## Validation

- `cargo fmt` clean; clippy `--all --features host` and `--features host,zk`; the CI akita clippy lanes (`jolt-prover` ×3 incl. profiling, `jolt-verifier` ×2)
- nextest: `jolt-field` (default, `solinas`, `solinas,parallel`), `jolt-kernels` (±`zk`), `jolt-witness`
- Acceptance suites: `jolt-prover --features prover-fixtures` (21 passed — byte-diff ratchets vs legacy), `--features akita,prover-fixtures` (19 passed), `--features prover-fixtures,zk` (14 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)