### PR TITLE
fix(witness): refuse dense RAM oracle grids past a documented byte cap

### DIFF
--- a/crates/jolt-witness/src/backend/trace/cycle.rs
+++ b/crates/jolt-witness/src/backend/trace/cycle.rs
@@ -56,17 +56,12 @@ impl<T: TraceSource> TraceBackend<T> {
     {
         let selector = RaChunkSelector::new(index, chunks, chunk_bits)?;
         let cycles = checked_pow2(self.config.log_t)?;
-        let log_rows = chunk_bits.checked_add(self.config.log_t).ok_or_else(|| {
-            WitnessError::InvalidDimensions {
-                label: JOLT_VM_LABEL,
-                reason: "one-hot rows overflow".to_owned(),
-            }
-        })?;
+        let len = checked_dense_grid_len::<F>(checked_pow2(chunk_bits)?, cycles)?;
         let hot_addresses: Vec<Option<usize>> = self.walk_cycles(|row, next, env| {
             W::extract_indexed(selector, row, next, env).map(W::into)
         })?;
         // The selector's mask bounds every hot address below `2^chunk_bits`.
-        let mut values = jolt_utils::unsafe_allocate_zero_vec(checked_pow2(log_rows)?);
+        let mut values = jolt_utils::unsafe_allocate_zero_vec(len);
         for (cycle, address) in hot_addresses.into_iter().enumerate() {
             if let Some(address) = address {
                 values[address * cycles + cycle] = F::one();
@@ -85,11 +80,12 @@ impl<T: TraceSource> TraceBackend<T> {
     ) -> Result<Vec<F>, WitnessError> {
         let chunk_bits = self.config.one_hot.committed_chunk_bits();
         let cycles = checked_pow2(self.config.log_t)?;
+        let len = checked_dense_grid_len::<F>(checked_pow2(chunk_bits)?, cycles)?;
         let selected_rows: Vec<usize> = self.walk_cycles(|row, next, env| {
             crate::witnesses::BalancedIncRow::extract_indexed(column, row, next, env)
                 .map(|selected| selected.0)
         })?;
-        let mut values = vec![F::zero(); checked_pow2(self.one_hot_log_rows()?)?];
+        let mut values = vec![F::zero(); len];
         for (cycle, selected_row) in selected_rows.into_iter().enumerate() {
             if selected_row >> chunk_bits != 0 {
                 return Err(WitnessError::InvalidWitnessData {

--- a/crates/jolt-witness/src/backend/trace/mod.rs
+++ b/crates/jolt-witness/src/backend/trace/mod.rs
@@ -433,6 +433,45 @@ fn invalid_compact_row(row: &TraceRow, reason: &'static str) -> WitnessError {
     }
 }
 
+/// Upper bound, in bytes, on a dense `(K × T)` oracle grid materialized by
+/// the trace backend. The RAM read-write grids are `ram_K · 2^log_T` field
+/// elements, so the request grows linearly with the trace length and reaches
+/// hundreds of GiB at profiling scales (`ram_K = 4096`, `log_T = 22`, 32-byte
+/// field: 2^39 bytes). Past this bound the global allocator aborts the
+/// process with an opaque `memory allocation of N bytes failed`; refusing
+/// with a `WitnessError` keeps the failure actionable. 32 GiB admits every
+/// in-tree test and the documented small-scale profiling defaults.
+pub(crate) const MAX_DENSE_GRID_BYTES: usize = 1 << 35;
+
+/// The element count of a dense `addresses × cycles` grid of `F`, refused
+/// with an actionable error when the byte size overflows or exceeds
+/// [`MAX_DENSE_GRID_BYTES`].
+pub(crate) fn checked_dense_grid_len<F>(
+    addresses: usize,
+    cycles: usize,
+) -> Result<usize, WitnessError> {
+    let len = addresses
+        .checked_mul(cycles)
+        .ok_or_else(|| WitnessError::InvalidDimensions {
+            label: JOLT_VM_LABEL,
+            reason: format!("dense grid of {addresses} addresses x {cycles} cycles overflows"),
+        })?;
+    let bytes = len.checked_mul(core::mem::size_of::<F>());
+    match bytes {
+        Some(bytes) if bytes <= MAX_DENSE_GRID_BYTES => Ok(len),
+        _ => Err(WitnessError::InvalidDimensions {
+            label: JOLT_VM_LABEL,
+            reason: format!(
+                "dense grid of {addresses} addresses x {cycles} cycles needs {} bytes \
+                 (> {MAX_DENSE_GRID_BYTES} max); this naive materialization is a test \
+                 oracle sized for small traces — use the optimized backend for larger \
+                 shapes",
+                bytes.map_or_else(|| "overflowing".to_owned(), |bytes| bytes.to_string()),
+            ),
+        }),
+    }
+}
+
 pub(crate) fn checked_pow2(log_rows: usize) -> Result<usize, WitnessError> {
     if log_rows >= usize::BITS as usize {
         return Err(WitnessError::InvalidDimensions {

--- a/crates/jolt-witness/src/backend/trace/mod.rs
+++ b/crates/jolt-witness/src/backend/trace/mod.rs
@@ -434,13 +434,15 @@ fn invalid_compact_row(row: &TraceRow, reason: &'static str) -> WitnessError {
 }
 
 /// Upper bound, in bytes, on a dense `(K × T)` oracle grid materialized by
-/// the trace backend. The RAM read-write grids are `ram_K · 2^log_T` field
-/// elements, so the request grows linearly with the trace length and reaches
+/// the trace backend: the RAM and register read-write grids and the one-hot
+/// RA grids. The request grows linearly with the trace length and reaches
 /// hundreds of GiB at profiling scales (`ram_K = 4096`, `log_T = 22`, 32-byte
 /// field: 2^39 bytes). Past this bound the global allocator aborts the
 /// process with an opaque `memory allocation of N bytes failed`; refusing
 /// with a `WitnessError` keeps the failure actionable. 32 GiB admits every
-/// in-tree test and the documented small-scale profiling defaults.
+/// in-tree test and the fibonacci profiling default (scale 16); the larger
+/// documented profiling defaults are refused by design and belong on the
+/// optimized backend.
 pub(crate) const MAX_DENSE_GRID_BYTES: usize = 1 << 35;
 
 /// The element count of a dense `addresses × cycles` grid of `F`, refused

--- a/crates/jolt-witness/src/backend/trace/ram.rs
+++ b/crates/jolt-witness/src/backend/trace/ram.rs
@@ -23,7 +23,8 @@ impl<T: TraceSource> TraceBackend<T> {
         let cycles = checked_pow2(self.config.log_t)?;
         let addresses = self.config.ram_k;
         let mut state = self.initial_ram_state()?;
-        let mut values = jolt_utils::unsafe_allocate_zero_vec(addresses * cycles);
+        let mut values =
+            jolt_utils::unsafe_allocate_zero_vec(checked_dense_grid_len::<F>(addresses, cycles)?);
 
         for cycle in 0..cycles {
             for (address, value) in state.iter().copied().enumerate() {
@@ -51,7 +52,8 @@ impl<T: TraceSource> TraceBackend<T> {
     pub(crate) fn materialize_ram_ra<F: JoltField>(&self) -> Result<Vec<F>, WitnessError> {
         let cycles = checked_pow2(self.config.log_t)?;
         let addresses = self.config.ram_k;
-        let mut values = jolt_utils::unsafe_allocate_zero_vec(addresses * cycles);
+        let mut values =
+            jolt_utils::unsafe_allocate_zero_vec(checked_dense_grid_len::<F>(addresses, cycles)?);
 
         for cycle in 0..cycles {
             let Some(row) = self.trace.trace.get(cycle) else {

--- a/crates/jolt-witness/src/backend/trace/registers.rs
+++ b/crates/jolt-witness/src/backend/trace/registers.rs
@@ -21,7 +21,10 @@ impl<T: TraceSource> TraceBackend<T> {
 
         let cycles = checked_pow2(self.config.log_t)?;
         let register_count = checked_pow2(REGISTER_ADDRESS_BITS)?;
-        let mut values = jolt_utils::unsafe_allocate_zero_vec(register_count * cycles);
+        let mut values = jolt_utils::unsafe_allocate_zero_vec(checked_dense_grid_len::<F>(
+            register_count,
+            cycles,
+        )?);
 
         if id == JoltVirtualPolynomial::RegistersVal {
             let mut state = vec![0u64; register_count];

--- a/crates/jolt-witness/src/backend/trace/tests.rs
+++ b/crates/jolt-witness/src/backend/trace/tests.rs
@@ -1244,3 +1244,36 @@ fn backend_drops_only_canonical_trailing_padding() {
         [1, 1, 1, 1].map(Fr::from_u64)
     );
 }
+
+/// The dense-grid capacity formula: in-range shapes pass through, the
+/// profiling-scale shape that used to abort the process (`ram_K = 4096`,
+/// `log_T = 22`, 32-byte field: a 2^39-byte request) is refused with an
+/// actionable error, and the element/byte products refuse on overflow
+/// instead of wrapping.
+#[test]
+fn dense_grid_len_is_capped_and_overflow_checked() {
+    assert_eq!(checked_dense_grid_len::<Fr>(4096, 1 << 10), Ok(4096 << 10));
+    assert_eq!(
+        checked_dense_grid_len::<Fr>(
+            MAX_DENSE_GRID_BYTES / core::mem::size_of::<Fr>() / (1 << 10),
+            1 << 10
+        ),
+        Ok(MAX_DENSE_GRID_BYTES / core::mem::size_of::<Fr>())
+    );
+
+    let refused = checked_dense_grid_len::<Fr>(4096, 1 << 22).unwrap_err();
+    let reason = match refused {
+        WitnessError::InvalidDimensions { reason, .. } => reason,
+        other => format!("expected InvalidDimensions, got {other:?}"),
+    };
+    assert!(reason.contains(&(1_u64 << 39).to_string()), "{reason}");
+
+    assert!(matches!(
+        checked_dense_grid_len::<Fr>(usize::MAX, 2),
+        Err(WitnessError::InvalidDimensions { .. })
+    ));
+    assert!(matches!(
+        checked_dense_grid_len::<Fr>(usize::MAX / 8, 1),
+        Err(WitnessError::InvalidDimensions { .. })
+    ));
+}


### PR DESCRIPTION
## Summary

The reference trace backend builds several dense tables with one field element for every (address, cycle) pair. Their size grows linearly with the trace length and can reach hundreds of GiB at normal profiling scales.

Today, Jolt attempts those allocations directly. If the machine cannot satisfy one, the global allocator aborts the process with an opaque message. This PR checks the requested size first and returns an actionable error instead.

This is a safety guard for the reference backend; it does not make the dense representation use less memory. Large traces should use the optimized backend.

## Failure mode

The affected tables live in **crates/jolt-witness/src/backend/trace/** and include:

- RAM value and read-address tables
- Register read/write tables
- One-hot read-address tables

For example:

    cargo run --release -p jolt-prover --features profiling,akita -- \
        profile --name fibonacci --scale 22 --format none

On main at **72dc645**, the RAM table has 8,192 addresses and 2^22 cycles. At 16 bytes per field element, that is:

    8192 × 4,194,304 × 16 bytes = 549,755,813,888 bytes (512 GiB)

The process aborts before proving:

    memory allocation of 549755813888 bytes failed

## What changes

All dense trace-backend grids are now sized through **checked_dense_grid_len**. The helper:

1. checks the address-by-cycle multiplication for overflow;
2. checks the conversion from elements to bytes for overflow;
3. enforces a 32 GiB limit per dense grid; and
4. returns **WitnessError::InvalidDimensions** with the requested shape, byte count, and a suggestion to use the optimized backend.

The 32 GiB value is an engineering guardrail, not a claim that every machine can safely allocate 32 GiB. It admits every in-tree test and the Fibonacci default at scale 16 while refusing shapes for which the naive dense backend is clearly unsuitable. It is also a per-grid limit, not a bound on total prover memory.

## Scope

For requests within the limit, behavior is unchanged. This PR does not change:

- the optimized backend;
- proof semantics or wire formats; or
- proof bytes for configurations the reference backend can materialize.

## Evidence

| Scenario | Result |
|---|---|
| Before: Fibonacci, scale 22, reference backend | Process aborts while requesting a 512 GiB allocation |
| After: same command | Returns **InvalidDimensions** with the shape and byte count |
| After: SHA-2 chain, scale 26, optimized backend | Completes end-to-end and verifies; stage-wall sum 64.77 s |
| In-tree tests and Fibonacci scale 16 | Remain within the limit |

## Test coverage

**dense_grid_len_is_capped_and_overflow_checked** covers:

- an ordinary in-range shape;
- the exact 32 GiB boundary;
- the 512 GiB profiling shape;
- overflow in the element-count multiplication; and
- overflow in the byte-count multiplication.