### PR TITLE
ci: same-runner A/B comparison for crate benchmarks

### DIFF
--- a/.github/workflows/bench-crates.yml
+++ b/.github/workflows/bench-crates.yml
@@ -1,17 +1,27 @@
 name: Benchmark modular crates
 
 on:
-  push:
-    branches: [main]
-    paths:
-      - "crates/**"
   pull_request:
     branches: [main]
+    # Only paths that can change the benched code: the four benched crates,
+    # their sole in-repo dependency (jolt-utils), and the build/toolchain inputs.
     paths:
-      - "crates/**"
+      - "crates/jolt-crypto/**"
+      - "crates/jolt-field/**"
+      - "crates/jolt-poly/**"
+      - "crates/jolt-transcript/**"
+      - "crates/jolt-utils/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - "rust-toolchain.toml"
+      - ".github/workflows/bench-crates.yml"
 
 env:
   CARGO_TERM_COLOR: always
+  # Every CPU observed in the hosted x64 fleet (Xeon 8370C/8573C, EPYC 7763/9V74)
+  # supports BMI2+ADX+AVX2. Without these flags the fp128 mulx/adx asm and the
+  # packed SIMD kernels are compile-time dead code and the benches time fallbacks.
+  RUSTFLAGS: -C target-feature=+bmi2,+adx,+avx2
 
 concurrency:
   group: bench-crates-${{ github.head_ref || github.ref }}
@@ -21,76 +31,73 @@ jobs:
   bench:
     runs-on: ubuntu-latest
     name: Criterion benchmarks
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@v7.0.1
+        with:
+          # Depth 2 reaches both parents of the synthetic merge commit, so the
+          # base leg can check out the exact main tip this PR merges against.
+          fetch-depth: 2
+
       - uses: actions-rust-lang/setup-rust-toolchain@v1
 
       - name: Install critcmp
         run: cargo install critcmp --locked
 
-      # On main push: save baseline
-      - name: Run benchmarks (baseline)
-        if: github.event_name == 'push'
-        run: >
-          cargo bench
-          -p jolt-crypto
-          -p jolt-field
-          -p jolt-poly
-          -p jolt-transcript
-          --features jolt-field/solinas,jolt-field/asm
-          --bench '*'
-          -- --save-baseline main_run
+      - name: Resolve base and head
+        id: refs
+        run: |
+          git rev-parse --verify -q HEAD^2 >/dev/null || { echo "::error::expected the PR merge commit, got a non-merge HEAD"; exit 1; }
+          { echo "head=$(git rev-parse HEAD)"; echo "base=$(git rev-parse HEAD^1)"; } >> "$GITHUB_OUTPUT"
 
-      - name: Upload baseline
-        if: github.event_name == 'push'
-        uses: actions/upload-artifact@v7
-        with:
-          name: criterion-baseline
-          path: target/criterion/
-          retention-days: 30
-
-      # On PR: compare against baseline
-      - name: Download baseline
-        if: github.event_name == 'pull_request'
-        uses: dawidd6/action-download-artifact@v24
-        with:
-          name: criterion-baseline
-          path: target/criterion/
-          branch: main
-          workflow: bench-crates.yml
-          if_no_artifact_found: warn
+      # Base and PR are benchmarked back-to-back on the SAME runner. Comparing
+      # against a stored main baseline measured on a different VM flagged most of
+      # the suite on unrelated PRs: the hosted x64 fleet mixes CPU models, which
+      # alone shifts wall time by 14% (median) to 34% (p90) between runs.
+      - name: Run benchmarks (base)
+        run: |
+          git checkout --quiet ${{ steps.refs.outputs.base }}
+          cargo bench \
+            -p jolt-crypto \
+            -p jolt-field \
+            -p jolt-poly \
+            -p jolt-transcript \
+            --features jolt-field/solinas,jolt-field/asm \
+            --bench '*' \
+            -- --save-baseline base_run --noplot
 
       - name: Run benchmarks (PR)
