### PR TITLE
chore(deps): fix cargo audit findings and add nightly cargo audit workflow

### DIFF
--- a/.github/workflows/cargo-audit.yml
+++ b/.github/workflows/cargo-audit.yml
@@ -1,0 +1,99 @@
+# Nightly `cargo audit` of every tracked Cargo.lock — the workspace lockfile
+# plus the two cargo-fuzz workspaces that commit one (jolt-eval/fuzz and
+# crates/jolt-field/fuzz) — against the RustSec advisory database. The other
+# fuzz workspaces commit no lockfile and resolve fresh on every fuzz-crates.yml
+# run, so they are not covered here. Dependabot security alerts cover the root
+# workspace's crates.io dependencies too, but they only reach whoever has
+# alerts enabled; this run fails loudly and files an issue.
+#
+# POLICY — vulnerabilities always fail. `--deny unsound --deny yanked` also
+# fails the run on unsound crates and yanked versions: both are actionable with
+# `cargo update -p <crate>` and all tracked lockfiles are clean of them as of
+# this workflow landing. `unmaintained` advisories only warn, because denying
+# them would fail every run: bincode 2 is the workspace's own serialization
+# format and bincode 1 comes via dory-pcs and iai-callgrind; paste is a direct
+# dependency of tracer and z3-verifier and is also pinned by arkworks, plonky3,
+# alloy and ZeroOS; derivative (ark-ff 0.3/0.4), fxhash (rust-code-analysis)
+# and proc-macro-error2 (alloy-sol-macro, iai-callgrind) are transitive with
+# no fix short of upstream changes.
+#
+# Nightly-only by design: new advisories land against an unchanged lockfile, so
+# a PR-blocking check would fail unrelated PRs the day an advisory is published.
+# The only PR trigger is a change to this file, so edits to the workflow get
+# exercised before merge. `workflow_dispatch` allows on-demand runs (e.g. to
+# confirm a `cargo update` cleared a finding).
+#
+# TRIAGE — the run log has the `Crate:` / `ID:` / `Solution:` lines. Prefer
+# `cargo update -p <crate>` (use `--manifest-path` for the fuzz lockfiles) when
+# a patched version exists; otherwise bump or drop the dependent crate (or the
+# feature that pulls it in). Only as a last resort ignore the advisory in
+# `.cargo/audit.toml` (`[advisories] ignore = ["RUSTSEC-..."]`) with a comment
+# explaining why the vulnerable code path is unreachable.
+name: Cargo Audit
+
+on:
+  schedule:
+    # 06:27 UTC nightly (off the top of the hour to dodge scheduler congestion)
+    - cron: "27 6 * * *"
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - ".github/workflows/cargo-audit.yml"
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  cargo-audit:
+    runs-on: ubuntu-latest
+    # Backstop only. The real bound is the step-level timeout below: a job-level
+    # timeout CANCELS the job, which skips the `if: failure()` reporting step, so
+    # a hang would go unreported. Keep this comfortably above the step budget.
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v7.0.1
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          cache: false
+      - name: Install cargo-audit
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-audit
+      - name: Audit every tracked Cargo.lock
+        # Step-level (not job-level) so a stalled advisory-db or index fetch
+        # fails this step and the reporting step below still runs. Audits all
+        # lockfiles before exiting so one finding doesn't hide another.
+        timeout-minutes: 10
+        run: |
+          status=0
+          while IFS= read -r lock; do
+            echo "::group::cargo audit ${lock}"
+            if ! cargo audit --deny unsound --deny yanked --file "${lock}"; then
+              echo "::error file=${lock}::cargo audit failed for ${lock}"
+              status=1
+            fi
+            echo "::endgroup::"
+          done < <(git ls-files -- 'Cargo.lock' '**/Cargo.lock')
+          exit "${status}"
+      - name: File failure issue
+        # Skipped on the self-test PR trigger: a failure there is not a nightly
+        # regression (and fork PRs get a read-only token anyway).
+        if: failure() && github.event_name != 'pull_request'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          existing=$(gh issue list --repo "$GITHUB_REPOSITORY" \
+            --state open --search "in:title \"Nightly cargo audit failed\"" \
+            --json number --jq 'length')
+          if [ "$existing" -eq 0 ]; then
+            body=$(printf '%s\n\n%s\n\n%s' \
+              "The scheduled cargo-audit run failed: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" \
+              "A RustSec advisory (vulnerability, unsound crate, or yanked version) matches a crate in one of the tracked Cargo.lock files. The run log has the \`Crate:\` / \`ID:\` / \`Solution:\` lines for each finding." \
+              "Fix with \`cargo update -p <crate>\` when a patched version exists (\`--manifest-path\` for the fuzz lockfiles); otherwise bump or drop the dependent crate. See the TRIAGE notes in the header comment of .github/workflows/cargo-audit.yml.")
+            gh issue create --repo "$GITHUB_REPOSITORY" \
+              --title "Nightly cargo audit failed" \
+              --body "$body"
+          else
+            echo "Open failure issue already exists; not filing a duplicate."
+          fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,6 +71,7 @@ Spec analysis can also be triggered externally by adding the `claude-spec-review
 
 - Rust toolchain (see `rust-toolchain.toml`)
 - [cargo-nextest](https://nexte.st/) for running tests
+- [cargo-audit](https://github.com/rustsec/rustsec/tree/main/cargo-audit) for the dependency-advisory check
 
 ### Key Commands
 
@@ -88,6 +89,10 @@ cargo nextest run --cargo-quiet
 # Primary correctness check
 cargo nextest run -p jolt-prover-legacy muldiv --cargo-quiet --features host
 cargo nextest run -p jolt-prover-legacy muldiv --cargo-quiet --features host,zk
+
+# Dependency advisories (CI runs this nightly over every tracked Cargo.lock;
+# see .github/workflows/cargo-audit.yml for the policy and triage steps)
+cargo audit --deny unsound --deny yanked
 ```
 
 ## PR Titles and Commit Messages

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1072,6 +1072,7 @@ dependencies = [
  "ark-std 0.6.0",
  "digest 0.10.7",
  "num-bigint",
+ "serde_with",
 ]
 
 [[package]]
