### PR TITLE
docs: weekly freshness pass (Aug 31)

### DIFF
--- a/agent-skills/jolt/SKILL.md
+++ b/agent-skills/jolt/SKILL.md
@@ -114,10 +114,10 @@ For `PrivateInput<T>`, enable `zk` on the host only (see Step 7). The macro enfo
 
 | Hash | Cycles | vs SHA-256 | Max input |
 |------|--------|-----------|-----------|
-| BLAKE3 | 781 | 9.1x faster | 64 bytes (single block only) |
-| Blake2b | 1,235 | 5.8x faster | unlimited |
-| Keccak-256 | 3,680 | 1.9x faster | unlimited |
-| SHA-256 | 7,140 | baseline | unlimited |
+| BLAKE3 | 781 | 5.8x faster | 64 bytes (single block only) |
+| Blake2b | 1,235 | 3.6x faster | unlimited |
+| Keccak-256 | 3,645 | 1.2x faster | unlimited |
+| SHA-256 | 4,501 | baseline | unlimited |
 
 BLAKE3 is fastest but capped at 64 bytes. For variable-length hashing, Blake2b is the best choice. SHA-256 must be used when the hash is dictated by an external protocol (e.g., JWT RSA-SHA256 signatures).
 

--- a/book/src/how/optimizations/inlines.md
+++ b/book/src/how/optimizations/inlines.md
@@ -133,12 +133,12 @@ The table below compares the performance of reference and inline implementations
 
 | Hash Function | Implementation | Cycles | Cycles Per Byte (CPB) | Speedup |
 |--------------|----------------|----------------|----------------------|---------|
-| SHA-256      | [sha2 crate](https://crates.io/crates/sha2)      | 10,414,653     | 317.83               | -       |
-| SHA-256      | **Jolt Inline**     | **1,545,643**  | **47.17**            | **6.74×** |
-| Keccak-256   | [sha3 crate](https://crates.io/crates/sha3)      | 2,556,519      | 78.02                | -       |
-| Keccak-256   | **Jolt Inline**     | **848,224**    | **25.89**            | **3.01×** |
-| Blake2B      | [blake2 crate](https://crates.io/crates/blake2)      | 951,043        | 29.02                | -       |
-| Blake2B      | **Jolt Inline**     | **303,148**    | **9.25**             | **3.14×** |
+| SHA-256      | [sha2 crate](https://crates.io/crates/sha2)      | 2,380,389      | 72.64                | -       |
+| SHA-256      | **Jolt Inline**     | **1,037,131**  | **31.65**            | **2.30×** |
+| Keccak-256   | [sha3 crate](https://crates.io/crates/sha3)      | 1,938,499      | 59.16                | -       |
+| Keccak-256   | **Jolt Inline**     | **805,298**    | **24.58**            | **2.41×** |
+| Blake2B      | [blake2 crate](https://crates.io/crates/blake2)      | 820,496        | 25.04                | -       |
+| Blake2B      | **Jolt Inline**     | **304,185**    | **9.28**             | **2.70×** |
 
 *Note: Blake3 currently supports inputs up to 64 bytes. Full implementation for larger inputs is in development.*
 
@@ -154,9 +154,9 @@ The following table shows the data that can be proved by each of the Jolt inline
 
 | Hash Function | MacBook M4 Max (500 kHz) | Threadripper Pro 7975WX (1.5 MHz) |
 |--------------|---------------------|----------------------|
-| SHA-256 Inline | 10.4 KiB/s | 31.1 KiB/s |
-| Keccak-256 Inline | 18.9 KiB/s | 56.6 KiB/s |
-| Blake2B Inline | 52.8 KiB/s | 158.3 KiB/s |
+| SHA-256 Inline | 15.4 KiB/s | 46.3 KiB/s |
+| Keccak-256 Inline | 19.9 KiB/s | 59.6 KiB/s |
+| Blake2B Inline | 52.6 KiB/s | 157.8 KiB/s |
 
 
 ## Jolt CPU Advantages


### PR DESCRIPTION
## Week's changes reviewed
24 commits on main since Aug 24 — notable for docs: #1795 (HyperKZG deletion), #1790 (SHA-256 XORROTW tables), #1751/#1753 (DIV/REM + W-shift row counts), #1762 (fused loads), #1746 (guest allocator), #1732/#1798 (Akita → modular prover).

## Drift found
Only the hash inline benchmark numbers: #1790 cut SHA-256 rows/block 2,300 → 1,996 (custom-IV) / 2,260 → 1,960 (fixed-IV), invalidating the published SHA-256 cycle counts in `book/src/how/optimizations/inlines.md` and `agent-skills/jolt/SKILL.md`.

## Fixes (all values re-measured, not extrapolated)
Re-measured every table row on one toolchain at HEAD via the hash-bench guest (`start/end_cycle_tracking` markers → `trace_analyze`, total cycles = real + virtual, in-guest `assert_eq!(ref, inline)`):

- **book 32 KiB table**: SHA-256 inline 1,545,643 → 1,037,131 cycles (47.17 → 31.65 CPB). Reference rows had also drifted from older toolchains (sha2 crate 10.4M → 2.38M), so speedups fall to 2.30×/2.41×/2.70×; derived KiB/s throughput table updated to match.
- **SKILL.md 64 B table**: SHA-256 7,140 → 4,501; Keccak-256 3,680 → 3,645; ratios recomputed. Blake2b (1,235) and BLAKE3 (781) reproduce the published numbers exactly, validating the measurement method.
- Cross-check: 513 blocks × 1,996 rows ≈ 1,023,912 of the 1,037,131 measured cycles; rows/block pinned by `test_sha256_inline_rows_per_block`.

## Verified no drift
CLAUDE.md / README.md / rest of book/ / .claude/skills checked against the week's commits — #1795 already updated CLAUDE.md (crate count, poly/ module map); no doc surface states the changed DIV/REM/W-shift sequence lengths, allocator algorithm, or BytecodePCMapper internals.