-        if: github.event_name == 'pull_request'
-        run: >
-          cargo bench
-          -p jolt-crypto
-          -p jolt-field
-          -p jolt-poly
-          -p jolt-transcript
-          --features jolt-field/solinas,jolt-field/asm
-          --bench '*'
-          -- --save-baseline pr_run
+        run: |
+          git checkout --quiet ${{ steps.refs.outputs.head }}
+          cargo bench \
+            -p jolt-crypto \
+            -p jolt-field \
+            -p jolt-poly \
+            -p jolt-transcript \
+            --features jolt-field/solinas,jolt-field/asm \
+            --bench '*' \
+            -- --save-baseline pr_run --noplot
 
+      # Same-VM back-to-back legs still drift a few percent (frequency scaling,
+      # noisy neighbors), more on the rayon-parallel poly benches; 10% keeps
+      # those quiet while cross-VM offsets no longer apply.
       - name: Compare benchmarks
-        if: github.event_name == 'pull_request'
         id: critcmp
         run: |
-          if ls target/criterion/*/main_run/ &>/dev/null; then
-            OUTPUT=$(critcmp main_run pr_run --threshold 5 2>&1) || true
-            echo "comparison<<EOF" >> "$GITHUB_OUTPUT"
-            echo "$OUTPUT" >> "$GITHUB_OUTPUT"
-            echo "EOF" >> "$GITHUB_OUTPUT"
-          fi
+          OUTPUT=$(critcmp base_run pr_run --threshold 10)
+          echo "comparison<<EOF" >> "$GITHUB_OUTPUT"
+          echo "$OUTPUT" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
 
       - name: Post benchmark comparison
-        if: github.event_name == 'pull_request' && steps.critcmp.outputs.comparison != '' && github.event.pull_request.head.repo.full_name == github.repository
+        if: steps.critcmp.outputs.comparison != '' && github.event.pull_request.head.repo.full_name == github.repository
         continue-on-error: true
         uses: actions/github-script@v9
         with:
           script: |
             const marker = '<!-- bench-crates -->';
-            const body = `${marker}\n## Benchmark comparison (crates)\n\n\`\`\`\n${process.env.COMPARISON}\n\`\`\``;
+            const header = `Same-runner A/B: \`base_run\` = ${process.env.BASE_SHA.slice(0, 9)} (merge target) vs \`pr_run\` = ${process.env.HEAD_SHA.slice(0, 9)} (merge commit), threshold 10%.`;
+            const body = `${marker}\n## Benchmark comparison (crates)\n\n${header}\n\n\`\`\`\n${process.env.COMPARISON}\n\`\`\``;
             const { data: comments } = await github.rest.issues.listComments({
               issue_number: context.issue.number,
               owner: context.repo.owner,
@@ -114,3 +121,5 @@ jobs:
             }
         env:
           COMPARISON: ${{ steps.critcmp.outputs.comparison }}
+          BASE_SHA: ${{ steps.refs.outputs.base }}
+          HEAD_SHA: ${{ steps.refs.outputs.head }}

--- a/.github/workflows/bench-crates.yml
+++ b/.github/workflows/bench-crates.yml
@@ -15,6 +15,7 @@ on:
       - "Cargo.lock"
       - "rust-toolchain.toml"
       - ".github/workflows/bench-crates.yml"
+      - "scripts/ci/bench_comment.py"
 
 env:
   CARGO_TERM_COLOR: always
@@ -40,9 +41,6 @@ jobs:
           fetch-depth: 2
 
       - uses: actions-rust-lang/setup-rust-toolchain@v1
-
-      - name: Install critcmp
-        run: cargo install critcmp --locked
 
       - name: Resolve base and head
         id: refs
@@ -78,26 +76,24 @@ jobs:
             --bench '*' \
             -- --save-baseline pr_run --noplot
 
-      # Same-VM back-to-back legs still drift a few percent (frequency scaling,
-      # noisy neighbors), more on the rayon-parallel poly benches; 10% keeps
-      # those quiet while cross-VM offsets no longer apply.
-      - name: Compare benchmarks
-        id: critcmp
+      # Bolds the faster run per benchmark and colors entries whose delta
+      # exceeds the noise threshold (see NOISE_THRESHOLD in the script).
+      - name: Render comparison
         run: |
-          OUTPUT=$(critcmp base_run pr_run --threshold 10)
-          echo "comparison<<EOF" >> "$GITHUB_OUTPUT"
-          echo "$OUTPUT" >> "$GITHUB_OUTPUT"
-          echo "EOF" >> "$GITHUB_OUTPUT"
+          python3 scripts/ci/bench_comment.py ${{ steps.refs.outputs.base }} ${{ steps.refs.outputs.head }} > "$RUNNER_TEMP/bench-comment.md"
+          cat "$RUNNER_TEMP/bench-comment.md"
 
       - name: Post benchmark comparison
-        if: steps.critcmp.outputs.comparison != '' && github.event.pull_request.head.repo.full_name == github.repository
+        if: github.event.pull_request.head.repo.full_name == github.repository
         continue-on-error: true
         uses: actions/github-script@v9
         with:
           script: |
-            const marker = '<!-- bench-crates -->';
-            const header = `Same-runner A/B: \`base_run\` = ${process.env.BASE_SHA.slice(0, 9)} (merge target) vs \`pr_run\` = ${process.env.HEAD_SHA.slice(0, 9)} (merge commit), threshold 10%.`;
-            const body = `${marker}\n## Benchmark comparison (crates)\n\n${header}\n\n\`\`\`\n${process.env.COMPARISON}\n\`\`\``;
+            const fs = require('fs');
+            const body = fs.readFileSync(process.env.COMMENT_PATH, 'utf8');
+            // The renderer owns the comment body; its first line is the
+            // sticky-comment marker used to find the comment to update.
+            const marker = body.split('\n', 1)[0];
             const { data: comments } = await github.rest.issues.listComments({
               issue_number: context.issue.number,
               owner: context.repo.owner,
@@ -120,6 +116,4 @@ jobs:
               });
             }
         env:
-          COMPARISON: ${{ steps.critcmp.outputs.comparison }}
-          BASE_SHA: ${{ steps.refs.outputs.base }}
-          HEAD_SHA: ${{ steps.refs.outputs.head }}
+          COMMENT_PATH: ${{ runner.temp }}/bench-comment.md

--- a/.github/workflows/bench-crates.yml
+++ b/.github/workflows/bench-crates.yml
@@ -17,6 +17,10 @@ on:
       - ".github/workflows/bench-crates.yml"
       - "scripts/ci/bench_comment.py"
 
+permissions:
+  contents: read
+  pull-requests: write
+
 env:
   CARGO_TERM_COLOR: always
   # Every CPU observed in the hosted x64 fleet (Xeon 8370C/8573C, EPYC 7763/9V74)
@@ -46,38 +50,40 @@ jobs:
         id: refs
         run: |
           git rev-parse --verify -q HEAD^2 >/dev/null || { echo "::error::expected the PR merge commit, got a non-merge HEAD"; exit 1; }
-          { echo "head=$(git rev-parse HEAD)"; echo "base=$(git rev-parse HEAD^1)"; } >> "$GITHUB_OUTPUT"
+          { echo "merge=$(git rev-parse HEAD)"; echo "base=$(git rev-parse HEAD^1)"; echo "head=$(git rev-parse HEAD^2)"; } >> "$GITHUB_OUTPUT"
 
       # Base and PR are benchmarked back-to-back on the SAME runner. Comparing
       # against a stored main baseline measured on a different VM flagged most of
       # the suite on unrelated PRs: the hosted x64 fleet mixes CPU models, which
       # alone shifts wall time by 14% (median) to 34% (p90) between runs.
-      - name: Run benchmarks (base)
+      #
+      # The base leg always runs first. On the validation run (no code change
+      # between legs) the second leg came out ~0.2% faster (median; 42 of 57
+      # non-zero rows) — a systematic lean far below the 10% threshold. Don't
+      # tighten the threshold to a few percent without switching to an
+      # alternating (A/B/A) order.
+      - name: Run benchmarks (base, then PR)
+        env:
+          BASE: ${{ steps.refs.outputs.base }}
+          MERGE: ${{ steps.refs.outputs.merge }}
         run: |
-          git checkout --quiet ${{ steps.refs.outputs.base }}
-          cargo bench \
-            -p jolt-crypto \
-            -p jolt-field \
-            -p jolt-poly \
-            -p jolt-transcript \
-            --features jolt-field/solinas,jolt-field/asm \
-            --bench '*' \
-            -- --save-baseline base_run --noplot
+          for leg in "$BASE base_run" "$MERGE pr_run"; do
+            read -r sha baseline <<< "$leg"
+            echo "::group::$baseline @ $sha"
+            git checkout --quiet "$sha"
+            cargo bench \
+              -p jolt-crypto \
+              -p jolt-field \
+              -p jolt-poly \
+              -p jolt-transcript \
+              --features jolt-field/solinas,jolt-field/asm \
+              --bench '*' \
+              -- --save-baseline "$baseline" --noplot
+            echo "::endgroup::"
+          done
 
-      - name: Run benchmarks (PR)
-        run: |
-          git checkout --quiet ${{ steps.refs.outputs.head }}
-          cargo bench \
-            -p jolt-crypto \
-            -p jolt-field \
-            -p jolt-poly \
-            -p jolt-transcript \
-            --features jolt-field/solinas,jolt-field/asm \
-            --bench '*' \
-            -- --save-baseline pr_run --noplot
-
-      # Bolds the faster run per benchmark and colors entries whose delta
-      # exceeds the noise threshold (see NOISE_THRESHOLD in the script).
+      # Bolds the faster run per benchmark and colors the Δ of entries whose
+      # delta exceeds the noise threshold (see NOISE_THRESHOLD in the script).
       - name: Render comparison
         run: |
           python3 scripts/ci/bench_comment.py ${{ steps.refs.outputs.base }} ${{ steps.refs.outputs.head }} > "$RUNNER_TEMP/bench-comment.md"
@@ -94,10 +100,11 @@ jobs:
             // The renderer owns the comment body; its first line is the
             // sticky-comment marker used to find the comment to update.
             const marker = body.split('\n', 1)[0];
-            const { data: comments } = await github.rest.issues.listComments({
+            const comments = await github.paginate(github.rest.issues.listComments, {
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
+              per_page: 100,
             });
             const existing = comments.find(c => c.body.includes(marker));
             if (existing) {

--- a/scripts/ci/bench_comment.py
+++ b/scripts/ci/bench_comment.py
@@ -4,16 +4,14 @@
 Reads every ``<criterion-dir>/**/{base_run,pr_run}/estimates.json`` pair saved
 by ``cargo bench -- --save-baseline {base_run,pr_run}`` and prints a GitHub
 Markdown comment to stdout: per benchmark, the faster run is bolded, and when
