### PR TITLE
fix(akita): report exact packed proof sizes

### DIFF
--- a/crates/jolt-akita/src/adapters.rs
+++ b/crates/jolt-akita/src/adapters.rs
@@ -613,6 +613,23 @@ pub struct AkitaBatchProof {
     pub(crate) serialized_akita_proof: Vec<u8>,
 }
 
+impl AkitaBatchProof {
+    /// Headerless backend proof body produced by Akita's canonical encoder.
+    pub fn backend_proof_body_size(&self) -> usize {
+        self.serialized_akita_proof.len()
+    }
+
+    /// Sum of the raw component bytes before the enclosing Jolt serializer
+    /// adds container tags or length prefixes.
+    pub fn unframed_payload_size(&self) -> Option<usize> {
+        self.statement_bridge
+            .len()
+            .checked_add(self.serialized_schedule_selection.len())?
+            .checked_add(self.serialized_akita_proof_shape.len())?
+            .checked_add(self.serialized_akita_proof.len())
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct AkitaHidingCommitment {

--- a/crates/jolt-prover/src/profile.rs
+++ b/crates/jolt-prover/src/profile.rs
@@ -534,13 +534,10 @@ pub fn run_sweep(args: &BenchmarkArgs) -> bool {
     failed.is_empty()
 }
 
-/// One proved workload, as the reporting tail consumes it. `proof_size` is
-/// `None` on the packed build: the upstream akita field type has no serde
-/// support at the pinned revision, so the packed proof has no byte encoding
-/// to measure yet (the CSV rows carry 0 as an explicit placeholder).
+/// One proved workload, as the reporting tail consumes it.
 struct ProvenRun {
     duration: std::time::Duration,
-    proof_size: Option<usize>,
+    proof_size: usize,
 }
 
 fn run_workload(workload: Workload, scale: u32, backend: BackendKind, run_dir: &Path) {
@@ -578,13 +575,7 @@ fn run_workload(workload: Workload, scale: u32, backend: BackendKind, run_dir: &
         trace_output,
         backend,
     );
-    let (duration, proof_size) = (run.duration, run.proof_size.unwrap_or(0));
-    if run.proof_size.is_none() {
-        println!(
-            "modular {bench_name} (2^{scale}): proof size unavailable \
-             (no packed-proof byte encoding yet); CSV carries 0"
-        );
-    }
+    let (duration, proof_size) = (run.duration, run.proof_size);
 
     let proving_hz = trace_length as f64 / duration.as_secs_f64();
     let padded_proving_hz = trace_length.next_power_of_two() as f64 / duration.as_secs_f64();
@@ -596,6 +587,7 @@ fn run_workload(workload: Workload, scale: u32, backend: BackendKind, run_dir: &
         proving_hz / 1000.0,
         padded_proving_hz / 1000.0,
     );
+    println!("modular {bench_name} (2^{scale}, {backend_label}): Proof size {proof_size} bytes");
     if let Some(peak) = peak_rss_bytes() {
         println!(
             "modular {} (2^{}, {backend_label}): Peak RSS {}",
@@ -745,7 +737,7 @@ fn prove_workload(
 
     ProvenRun {
         duration,
-        proof_size: Some(proof_size),
+        proof_size,
     }
 }
 
@@ -848,6 +840,21 @@ fn prove_workload(
     .expect("modular packed prove");
     let duration = now.elapsed();
 
+    let akita_proof_body_size = proof.joint_opening_proof.backend_proof_body_size();
+    let akita_opening_unframed_size = proof
+        .joint_opening_proof
+        .unframed_payload_size()
+        .expect("packed opening component lengths must fit usize");
+    let proof_size = bincode::serde::encode_to_vec(&proof, bincode::config::standard())
+        .expect("serialize packed proof")
+        .len();
+    tracing::info!(
+        akita_proof_body_size,
+        akita_opening_unframed_size,
+        jolt_proof_wire_size = proof_size,
+        "packed proof sizes"
+    );
+
     // --- Correctness gate (unmeasured): the proof must verify.
     jolt_verifier::verify::<AkitaField, AkitaScheme, AkitaVc, AkitaTranscript>(
         &prover_preprocessing.verifier,
@@ -859,9 +866,7 @@ fn prove_workload(
 
     ProvenRun {
         duration,
-        // The packed proof has no byte encoding to measure: the upstream
-        // akita field type carries no serde support at the pinned revision.
-        proof_size: None,
+        proof_size,
     }
 }
 

--- a/crates/jolt-prover/tests/akita_e2e.rs
+++ b/crates/jolt-prover/tests/akita_e2e.rs
@@ -264,6 +264,28 @@ mod muldiv {
         };
         verify(&proof).expect("packed verifier should accept the packed proof");
 
+        let encoded = bincode::serde::encode_to_vec(&proof, bincode::config::standard())
+            .expect("serialize packed proof");
+        let (decoded, consumed): (AkitaJoltProof, usize) =
+            bincode::serde::decode_from_slice(&encoded, bincode::config::standard())
+                .expect("deserialize packed proof");
+        assert_eq!(consumed, encoded.len());
+        assert_eq!(decoded, proof);
+        let backend_proof_body_size = proof.joint_opening_proof.backend_proof_body_size();
+        let unframed_payload_size = proof
+            .joint_opening_proof
+            .unframed_payload_size()
+            .expect("packed proof component sizes should fit in usize");
+        assert!(
+            unframed_payload_size >= backend_proof_body_size,
+            "the unframed Akita opening contains its headerless proof body"
+        );
+        assert!(
+            encoded.len() > unframed_payload_size,
+            "the full Jolt wire proof contains framing beyond the Akita opening"
+        );
+        verify(&decoded).expect("deserialized packed proof should verify");
+
         // Live tampers on the fused-inc pipeline's claim wires: the fused
         // increment's reduced claim and the hamming-reduction digit/carry
         // finals each participate in a batched output fold — an offset on


### PR DESCRIPTION
## Summary

This PR makes packed Akita proof sizes measurable in the standard modular profiler and adds an end-to-end serialization regression test.

It preserves the intended wire boundary:

- Akita's canonical backend proof body remains headerless;
- Jolt continues to own its outer Serde/bincode framing;
- profiler CSV rows now report the exact full Jolt wire-proof size instead of the previous `0` placeholder.

### Diff metadata

- Base: `7d33a217c3c69c7a6b6edfd2847e776b91a6ec7d` (`main`)
- Head: `db5fef4ef653407297fc8bde3b0a807a992da60d`
- Commits: 1
- Files changed: 3
- Diff: 60 insertions, 16 deletions

## Motivation

The packed profiler treated proof sizing as unavailable because of a stale assumption that the vendored Akita field had no Serde support. Jolt's packed field is already serialized canonically as fixed-width little-endian bytes, so the full `JoltProof` can be encoded and measured directly.

That distinction matters for performance work: the raw Akita body, the complete unframed Akita opening payload, and the actual Jolt wire proof answer different questions and should not be conflated.

## Change surface

| Area | Before | After |
|---|---|---|
| Akita adapter | Raw proof bytes were private and not measurable by the profiler | Exposes checked byte counts for the headerless backend body and complete unframed opening payload |
| Profiler | Packed proof size was `None`; console and CSV used an unavailable/`0` placeholder | Serializes the full proof with the standard bincode configuration and reports the exact byte length |
| Telemetry | No packed proof-size decomposition | Emits raw Akita body, unframed Akita opening, and full Jolt wire sizes |
| Regression coverage | Packed proofs were verified only in memory | Full proof is encoded, decoded, compared byte-for-structure, and verified after decoding |

## Wire-format boundary

This does not add proof framing to Akita. `AkitaBatchProof::backend_proof_body_size` measures the bytes already produced by Akita's canonical compressed encoder. `unframed_payload_size` checked-sums the raw Akita opening components before Jolt's serializer adds container tags or length prefixes.

The profiler separately bincode-encodes the enclosing Jolt proof. That is the size written to `modular_timings.csv` and printed to the console.

On the optimized Fibonacci `2^16` profiling run used to validate this patch:

- headerless Akita proof body: 70,560 bytes;
- complete unframed Akita opening: 72,129 bytes;
- full Jolt Serde/bincode proof: 90,595 bytes.

## Validation completed at `db5fef4ef`

The following passed locally:

- `cargo fmt -q --all`
- `cargo clippy -q -p jolt-prover --features akita,profiling --bin jolt-prover -- -D warnings`
- `cargo check -q -p jolt-prover --features akita,profiling --bin jolt-prover`
- `cargo nextest run --release -p jolt-prover muldiv_e2e_akita --features prover-fixtures,akita --cargo-quiet`
  - standard packed muldiv;
  - forced-K=256 packed muldiv;
  - committed-program packed muldiv.
- optimized release profiler in both no-subscriber and Chrome/Perfetto modes at Fibonacci `2^16`

## Scope and follow-up

This PR deliberately does not change schedule generation, schedule selection, setup ownership, or recursive setup offloading. Those remain in the coordinated Akita catalog work and a later Jolt integration once the native catalog API is stable.

## Reviewer map

1. `crates/jolt-akita/src/adapters.rs` — byte-boundary accessors
2. `crates/jolt-prover/src/profile.rs` — exact measurement and reporting
3. `crates/jolt-prover/tests/akita_e2e.rs` — serialized round-trip and verification coverage
