### PR TITLE
docs: weekly freshness pass (Sep 7)

### DIFF
--- a/book/src/how/formal-verification/field-kernels-trust-boundary.md
+++ b/book/src/how/formal-verification/field-kernels-trust-boundary.md
@@ -171,9 +171,10 @@ the following evidence.
 7. Evidence that the claimed execution path reaches that code.
 8. Every operation and representation that remains outside the claim.
 
-The current legacy `akita` feature still reaches the external Akita field
-implementation. The Jolt Fp128 theorems do not cover that runtime path. The
-field cutover and downstream binary inspection must happen before a claim about
+The current `akita` path uses the shared `jolt_field::Fp128` type but enables
+only `jolt-field/solinas`, not `asm`, so it runs the portable Rust bodies. The
+Jolt Fp128 theorems do not cover that runtime path. Enabling `asm` on the
+product and inspecting the downstream binary must happen before a claim about
 the complete Akita path is valid.
 
 ## Claim language

--- a/book/src/how/formal-verification/field-kernels.md
+++ b/book/src/how/formal-verification/field-kernels.md
@@ -423,11 +423,13 @@ The result relies on the following assumptions.
 
 Jolt owns the kernel, theorem, proof object, and inspection witness. This
 does not yet prove every executable that depends on Jolt. In particular, the
-current legacy `akita` feature in `jolt-prover` still reaches the external
-Akita field implementation instead of `Prime128OffsetA7F7`. These theorems do
-not cover that path. The final cutover must route the production prover or
-verifier through this field type and inspect that final binary before making
-a claim about the complete production path.
+`akita` path (`jolt-akita` and the `akita` features of `jolt-prover` and
+`jolt-prover-legacy`) now uses the shared `jolt_field::Fp128` at
+`Prime128OffsetA7F7`, but it enables only `jolt-field/solinas`, not `asm`, so
+it runs the portable Rust bodies rather than the proved kernels. These
+theorems do not cover that path. A production rollout must forward `asm` from
+the product's feature configuration and inspect that final binary before
+making a claim about the complete production path.
 
 ## Running the checks
 


### PR DESCRIPTION
## Week's changes (27 commits since #1823)

Doc-relevant: Akita shared-field cutover (#1796), Akita schedule externalization + opening changes (#1844, #1842, #1829, #1840, #1817), profiling setup/verifier thread modes (#1841), kernels visit-helper retirement (#1830), prover memory (#1734), SB/SH/SW fused RMW (#1768), inline row-count perf (#1749, sha2 σ shifts).

## Drift found

- `book/src/how/formal-verification/field-kernels.md` and `field-kernels-trust-boundary.md` still said the `akita` feature "reaches the external Akita field implementation instead of `Prime128OffsetA7F7`". Since #1796 the Akita path is the shared `jolt_field::Fp128` at that modulus (`akita-field` is gone from `Cargo.lock`; `akita-config`/`akita-algebra` depend on `jolt-field`; `crates/jolt-prover-legacy/src/field/akita.rs` header). The remaining gap is that `jolt-akita` enables only `jolt-field/solinas`, not `asm`, so the proved kernels are not what runs.

## Fixes

- Rewrote the two limitation paragraphs to state the actual reason the theorems don't cover the Akita path (portable Rust bodies, `asm` not forwarded), keeping the "inspect the final binary" requirement.

## Verified, no change needed

- `CLAUDE.md` allocative rules already updated by #1830 (`jolt_kernels::backend::visit_heap_free_elements` exists; `visit_scalars`/`visit_scalar_rows` gone from all doc surfaces).
- `book/src/usage/profiling/zkvm_profiling.md` (updated in #1841): `--backend reference|optimized`, `--scale`, `--format`, `--min-scale 18`/`--max-scale 21` defaults, `--resume` match `crates/jolt-prover/src/profile.rs`; `scripts/benchmark_summary.py --protocol/--metric` present.
- `book/src/dev/testing-gates.md` (added in #1817): test names `muldiv_e2e_akita_committed_program`, `prover_matches_legacy_on_committed_muldiv_akita`, `catalogs_match_planner_regeneration` exist; 128-row cap = `MAX_PROVISIONED_ROWS` in `crates/jolt-akita/src/schedule_registry.rs`; ≤4 advice-presence rows matches `precommit_combinations` (3 + mandatory); `scripts/ci/fs-soundness.sh`, `fs-audit` feature, `tests/fs_obligations.rs` exist.
- `field-kernels.md` "no product crate enables `jolt-field/asm`" still true (only `fuzzing`/`fp128-proof-linkage` imply it); `MAX_COMMIT_ACCUMULATIONS` still has no production consumer.
- All `crates/…`, `scripts/…`, `specs/…` paths cited in CLAUDE.md, README.md, book/, `.claude/skills/*/SKILL.md`, `agent-skills/jolt/SKILL.md` resolve.