@@ -1708,7 +1709,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1913,9 +1914,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -2473,7 +2474,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2934,7 +2935,7 @@ dependencies = [
  "env_logger",
  "glob",
  "indexmap 2.14.0",
- "inferno 0.12.8",
+ "inferno",
  "itertools 0.14.0",
  "lazy_static",
  "log",
@@ -3031,24 +3032,6 @@ dependencies = [
 
 [[package]]
 name = "inferno"
-version = "0.11.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "232929e1d75fe899576a3d5c7416ad0d88dbfbb3c3d6aa00873a7408a50ddb88"
-dependencies = [
- "ahash",
- "indexmap 2.14.0",
- "is-terminal",
- "itoa",
- "log",
- "num-format",
- "once_cell",
- "quick-xml 0.26.0",
- "rgb",
- "str_stack",
-]
-
-[[package]]
-name = "inferno"
 version = "0.12.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c460d4fa06223667240720ab69a8045133755ae6dfbe100cf481b95e3a014f1"
@@ -3064,7 +3047,7 @@ dependencies = [
  "log",
  "num-format",
  "once_cell",
- "quick-xml 0.41.0",
+ "quick-xml",
  "rgb",
  "str_stack",
 ]
@@ -3085,17 +3068,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4f0c30c76f2f4ccee3fe55a2435f691ca00c0e4bd87abe4f4a851b1d4dac39b"
 dependencies = [
  "rustversion",
-]
-
-[[package]]
-name = "is-terminal"
-version = "0.4.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
-dependencies = [
- "hermit-abi",
- "libc",
- "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3749,7 +3721,7 @@ dependencies = [
  "eyre",
  "fixedbitset 0.5.7",
  "iai-callgrind",
- "inferno 0.12.8",
+ "inferno",
  "itertools 0.15.0",
  "jolt-akita",
  "jolt-blindfold",
@@ -4186,9 +4158,9 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "memmap2"
-version = "0.9.10"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
 dependencies = [
  "libc",
 ]
@@ -4724,7 +4696,7 @@ dependencies = [
  "p3-matrix",
  "p3-maybe-rayon",
  "p3-util",
- "spin 0.10.0",
+ "spin 0.10.1",
  "tracing",
 ]
 
@@ -4814,7 +4786,7 @@ dependencies = [
  "paste",
  "rand 0.10.2",
  "serde",
- "spin 0.10.0",
+ "spin 0.10.1",
  "tracing",
 ]
 
@@ -5125,7 +5097,6 @@ dependencies = [
  "backtrace 0.3.76",
  "cfg-if",
  "findshlibs",
- "inferno 0.11.21",
  "libc",
  "log",
  "nix",
@@ -5135,7 +5106,7 @@ dependencies = [
  "prost-derive 0.12.6",
  "sha2 0.10.9",
  "smallvec",
- "spin 0.10.0",
+ "spin 0.10.1",
  "symbolic-demangle",
  "tempfile",
  "thiserror 2.0.18",
@@ -5357,15 +5328,6 @@ name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
-
-[[package]]
-name = "quick-xml"
-version = "0.26.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f50b1c63b38611e7d4d7f68b82d3ad0cc71a2ad2e7f61fc10f1328d917c93cd"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "quick-xml"
@@ -5827,14 +5789,15 @@ dependencies = [
 
 [[package]]
 name = "ruint"
-version = "1.17.2"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c141e807189ad38a07276942c6623032d3753c8859c146104ac2e4d68865945a"
+checksum = "f5e99bff0393163bb25029a6af25d3d8d202ba5b5438a74d1bd8789f5c822970"
 dependencies = [
  "alloy-rlp",
  "ark-ff 0.3.0",
  "ark-ff 0.4.2",
  "ark-ff 0.5.0",
+ "ark-ff 0.6.0",
  "bytes",
  "fastrlp 0.3.1",
  "fastrlp 0.4.0",
@@ -5938,7 +5901,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6513,15 +6476,15 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
 
 [[package]]
 name = "spin"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
+checksum = "023a211cb3138dbc438680b32560ad89f699977624c9f8dbb95a47d5b4c07dd3"
 dependencies = [
  "lock_api",
 ]
@@ -6795,7 +6758,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7444,7 +7407,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -7947,7 +7910,7 @@ name = "zeroos-rng"
 version = "0.1.0"
 source = "git+https://github.com/LayerZero-Labs/ZeroOS.git?rev=c572b88a643474317e4b0c7e53ac722a98a0e050#c572b88a643474317e4b0c7e53ac722a98a0e050"
 dependencies = [
- "spin 0.9.8",
+ "spin 0.9.9",
  "zeroos-foundation",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3635,7 +3635,6 @@ dependencies = [
  "libc",
  "memory-stats",
  "pprof",
- "prost 0.14.4",
  "schemars 1.2.2",
  "serde",
  "serde_json",
@@ -3749,7 +3748,6 @@ dependencies = [
  "num-traits",
  "postcard",
  "pprof",
- "prost 0.14.4",
  "rand 0.8.7",
  "rand_chacha 0.3.1",
  "rand_core 0.6.4",
@@ -5101,9 +5099,9 @@ dependencies = [
  "log",
  "nix",
  "once_cell",
- "prost 0.12.6",
+ "prost",
  "prost-build",
- "prost-derive 0.12.6",
+ "prost-derive",
  "sha2 0.10.9",
  "smallvec",
  "spin 0.10.1",
@@ -5239,17 +5237,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "deb1435c188b76130da55f17a466d252ff7b1418b2ad3e037d127b94e3411f29"
 dependencies = [
  "bytes",
- "prost-derive 0.12.6",
-]
-
-[[package]]
-name = "prost"
-version = "0.14.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "528ac67416ff8646872a3c02cad9cc4ee5dc9f9540c9b10771855c95cb2e5ae1"
-dependencies = [
- "bytes",
- "prost-derive 0.14.4",
+ "prost-derive",
 ]
 
 [[package]]
@@ -5266,7 +5254,7 @@ dependencies = [
  "once_cell",
  "petgraph",
  "prettyplease",
- "prost 0.12.6",
+ "prost",
  "prost-types",
  "regex",
  "syn 2.0.119",
@@ -5287,25 +5275,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "prost-derive"
-version = "0.14.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
-dependencies = [
- "anyhow",
- "itertools 0.12.1",
- "proc-macro2",
- "quote",
- "syn 2.0.119",
-]
-
-[[package]]
 name = "prost-types"
 version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9091c90b0a32608e984ff2fa4091273cbdd755d54935c51d520887f4a1dbd5b0"
 dependencies = [
- "prost 0.12.6",
+ "prost",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -368,11 +368,9 @@ tracing-chrome = "0.7.1"
 tracing-subscriber = { version = "0.3.23", features = ["fmt", "env-filter"] }
 inferno = { version = "0.12.3" }
 allocative = { version = "=0.3.6" }
-pprof = { version = "0.15", features = [
-  "prost-codec",
-  "flamegraph",
-  "frame-pointer",
-] }
+# No `flamegraph` feature: it pulls in inferno 0.11 (quick-xml 0.26,
+# RUSTSEC-2026-0194/0195) and only the `.pprof()` protobuf output is used.
+pprof = { version = "0.15", features = ["prost-codec", "frame-pointer"] }
 prost = "0.14"
 
 # Parsing

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -371,7 +371,6 @@ allocative = { version = "=0.3.6" }
 # No `flamegraph` feature: it pulls in inferno 0.11 (quick-xml 0.26,
 # RUSTSEC-2026-0194/0195) and only the `.pprof()` protobuf output is used.
 pprof = { version = "0.15", features = ["prost-codec", "frame-pointer"] }
-prost = "0.14"
 
 # Parsing
 syn = { version = "3", features = ["full"] }

--- a/crates/jolt-profiling/Cargo.toml
+++ b/crates/jolt-profiling/Cargo.toml
@@ -20,7 +20,7 @@ workspace = true
 # host builds.
 default = ["summary"]
 monitor = ["dep:sysinfo"]
-pprof = ["dep:pprof", "dep:prost"]
+pprof = ["dep:pprof"]
 allocative = ["dep:allocative"]
 # The flush-time summary pipeline (`summary` module): chrome-trace
 # aggregation into the schema-versioned `summary.json`.
@@ -41,8 +41,3 @@ serde = { workspace = true, features = ["derive", "std"], optional = true }
 serde_json = { workspace = true, features = ["std"], optional = true }
 sysinfo = { workspace = true, optional = true }
 pprof = { workspace = true, optional = true }
-prost = { workspace = true, optional = true }
-
-[package.metadata.cargo-machete]
-# prost is required by pprof's prost-codec feature but not directly imported
-ignored = ["prost"]

--- a/crates/jolt-prover-legacy/Cargo.toml
+++ b/crates/jolt-prover-legacy/Cargo.toml
@@ -67,7 +67,7 @@ prover = [
 minimal = ["ark-ec/std", "ark-ff/std", "ark-std/std", "ark-ff/asm", "rayon"]
 allocative = ["dep:inferno"]
 monitor = ["dep:sysinfo"]
-pprof = ["dep:pprof", "dep:prost"]
+pprof = ["dep:pprof"]
 test_incremental = []
 challenge-254-bit = []
 field-inline = [
@@ -142,10 +142,6 @@ jolt-inlines-keccak256 = { workspace = true, features = [
 ], optional = true }
 sysinfo = { workspace = true, optional = true }
 pprof = { workspace = true, optional = true }
-prost = { workspace = true, optional = true }
-
-[package.metadata.cargo-machete]
-ignored = ["prost"]
 
 [dev-dependencies]
 criterion.workspace = true

--- a/crates/jolt-prover-legacy/Cargo.toml
+++ b/crates/jolt-prover-legacy/Cargo.toml
@@ -141,12 +141,8 @@ jolt-inlines-keccak256 = { workspace = true, features = [
   "host",
 ], optional = true }
 sysinfo = { workspace = true, optional = true }
-pprof = { version = "0.15", features = [
-  "prost-codec",
-  "flamegraph",
-  "frame-pointer",
-], optional = true }
-prost = { version = "0.14", optional = true }
+pprof = { workspace = true, optional = true }
+prost = { workspace = true, optional = true }
 
 [package.metadata.cargo-machete]
 ignored = ["prost"]

--- a/jolt-eval/fuzz/Cargo.lock
+++ b/jolt-eval/fuzz/Cargo.lock
@@ -4,9 +4,9 @@ version = 4
 
 [[package]]
 name = "addr2line"
-version = "0.26.1"
+version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59317f77929f0e679d39364702289274de2f0f0b22cbf50b2b8cff2169a0b27a"
+checksum = "e567177890eb1617b1f774005b66b26b2377afd138a2ca37aae7d8f0c81429d4"
 dependencies = [
  "cpp_demangle",
  "fallible-iterator",
@@ -142,9 +142,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "arbitrary"
@@ -564,7 +564,7 @@ dependencies = [
  "allocative",
  "ark-serialize 0.5.0",
  "serde",
- "syn 2.0.117",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -649,9 +649,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -811,9 +811,9 @@ dependencies = [
 
 [[package]]
 name = "dory-pcs"
-version = "0.4.0"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c6a5b6aa708db35ced06eeef3d2b4408004c76279091e0bc387f8fd42796555"
+checksum = "065945e9fff3c7dac5d6f72f8260eac82ad577e7c7009b6290847d1252d14d78"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -836,6 +836,33 @@ name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
+name = "dynasm"
+version = "5.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd358e74d2f8d71a11b7a2c51c67ad5df3de06003b0596875e47bc09126c894e"
+dependencies = [
+ "bitflags",
+ "byteorder",
+ "lazy_static",
+ "proc-macro-error3",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "dynasmrt"
+version = "5.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6efe03f6bd356ae85eeea7ee14c2bf54e664a949d089d238364b5a99afbc4116"
+dependencies = [
+ "byteorder",
+ "dynasm",
+ "fnv",
+ "memmap2",
+]
 
 [[package]]
 name = "educe"
@@ -1053,9 +1080,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.33.1"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19e16c5073773ccf057c282be832a59ee53ef5ff98db3aeff7f8314f52ffc196"
+checksum = "1033caf0b349c518623b5396bfb2cf0bddf44f0306d543a250e5743297aafd10"
 dependencies = [
  "stable_deref_trait",
 ]
@@ -1236,6 +1263,7 @@ dependencies = [
  "jolt-r1cs",
  "jolt-sumcheck",
  "jolt-transcript",
+ "jolt-utils",
  "rand_core 0.6.4",
  "rayon",
  "serde",
@@ -1254,6 +1282,7 @@ dependencies = [
  "jolt-openings",
  "jolt-poly",
  "jolt-riscv",
+ "jolt-utils",
  "serde",
  "thiserror 2.0.18",
 ]
@@ -1264,7 +1293,7 @@ version = "0.1.0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1298,6 +1327,7 @@ dependencies = [
  "jolt-crypto",
  "jolt-field",
  "jolt-openings",
+ "jolt-optimizations",
  "jolt-poly",
  "jolt-transcript",
  "rayon",
@@ -1320,13 +1350,16 @@ dependencies = [
  "jolt-dory",
  "jolt-eval-macros",
  "jolt-field",
+ "jolt-inlines-keccak256",
  "jolt-inlines-secp256k1",
  "jolt-inlines-sha2",
  "jolt-program",
  "jolt-prover-legacy",
  "jolt-riscv",
+ "jolt-tracer-x86",
  "jolt-transcript",
  "jolt-verifier",
+ "libc",
  "postcard",
  "rand 0.8.7",
  "rust-code-analysis",
@@ -1355,7 +1388,7 @@ version = "0.1.0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1365,10 +1398,11 @@ dependencies = [
  "ark-bn254",
  "ark-ff 0.5.0",
  "ark-serialize 0.5.0",
+ "cc",
  "num-traits",
- "rand 0.8.7",
  "rand_core 0.6.4",
  "serde",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1427,7 +1461,6 @@ dependencies = [
  "jolt-field",
  "jolt-poly",
  "jolt-transcript",
- "rayon",
  "serde",
  "thiserror 2.0.18",
  "tracing",
@@ -1465,12 +1498,28 @@ name = "jolt-poly"
 version = "0.1.0"
 dependencies = [
  "jolt-field",
+ "jolt-utils",
  "num-traits",
  "rand_core 0.6.4",
  "rayon",
  "serde",
  "thiserror 2.0.18",
  "tracing",
+]
+
+[[package]]
+name = "jolt-profiling"
+version = "0.1.0"
+dependencies = [
+ "libc",
+ "memory-stats",
+ "schemars",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tracing",
+ "tracing-chrome",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -1515,14 +1564,16 @@ dependencies = [
  "jolt-openings",
  "jolt-optimizations",
  "jolt-poly",
+ "jolt-profiling",
  "jolt-program",
  "jolt-riscv",
  "jolt-sumcheck",
  "jolt-transcript",
+ "jolt-utils",
  "jolt-verifier",
  "memory-stats",
  "num",
- "num-derive 0.4.2",
+ "num-derive 0.5.1",
  "num-traits",
  "postcard",
  "rand 0.8.7",
@@ -1530,7 +1581,7 @@ dependencies = [
  "rand_core 0.6.4",
  "rayon",
  "serde",
- "sha3",
+ "sha3 0.12.0",
  "strum",
  "strum_macros",
  "thiserror 2.0.18",
@@ -1581,6 +1632,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "jolt-tracer-x86"
+version = "0.1.0"
+dependencies = [
+ "common",
+ "dynasmrt",
+ "jolt-platform",
+ "jolt-program",
+ "jolt-riscv",
+ "libc",
+ "tracer",
+]
+
+[[package]]
 name = "jolt-transcript"
 version = "0.1.0"
 dependencies = [
@@ -1592,6 +1656,14 @@ dependencies = [
  "light-poseidon",
  "rand 0.8.7",
  "spongefish",
+]
+
+[[package]]
+name = "jolt-utils"
+version = "0.1.0"
+dependencies = [
+ "num-traits",
+ "rayon",
 ]
 
 [[package]]
@@ -1625,7 +1697,7 @@ version = "0.1.0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1747,9 +1819,9 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "memmap2"
-version = "0.9.10"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
 dependencies = [
  "libc",
 ]
@@ -1829,13 +1901,13 @@ dependencies = [
 
 [[package]]
 name = "num-derive"
-version = "0.4.2"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
+checksum = "e4e98dc3b890f6c23a0f9d3d491a2823d0dea0fa656302a13dd225fa924112a8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1890,9 +1962,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.39.1"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e5a6c098c7a3b6547378093f5cc30bc54fd361ce711e05293a5cc589562739b"
+checksum = "dd229a0361b9d0d4396176e02d65897f487eebeab7caa6d443855ee152ca0b9c"
 dependencies = [
  "crc32fast",
  "flate2",
@@ -2133,6 +2205,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-error-attr3"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e564d14133360e1ae169ffde5da25881b5fa47261665b8e5713c212c27799da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "proc-macro-error3"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f0d4471b3436c22106b21913b1dda531558918ae9b7ec55d58aa84b43552233"
+dependencies = [
+ "proc-macro-error-attr3",
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2345,9 +2439,9 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "ruzstd"
-version = "0.8.2"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5ff0cc5e135c8870a775d3320910cd9b564ec036b4dc0b8741629020be63f01"
+checksum = "a252f5e20f038fe7b4ea53e073e65398d652c864cc162fc77c56c2f13717b888"
 dependencies = [
  "twox-hash",
 ]
@@ -2474,6 +2568,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha3"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc9bad02c26382724b2d2692c6f179285e4b54eeecd7968f52a50059c3c11759"
+dependencies = [
+ "digest 0.11.2",
+ "keccak 0.2.0",
+ "sponge-cursor",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2510,6 +2615,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "sponge-cursor"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a0219bd7d979d58245a4f41f695e1ac9f8befdffadd7f61f1bae9e39abc6620"
+
+[[package]]
 name = "spongefish"
 version = "0.7.0"
 source = "git+https://github.com/arkworks-rs/spongefish?rev=d2d190b1329d35ac9577438d05aed4f17a57b9f9#d2d190b1329d35ac9577438d05aed4f17a57b9f9"
@@ -2522,7 +2633,7 @@ dependencies = [
  "p3-koala-bear",
  "rand 0.8.7",
  "sha2",
- "sha3",
+ "sha3 0.11.0",
 ]
 
 [[package]]
@@ -2692,6 +2803,7 @@ dependencies = [
  "object",
  "paste",
  "postcard",
+ "rayon",
  "serde",
  "serde_json",
  "strum",


### PR DESCRIPTION
## Summary

`cargo audit` on `main` reported four vulnerabilities plus unsound and yanked warnings. This PR fixes them, adds a nightly `cargo audit` workflow, and drops a dead workspace dependency that the review surfaced.

### Vulnerability fixes

| Crate | Fix | Advisory |
|---|---|---|
| quick-xml 0.26.0 | Drop pprof's unused `flamegraph` feature (removes inferno 0.11.21, quick-xml 0.26.0, is-terminal 0.4.17) | RUSTSEC-2026-0194, RUSTSEC-2026-0195 |
| crossbeam-epoch 0.9.18 → 0.9.20 | `cargo update` | RUSTSEC-2026-0204 |
| ruint 1.17.2 → 1.20.0 | `cargo update` | RUSTSEC-2026-0220 |
| memmap2 0.9.10 → 0.9.11 | `cargo update` | RUSTSEC-2026-0186 (unsound) |
| spin 0.9.8 → 0.9.9, 0.10.0 → 0.10.1 | `cargo update` | yanked |

`jolt-eval/fuzz/Cargo.lock` gets the same crossbeam-epoch and memmap2 fixes plus anyhow 1.0.102 → 1.0.104 (RUSTSEC-2026-0190, unsound) and gimli 0.33.1 → 0.34.0 (yanked). That lock was stale against its path deps, so cargo re-synced 18 packages; tree-sitter stays pinned at 0.20.9 (see #1688).

pprof upstream (crates.io and master) still pins inferno `^0.11`, and Jolt only uses pprof's `.pprof()` protobuf output, so dropping the `flamegraph` feature is the fix rather than an advisory ignore. `jolt-prover-legacy`'s pprof declaration now inherits the workspace one.

All three tracked lockfiles now pass `cargo audit --deny unsound --deny yanked`. The six remaining `unmaintained` warnings (bincode ×2, derivative, fxhash, paste, proc-macro-error2) have no fix short of upstream changes; the workflow header records where each comes from.

### Nightly workflow

`.github/workflows/cargo-audit.yml` runs nightly and on `workflow_dispatch`, loops over every tracked `Cargo.lock`, and files a deduplicated issue on failure, in the same shape as `z3-nightly.yml` (including the step-level timeout so a hang still reports). It also runs on PRs that edit the workflow file itself, so this PR exercises it. CONTRIBUTING.md lists the command and the cargo-audit prerequisite.

### Dead `prost` dependency

The workspace `prost = "0.14"` behind the two `pprof` features was never named by any Rust source: pprof re-exports `Message` from its own prost 0.12 as `pprof::protos::Message`. Removed along with the cargo-machete ignores that hid it; drops prost 0.14.4 and prost-derive 0.14.4 from the lock.

## Verification

- `cargo audit --deny unsound --deny yanked` exits 0 on `Cargo.lock`, `jolt-eval/fuzz/Cargo.lock`, and `crates/jolt-field/fuzz/Cargo.lock`
- `cargo metadata --locked` for the root and `jolt-eval/fuzz` manifests
- `cargo clippy --all --all-targets -- -D warnings` with `--features host` and `--features host,zk`
- `cargo check -p jolt-profiling --features pprof` and `cargo check -p jolt-prover-legacy --features host,pprof`
- `cargo nextest run -p jolt-prover-legacy muldiv` with `host` and with `host,zk`
- `cargo machete --with-metadata`, `taplo fmt --check`, `typos`, `actionlint` (with shellcheck)

## Rebase onto main

Rebased onto fc4d481ff after #1844, #1849 and #1821 moved the akita and ZeroOS git pins and added `examples/large-alloc`. Only `Cargo.lock` conflicted. The lock was regenerated rather than hand-merged: start from main's lock, then `cargo update <crate>@<old> --precise <new>` for the five bumps (the `flamegraph` and `prost` removals re-sync automatically). The net change vs main is the same nine packages listed above, and the non-lock diff of both commits is byte-identical to the pre-rebase commits.

While unlocking the bumped crates, cargo also re-resolved five `cfg(windows)`-only `windows-sys` edges (colored and winapi-util to 0.48.0; errno, rustix and tempfile to 0.61.2) back to the choices this branch had before #1844 moved them to 0.52.0. All three windows-sys versions stay in the lock (0.52.0 via memory-stats) and `cargo metadata --locked` passes. A single-pass regeneration from main's lock reproduces the committed lock byte for byte.

Re-run on the rebased tip: `cargo audit --deny unsound --deny yanked` on all three lockfiles, `cargo metadata --locked` for the root and both fuzz manifests, clippy with `host` and `host,zk`, the two pprof `cargo check`s, `taplo fmt --check`, `typos`, and the muldiv e2e tests with `host` and `host,zk`.

## Not in this PR

- Five fuzz workspaces (`crates/{jolt-crypto,jolt-dory,jolt-poly,jolt-sumcheck,jolt-transcript}/fuzz`) commit no lockfile and resolve fresh in CI. Their dependencies are a subset of the root lock, so the root audit covers the same advisories; the workflow header documents this.
- Dependabot only covers the root workspace, so a finding in a fuzz lockfile needs a manual `cargo update --manifest-path`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