-the relative difference exceeds ``NOISE_THRESHOLD`` the entry is colored
-(green = PR faster, red = PR slower). Coloring uses GitHub's client-side math
-rendering (``$\\color{..}..$``), the only inline text coloring GitHub Markdown
-supports; colored cells therefore use ASCII-only TeX (``\\pm``, ``\\mu``,
-``\\%``) instead of the plain-text ``±``/``µ``.
+the relative difference exceeds ``NOISE_THRESHOLD`` the Δ cell is colored
+(green = PR faster, red = PR slower) via GitHub's client-side math rendering
+(``$\\color{..}..$``), the only inline text coloring GitHub Markdown supports.
 
 Usage: bench_comment.py <base-sha> <head-sha> [criterion-dir]
 
-The first output line is the HTML marker the workflow's comment step uses to
-upsert the sticky PR comment.
+The SHAs (merge target, PR head) are display-only. The first output line is the
+HTML marker the workflow's comment step uses to upsert the sticky PR comment.
 """
 
 from __future__ import annotations
@@ -29,13 +27,8 @@ MARKER = "<!-- bench-crates -->"
 # noisy neighbors), more on the rayon-parallel jolt-poly benches.
 NOISE_THRESHOLD = 0.10
 
-# (scale in ns, plain suffix, TeX suffix)
-UNITS = [
-    (1.0, "ns", r"\text{ns}"),
-    (1e3, "µs", r"\mu\text{s}"),
-    (1e6, "ms", r"\text{ms}"),
-    (1e9, "s", r"\text{s}"),
-]
+# (scale in ns, suffix)
+UNITS = [(1.0, "ns"), (1e3, "µs"), (1e6, "ms"), (1e9, "s")]
 
 TABLE_HEADER = (
     "| Benchmark | `base_run` (merge target) | `pr_run` (this PR) | Δ |\n"
@@ -58,25 +51,24 @@ def load_baseline(criterion_dir: Path, name: str) -> dict[str, tuple[float, floa
     return out
 
 
-def time_cell(mean_ns: float, sd_ns: float, bold: bool, color: str | None) -> str:
-    scale, suffix, tex = UNITS[0]
+def time_cell(mean_ns: float, sd_ns: float, bold: bool) -> str:
+    scale, suffix = UNITS[0]
     for candidate in UNITS:
         if mean_ns >= candidate[0]:
-            scale, suffix, tex = candidate
-    value, sd = mean_ns / scale, sd_ns / scale
-    if color is not None:
-        return f"${{\\color{{{color}}}\\mathbf{{{value:.1f} \\pm {sd:.2f}}}\\ {tex}}}$"
-    text = f"{value:.1f}±{sd:.2f}{suffix}"
+            scale, suffix = candidate
+    text = f"{mean_ns / scale:.1f}±{sd_ns / scale:.2f}{suffix}"
     return f"**{text}**" if bold else text
 
 
 def delta_cell(pct: float, color: str | None) -> str:
+    # `+ 0.0` turns the -0.0 that rounding a tiny negative leaves into +0.0.
+    text = f"{round(pct, 1) + 0.0:+.1f}"
     # Markdown un-escapes backslash-punctuation inside $...$ before math
     # rendering, and a bare % starts a TeX comment — so % needs a double
     # backslash to reach MathJax as \%.
     if color is not None:
-        return f"${{\\color{{{color}}}\\mathbf{{{pct:+.1f}\\\\%}}}}$"
-    return f"{pct:+.1f}%"
+        return f"${{\\color{{{color}}}\\mathbf{{{text}\\\\%}}}}$"
+    return f"{text}%"
 
 
 @dataclass
@@ -95,8 +87,8 @@ def render_row(name: str, base: tuple[float, float], pr: tuple[float, float]) ->
     color = ("green" if pr_faster else "red") if significant else None
     cells = (
         f"`{name.replace('|', chr(92) + '|')}`",
-        time_cell(base_mean, base_sd, not pr_faster, None if pr_faster else color),
-        time_cell(pr_mean, pr_sd, pr_faster, color if pr_faster else None),
+        time_cell(base_mean, base_sd, not pr_faster),
+        time_cell(pr_mean, pr_sd, pr_faster),
         delta_cell(pct, color),
     )
     return Row(f"| {' | '.join(cells)} |", pct, significant)
@@ -124,8 +116,9 @@ def main() -> int:
         "## Benchmark comparison (crates)",
         "",
         f"Same-runner A/B: `base_run` = {base_sha[:9]} (merge target) vs "
-        f"`pr_run` = {head_sha[:9]} (merge commit). Bold = faster run; colored "
-        f"when the difference exceeds the ±{NOISE_THRESHOLD:.0%} noise threshold.",
+        f"`pr_run` = {head_sha[:9]} (PR head merged onto it). "
+        f"Bold = faster run; Δ colored when the difference exceeds the "
+        f"±{NOISE_THRESHOLD:.0%} noise threshold.",
         "",
     ]
     if significant:

--- a/scripts/ci/bench_comment.py
+++ b/scripts/ci/bench_comment.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+"""Render the bench-crates PR comparison comment from two Criterion baselines.
+
+Reads every ``<criterion-dir>/**/{base_run,pr_run}/estimates.json`` pair saved
+by ``cargo bench -- --save-baseline {base_run,pr_run}`` and prints a GitHub
+Markdown comment to stdout: per benchmark, the faster run is bolded, and when
+the relative difference exceeds ``NOISE_THRESHOLD`` the entry is colored
+(green = PR faster, red = PR slower). Coloring uses GitHub's client-side math
+rendering (``$\\color{..}..$``), the only inline text coloring GitHub Markdown
+supports; colored cells therefore use ASCII-only TeX (``\\pm``, ``\\mu``,
+``\\%``) instead of the plain-text ``±``/``µ``.
+
+Usage: bench_comment.py <base-sha> <head-sha> [criterion-dir]
+
+The first output line is the HTML marker the workflow's comment step uses to
+upsert the sticky PR comment.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+MARKER = "<!-- bench-crates -->"
+
+# Same-VM back-to-back legs still drift a few percent (frequency scaling,
+# noisy neighbors), more on the rayon-parallel jolt-poly benches.
+NOISE_THRESHOLD = 0.10
+
+# (scale in ns, plain suffix, TeX suffix)
+UNITS = [
+    (1.0, "ns", r"\text{ns}"),
+    (1e3, "µs", r"\mu\text{s}"),
+    (1e6, "ms", r"\text{ms}"),
+    (1e9, "s", r"\text{s}"),
+]
+
+TABLE_HEADER = (
+    "| Benchmark | `base_run` (merge target) | `pr_run` (this PR) | Δ |\n"
+    "|---|---|---|---|"
+)
+
+
+def load_baseline(criterion_dir: Path, name: str) -> dict[str, tuple[float, float]]:
+    """Map benchmark full_id -> (mean, std_dev), both in nanoseconds."""
+    out: dict[str, tuple[float, float]] = {}
+    for est_path in criterion_dir.rglob("estimates.json"):
+        if est_path.parent.name != name:
+            continue
+        bench = json.loads((est_path.parent / "benchmark.json").read_text())
+        est = json.loads(est_path.read_text())
+        out[bench["full_id"]] = (
+            est["mean"]["point_estimate"],
+            est["std_dev"]["point_estimate"],
+        )
+    return out
+
+
+def time_cell(mean_ns: float, sd_ns: float, bold: bool, color: str | None) -> str:
+    scale, suffix, tex = UNITS[0]
+    for candidate in UNITS:
+        if mean_ns >= candidate[0]:
+            scale, suffix, tex = candidate
+    value, sd = mean_ns / scale, sd_ns / scale
+    if color is not None:
+        return f"${{\\color{{{color}}}\\mathbf{{{value:.1f} \\pm {sd:.2f}}}\\ {tex}}}$"
+    text = f"{value:.1f}±{sd:.2f}{suffix}"
+    return f"**{text}**" if bold else text
+
+
+def delta_cell(pct: float, color: str | None) -> str:
+    # Markdown un-escapes backslash-punctuation inside $...$ before math
+    # rendering, and a bare % starts a TeX comment — so % needs a double
+    # backslash to reach MathJax as \%.
+    if color is not None:
+        return f"${{\\color{{{color}}}\\mathbf{{{pct:+.1f}\\\\%}}}}$"
+    return f"{pct:+.1f}%"
+
+
+@dataclass
+class Row:
+    markdown: str
+    pct: float
+    significant: bool
+
+
+def render_row(name: str, base: tuple[float, float], pr: tuple[float, float]) -> Row:
+    base_mean, base_sd = base
+    pr_mean, pr_sd = pr
+    pct = (pr_mean - base_mean) / base_mean * 100.0
+    significant = abs(pct) > NOISE_THRESHOLD * 100.0
+    pr_faster = pr_mean < base_mean
+    color = ("green" if pr_faster else "red") if significant else None
+    cells = (
+        f"`{name.replace('|', chr(92) + '|')}`",
+        time_cell(base_mean, base_sd, not pr_faster, None if pr_faster else color),
+        time_cell(pr_mean, pr_sd, pr_faster, color if pr_faster else None),
+        delta_cell(pct, color),
+    )
+    return Row(f"| {' | '.join(cells)} |", pct, significant)
+
+
+def main() -> int:
+    if len(sys.argv) not in (3, 4):
+        print(__doc__, file=sys.stderr)
+        return 2
+    base_sha, head_sha = sys.argv[1], sys.argv[2]
+    criterion_dir = Path(sys.argv[3]) if len(sys.argv) == 4 else Path("target/criterion")
+
+    base = load_baseline(criterion_dir, "base_run")
+    pr = load_baseline(criterion_dir, "pr_run")
+    common = sorted(set(base) & set(pr))
+    if not common:
+        print(f"no benchmark pairs found under {criterion_dir}", file=sys.stderr)
+        return 1
+
+    rows = [render_row(name, base[name], pr[name]) for name in common]
+    significant = sorted((r for r in rows if r.significant), key=lambda r: -abs(r.pct))
+
+    lines = [
+        MARKER,
+        "## Benchmark comparison (crates)",
+        "",
+        f"Same-runner A/B: `base_run` = {base_sha[:9]} (merge target) vs "
+        f"`pr_run` = {head_sha[:9]} (merge commit). Bold = faster run; colored "
+        f"when the difference exceeds the ±{NOISE_THRESHOLD:.0%} noise threshold.",
+        "",
+    ]
+    if significant:
+        lines += [
+            f"**{len(significant)} of {len(rows)} benchmarks differ by more than "
+            f"±{NOISE_THRESHOLD:.0%}:**",
+            "",
+            TABLE_HEADER,
+            *(r.markdown for r in significant),
+        ]
+    else:
+        lines.append(f"No differences above the ±{NOISE_THRESHOLD:.0%} noise threshold.")
+    lines += [
+        "",
+        "<details>",
+        f"<summary>All {len(rows)} benchmarks</summary>",
+        "",
+        TABLE_HEADER,
+        *(r.markdown for r in rows),
+        "",
+        "</details>",
+    ]
+
+    only_one = sorted(set(base) ^ set(pr))
+    if only_one:
+        shown = ", ".join(f"`{n}`" for n in only_one[:10])
+        suffix = ", …" if len(only_one) > 10 else ""
+        lines += ["", f"_{len(only_one)} benchmark(s) present in only one run: {shown}{suffix}_"]
+
+    print("\n".join(lines))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Problem

