### PR TITLE
fix(sdk): bump ZeroOS for kernel-side munmap region accounting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4034,6 +4034,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "large-alloc"
+version = "0.1.0"
+dependencies = [
+ "jolt-sdk",
+ "large-alloc-guest",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "large-alloc-guest"
+version = "0.1.0"
+dependencies = [
+ "jolt-sdk",
+ "libc",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4242,7 +4260,7 @@ dependencies = [
 [[package]]
 name = "mini-template"
 version = "0.1.0"
-source = "git+https://github.com/LayerZero-Labs/ZeroOS.git?rev=3b132ce862ba6769a4261d151f69ff32c5f0dc30#3b132ce862ba6769a4261d151f69ff32c5f0dc30"
+source = "git+https://github.com/LayerZero-Labs/ZeroOS.git?rev=c572b88a643474317e4b0c7e53ac722a98a0e050#c572b88a643474317e4b0c7e53ac722a98a0e050"
 
 [[package]]
 name = "miniz_oxide"
@@ -7812,7 +7830,7 @@ dependencies = [
 [[package]]
 name = "zeroos"
 version = "0.1.0"
-source = "git+https://github.com/LayerZero-Labs/ZeroOS.git?rev=3b132ce862ba6769a4261d151f69ff32c5f0dc30#3b132ce862ba6769a4261d151f69ff32c5f0dc30"
+source = "git+https://github.com/LayerZero-Labs/ZeroOS.git?rev=c572b88a643474317e4b0c7e53ac722a98a0e050#c572b88a643474317e4b0c7e53ac722a98a0e050"
 dependencies = [
  "zeroos-allocator-linked-list",
  "zeroos-arch-riscv",
@@ -7831,7 +7849,7 @@ dependencies = [
 [[package]]
 name = "zeroos-allocator-linked-list"
 version = "0.1.0"
-source = "git+https://github.com/LayerZero-Labs/ZeroOS.git?rev=3b132ce862ba6769a4261d151f69ff32c5f0dc30#3b132ce862ba6769a4261d151f69ff32c5f0dc30"
+source = "git+https://github.com/LayerZero-Labs/ZeroOS.git?rev=c572b88a643474317e4b0c7e53ac722a98a0e050#c572b88a643474317e4b0c7e53ac722a98a0e050"
 dependencies = [
  "linked_list_allocator",
  "zeroos-foundation",
@@ -7840,7 +7858,7 @@ dependencies = [
 [[package]]
 name = "zeroos-arch-riscv"
 version = "0.1.0"
-source = "git+https://github.com/LayerZero-Labs/ZeroOS.git?rev=3b132ce862ba6769a4261d151f69ff32c5f0dc30#3b132ce862ba6769a4261d151f69ff32c5f0dc30"
+source = "git+https://github.com/LayerZero-Labs/ZeroOS.git?rev=c572b88a643474317e4b0c7e53ac722a98a0e050#c572b88a643474317e4b0c7e53ac722a98a0e050"
 dependencies = [
  "cfg-if",
  "memoffset",
@@ -7854,7 +7872,7 @@ dependencies = [
 [[package]]
 name = "zeroos-backtrace"
 version = "0.1.0"
-source = "git+https://github.com/LayerZero-Labs/ZeroOS.git?rev=3b132ce862ba6769a4261d151f69ff32c5f0dc30#3b132ce862ba6769a4261d151f69ff32c5f0dc30"
+source = "git+https://github.com/LayerZero-Labs/ZeroOS.git?rev=c572b88a643474317e4b0c7e53ac722a98a0e050#c572b88a643474317e4b0c7e53ac722a98a0e050"
 dependencies = [
  "cfg-if",
  "zeroos-macros",
@@ -7863,7 +7881,7 @@ dependencies = [
 [[package]]
 name = "zeroos-build"
 version = "0.1.0"
-source = "git+https://github.com/LayerZero-Labs/ZeroOS.git?rev=3b132ce862ba6769a4261d151f69ff32c5f0dc30#3b132ce862ba6769a4261d151f69ff32c5f0dc30"
+source = "git+https://github.com/LayerZero-Labs/ZeroOS.git?rev=c572b88a643474317e4b0c7e53ac722a98a0e050#c572b88a643474317e4b0c7e53ac722a98a0e050"
 dependencies = [
  "anyhow",
  "clap",
@@ -7881,7 +7899,7 @@ dependencies = [
 [[package]]
 name = "zeroos-debug"
 version = "0.1.0"
-source = "git+https://github.com/LayerZero-Labs/ZeroOS.git?rev=3b132ce862ba6769a4261d151f69ff32c5f0dc30#3b132ce862ba6769a4261d151f69ff32c5f0dc30"
+source = "git+https://github.com/LayerZero-Labs/ZeroOS.git?rev=c572b88a643474317e4b0c7e53ac722a98a0e050#c572b88a643474317e4b0c7e53ac722a98a0e050"
 dependencies = [
  "cfg-if",
 ]
@@ -7889,7 +7907,7 @@ dependencies = [
 [[package]]
 name = "zeroos-device-console"
 version = "0.1.0"
-source = "git+https://github.com/LayerZero-Labs/ZeroOS.git?rev=3b132ce862ba6769a4261d151f69ff32c5f0dc30#3b132ce862ba6769a4261d151f69ff32c5f0dc30"
+source = "git+https://github.com/LayerZero-Labs/ZeroOS.git?rev=c572b88a643474317e4b0c7e53ac722a98a0e050#c572b88a643474317e4b0c7e53ac722a98a0e050"
 dependencies = [
  "libc",
  "zeroos-vfs-core",
@@ -7898,7 +7916,7 @@ dependencies = [
 [[package]]
 name = "zeroos-foundation"
 version = "0.1.0"
-source = "git+https://github.com/LayerZero-Labs/ZeroOS.git?rev=3b132ce862ba6769a4261d151f69ff32c5f0dc30#3b132ce862ba6769a4261d151f69ff32c5f0dc30"
+source = "git+https://github.com/LayerZero-Labs/ZeroOS.git?rev=c572b88a643474317e4b0c7e53ac722a98a0e050#c572b88a643474317e4b0c7e53ac722a98a0e050"
 dependencies = [
  "cfg-if",
  "libc",
@@ -7908,12 +7926,12 @@ dependencies = [
 [[package]]
 name = "zeroos-macros"
 version = "0.1.0"
-source = "git+https://github.com/LayerZero-Labs/ZeroOS.git?rev=3b132ce862ba6769a4261d151f69ff32c5f0dc30#3b132ce862ba6769a4261d151f69ff32c5f0dc30"
+source = "git+https://github.com/LayerZero-Labs/ZeroOS.git?rev=c572b88a643474317e4b0c7e53ac722a98a0e050#c572b88a643474317e4b0c7e53ac722a98a0e050"
 
 [[package]]
 name = "zeroos-os-linux"
 version = "0.1.0"
-source = "git+https://github.com/LayerZero-Labs/ZeroOS.git?rev=3b132ce862ba6769a4261d151f69ff32c5f0dc30#3b132ce862ba6769a4261d151f69ff32c5f0dc30"
+source = "git+https://github.com/LayerZero-Labs/ZeroOS.git?rev=c572b88a643474317e4b0c7e53ac722a98a0e050#c572b88a643474317e4b0c7e53ac722a98a0e050"
 dependencies = [
  "cfg-if",
  "libc",
@@ -7923,7 +7941,7 @@ dependencies = [
 [[package]]
 name = "zeroos-rng"
 version = "0.1.0"
-source = "git+https://github.com/LayerZero-Labs/ZeroOS.git?rev=3b132ce862ba6769a4261d151f69ff32c5f0dc30#3b132ce862ba6769a4261d151f69ff32c5f0dc30"
+source = "git+https://github.com/LayerZero-Labs/ZeroOS.git?rev=c572b88a643474317e4b0c7e53ac722a98a0e050#c572b88a643474317e4b0c7e53ac722a98a0e050"
 dependencies = [
  "spin 0.9.8",
  "zeroos-foundation",
@@ -7932,7 +7950,7 @@ dependencies = [
 [[package]]
 name = "zeroos-runtime-musl"
 version = "0.1.0"
-source = "git+https://github.com/LayerZero-Labs/ZeroOS.git?rev=3b132ce862ba6769a4261d151f69ff32c5f0dc30#3b132ce862ba6769a4261d151f69ff32c5f0dc30"
+source = "git+https://github.com/LayerZero-Labs/ZeroOS.git?rev=c572b88a643474317e4b0c7e53ac722a98a0e050#c572b88a643474317e4b0c7e53ac722a98a0e050"
 dependencies = [
  "zeroos-backtrace",
  "zeroos-debug",
@@ -7942,7 +7960,7 @@ dependencies = [
 [[package]]
 name = "zeroos-runtime-nostd"
 version = "0.1.0"
-source = "git+https://github.com/LayerZero-Labs/ZeroOS.git?rev=3b132ce862ba6769a4261d151f69ff32c5f0dc30#3b132ce862ba6769a4261d151f69ff32c5f0dc30"
+source = "git+https://github.com/LayerZero-Labs/ZeroOS.git?rev=c572b88a643474317e4b0c7e53ac722a98a0e050#c572b88a643474317e4b0c7e53ac722a98a0e050"
 dependencies = [
  "cfg-if",
  "zeroos-backtrace",
@@ -7952,7 +7970,7 @@ dependencies = [
 [[package]]
 name = "zeroos-scheduler-cooperative"
 version = "0.1.0"
-source = "git+https://github.com/LayerZero-Labs/ZeroOS.git?rev=3b132ce862ba6769a4261d151f69ff32c5f0dc30#3b132ce862ba6769a4261d151f69ff32c5f0dc30"
+source = "git+https://github.com/LayerZero-Labs/ZeroOS.git?rev=c572b88a643474317e4b0c7e53ac722a98a0e050#c572b88a643474317e4b0c7e53ac722a98a0e050"
 dependencies = [
  "cfg-if",
  "libc",
@@ -7963,7 +7981,7 @@ dependencies = [
 [[package]]
 name = "zeroos-vfs-core"
 version = "0.1.0"
-source = "git+https://github.com/LayerZero-Labs/ZeroOS.git?rev=3b132ce862ba6769a4261d151f69ff32c5f0dc30#3b132ce862ba6769a4261d151f69ff32c5f0dc30"
+source = "git+https://github.com/LayerZero-Labs/ZeroOS.git?rev=c572b88a643474317e4b0c7e53ac722a98a0e050#c572b88a643474317e4b0c7e53ac722a98a0e050"
 dependencies = [
  "libc",
  "zeroos-foundation",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,6 +88,8 @@ members = [
   "examples/multi-function/guest",
   "examples/alloc",
   "examples/alloc/guest",
+  "examples/large-alloc",
+  "examples/large-alloc/guest",
   "examples/stdlib",
   "examples/stdlib/guest",
   "examples/muldiv",
@@ -409,8 +411,8 @@ log = { version = "0.4" }
 env_logger = { version = "0.11" }
 
 # ZeroOS build system
-zeroos-build = { git = "https://github.com/LayerZero-Labs/ZeroOS.git", default-features = false, rev = "3b132ce862ba6769a4261d151f69ff32c5f0dc30" }
-zeroos = { git = "https://github.com/LayerZero-Labs/ZeroOS.git", default-features = false, rev = "3b132ce862ba6769a4261d151f69ff32c5f0dc30" }
+zeroos-build = { git = "https://github.com/LayerZero-Labs/ZeroOS.git", default-features = false, rev = "c572b88a643474317e4b0c7e53ac722a98a0e050" }
+zeroos = { git = "https://github.com/LayerZero-Labs/ZeroOS.git", default-features = false, rev = "c572b88a643474317e4b0c7e53ac722a98a0e050" }
 cfg-if = "1.0"
 riscv = { version = "0.16", default-features = false }
 

--- a/crates/jolt-prover-legacy/src/zkvm/prover.rs
+++ b/crates/jolt-prover-legacy/src/zkvm/prover.rs
@@ -3799,6 +3799,30 @@ mod tests {
         verify_verifier_proof(&prover_preprocessing, jolt_proof, io_device, None);
     }
 
+    /// Trace-only regression harness for ZeroOS's munmap region accounting
+    /// (LayerZero-Labs/ZeroOS c572b88a, pinned in the workspace Cargo.toml):
+    /// every guest allocation is past mallocng's individual-mmap threshold,
+    /// so each `free` issues a real `munmap`, and the guest additionally
+    /// issues POSIX-legal repeated and partial unmaps that must never reach
+    /// the ZeroOS kernel heap's free. Before that revision, ZeroOS forwarded
+    /// any guest-supplied (addr, len) straight to `kfree`, corrupting the
+    /// kernel heap free list and killing the guest; this asserts the guest
+    /// runs to completion.
+    #[test]
+    #[serial]
+    fn large_alloc_munmap_trace() {
+        let mut program = host::Program::new("large-alloc-guest");
+        program.set_std(true);
+        program.set_func("large_alloc_roundtrip");
+        program.set_heap_size(16777216);
+        program.set_stack_size(1048576);
+        let (_, _, _, io_device) = program.trace(&[], &[], &[]);
+        assert!(
+            !io_device.panic,
+            "large-alloc guest panicked: a non-exact munmap corrupted the ZeroOS kernel heap"
+        );
+    }
+
     /// Test BlindFold R1CS satisfaction using real sumcheck data from muldiv proof.
     ///
     /// This test extracts sumcheck polynomials from all 6 stages of a real Jolt proof

--- a/crates/jolt-prover-legacy/src/zkvm/prover.rs
+++ b/crates/jolt-prover-legacy/src/zkvm/prover.rs
@@ -2774,7 +2774,7 @@ mod tests {
     use serial_test::serial;
 
     use crate::curve::Bn254Curve;
-    use crate::host;
+    use crate::host::Program;
     use crate::poly::commitment::dory::{DoryGlobals, DoryLayout};
     #[cfg(feature = "zk")]
     use crate::poly::commitment::pedersen::PedersenGenerators;
@@ -2934,7 +2934,7 @@ mod tests {
     #[serial]
     fn fib_e2e_dory() {
         DoryGlobals::reset();
-        let mut program = host::Program::new("fibonacci-guest");
+        let mut program = Program::new("fibonacci-guest");
         let inputs = postcard::to_stdvec(&100u32).unwrap();
         let (bytecode, init_memory_state, _, e_entry) = program.decode();
         let (_, _, _, io_device) = program.trace(&inputs, &[], &[]);
@@ -2971,7 +2971,7 @@ mod tests {
     #[serial]
     fn oversized_trace_returns_error() {
         DoryGlobals::reset();
-        let mut program = host::Program::new("fibonacci-guest");
+        let mut program = Program::new("fibonacci-guest");
         let inputs = postcard::to_stdvec(&100u32).unwrap();
         let (bytecode, init_memory_state, _, e_entry) = program.decode();
         let (_, _, _, io_device) = program.trace(&inputs, &[], &[]);
@@ -3006,7 +3006,7 @@ mod tests {
     #[serial]
     fn small_trace_e2e_dory() {
         DoryGlobals::reset();
-        let mut program = host::Program::new("fibonacci-guest");
+        let mut program = Program::new("fibonacci-guest");
         let inputs = postcard::to_stdvec(&5u32).unwrap();
         let (bytecode, init_memory_state, _, e_entry) = program.decode();
         let (_, _, _, io_device) = program.trace(&inputs, &[], &[]);
@@ -3053,7 +3053,7 @@ mod tests {
     fn sha3_e2e_dory() {
         DoryGlobals::reset();
 
-        let mut program = host::Program::new("sha3-guest");
+        let mut program = Program::new("sha3-guest");
         program.set_func("sha3");
         let (bytecode, init_memory_state, _, e_entry) = program.decode();
         let inputs = postcard::to_stdvec(&[5u8; 32]).unwrap();
@@ -3104,7 +3104,7 @@ mod tests {
     fn sha2_e2e_dory() {
         DoryGlobals::reset();
 
-        let mut program = host::Program::new("sha2-guest");
+        let mut program = Program::new("sha2-guest");
         let (bytecode, init_memory_state, _, e_entry) = program.decode();
         let inputs = postcard::to_stdvec(&[5u8; 32]).unwrap();
         let (_, _, _, io_device) = program.trace(&inputs, &[], &[]);
@@ -3157,7 +3157,7 @@ mod tests {
         // should still work correctly through the full pipeline:
         // - Trusted: commit in preprocessing-only context, reduce in Stage 6, batch in Stage 8
         // - Untrusted: commit at prove time, reduce in Stage 6, batch in Stage 8
-        let mut program = host::Program::new("sha2-guest");
+        let mut program = Program::new("sha2-guest");
         let (bytecode, init_memory_state, _, e_entry) = program.decode();
         let inputs = postcard::to_stdvec(&[5u8; 32]).unwrap();
         let trusted_advice = postcard::to_stdvec(&[7u8; 32]).unwrap();
@@ -3217,7 +3217,7 @@ mod tests {
         // Tests that max-sized advice (4KB = 512 words) works with a minimal trace.
         // With balanced dims (sigma_a=5, nu_a=4 for 512 words), the minimum padded trace
         // (256 cycles -> total_vars=12) is sufficient to embed advice.
-        let mut program = host::Program::new("fibonacci-guest");
+        let mut program = Program::new("fibonacci-guest");
         let inputs = postcard::to_stdvec(&5u32).unwrap();
         let trusted_advice = vec![7u8; 4096];
         let untrusted_advice = vec![9u8; 4096];
@@ -3276,7 +3276,7 @@ mod tests {
         DoryGlobals::reset();
 
         // Tests a guest (merkle-tree) that actually consumes both trusted and untrusted advice.
-        let mut program = host::Program::new("merkle-tree-guest");
+        let mut program = Program::new("merkle-tree-guest");
         let (bytecode, init_memory_state, _, e_entry) = program.decode();
 
         // Merkle tree with 4 leaves: input=leaf1, trusted=[leaf2, leaf3], untrusted=leaf4
@@ -3340,7 +3340,7 @@ mod tests {
         //
         // For a small trace (256 cycles), the advice row coordinates span both Stage 6 (cycle)
         // and Stage 7 (address) challenges, verifying the two-phase reduction works correctly.
-        let mut program = host::Program::new("fibonacci-guest");
+        let mut program = Program::new("fibonacci-guest");
         let inputs = postcard::to_stdvec(&5u32).unwrap();
         let trusted_advice = postcard::to_stdvec(&[7u8; 32]).unwrap();
         let untrusted_advice = postcard::to_stdvec(&[9u8; 32]).unwrap();
@@ -3434,7 +3434,7 @@ mod tests {
     #[serial]
     fn memory_ops_e2e_dory() {
         DoryGlobals::reset();
-        let mut program = host::Program::new("memory-ops-guest");
+        let mut program = Program::new("memory-ops-guest");
         let (bytecode, init_memory_state, _, e_entry) = program.decode();
         let (_, _, _, io_device) = program.trace(&[], &[], &[]);
 
@@ -3471,7 +3471,7 @@ mod tests {
     #[serial]
     fn btreemap_e2e_dory() {
         DoryGlobals::reset();
-        let mut program = host::Program::new("btreemap-guest");
+        let mut program = Program::new("btreemap-guest");
         let (bytecode, init_memory_state, _, e_entry) = program.decode();
         let inputs = postcard::to_stdvec(&50u32).unwrap();
         let (_, _, _, io_device) = program.trace(&inputs, &[], &[]);
@@ -3547,7 +3547,7 @@ mod tests {
         eprintln!("sha2-chain: {iters} iterations, target 2^{log_t}");
 
         DoryGlobals::reset();
-        let mut program = host::Program::new("sha2-chain-guest");
+        let mut program = Program::new("sha2-chain-guest");
         let (bytecode, init_memory_state, _, e_entry) = program.decode();
         let (_, _, _, io_device) = program.trace(&inputs, &[], &[]);
         let (shared_preprocessing, _program_data) = test_shared_preprocessing(
@@ -3621,7 +3621,7 @@ mod tests {
     #[serial]
     fn muldiv_e2e_dory() {
         DoryGlobals::reset();
-        let mut program = host::Program::new("muldiv-guest");
+        let mut program = Program::new("muldiv-guest");
         let (bytecode, init_memory_state, _, e_entry) = program.decode();
         let inputs = postcard::to_stdvec(&[9u32, 5u32, 3u32]).unwrap();
         let (_, _, _, io_device) = program.trace(&inputs, &[], &[]);
@@ -3659,7 +3659,7 @@ mod tests {
     #[serial]
     fn muldiv_e2e_dory_committed_program_commitments() {
         DoryGlobals::reset();
-        let mut program = host::Program::new("muldiv-guest");
+        let mut program = Program::new("muldiv-guest");
         let (bytecode, init_memory_state, _, e_entry) = program.decode();
         let inputs = postcard::to_stdvec(&[9u32, 5u32, 3u32]).unwrap();
         let (_, _, _, io_device) = program.trace(&inputs, &[], &[]);
@@ -3709,7 +3709,7 @@ mod tests {
 
     fn muldiv_e2e_dory_committed_program_preprocessing_roundtrip_inner() {
         DoryGlobals::reset();
-        let mut program = host::Program::new("muldiv-guest");
+        let mut program = Program::new("muldiv-guest");
         let (bytecode, init_memory_state, _, e_entry) = program.decode();
         let inputs = postcard::to_stdvec(&[9u32, 5u32, 3u32]).unwrap();
         let (_, _, _, io_device) = program.trace(&inputs, &[], &[]);
@@ -3763,7 +3763,7 @@ mod tests {
     #[serial]
     fn stdlib_e2e_dory() {
         DoryGlobals::reset();
-        let mut program = host::Program::new("stdlib-guest");
+        let mut program = Program::new("stdlib-guest");
         program.set_std(true);
         program.set_func("int_to_string");
         let inputs = postcard::to_stdvec(&81i32).unwrap();
@@ -3811,7 +3811,7 @@ mod tests {
     #[test]
     #[serial]
     fn large_alloc_munmap_trace() {
-        let mut program = host::Program::new("large-alloc-guest");
+        let mut program = Program::new("large-alloc-guest");
         program.set_std(true);
         program.set_func("large_alloc_roundtrip");
         program.set_heap_size(16777216);
@@ -3938,7 +3938,7 @@ mod tests {
         }
 
         // Run muldiv prover to get a real proof
-        let mut program = host::Program::new("muldiv-guest");
+        let mut program = Program::new("muldiv-guest");
         let (bytecode, init_memory_state, _, e_entry) = program.decode();
         let inputs = postcard::to_stdvec(&[9u32, 5u32, 3u32]).unwrap();
         let (_, _, _, io_device) = program.trace(&inputs, &[], &[]);
@@ -4059,7 +4059,7 @@ mod tests {
     #[serial]
     #[should_panic]
     fn truncated_trace() {
-        let mut program = host::Program::new("fibonacci-guest");
+        let mut program = Program::new("fibonacci-guest");
         let (bytecode, init_memory_state, _, e_entry) = program.decode();
         let inputs = postcard::to_stdvec(&9u8).unwrap();
         let (lazy_trace, mut trace, final_memory_state, mut program_io) =
@@ -4099,7 +4099,7 @@ mod tests {
     #[serial]
     #[should_panic]
     fn malicious_trace() {
-        let mut program = host::Program::new("fibonacci-guest");
+        let mut program = Program::new("fibonacci-guest");
         let inputs = postcard::to_stdvec(&1u8).unwrap();
         let (bytecode, init_memory_state, _, e_entry) = program.decode();
         let (lazy_trace, trace, final_memory_state, mut program_io) =
@@ -4149,7 +4149,7 @@ mod tests {
     #[serial]
     fn initial_pc_is_constrained_to_entry_point() {
         DoryGlobals::reset();
-        let mut program = host::Program::new("fibonacci-guest");
+        let mut program = Program::new("fibonacci-guest");
         let inputs = postcard::to_stdvec(&9u8).unwrap();
         let (bytecode, init_memory_state, _, e_entry) = program.decode();
         let (lazy_trace, trace, final_memory_state, program_io) = program.trace(&inputs, &[], &[]);
@@ -4328,7 +4328,7 @@ mod tests {
         DoryGlobals::reset();
         DoryGlobals::set_layout(DoryLayout::AddressMajor);
 
-        let mut program = host::Program::new("fibonacci-guest");
+        let mut program = Program::new("fibonacci-guest");
         let inputs = postcard::to_stdvec(&50u32).unwrap();
         let (bytecode, init_memory_state, _, e_entry) = program.decode();
         let (_, _, _, io_device) = program.trace(&inputs, &[], &[]);
@@ -4368,7 +4368,7 @@ mod tests {
         DoryGlobals::set_layout(DoryLayout::AddressMajor);
 
         // Tests a guest (merkle-tree) that actually consumes both trusted and untrusted advice.
-        let mut program = host::Program::new("merkle-tree-guest");
+        let mut program = Program::new("merkle-tree-guest");
         let (bytecode, init_memory_state, _, e_entry) = program.decode();
 
         // Merkle tree with 4 leaves: input=leaf1, trusted=[leaf2, leaf3], untrusted=leaf4

--- a/examples/large-alloc/Cargo.toml
+++ b/examples/large-alloc/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "large-alloc"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+jolt-sdk = { workspace = true, features = ["host"] }
+tracing-subscriber.workspace = true
+tracing.workspace = true
+guest = { package = "large-alloc-guest", path = "./guest" }

--- a/examples/large-alloc/guest/Cargo.toml
+++ b/examples/large-alloc/guest/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "large-alloc-guest"
+version = "0.1.0"
+edition = "2021"
+
+[features]
+guest = []
+field-inline = ["jolt/field-inline"]
+
+[dependencies]
+jolt = { package = "jolt-sdk", path = "../../../jolt-sdk", features = [
+  "guest-std",
+] }
+libc = "0.2"
+
+[lib]
+test = false
+doctest = false
+bench = false
+
+[[bin]]
+name = "large-alloc-guest"
+path = "src/main.rs"
+test = false
+bench = false

--- a/examples/large-alloc/guest/src/lib.rs
+++ b/examples/large-alloc/guest/src/lib.rs
@@ -1,0 +1,85 @@
+use libc::{MAP_ANONYMOUS, MAP_FAILED, MAP_PRIVATE, PROT_READ, PROT_WRITE};
+
+/// std-guest exercise of ZeroOS's mmap/munmap region accounting.
+///
+/// Round 1 (mallocng path): every allocation is past musl mallocng's
+/// individual-mmap threshold (~128 KiB), so the malloc is served by `mmap`
+/// and the `drop` routes through a whole-mapping `munmap`.
+///
+/// Round 2 (POSIX repeated-unmap path): unmap the same range twice. POSIX
+/// allows a munmap range with no live mappings ("if there are no mappings in
+/// the specified address range, munmap() has no effect"), so the second call
+/// must succeed as a no-op. The guest kernel serves mappings from its heap
+/// allocator, which only understands whole-region frees — a repeated unmap
+/// must not reach it.
+///
+/// Round 3 (POSIX partial-unmap path): map a 16-page region, unmap its
+/// 8-page tail (allocators use this to trim reservations), keep using the
+/// live half, then release the whole original range.
+///
+/// The guest must survive all frees and keep allocating afterwards.
+#[jolt::provable(
+    heap_size = 16777216,
+    stack_size = 1048576,
+    max_trace_length = 16777216
+)]
+fn large_alloc_roundtrip() -> u64 {
+    let mut acc: u64 = 0;
+    for round in 0..4u64 {
+        // 256 KiB + a per-round page so the mappings differ in size.
+        let len = (256 << 10) + (round as usize) * 4096;
+        let mut buffer = vec![0u8; len];
+        let mut i = 0;
+        while i < len {
+            buffer[i] = (round as u8).wrapping_add(i as u8);
+            i += 4096;
+        }
+        acc = acc.wrapping_add(buffer.iter().map(|&byte| u64::from(byte)).sum::<u64>());
+        drop(buffer);
+    }
+
+    const PAGE: usize = 4096;
+    unsafe {
+        // Round 2: repeated unmap of the same range.
+        let base = libc::mmap(
+            core::ptr::null_mut(),
+            16 * PAGE,
+            PROT_READ | PROT_WRITE,
+            MAP_PRIVATE | MAP_ANONYMOUS,
+            -1,
+            0,
+        );
+        assert_ne!(base, MAP_FAILED, "anonymous mmap failed");
+        base.cast::<u8>().write(0xA5);
+        assert_eq!(libc::munmap(base, 16 * PAGE), 0);
+        assert_eq!(
+            libc::munmap(base, 16 * PAGE),
+            0,
+            "repeated munmap must no-op"
+        );
+
+        // Round 3: trim a reservation's tail, then release the whole range.
+        let base = libc::mmap(
+            core::ptr::null_mut(),
+            16 * PAGE,
+            PROT_READ | PROT_WRITE,
+            MAP_PRIVATE | MAP_ANONYMOUS,
+            -1,
+            0,
+        );
+        assert_ne!(base, MAP_FAILED, "anonymous mmap failed");
+        let base = base.cast::<u8>();
+        base.write(0xA5);
+        assert_eq!(libc::munmap(base.add(8 * PAGE).cast(), 8 * PAGE), 0);
+        base.add(7 * PAGE).write(0x5A);
+        acc = acc.wrapping_add(u64::from(base.read()) + u64::from(base.add(7 * PAGE).read()));
+        // Release the whole original range; the already-unmapped tail makes
+        // this a partially-live range, which POSIX also allows.
+        assert_eq!(libc::munmap(base.cast(), 16 * PAGE), 0);
+    }
+
+    // The heap must still serve large allocations after the raw unmaps.
+    let tail = vec![7u8; 512 << 10];
+    acc = acc.wrapping_add(tail.iter().map(|&byte| u64::from(byte)).sum::<u64>());
+    acc
+}

--- a/examples/large-alloc/guest/src/main.rs
+++ b/examples/large-alloc/guest/src/main.rs
@@ -1,0 +1,4 @@
+#![no_main]
+
+#[allow(unused_imports)]
+use large_alloc_guest::*;

--- a/examples/large-alloc/src/main.rs
+++ b/examples/large-alloc/src/main.rs
@@ -1,0 +1,23 @@
+use tracing::info;
+
+/// Executes the large-allocation roundtrip guest under the tracer (no
+/// proving) and fails loudly if the guest panicked. Manual harness for
+/// ZeroOS's mmap/munmap region accounting: each guest allocation is past
+/// musl mallocng's individual-mmap threshold, so every `drop` issues a real
+/// `munmap` against the guest kernel's heap. The CI regression test is
+/// `large_alloc_munmap_trace` in jolt-prover-legacy's prover tests.
+pub fn main() {
+    tracing_subscriber::fmt::init();
+
+    let target_dir = "/tmp/jolt-guest-targets";
+    let mut program = guest::compile_large_alloc_roundtrip(target_dir);
+
+    let (_lazy, trace, _memory, io_device) = program.trace(&[], &[], &[]);
+    info!("guest executed {} trace rows", trace.len());
+    assert!(
+        !io_device.panic,
+        "large-alloc guest panicked: the runtime failed a large free/munmap"
+    );
+    info!("outputs: {:?}", io_device.outputs);
+    info!("large-alloc roundtrip completed cleanly");
+}


### PR DESCRIPTION
## Summary

**Rescoped.** This PR originally added an SDK-level mmap/munmap guard (`jolt-sdk/src/runtime/mmap.rs`) to stop guest programs from corrupting ZeroOS's kernel heap through POSIX-legal but allocator-unsupported unmaps. That fix has since landed upstream in ZeroOS itself ([LayerZero-Labs/ZeroOS@c572b88a](https://github.com/LayerZero-Labs/ZeroOS/commit/c572b88a643474317e4b0c7e53ac722a98a0e050), "fix(os-linux): only forward exact whole-region munmaps to kfree"; see #1822), so the SDK guard is no longer needed and this PR now ships the kernel-side fix instead:

- **Bump the `zeroos`/`zeroos-build` pins** from `3b132ce8` to `c572b88a6`, which adds region accounting to ZeroOS's `sys_mmap`/`sys_munmap`: only an exact whole-region unmap reaches `kfree`; partial, interior, spanning, repeated, and unknown unmaps succeed as no-ops without touching the kernel heap; a full region table makes `sys_mmap` fail with `-ENOMEM` rather than create an untracked allocation.
- **Keep the `examples/large-alloc` regression harness** (per the checklist in #1822): a std guest whose allocations all cross mallocng's individual-mmap threshold, plus explicit repeated and partial-tail unmaps, plus a follow-up allocation confirming the heap survives.
- **Add a trace-only CI regression test**, `large_alloc_munmap_trace` in jolt-prover-legacy's prover tests, asserting the guest runs to completion.
- **Drop the SDK guard** (`mmap.rs`, the `trap.rs` interception, the `mod.rs` declaration): mmap/munmap route directly to ZeroOS again. Stacking the guard on the fixed kernel would be redundant and mildly harmful (a mapping evicted from the SDK's fixed-capacity table would never have its legitimate exact free forwarded).

## Failure mode (fixed upstream)

At the previous pin `3b132ce8`:

1. `sys_mmap` obtains an anonymous mapping with page-aligned `kmalloc`;
2. `sys_munmap` forwards the supplied (address, length) directly to `kfree`; and
3. `linked_list_allocator` expects exactly the pointer and layout returned by `kmalloc`.

A partial, interior, repeated, or stale unmap therefore asks the heap to free a block it never allocated, corrupting the free list, entering an unbounded allocator walk, or panicking in the machine-mode trap handler. This affects ordinary std guests: musl's mallocng uses individual `mmap` allocations for sufficiently large objects, so freeing a large `Vec` exercises the path.

## Validation

    cargo run --release -p large-alloc

| Scenario | Result |
|---|---|
| Old pin (`3b132ce8`) | Guest hangs or panics in the trap handler when the kernel-heap free list is corrupted |
| New pin (`c572b88a6`) | Completes cleanly and returns its checksum |

Closes the Jolt half of #1822.
