### PR TITLE
ci: run pr-title check on pull_request_target so it cannot be skipped

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,10 +1,5 @@
 name: PR Title
 
-# pull_request_target (not pull_request): GitHub skips every pull_request
-# workflow when it cannot build the merge commit (conflicting PR), so a
-# pull_request-triggered title check can be silently absent. The job only
-# reads the PR title from the event payload; it never checks out or runs PR
-# code, so the elevated context is safe.
 on:
   pull_request_target:
     types: [opened, edited, reopened, synchronize, ready_for_review]

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,8 +1,13 @@
 name: PR Title
 
+# pull_request_target (not pull_request): GitHub skips every pull_request
+# workflow when it cannot build the merge commit (conflicting PR), so a
+# pull_request-triggered title check can be silently absent. The job only
+# reads the PR title from the event payload; it never checks out or runs PR
+# code, so the elevated context is safe.
 on:
-  pull_request:
-    types: [opened, edited, reopened, synchronize]
+  pull_request_target:
+    types: [opened, edited, reopened, synchronize, ready_for_review]
 
 permissions: {}
 


### PR DESCRIPTION
## Why

Draft PR #1837 got zero \`pull_request\`-triggered workflow runs (no PR Title, no Rust CI) — only \`pull_request_target\` workflows (Spec Workflow) and Socket ran. Root cause: the PR is in merge conflict, so GitHub never created the merge ref, and GitHub does not run \`pull_request\` workflows when it cannot compute the merge commit.

Evidence:
- \`gh pr view 1837\`: \`mergeable: CONFLICTING\`, \`mergeStateStatus: DIRTY\` (13 commits behind main; \`git merge-tree origin/main refs/pull/1837/head\` → content conflict in \`Cargo.lock\`).
- \`git ls-remote origin refs/pull/1837/*\` → only \`refs/pull/1837/head\`; no \`refs/pull/1837/merge\`. A PR where the title check ran (#1829) has \`refs/pull/1829/merge\`.
- \`gh api repos/a16z/jolt/actions/runs?head_sha=59ec68cc…\` → the only run is \`Spec Workflow\` (\`pull_request_target\`).
- Head commit message has no \`[skip ci]\`; workflow has no \`paths\` filter or concurrency; the same workflow passed on five other PRs the same day.

## Change

- Trigger on \`pull_request_target\` instead of \`pull_request\`. That event is evaluated against the base branch and does not need the merge commit, so the check runs on conflicting PRs too. Safe here: the job reads only \`github.event.pull_request.title\` and never checks out or executes PR code; \`permissions: {}\` unchanged.
- Add \`ready_for_review\` to the trigger types.

## Admin follow-up (branch protection, not applied here)

Settings → Branches → \`main\` rule → "Require status checks to pass before merging" → add **Conventional Commits** (the job name). Equivalent API:

\`\`\`
gh api -X PATCH repos/a16z/jolt/branches/main/protection/required_status_checks \
  -f strict=false -f 'contexts[]=Conventional Commits'
\`\`\`
(\`contexts[]\` appends to the existing list only if the current list is passed too — read it first with \`gh api repos/a16z/jolt/branches/main/protection/required_status_checks\`.)

A required check that never reports blocks merge, which is the intended stricter behavior: a PR whose title check did not run cannot be merged.