The bench comparison this workflow posts is dominated by runner noise, not code changes. From the last 15 PRs with a `<!-- bench-crates -->` comment, 10 touched **none** of the four benched crates, yet 9 of those got flagged rows — 380 spurious rows total, median ~46 flagged benches per PR out of a 62-ID suite. Spurious ratios: median 1.14x, p90 1.34x, max 1.87x, with 61/67 bench names flagged in *both* directions across PRs (e.g. `pairing` 1.55x slower on #1705, 1.20x faster on #1748). The signature is a whole-suite uniform shift (#1790: all 51 rows in a 1.25–1.34x band): baseline and PR runs land on different VMs from a heterogeneous CPU fleet (`fp64 packed_mul` measures 1.5ns on one run and 2.8ns on another). The baseline artifact is also stale by construction — one Aug 27 artifact served every PR for 4+ days, and it tracks latest main, not the PR's merge target.

Criterion's 3s default warmup applies to every bench (no custom configs anywhere), so warmup was ruled out as the cause.

## Fix: bench base and head back-to-back on the same runner

The PR job now checks out the merge commit's first parent (the exact main tip the PR merges against), benches it as `base_run`, checks out the merge commit, benches `pr_run`, and compares locally with critcmp. Same-VM back-to-back runs measure ~1.5–3% drift vs the 14%/34% cross-VM offsets, so the comparison becomes meaningful.

Details:

- **PR-only trigger** — the push-to-main baseline job, artifact upload/download, and the `dawidd6/action-download-artifact` dependency are gone. Existing `criterion-baseline` artifacts age out via their 30-day retention.
- **Paths narrowed** to the four benched crates + `jolt-utils` (their only in-repo dependency, per `cargo metadata`) + `Cargo.toml`/`Cargo.lock`/`rust-toolchain.toml` + the workflow itself. Most spurious comments were on PRs that could not have changed these numbers.
- **Threshold 5% → 10%** — the 11 `poly_ops` benches are rayon-parallel on 4 shared vCPUs and still see within-job tenancy drift; 10% keeps them quiet while cross-VM offsets no longer apply. The first validation run on this PR confirmed the design: **zero** of the 62 benchmarks differed by more than 10% between the two same-VM legs, where the old cross-VM comparison flagged ~46 rows on a median unrelated PR.
- **critcmp replaced by `scripts/ci/bench_comment.py`** — the comment is now a Markdown table instead of a critcmp code fence: the meaningless `? ?/sec` throughput column is gone (no bench declares a Criterion throughput), the faster run is **bolded** per benchmark, and entries whose delta exceeds the noise threshold are colored green (PR faster) / red (PR slower) via GitHub's math rendering (the only inline text color GFM supports; verified against the markdown API, including the `\%`-in-math escaping gotcha). Significant rows are listed up top sorted by magnitude; the full table is collapsed in a `<details>` block. This also removes critcmp's exit-1-on-quiet behavior, which failed the first validation run.
- **`RUSTFLAGS: -C target-feature=+bmi2,+adx,+avx2`** — with no target-feature config, the fp128 `mulx`/`adcx` asm specialization and the packed SIMD paths were compile-time dead code in CI, so the "packed"/asm-oriented benches timed scalar fallbacks. Every CPU observed in the hosted x64 fleet (Xeon 8370C/8573C, EPYC 7763/9V74) supports all three features. Verified: `cargo check --benches` for all four crates and a full-codegen `cargo build` of `jolt-field --features solinas,asm` both pass for `x86_64-unknown-linux-gnu` with these flags.
- **`--noplot`** — nothing consumes the HTML reports; skipping plotting saves time in each leg.
- **`timeout-minutes: 90`** backstop. The job roughly doubles (~14 → ~28–30 min warm; the first run is cold because RUSTFLAGS changes the rust-cache key).
- The sticky comment keeps its marker and now names both SHAs and the threshold.
- A non-merge `HEAD` (e.g. conflicted PR) fails loudly at the resolve step instead of benching the wrong ref.

This PR modifies the workflow file, which is itself in the new path filter — so the run on this PR exercises the new A/B flow end-to-end.

## Not in this PR

Instruction-count gating (CodSpeed simulation mode or wiring up jolt-eval's existing `callgrind:*` objectives) would get the noise floor to ~0.00001% and is the natural next step; this change fixes the comparison methodology without new dependencies or services.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
