### PR TITLE
docs(agents): clarify authorization and verification scope

### DIFF
--- a/.claude/skills/ci-code-review/SKILL.md
+++ b/.claude/skills/ci-code-review/SKILL.md
@@ -54,7 +54,7 @@ Follow these steps:
 
    For each issue from the agents:
    - For complex logic/semantic issues, reason through whether the bug is real and exploitable.
-   - For issues you can verify mechanically (e.g., a failing test), prefer direct verification (run the test).
+   - For mechanically checkable issues, inspect existing tests and CI results; do not run builds or tests unless the user explicitly requests them.
 
    Score each issue 0-100 AFTER validation:
    - 0: False positive, doesn't stand up to scrutiny, or pre-existing issue

--- a/.claude/skills/implement-spec/SKILL.md
+++ b/.claude/skills/implement-spec/SKILL.md
@@ -15,9 +15,9 @@ This skill runs locally or in Claude Code cloud (claude.ai/code) — NOT in CI. 
 - Read CLAUDE.md for project conventions, testing requirements, and architecture.
 - Each phase must complete before the next begins.
 - Parallel execution within phases where possible.
-- If something in the spec is ambiguous, post a PR comment rather than guessing.
+- Resolve routine implementation choices from the spec and repository conventions. For ambiguity affecting correctness, scope, or acceptance criteria, post a focused PR question and continue unaffected work.
 - Do not add features, refactor code, or make improvements beyond the spec.
-- If the spec lacks the `claude-spec-approved` label, warn that it hasn't been analyzed yet (implementation from an unanalyzed spec risks rework), but proceed if the user insists.
+- If the spec lacks the `claude-spec-approved` label, note that it hasn't been analyzed. An explicit user instruction to implement it is sufficient authorization; otherwise request approval.
 </Execution_Policy>
 
 <Steps>
@@ -65,7 +65,7 @@ This skill runs locally or in Claude Code cloud (claude.ai/code) — NOT in CI. 
 
 ## Phase 3: QA
 
-Cycle until all checks pass (up to 5 cycles):
+Run the checks sequentially until all pass (up to 5 cycles). Repeat checks only when a failure or subsequent change requires it; complete the full matrix before handoff.
 
 1. **Format**: `cargo fmt -q`
 2. **Lint** (both modes):
@@ -81,7 +81,7 @@ If the same error persists 3 times, stop and post a PR comment describing the fu
 
 ## Phase 4: Validate
 
-Run parallel validation:
+Validate the result, reusing Phase 3 results unless subsequent changes invalidate them:
 
 1. **Correctness**: All spec evaluation criteria pass.
 2. **Mechanical checks (jolt-eval)**: For each objective named in the spec's Evaluation → Performance section, run `cargo run -p jolt-eval --bin measure-objectives -- --objective <name>` and confirm it moved in the declared direction (or stayed within the declared tolerance). All invariants named or introduced in the spec's Intent → Invariants section must pass — the Phase 3 `cargo nextest run -p jolt-eval` covers seed corpus + random inputs.

--- a/.claude/skills/new-invariant/SKILL.md
+++ b/.claude/skills/new-invariant/SKILL.md
@@ -12,7 +12,7 @@ This skill handles all the boilerplate: creating the invariant struct + input ty
 
 <Execution_Policy>
 - The user must provide an invariant name (lowercase with underscores, e.g. `sumcheck_binding`).
-- Ask the user what property is being checked and what the input type should look like before writing code.
+- Use the request, spec, and repository context to establish the property and input type; ask only for missing requirements before writing code.
 - Follow existing patterns exactly — study the split_eq_bind and soundness invariants as models.
 - Always run clippy and the auto-generated tests before reporting success.
 </Execution_Policy>
@@ -22,7 +22,7 @@ This skill handles all the boilerplate: creating the invariant struct + input ty
 ## Phase 1: Gather Requirements
 
 1. Validate the argument `{{ARGUMENTS}}`: must be a valid Rust identifier (lowercase alphanumeric + underscores). Reject otherwise.
