### PR TITLE
fix(blindfold): keep the random-instance blinding on final-opening rows

### DIFF
--- a/crates/jolt-blindfold/src/prove.rs
+++ b/crates/jolt-blindfold/src/prove.rs
@@ -274,8 +274,10 @@ where
         reason = "dedicated rows come from final-opening coordinates, range-checked against the witness grid in witness_coordinate"
     )]
     for row in dedicated_rows {
+        // Values only: the folded row must stay dedicated for the verifier's
+        // opening check, while the row blinding stays random so the published
+        // row commitment hides the final evaluation and its Dory blinding.
         random_witness_rows[row].fill(F::zero());
-        random_witness_blindings[row] = F::zero();
     }
     #[expect(
         clippy::indexing_slicing,

--- a/crates/jolt-blindfold/tests/assignment_pipeline.rs
+++ b/crates/jolt-blindfold/tests/assignment_pipeline.rs
@@ -10,7 +10,7 @@ mod support;
 
 use jolt_blindfold::{BlindFoldProtocol, BlindFoldWitness, ProverError};
 use jolt_claims::{constant, opening};
-use jolt_crypto::{Bn254G1, PedersenSetup, VectorCommitment};
+use jolt_crypto::{Bn254G1, JoltGroup, PedersenSetup, VectorCommitment};
 use jolt_sumcheck::{CommittedSumcheckWitness, SumcheckDomainSpec, SumcheckStatement};
 use jolt_transcript::{Blake2bTranscript, Transcript};
 use rand_chacha::ChaCha20Rng;
@@ -393,4 +393,68 @@ fn assign_witness_rejects_output_claim_blinding_count_mismatch() {
             ..
         })
     ));
+}
+
+/// The final-opening rows are opened at fixed coordinates, so the proof
+/// publishes their real-instance commitments together with the folded
+/// opening blindings. Unblinding a real row with the published folded
+/// blinding must not recover a deterministic commitment to the hidden
+/// evaluation or to its Dory blinding.
+#[test]
+fn final_opening_rows_stay_hidden_from_public_proof_data() {
+    let mut rng = ChaCha20Rng::seed_from_u64(0x00C0_57AC);
+    let fixture = assignment_fixture(&mut rng);
+    let stage_refs: Vec<&CommittedSumcheckWitness<F>> = fixture.stage_witnesses.iter().collect();
+    let assigned = fixture
+        .protocol
+        .assign_witness(
+            &STAGE_DOMAINS,
+            &stage_refs,
+            &fixture.eval_outputs,
+            &fixture.eval_blindings,
+            &mut rng,
+        )
+        .expect("witness assigns");
+
+    let mut prover_transcript = Blake2bTranscript::<F>::new(TRANSCRIPT_LABEL);
+    append_protocol_transcript_prefix(&fixture.protocol, &mut prover_transcript);
+    let proof = jolt_blindfold::prove::<F, VC, _, _>(
+        &fixture.setup,
+        &fixture.protocol,
+        &mut prover_transcript,
+        BlindFoldWitness {
+            rows: &assigned.rows,
+            blindings: &assigned.blindings,
+            eval_outputs: &fixture.eval_outputs,
+            eval_blindings: &fixture.eval_blindings,
+        },
+        &mut rng,
+    )
+    .expect("assigned witness proves");
+
+    let g0 = fixture.setup.message_generators[0];
+    let h = fixture.setup.blinding_generator;
+    let aux_start = fixture.protocol.dimensions.witness_rows.auxiliary.start;
+    let coordinates = fixture
+        .protocol
+        .final_opening_witness_coordinates()
+        .expect("final opening coordinates")[0];
+
+    let eval_row = coordinates.evaluation.expect("evaluation row").row;
+    let real_eval_row = proof.auxiliary_row_commitments[eval_row - aux_start];
+    let folded_eval_blinding = proof.folded_eval_output_openings[0].combined_blinding;
+    assert_ne!(
+        real_eval_row - h.scalar_mul(&folded_eval_blinding),
+        g0.scalar_mul(&fixture.eval_outputs[0]),
+        "the hidden batched evaluation is recoverable as g0^y from public proof data"
+    );
+
+    let blinding_row = coordinates.blinding.expect("blinding row").row;
+    let real_blinding_row = proof.auxiliary_row_commitments[blinding_row - aux_start];
+    let folded_blinding_blinding = proof.folded_eval_blinding_openings[0].combined_blinding;
+    assert_ne!(
+        real_blinding_row - h.scalar_mul(&folded_blinding_blinding),
+        g0.scalar_mul(&fixture.eval_blindings[0]),
+        "the hidden Dory evaluation blinding is recoverable as g0^r from public proof data"
+    );
 }


### PR DESCRIPTION
## Summary

The modular BlindFold prover zeroes the random Nova instance's blinding on the two dedicated final-opening rows (`crates/jolt-blindfold/src/prove.rs`). Only the row *values* need to be zero there, so the folded row stays dedicated for the verifier's `require_dedicated_row` check. Zeroing the *blinding* breaks hiding: the folded opening's `combined_blinding` is then `b_real + r·0 = b_real`, and the proof also publishes the real row commitment `C_real = g₀·y + h·b_real`. Anyone computes

```
C_real − combined_blinding·h = g₀·y            (hidden batched Dory evaluation)
C_real′ − combined_blinding′·h = g₀·r_y        (its Dory blinding)
```

from proof and setup alone: a deterministic, unblinded commitment to the value `y_com` exists to hide. Given a candidate witness, `y = Σ γ_i·scale_i·P_i(r)` is recomputable from the public transcript, so one group element decides "was the witness W?". Soundness is unaffected. The legacy BlindFold drew every random-instance blinding fresh; the zero came in with the modular port (#1635).

## Changes

- `prove.rs`: stop overwriting `random_witness_blindings[row]` for dedicated rows; keep the values-only fill with a comment stating why the two differ.
- `tests/assignment_pipeline.rs`: `final_opening_rows_stay_hidden_from_public_proof_data` unblinds the real eval and blinding rows with the published folded blindings and asserts neither equals `g₀·y` / `g₀·r_y`. Fails on `main`, passes with the fix.

## Testing

- [x] `cargo nextest run -p jolt-blindfold` (76/76, new test included; the new test fails with the `prove.rs` change stashed)
- [x] `cargo nextest run -p jolt-verifier --features prover-fixtures,zk -E 'binary(completeness)'`: `zk_muldiv_verifier_proof_is_accepted`, `zk_committed_muldiv_verifier_proof_is_accepted`, `zk_committed_muldiv_blindfold_shape_audit_matches_modular_protocol` pass with the fix. `zk_muldiv_blindfold_shape_audit_matches_modular_protocol` fails identically on unmodified `main` (227 vs 221), unrelated.
- [x] `cargo clippy -p jolt-blindfold --all-targets -- -D warnings` and `cargo fmt` pass

## Security Considerations

Zero-knowledge fix; no change to what the verifier accepts. The verifier's checks are linear in the row blinding, so acceptance is identical for any random blinding. After the fix, every published scalar about the dedicated rows (`folded_eval_outputs`, `combined_blinding`, `folded_eval_blindings`) is one-time-padded by an independent uniform from the random instance, and every published group element is a hiding Pedersen commitment, so the standard Nova simulator applies. The existing statistical-independence tests test marginals and could not see this joint relation; the new test is a deterministic check of the exact recovery.

## Breaking Changes

None.
