### PR TITLE
fix(z3-verifier): model the W-form right-shift virtual instructions

### DIFF
--- a/z3-verifier/src/virtual_sequences.rs
+++ b/z3-verifier/src/virtual_sequences.rs
@@ -68,11 +68,16 @@ use tracer::{
         virtual_pow2::VirtualPow2,
         virtual_pow2_w::VirtualPow2W,
         virtual_shift_right_bitmask::VirtualShiftRightBitmask,
+        virtual_shift_right_bitmask_w::VirtualShiftRightBitmaskW,
         virtual_sign_extend_word::VirtualSignExtendWord,
         virtual_sra::VirtualSRA,
         virtual_srai::VirtualSRAI,
+        virtual_sraiw::VirtualSRAIW,
+        virtual_sraw::VirtualSRAW,
         virtual_srl::VirtualSRL,
         virtual_srli::VirtualSRLI,
+        virtual_srliw::VirtualSRLIW,
+        virtual_srlw::VirtualSRLW,
         virtual_window_mask_b::VirtualWindowMaskB,
         virtual_window_mask_h::VirtualWindowMaskH,
         virtual_window_mask_w::VirtualWindowMaskW,
@@ -260,6 +265,13 @@ fn trailing_zeros(bv: &BV, bitsz: u32) -> BV {
     tz_recursive(bv, bitsz, bitsz)
 }
 
+/// Shift amount of a W-form bitmask immediate (`2^32 - 2^shift`), scaled to the
+/// model's word width. The encoded shift is already masked to five bits, so the
+/// narrower mask here only re-folds it for reduced-width runs.
+fn word_shift_from_bitmask(imm: u64, cpu: &SymbolicCpu) -> u64 {
+    (imm.trailing_zeros() & (cpu.word_bits - 1)) as u64
+}
+
 fn symbolic_exec(instr: &Instruction, cpu: &mut SymbolicCpu) {
     match instr {
         Instruction::ADD(ADD { operands, .. }) => {
@@ -428,9 +440,32 @@ fn symbolic_exec(instr: &Instruction, cpu: &mut SymbolicCpu) {
             let shift = trailing_zeros(&rs2, cpu.bv_bits);
             cpu.x[operands.rd as usize] = rs1.bvlshr(&shift);
         }
+        Instruction::VirtualSRAW(VirtualSRAW { operands, .. }) => {
+            let rs1 = cpu.x[operands.rs1 as usize].clone();
+            let rs2 = cpu.x[operands.rs2 as usize].clone();
+            let shift = trailing_zeros(&cpu.word_extract(&rs2), cpu.word_bits);
+            cpu.x[operands.rd as usize] = cpu.sign_ext_word(&cpu.word_extract(&rs1).bvashr(&shift));
+        }
+        Instruction::VirtualSRLW(VirtualSRLW { operands, .. }) => {
+            let rs1 = cpu.x[operands.rs1 as usize].clone();
+            let rs2 = cpu.x[operands.rs2 as usize].clone();
+            let shift = trailing_zeros(&cpu.word_extract(&rs2), cpu.word_bits);
+            cpu.x[operands.rd as usize] = cpu.sign_ext_word(&cpu.word_extract(&rs1).bvlshr(&shift));
+        }
         Instruction::VirtualShiftRightBitmask(VirtualShiftRightBitmask { operands, .. }) => {
             let shift = cpu.x[operands.rs1 as usize].clone() & cpu.bv_u64((cpu.bv_bits - 1) as u64);
             let inv_shift: BV = cpu.bv_u64(cpu.bv_bits as u64) - &shift;
+            let ones =
+                (BV::from_u64(1, cpu.bv_bits * 2).bvshl(inv_shift.zero_ext(cpu.bv_bits))) - 1;
+            cpu.x[operands.rd as usize] = ones
+                .bvshl(shift.zero_ext(cpu.bv_bits))
+                .extract(cpu.bv_bits - 1, 0)
+        }
+        Instruction::VirtualShiftRightBitmaskW(VirtualShiftRightBitmaskW { operands, .. }) => {
+            // 2^word_bits - 2^shift: the W bitmask spans the word, not the register.
+            let shift =
+                cpu.x[operands.rs1 as usize].clone() & cpu.bv_u64((cpu.word_bits - 1) as u64);
+            let inv_shift: BV = cpu.bv_u64(cpu.word_bits as u64) - &shift;
             let ones =
                 (BV::from_u64(1, cpu.bv_bits * 2).bvshl(inv_shift.zero_ext(cpu.bv_bits))) - 1;
             cpu.x[operands.rd as usize] = ones
@@ -567,6 +602,18 @@ fn symbolic_exec(instr: &Instruction, cpu: &mut SymbolicCpu) {
                 _ => shift_amt as u64 & (cpu.bv_bits - 1) as u64,
             };
             cpu.x[operands.rd as usize] = cpu.sign_extend(&rs1.bvashr(scaled_shift));
+        }
+        Instruction::VirtualSRAIW(VirtualSRAIW { operands, .. }) => {
+            let rs1 = cpu.x[operands.rs1 as usize].clone();
+            let scaled_shift = word_shift_from_bitmask(operands.imm, cpu);
+            cpu.x[operands.rd as usize] =
+                cpu.sign_ext_word(&cpu.word_extract(&rs1).bvashr(scaled_shift));
+        }
+        Instruction::VirtualSRLIW(VirtualSRLIW { operands, .. }) => {
+            let rs1 = cpu.x[operands.rs1 as usize].clone();
+            let scaled_shift = word_shift_from_bitmask(operands.imm, cpu);
+            cpu.x[operands.rd as usize] =
+                cpu.sign_ext_word(&cpu.word_extract(&rs1).bvlshr(scaled_shift));
         }
         Instruction::XOR(XOR { operands, .. }) => {
             let rs1 = cpu.x[operands.rs1 as usize].clone();


### PR DESCRIPTION
## Summary

Fixes #1803. The nightly Z3 suite has been red since 2026-08-25 (last green: `ff9f8c1`, first red: `53ed6c3`). Eight obligations fail — SRAIW, SRAW, SRLIW, SRLW × correctness+consistency — all at the `_ => panic!("Unsupported instruction ... in symbolic_exec")` arm:

```
Unsupported instruction VirtualSRAIW      (SRAIW ×2)
Unsupported instruction VirtualSRLIW      (SRLIW ×2)
Unsupported instruction VirtualShiftRightBitmaskW  (SRAW, SRLW ×2 each)
```

#1753 lowered the W-form right shifts onto five new virtual instructions; the hand-written z3 model was never taught them, so every W right-shift obligation aborts before reaching the solver. This is the "model drifted from an expansion change" cause named in the issue text, not a regressed obligation — see Security Considerations.

## Changes

- Model `VirtualSRAW` / `VirtualSRLW`: shift amount is `trailing_zeros` of the word-extracted bitmask in `rs2`, applied to the word and sign-extended (`bvashr` / `bvlshr`).
- Model `VirtualShiftRightBitmaskW`: `2^word_bits - 2^shift`, the W bitmask spanning the word rather than the register.
- Model `VirtualSRAIW` / `VirtualSRLIW` via a `word_shift_from_bitmask` helper, mirroring the existing scaling in the `VirtualSRLI` / `VirtualSRAI` arms.

Shift amounts scale with `word_bits` rather than a hardcoded 32, so the arms stay faithful under `Z3_VERIFIER_BV_BITS` reduced-width runs (`word_bits = bv_bits / 2`).

The arms were derived from the expansions themselves — `expand_sraw` emits `VirtualShiftRightBitmaskW(rd = v_bitmask, rs1 = rs2)` then `VirtualSRAW(rd, rs1, v_bitmask)`; `expand_sraiw` emits a single `VirtualSRAIW` carrying `right_shift_bitmask(shift, 32)` — and they discharge against the suite's existing independent expected-semantics closures, which were already correct and unchanged.

## Testing

`cargo test -p z3-verifier --release`: **96 passed, 0 failed, 20 ignored**, up from 88 passed / 8 failed. The eight named tests go red → green; no other test changes state, and no expected-semantics closure was touched.

- [x] Ran tests for modified crates
- [x] `cargo clippy` and `cargo fmt` pass

## Security Considerations

No effect on proof soundness, verifier correctness, or private inputs — this changes only the z3-verifier test model, which is not in the proving or verifying path.

Worth stating explicitly given the issue text asks that failures be treated as potential soundness signals: these eight are **not** counterexamples. Each is a `panic!` on an unmodelled instruction raised before any `Solver::check`, so no obligation was ever discharged and none reported `Sat`. The underlying property was unproven, not disproven — and with this PR the W right-shift expansions are proved for the first time since #1753.

## Breaking Changes

None