-2. Ask the user:
+2. Gather these requirements from existing context; ask the user only for missing information:
    - What property does this invariant check? (becomes the `description()`)
    - What does the input look like? (fields, types, ranges)
    - What synthesis targets should it support? (`Test`, `Fuzz`, `RedTeam`)

--- a/.claude/skills/new-objective/SKILL.md
+++ b/.claude/skills/new-objective/SKILL.md
@@ -12,7 +12,7 @@ This skill handles all the boilerplate: creating the objective struct, implement
 
 <Execution_Policy>
 - The user must provide an objective name (lowercase with underscores, e.g. `cyclomatic_complexity`).
-- Ask the user what is being measured and whether it's a static analysis or performance objective.
+- Use the request, spec, and repository context to identify the measurement and objective kind; ask only for missing requirements.
 - Follow existing patterns exactly — study lloc.rs (static analysis) and binding.rs (performance) as models.
 - Always run clippy and tests before reporting success.
 </Execution_Policy>
@@ -22,7 +22,7 @@ This skill handles all the boilerplate: creating the objective struct, implement
 ## Phase 1: Gather Requirements
 
 1. Validate the argument `{{ARGUMENTS}}`: must be a valid Rust identifier (lowercase alphanumeric + underscores). Reject otherwise.
-2. Ask the user:
+2. Gather these requirements from existing context; ask the user only for missing information:
    - What is being measured? (becomes the `description()`)
    - Is this a **static analysis** objective or a **performance** objective?
      - Static analysis: computes a metric by analyzing source code (e.g. lines of code, complexity). Overrides `collect_measurement()`, uses `Setup = ()`.

--- a/.claude/skills/new-spec/SKILL.md
+++ b/.claude/skills/new-spec/SKILL.md
@@ -54,7 +54,7 @@ Record changes to existing `jolt-eval` invariants and any new ones to add in the
 Ask: "What is explicitly out of scope?" Push back if non-goals are vague — "you said 'not performance-critical', but the hot path in `crates/jolt-poly/` multiplies across thousands of rounds. Is there a concrete budget?"
 
 #### Evaluation — Acceptance Criteria
-Ask: "What test would prove this works? Give me concrete, checkable criteria." Each criterion must be a checkbox item. Push for specificity — "existing tests pass" is not enough; ask what NEW tests are needed.
+Ask: "What check would prove this works? Give me concrete, checkable criteria." Each criterion must be a checkbox item. Name the behavior and evidence required; reuse existing coverage when sufficient and add tests only for distinct gaps.
 
 #### Evaluation — Testing Strategy
 Ask: "Which existing tests must keep passing? What new tests are needed? Does this need both `--features host` and `--features host,zk` coverage?"

--- a/.claude/skills/update-docs/SKILL.md
+++ b/.claude/skills/update-docs/SKILL.md
@@ -69,7 +69,7 @@ Before making any changes, present a summary to the user:
    - **New page(s) warranted** — describe what the new page would cover and where it fits in SUMMARY.md
 3. **Proposed changes**: For each doc file you plan to modify or create, describe specifically what you'll change
 
-Wait for user confirmation before proceeding to Step 5.
+If the user requested documentation edits, proceed to Step 5. If they requested only analysis or required approval before edits, stop after the findings and await authorization.
 
 ## Step 5: Make the changes
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,6 +4,14 @@
 
 Jolt is a zkVM (zero-knowledge virtual machine) for RISC-V (RV64IMAC) that efficiently proves and verifies program execution. It uses sumcheck-based protocols, multilinear polynomial commitments (Dory), and the Twist/Shout lookup argument.
 
+## Agent Workflow
+
+- Carry an authorized request through implementation and verification. Resolve routine choices from repository conventions; ask only when missing information would materially change correctness or scope. Continue independent work while an answer is pending.
+- User instructions take precedence over skill guidance. Reuse authorization and answers already supplied. If a skill blocks requested work, cite its exact file and instruction and explain the conflict.
+- Read relevant code before asking about repository facts. Use `rg` for searches; batch independent reads when supported, and wait for required results before dependent work. Run Cargo commands sequentially, including across agents.
+- Treat follow-up messages as updates to the active task unless the user cancels or replaces it.
+- Lead with the result. Keep explanations concise and concrete; report checks actually run, their results, and any remaining blocker. Preserve required output formats in automated workflows.
+
 ## Essential Commands
 
 ### Linting and Formatting
@@ -256,6 +264,8 @@ Concrete implementations: `OuterRemainingSumcheckParams` (spartan/outer.rs), `Ra
 
 ### Testing Guidelines
 
+- Match verification to the changed behavior and complete the applicable checks above and in the invoked workflow. After they pass, repeat or broaden checks only for further changes, failures, or unresolved concerns.
+- Add tests for distinct failure signals, not to mirror the implementation or require new tests for every low-impact edit.
 - Do not add old-vs-new equivalence tests that reimplement the pre-change logic as the oracle. Transition-validation belongs in the PR process (byte-parity CI vs a living reference, one-off scripts), not the permanent suite. Permanent tests must assert against independent ground truth: spec vectors, golden fixtures, live reference paths (e.g. `jolt-kernels`' reference tier, the legacy-prover byte-parity suites), or properties. If the old code is deleted, its reimplementation in a test is dead weight — delete the test rather than keep the old logic alive inside it. A `#[cfg(test)]` copy of superseded production code "kept as the oracle" is the same anti-pattern.
 
 ### Lint Policy

--- a/agent-skills/jolt/SKILL.md
+++ b/agent-skills/jolt/SKILL.md
@@ -6,6 +6,8 @@ allowed-tools: Bash, Read, Edit, Write, Glob, Grep, Task
 
 **Invoke when** the user says: "make this Jolt provable", "wrap this in Jolt", "prove this with Jolt", "add ZK proofs to this", "make this zero-knowledge", "make this provable", "jolt-ify this".
 
+Follow the user's instructions and the target repository's conventions. Do not ask again for authorization already supplied; if a skill instruction blocks requested work, cite it and explain why.
+
 #### Step 1 — Identify the computation to prove
 
 Look for a **pure, deterministic Rust function** — inputs in, result out, no I/O or side effects. If not obvious, ask:
@@ -38,8 +40,7 @@ cargo install --git https://github.com/a16z/jolt --force jolt  # if not
 
 #### Step 4 — Scaffold
 
-If inside an existing Rust library repo, propose:
-> "I'll create `<library-name>-jolt/` here with the proof scaffold and import your library as a path dependency. Sound good?"
+If inside an existing Rust library repo, create `<library-name>-jolt/` with the proof scaffold and import the library as a path dependency. Honor any location already specified by the user.
 
 ```bash
 jolt new <project-name>        # standard mode


### PR DESCRIPTION
## Summary

Model-neutral guidance changes after auditing the [official GPT-6 Astra guide](https://developers.openai.com/api/docs/guides/latest-model?model=gpt-6-astra).

- `CLAUDE.md` (also read through the tracked `AGENTS.md` symlink): explicit user/skill precedence, continued work within authorized scope, evidence-first searches, independent read batching, sequential Cargo, concise results, and bounded verification.
- `implement-spec`, `new-invariant`, `new-objective`, `update-docs`, and the exported Jolt skill: reuse supplied answers and authorization; retain questions for missing requirements and approval when edits were not requested.
- `ci-code-review`: remove the instruction to run tests that contradicted its CI-only testing rule. `new-spec`: require concrete acceptance evidence without demanding a new test for every change.

## Preserved

- Required host/ZK checks, protocol invariants, command examples, skill metadata, and the AGENTS symlink.
- Claude model names, agent counts, tool names, routine dispatch, and interactive spec interviews. Astra-specific API changes and blanket delegation are outside this shared-guidance patch.
- No new untracked guidance was found. All eight modified files were tracked; changes are isolated in one branch.

## Verification

- `git diff --check` and staged diff inspection.
- Compared every fenced code block and skill frontmatter with the base: unchanged.
- Verified the tracked AGENTS symlink and the original main checkout's index/status are unchanged.
- Commit hooks passed: typos, style invariants, formatting, and `cargo clippy --all --all-targets -q --message-format=short -- -D warnings` (default features). No tests added or run.

No model A/B evaluation performed; this PR changes instructions, not the agent provider.
