### PR TITLE
fix(verifier): close soundness-review gaps G3, G4, G5, G6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3802,6 +3802,7 @@ dependencies = [
  "jolt-claims",
  "jolt-field",
  "jolt-poly",
+ "jolt-riscv",
  "num-traits",
  "rand_chacha 0.3.1",
  "rand_core 0.6.4",

--- a/crates/jolt-claims/src/protocols/jolt/geometry/committed_openings.rs
+++ b/crates/jolt-claims/src/protocols/jolt/geometry/committed_openings.rs
@@ -124,14 +124,17 @@ pub struct FinalOpeningPointInputs<'a, F: JoltField> {
 
 /// Unified big-endian opening point for the stage 8 batched PCS opening.
 ///
+/// The native point is assembled from the stage 6 cycle challenges and the
+/// stage 7 address challenges in the order the active trace layout expects.
 /// When a precommitted polynomial spans more variables than the native trace
-/// domain, its opening point anchors the batch (all dominant anchors must
-/// agree). Otherwise the point is assembled from the stage 6 cycle challenges
-/// and the stage 7 address challenges in the order the active trace layout
-/// expects.
+/// domain, its opening point anchors the batch instead (all dominant anchors
+/// must agree), and every native challenge must appear in it: the RA and Inc
+/// claims were made at the native blocks, and `commitment_embedding_scale`
+/// embeds them into the anchor by challenge value.
 pub fn final_opening_point<F: JoltField>(
     inputs: FinalOpeningPointInputs<'_, F>,
 ) -> Result<Vec<F>, JoltFormulaPointError> {
+    let native_point = native_final_opening_point(&inputs)?;
     let native_main_vars = inputs.log_t + inputs.log_k_chunk;
     let mut dominant: Option<(usize, &[F])> = None;
     for (index, point) in inputs.precommitted_anchor_points.iter().enumerate() {
@@ -139,44 +142,67 @@ pub fn final_opening_point<F: JoltField>(
             dominant = Some((index, point));
         }
     }
-    if let Some((first, dominant_point)) = dominant {
-        if dominant_point.len() > native_main_vars {
-            for (index, point) in inputs.precommitted_anchor_points.iter().enumerate() {
-                if point.len() == dominant_point.len() && *point != dominant_point {
-                    return Err(JoltFormulaPointError::IncompatibleDominantAnchors {
-                        first,
-                        second: index,
-                    });
-                }
-            }
-            return Ok(dominant_point.to_vec());
+    let Some((first, dominant_point)) = dominant else {
+        return Ok(native_point);
+    };
+    if dominant_point.len() <= native_main_vars {
+        return Ok(native_point);
+    }
+    for (index, point) in inputs.precommitted_anchor_points.iter().enumerate() {
+        if point.len() == dominant_point.len() && *point != dominant_point {
+            return Err(JoltFormulaPointError::IncompatibleDominantAnchors {
+                first,
+                second: index,
+            });
         }
     }
+    if let Some(missing) = native_point
+        .iter()
+        .position(|challenge| !dominant_point.contains(challenge))
+    {
+        return Err(
+            JoltFormulaPointError::DominantAnchorMissingNativeChallenge {
+                anchor: first,
+                native_index: missing,
+            },
+        );
+    }
+    Ok(dominant_point.to_vec())
+}
 
+/// The native trace-domain opening point: the stage 7 address block and the
+/// stage 6 cycle block in the active trace layout's order. The hamming-weight
+/// point's cycle suffix must prefix the stage 6 cycle challenges in both
+/// layouts: the RA claims were made at that suffix, and the point returned
+/// here (or the anchor containing it) is where they are opened.
+fn native_final_opening_point<F: JoltField>(
+    inputs: &FinalOpeningPointInputs<'_, F>,
+) -> Result<Vec<F>, JoltFormulaPointError> {
     if inputs.hamming_weight_opening_point.len() < inputs.log_k_chunk {
         return Err(JoltFormulaPointError::OpeningPointLengthMismatch {
             expected: inputs.log_k_chunk,
             got: inputs.hamming_weight_opening_point.len(),
         });
     }
-    let r_address_stage7 = &inputs.hamming_weight_opening_point[..inputs.log_k_chunk];
+    let (r_address_stage7, native_cycle) = inputs
+        .hamming_weight_opening_point
+        .split_at(inputs.log_k_chunk);
     let r_cycle_stage6 = inputs.inc_claim_reduction_opening_point;
+    if r_cycle_stage6.len() < native_cycle.len() {
+        return Err(
+            JoltFormulaPointError::CycleChallengesShorterThanNativeCycle {
+                expected: native_cycle.len(),
+                got: r_cycle_stage6.len(),
+            },
+        );
+    }
+    let (cycle_prefix, cycle_extra) = r_cycle_stage6.split_at(native_cycle.len());
+    if cycle_prefix != native_cycle {
+        return Err(JoltFormulaPointError::CyclePrefixMismatch);
+    }
     match inputs.trace_order {
         TracePolynomialOrder::AddressMajor => Ok([r_cycle_stage6, r_address_stage7].concat()),
         TracePolynomialOrder::CycleMajor => {
-            let native_cycle = &inputs.hamming_weight_opening_point[inputs.log_k_chunk..];
-            if r_cycle_stage6.len() < native_cycle.len() {
-                return Err(
-                    JoltFormulaPointError::CycleChallengesShorterThanNativeCycle {
-                        expected: native_cycle.len(),
-                        got: r_cycle_stage6.len(),
-                    },
-                );
-            }
-            if &r_cycle_stage6[..native_cycle.len()] != native_cycle {
-                return Err(JoltFormulaPointError::CycleMajorCyclePrefixMismatch);
-            }
-            let cycle_extra = &r_cycle_stage6[native_cycle.len()..];
             Ok([cycle_extra, r_address_stage7, native_cycle].concat())
         }
     }
@@ -303,7 +329,7 @@ mod tests {
     #[test]
     fn final_opening_point_orders_cycle_before_address_for_address_major() {
         let hamming_point: Vec<Fr> = (1..=6).map(Fr::from_u64).collect();
-        let inc_point: Vec<Fr> = (11..=14).map(Fr::from_u64).collect();
+        let inc_point: Vec<Fr> = hamming_point[2..].to_vec();
 
         let point = final_opening_point(FinalOpeningPointInputs {
             log_t: 4,
@@ -324,11 +350,37 @@ mod tests {
     }
 
     #[test]
+    fn final_opening_point_rejects_hamming_cycle_suffix_mismatch_in_both_orders() {
+        let hamming_point: Vec<Fr> = (1..=6).map(Fr::from_u64).collect();
+        let mut inc_point: Vec<Fr> = hamming_point[2..].to_vec();
+        inc_point[0] += Fr::from_u64(1);
+
+        for trace_order in [
+            TracePolynomialOrder::CycleMajor,
+            TracePolynomialOrder::AddressMajor,
+        ] {
+            assert_eq!(
+                final_opening_point(FinalOpeningPointInputs {
+                    log_t: 4,
+                    log_k_chunk: 2,
+                    trace_order,
+                    hamming_weight_opening_point: &hamming_point,
+                    inc_claim_reduction_opening_point: &inc_point,
+                    precommitted_anchor_points: &[],
+                }),
+                Err(JoltFormulaPointError::CyclePrefixMismatch)
+            );
+        }
+    }
+
+    #[test]
     fn final_opening_point_anchors_on_dominant_precommitted_opening() {
         let hamming_point: Vec<Fr> = (1..=6).map(Fr::from_u64).collect();
         let inc_point: Vec<Fr> = hamming_point[2..].to_vec();
-        let dominant: Vec<Fr> = (21..=28).map(Fr::from_u64).collect();
-        let conflicting: Vec<Fr> = (31..=38).map(Fr::from_u64).collect();
+        // The anchor is a permutation of the native challenges plus extra
+        // alignment challenges.
+        let dominant: Vec<Fr> = [21, 22, 3, 4, 1, 2, 5, 6].map(Fr::from_u64).to_vec();
+        let conflicting: Vec<Fr> = [31, 32, 3, 4, 1, 2, 5, 6].map(Fr::from_u64).to_vec();
 
         let point = final_opening_point(FinalOpeningPointInputs {
             log_t: 4,
@@ -354,6 +406,31 @@ mod tests {
                 first: 0,
                 second: 1
             })
+        );
+    }
+
+    #[test]
+    fn final_opening_point_rejects_dominant_anchor_missing_native_challenge() {
+        let hamming_point: Vec<Fr> = (1..=6).map(Fr::from_u64).collect();
+        let inc_point: Vec<Fr> = hamming_point[2..].to_vec();
+        // Drops the second stage-7 address challenge (value 2).
+        let anchor: Vec<Fr> = [21, 22, 3, 4, 1, 23, 5, 6].map(Fr::from_u64).to_vec();
+
+        assert_eq!(
+            final_opening_point(FinalOpeningPointInputs {
+                log_t: 4,
+                log_k_chunk: 2,
+                trace_order: TracePolynomialOrder::CycleMajor,
+                hamming_weight_opening_point: &hamming_point,
+                inc_claim_reduction_opening_point: &inc_point,
+                precommitted_anchor_points: &[&anchor],
+            }),
+            Err(
+                JoltFormulaPointError::DominantAnchorMissingNativeChallenge {
+                    anchor: 0,
+                    native_index: 1,
+                }
+            )
         );
     }
 }

--- a/crates/jolt-claims/src/protocols/jolt/geometry/dimensions.rs
+++ b/crates/jolt-claims/src/protocols/jolt/geometry/dimensions.rs
@@ -13,28 +13,30 @@ use super::{
 
 pub const REGISTER_ADDRESS_BITS: usize = 7;
 
-/// Spartan outer eq-constraint rows per cycle in the RV64 R1CS.
-const RV64_SPARTAN_OUTER_ROW_COUNT: usize = 19;
-/// Spartan product-constraint lanes per cycle in the RV64 R1CS.
-const RV64_SPARTAN_PRODUCT_LANES: usize = 3;
-/// Eq-constraint rows and product lanes the `field-inline` extension appends.
-#[cfg(feature = "field-inline")]
-const FIELD_INLINE_SPARTAN_OUTER_ROW_COUNT: usize = 8;
-#[cfg(not(feature = "field-inline"))]
-const FIELD_INLINE_SPARTAN_OUTER_ROW_COUNT: usize = 0;
-#[cfg(feature = "field-inline")]
-const FIELD_INLINE_SPARTAN_PRODUCT_LANES: usize = 2;
-#[cfg(not(feature = "field-inline"))]
-const FIELD_INLINE_SPARTAN_PRODUCT_LANES: usize = 0;
+/// Spartan outer eq-constraint rows and product lanes per cycle, per
+/// constraint table. `jolt-r1cs` builds the tables and depends on this crate,
+/// so it cannot own the uni-skip geometry below; instead each table module
+/// statically asserts its counts against these
+/// (`jolt_r1cs::constraints::{rv64, field_constraints}`).
+pub const RV64_SPARTAN_OUTER_ROW_COUNT: usize = 19;
+pub const RV64_SPARTAN_PRODUCT_LANES: usize = 3;
+pub const FIELD_INLINE_SPARTAN_OUTER_ROW_COUNT: usize = 8;
+pub const FIELD_INLINE_SPARTAN_PRODUCT_LANES: usize = 2;
 
-/// Row and lane counts of the composed Spartan R1CS. `jolt-r1cs` builds the
-/// constraint tables and depends on this crate, so it cannot be the owner of
-/// the uni-skip geometry below; instead it statically asserts its table sizes
-/// against these counts (`jolt_r1cs::constraints::jolt`).
-pub const SPARTAN_OUTER_ROW_COUNT: usize =
-    RV64_SPARTAN_OUTER_ROW_COUNT + FIELD_INLINE_SPARTAN_OUTER_ROW_COUNT;
-pub const SPARTAN_PRODUCT_LANES: usize =
-    RV64_SPARTAN_PRODUCT_LANES + FIELD_INLINE_SPARTAN_PRODUCT_LANES;
+/// Row and lane counts of the composed Spartan R1CS: the RV64 table plus,
+/// under `field-inline`, the appended native-field table.
+pub const SPARTAN_OUTER_ROW_COUNT: usize = RV64_SPARTAN_OUTER_ROW_COUNT
+    + if cfg!(feature = "field-inline") {
+        FIELD_INLINE_SPARTAN_OUTER_ROW_COUNT
+    } else {
+        0
+    };
+pub const SPARTAN_PRODUCT_LANES: usize = RV64_SPARTAN_PRODUCT_LANES
+    + if cfg!(feature = "field-inline") {
+        FIELD_INLINE_SPARTAN_PRODUCT_LANES
+    } else {
+        0
+    };
 
 /// Uni-skip geometry: the outer first round skips over half the constraint
 /// rows (each row group is one Lagrange node), the product first round over one

--- a/crates/jolt-claims/src/protocols/jolt/geometry/dimensions.rs
+++ b/crates/jolt-claims/src/protocols/jolt/geometry/dimensions.rs
@@ -12,10 +12,38 @@ use super::{
 };
 
 pub const REGISTER_ADDRESS_BITS: usize = 7;
-pub const OUTER_UNISKIP_DOMAIN_SIZE: usize = 10;
-pub const OUTER_UNISKIP_FIRST_ROUND_DEGREE: usize = 27;
-pub const PRODUCT_UNISKIP_DOMAIN_SIZE: usize = 3;
-pub const PRODUCT_UNISKIP_FIRST_ROUND_DEGREE: usize = 6;
+
+/// Spartan outer eq-constraint rows per cycle in the RV64 R1CS.
+const RV64_SPARTAN_OUTER_ROW_COUNT: usize = 19;
+/// Spartan product-constraint lanes per cycle in the RV64 R1CS.
+const RV64_SPARTAN_PRODUCT_LANES: usize = 3;
+/// Eq-constraint rows and product lanes the `field-inline` extension appends.
+#[cfg(feature = "field-inline")]
+const FIELD_INLINE_SPARTAN_OUTER_ROW_COUNT: usize = 8;
+#[cfg(not(feature = "field-inline"))]
+const FIELD_INLINE_SPARTAN_OUTER_ROW_COUNT: usize = 0;
+#[cfg(feature = "field-inline")]
+const FIELD_INLINE_SPARTAN_PRODUCT_LANES: usize = 2;
+#[cfg(not(feature = "field-inline"))]
+const FIELD_INLINE_SPARTAN_PRODUCT_LANES: usize = 0;
+
+/// Row and lane counts of the composed Spartan R1CS. `jolt-r1cs` builds the
+/// constraint tables and depends on this crate, so it cannot be the owner of
+/// the uni-skip geometry below; instead it statically asserts its table sizes
+/// against these counts (`jolt_r1cs::constraints::jolt`).
+pub const SPARTAN_OUTER_ROW_COUNT: usize =
+    RV64_SPARTAN_OUTER_ROW_COUNT + FIELD_INLINE_SPARTAN_OUTER_ROW_COUNT;
+pub const SPARTAN_PRODUCT_LANES: usize =
+    RV64_SPARTAN_PRODUCT_LANES + FIELD_INLINE_SPARTAN_PRODUCT_LANES;
+
+/// Uni-skip geometry: the outer first round skips over half the constraint
+/// rows (each row group is one Lagrange node), the product first round over one
+/// node per lane; both have a cubic per-node relation, so the first-round
+/// degree is `3 * (domain_size - 1)`.
+pub const OUTER_UNISKIP_DOMAIN_SIZE: usize = SPARTAN_OUTER_ROW_COUNT.div_ceil(2);
+pub const OUTER_UNISKIP_FIRST_ROUND_DEGREE: usize = 3 * (OUTER_UNISKIP_DOMAIN_SIZE - 1);
+pub const PRODUCT_UNISKIP_DOMAIN_SIZE: usize = SPARTAN_PRODUCT_LANES;
+pub const PRODUCT_UNISKIP_FIRST_ROUND_DEGREE: usize = 3 * (PRODUCT_UNISKIP_DOMAIN_SIZE - 1);
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub enum TracePolynomialOrder {

--- a/crates/jolt-claims/src/protocols/jolt/geometry/error.rs
+++ b/crates/jolt-claims/src/protocols/jolt/geometry/error.rs
@@ -22,9 +22,13 @@ pub enum JoltFormulaPointError {
     #[error("stage 6 cycle challenges ({got}) shorter than native cycle vars ({expected})")]
     CycleChallengesShorterThanNativeCycle { expected: usize, got: usize },
     #[error(
-        "cycle-major final opening expects the stage 6 cycle prefix to equal the native cycle vars"
+        "final opening expects the stage 6 cycle challenges to start with the hamming-weight cycle vars"
     )]
-    CycleMajorCyclePrefixMismatch,
+    CyclePrefixMismatch,
+    #[error(
+        "dominant precommitted anchor {anchor} does not contain native opening challenge {native_index}"
+    )]
+    DominantAnchorMissingNativeChallenge { anchor: usize, native_index: usize },
     #[error(
         "cycle-phase final opening requested with {active_address_rounds} active address-phase rounds remaining"
     )]

--- a/crates/jolt-dory/src/scheme.rs
+++ b/crates/jolt-dory/src/scheme.rs
@@ -23,6 +23,34 @@ use crate::routines::{JoltG1Routines, JoltG2Routines};
 use crate::transcript::JoltToDoryTranscript;
 use crate::types::{DoryCommitment, DoryHint, DoryProof, DoryProverSetup, DoryVerifierSetup};
 
+/// The balanced Dory matrix split every commitment and opening in this crate
+/// uses: `sigma = ceil(num_vars / 2)` column variables, the rest rows.
+pub(crate) const fn balanced_split(num_vars: usize) -> DoryMatrixSplit {
+    let sigma = num_vars.div_ceil(2);
+    DoryMatrixSplit {
+        nu: num_vars - sigma,
+        sigma,
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct DoryMatrixSplit {
+    pub(crate) nu: usize,
+    pub(crate) sigma: usize,
+}
+
+/// Pins the proof's `(nu, sigma)` to the split the commitment was formed
+/// over. `dory::verify` only checks `nu + sigma == point.len()` and
+/// `nu <= sigma`, so without this gate the split is a free prover degree of
+/// freedom in the Fiat-Shamir statement.
+fn require_balanced_split(proof: &DoryProof, point_len: usize) -> Result<(), OpeningsError> {
+    let expected = balanced_split(point_len);
+    if proof.0.nu != expected.nu || proof.0.sigma != expected.sigma {
+        return Err(OpeningsError::VerificationFailed);
+    }
+    Ok(())
+}
+
 // All jolt types below are #[repr(transparent)] over the same arkworks
 // inner type as their dory-pcs counterpart, guaranteeing identical layout.
 
@@ -237,10 +265,8 @@ impl CommitmentScheme for DoryScheme {
         hint: Option<Self::OpeningHint>,
         transcript: &mut impl Transcript<Challenge = Self::Field>,
     ) -> Result<Self::Proof, OpeningsError> {
-        let num_vars = point.len();
         let adapter = DorySourceAdapter::new(poly);
-        let sigma = num_vars.div_ceil(2);
-        let nu = num_vars - sigma;
+        let DoryMatrixSplit { nu, sigma } = balanced_split(point.len());
 
         let (row_commitments, commit_blind) = match hint {
             Some(h) => h.into_ark_parts(),
@@ -282,6 +308,7 @@ impl CommitmentScheme for DoryScheme {
         setup: &Self::VerifierSetup,
         transcript: &mut impl Transcript<Challenge = Self::Field>,
     ) -> Result<(), OpeningsError> {
+        require_balanced_split(proof, point.len())?;
         let ark_point: Vec<ArkFr> = point.iter().rev().map(jolt_fr_to_ark).collect();
         let ark_eval = jolt_fr_to_ark(&eval);
         let ark_commitment = jolt_gt_to_ark(&commitment.0);
@@ -384,10 +411,8 @@ impl ZkOpeningScheme for DoryScheme {
         hint: Self::OpeningHint,
         transcript: &mut impl Transcript<Challenge = Self::Field>,
     ) -> Result<(Self::Proof, Self::HidingCommitment, Self::Blind), OpeningsError> {
-        let num_vars = point.len();
         let adapter = DorySourceAdapter::new(poly);
-        let sigma = num_vars.div_ceil(2);
-        let nu = num_vars - sigma;
+        let DoryMatrixSplit { nu, sigma } = balanced_split(point.len());
         let (row_commitments, commit_blind) = hint.into_ark_parts();
 
         let ark_point: Vec<ArkFr> = point.iter().rev().map(jolt_fr_to_ark).collect();
@@ -425,6 +450,7 @@ impl ZkOpeningScheme for DoryScheme {
         setup: &Self::VerifierSetup,
         transcript: &mut impl Transcript<Challenge = Self::Field>,
     ) -> Result<Self::HidingCommitment, OpeningsError> {
+        require_balanced_split(proof, point.len())?;
         let ark_point: Vec<ArkFr> = point.iter().rev().map(jolt_fr_to_ark).collect();
         // In ZK mode dory::verify reads the evaluation commitment from `proof.y_com`,
         // so the caller-side eval is unused here.
@@ -516,14 +542,13 @@ fn compute_row_commitments<P: MultilinearPoly<Fr> + ?Sized>(
     setup: &DoryProverSetup,
 ) -> Result<Vec<ArkG1>, OpeningsError> {
     let num_vars = poly.num_vars();
-    let sigma = num_vars.div_ceil(2);
+    let DoryMatrixSplit { nu, sigma } = balanced_split(num_vars);
     let max_cols = setup.0.g1_vec.len();
     let max_rows = setup.0.g2_vec.len();
     // An oversized polynomial must surface as the commit API's Err, not as an
     // out-of-bounds slice panic on the SRS below.
-    let fits = sigma < usize::BITS as usize
-        && (1usize << sigma) <= max_cols
-        && (1usize << (num_vars - sigma)) <= max_rows;
+    let fits =
+        sigma < usize::BITS as usize && (1usize << sigma) <= max_cols && (1usize << nu) <= max_rows;
     if !fits {
         return Err(OpeningsError::PolynomialTooLarge {
             poly_size: num_vars,
@@ -531,7 +556,7 @@ fn compute_row_commitments<P: MultilinearPoly<Fr> + ?Sized>(
         });
     }
     let num_cols = 1usize << sigma;
-    let num_rows = 1usize << (num_vars - sigma);
+    let num_rows = 1usize << nu;
 
     Ok(if poly.is_one_hot() {
         commit_rows_one_hot(poly, num_rows, num_cols, &setup.0)

--- a/crates/jolt-dory/tests/commit_open_verify.rs
+++ b/crates/jolt-dory/tests/commit_open_verify.rs
@@ -222,6 +222,69 @@ fn wrong_point_rejected() {
     assert!(result.is_err(), "tampered point must be rejected");
 }
 
+/// A `(nu, sigma)` split other than the balanced one the commitment was formed
+/// over: still `nu + sigma == point.len()` and `nu <= sigma`, so only the
+/// verifier's split gate distinguishes it from an honest proof.
+fn unbalanced_split(num_vars: usize) -> (usize, usize) {
+    let sigma = num_vars.div_ceil(2) + 1;
+    (num_vars - sigma, sigma)
+}
+
+#[test]
+fn unbalanced_matrix_split_rejected() {
+    let num_vars = 4;
+    let mut rng = ChaCha20Rng::seed_from_u64(550);
+
+    let prover_setup = DoryScheme::setup_prover(num_vars);
+    let verifier_setup = DoryScheme::setup_verifier(num_vars);
+    let poly = Polynomial::<Fr>::random(num_vars, &mut rng);
+    let point: Vec<Fr> = (0..num_vars)
+        .map(|_| <Fr as Field>::random(&mut rng))
+        .collect();
+    let eval = poly.evaluate(&point);
+    let (commitment, hint) = DoryScheme::commit(poly.evaluations(), &prover_setup).unwrap();
+
+    let mut pt = Blake2bTranscript::new(b"unbalanced-split");
+    let mut proof =
+        DoryScheme::open(&poly, &point, eval, &prover_setup, Some(hint), &mut pt).unwrap();
+    (proof.0.nu, proof.0.sigma) = unbalanced_split(num_vars);
+
+    let mut vt = Blake2bTranscript::new(b"unbalanced-split");
+    let result = DoryScheme::verify(&commitment, &point, eval, &proof, &verifier_setup, &mut vt);
+    assert!(
+        result.is_err(),
+        "a prover-chosen matrix split must be rejected"
+    );
+}
+
+#[test]
+fn zk_unbalanced_matrix_split_rejected() {
+    let num_vars = 4;
+    let mut rng = ChaCha20Rng::seed_from_u64(551);
+
+    let prover_setup = DoryScheme::setup_prover(num_vars);
+    let verifier_setup = DoryScheme::setup_verifier(num_vars);
+    let poly = Polynomial::<Fr>::random(num_vars, &mut rng);
+    let point: Vec<Fr> = (0..num_vars)
+        .map(|_| <Fr as Field>::random(&mut rng))
+        .collect();
+    let eval = poly.evaluate(&point);
+    let (commitment, hint) =
+        <DoryScheme as ZkOpeningScheme>::commit_zk(poly.evaluations(), &prover_setup).unwrap();
+
+    let mut pt = Blake2bTranscript::new(b"zk-unbalanced-split");
+    let (mut proof, _eval_com, _blind) =
+        DoryScheme::open_zk(&poly, &point, eval, &prover_setup, hint, &mut pt).unwrap();
+    (proof.0.nu, proof.0.sigma) = unbalanced_split(num_vars);
+
+    let mut vt = Blake2bTranscript::new(b"zk-unbalanced-split");
+    let result = DoryScheme::verify_zk(&commitment, &point, &proof, &verifier_setup, &mut vt);
+    assert!(
+        result.is_err(),
+        "ZK: a prover-chosen matrix split must be rejected"
+    );
+}
+
 #[test]
 fn combine_linear_combination() {
     let num_vars = 3;

--- a/crates/jolt-prover-legacy/src/zkvm/prover.rs
+++ b/crates/jolt-prover-legacy/src/zkvm/prover.rs
@@ -367,6 +367,7 @@ impl<
             );
             return Err(jolt_verifier::VerifierError::InvalidTraceLength {
                 got: padded_trace_len,
+                min: PCS::MIN_PADDED_TRACE_LENGTH,
                 max: max_padded_trace_length,
             });
         }

--- a/crates/jolt-prover/src/akita/stage0.rs
+++ b/crates/jolt-prover/src/akita/stage0.rs
@@ -91,6 +91,7 @@ where
         config.trace_length,
         config.ram_K,
         config.trace_polynomial_order,
+        config.rw_config,
         config.one_hot_config,
         trusted_advice.is_some(),
         false,

--- a/crates/jolt-prover/src/config.rs
+++ b/crates/jolt-prover/src/config.rs
@@ -3,23 +3,22 @@
 //! These five values are exactly the proof's wire config block
 //! (`JoltProof::{trace_length, ram_K, rw_config, one_hot_config,
 //! trace_polynomial_order}`) plus the Fiat-Shamir preamble inputs. The
-//! derivation policies here must match `jolt-prover-legacy`'s choices
-//! byte-for-byte while it remains the parity oracle; the byte-diff harness
-//! pins them.
+//! chunking and phase-split policies are the verifier's
+//! (`jolt_verifier::config`), which validates every proof against them; they
+//! must match `jolt-prover-legacy`'s choices byte-for-byte while it remains
+//! the parity oracle, and the byte-diff harness pins them.
 
-use common::constants::{ONEHOT_CHUNK_THRESHOLD_LOG_T, REGISTER_COUNT, XLEN};
 use common::jolt_device::MemoryLayout;
 use jolt_claims::protocols::jolt::{JoltOneHotConfig, JoltReadWriteConfig, TracePolynomialOrder};
 use jolt_field::JoltField;
 use jolt_program::execution::{RamAccess, TraceRow};
 use jolt_riscv::JoltTraceRow;
+use jolt_verifier::config::{one_hot_config_policy, read_write_config_policy};
 #[cfg(feature = "parallel")]
 use rayon::prelude::*;
 
 use crate::ProverError;
 
-/// The full instruction lookup key width: two `XLEN`-bit operands.
-const LOOKUP_ADDRESS_BITS: usize = 2 * XLEN;
 #[cfg(feature = "parallel")]
 const PARALLEL_DERIVE_MIN_ROWS: usize = 1 << 16;
 
@@ -147,11 +146,16 @@ impl ProverConfig {
         let ram_K = touched.max(image_end).next_power_of_two() as usize;
 
         let log_T = trace_length.ilog2() as usize;
+        let rw_config = read_write_config_policy(log_T, ram_K.ilog2() as usize).ok_or(
+            ProverError::Unsupported {
+                reason: "read-write phase round counts do not fit the wire config",
+            },
+        )?;
         Ok(Self {
             trace_length,
             ram_K,
-            rw_config: read_write_config(log_T, ram_K.ilog2() as usize),
-            one_hot_config: one_hot_config(log_T),
+            rw_config,
+            one_hot_config: one_hot_config_policy(log_T),
             trace_polynomial_order: TracePolynomialOrder::CycleMajor,
         })
     }
@@ -196,39 +200,6 @@ pub fn remap_address(address: u64, memory_layout: &MemoryLayout) -> Option<u64> 
     let lowest = memory_layout.get_lowest_address();
     assert!(address >= lowest, "Unexpected address {address}");
     Some((address - lowest) / 8)
-}
-
-/// Read-write checking phase splits: cycle variables in phase 1, address
-/// variables in phase 2 (registers have a fixed 2^7 address space).
-#[expect(non_snake_case)]
-fn read_write_config(log_T: usize, ram_log_K: usize) -> JoltReadWriteConfig {
-    JoltReadWriteConfig {
-        ram_rw_phase1_num_rounds: log_T as u8,
-        ram_rw_phase2_num_rounds: ram_log_K as u8,
-        registers_rw_phase1_num_rounds: log_T as u8,
-        registers_rw_phase2_num_rounds: REGISTER_COUNT.ilog2() as u8,
-    }
-}
-
-/// One-hot chunking policy, mirroring `jolt-prover-legacy`'s
-/// `OneHotConfig::new`: below the trace-length threshold (`log_T < 25`),
-/// 4-bit committed chunks and `LOG_K/8 = 16`-bit virtual-RA chunks; at or
-/// above it, 8-bit committed chunks and `LOG_K/4 = 32`-bit virtual-RA chunks
-/// (a branch that requires a 2^25-cycle trace and may never have run in
-/// practice — kept for parity).
-#[expect(non_snake_case)]
-fn one_hot_config(log_T: usize) -> JoltOneHotConfig {
-    if log_T < ONEHOT_CHUNK_THRESHOLD_LOG_T {
-        JoltOneHotConfig {
-            log_k_chunk: 4,
-            lookups_ra_virtual_log_k_chunk: (LOOKUP_ADDRESS_BITS / 8) as u8,
-        }
-    } else {
-        JoltOneHotConfig {
-            log_k_chunk: 8,
-            lookups_ra_virtual_log_k_chunk: (LOOKUP_ADDRESS_BITS / 4) as u8,
-        }
-    }
 }
 
 /// The committed-program precommitted candidates' variable counts, folded

--- a/crates/jolt-prover/src/dory/stages/stage0.rs
+++ b/crates/jolt-prover/src/dory/stages/stage0.rs
@@ -119,6 +119,7 @@ where
         config.trace_length,
         config.ram_K,
         config.trace_polynomial_order,
+        config.rw_config,
         config.one_hot_config,
         trusted_advice.is_some(),
         untrusted_advice_present,

--- a/crates/jolt-r1cs/Cargo.toml
+++ b/crates/jolt-r1cs/Cargo.toml
@@ -12,6 +12,7 @@ workspace = true
 jolt-claims.workspace = true
 jolt-field = { path = "../jolt-field" }
 jolt-poly = { path = "../jolt-poly" }
+jolt-riscv.workspace = true
 num-traits.workspace = true
 rayon = { workspace = true, optional = true }
 serde = { workspace = true, features = ["derive"] }

--- a/crates/jolt-r1cs/src/constraints/field_constraints.rs
+++ b/crates/jolt-r1cs/src/constraints/field_constraints.rs
@@ -14,6 +14,9 @@
 //! statement and must not back a proof path.
 
 use crate::constraint::SparseRow;
+use jolt_claims::protocols::jolt::geometry::dimensions::{
+    FIELD_INLINE_SPARTAN_OUTER_ROW_COUNT, FIELD_INLINE_SPARTAN_PRODUCT_LANES,
+};
 use jolt_field::JoltField;
 
 type ConstraintRows<F> = (Vec<SparseRow<F>>, Vec<SparseRow<F>>, Vec<SparseRow<F>>);
@@ -56,6 +59,14 @@ pub const ROW_FIELD_PRODUCT: usize = NUM_EQ_CONSTRAINTS;
 pub const ROW_FIELD_INV_PRODUCT: usize = NUM_EQ_CONSTRAINTS + 1;
 pub const NUM_PRODUCT_CONSTRAINTS: usize = 2;
 pub const NUM_CONSTRAINTS_PER_CYCLE: usize = NUM_EQ_CONSTRAINTS + NUM_PRODUCT_CONSTRAINTS;
+
+// The `field-inline` uni-skip geometry in `jolt-claims` is derived from these
+// counts.
+const _: () = assert!(
+    NUM_EQ_CONSTRAINTS == FIELD_INLINE_SPARTAN_OUTER_ROW_COUNT
+        && NUM_PRODUCT_CONSTRAINTS == FIELD_INLINE_SPARTAN_PRODUCT_LANES,
+    "field-inline constraint table diverges from the jolt-claims Spartan geometry"
+);
 
 pub const fn const_column() -> usize {
     V_CONST

--- a/crates/jolt-r1cs/src/constraints/jolt.rs
+++ b/crates/jolt-r1cs/src/constraints/jolt.rs
@@ -14,7 +14,17 @@ use thiserror::Error as ThisError;
 use crate::SparseRow;
 use crate::{ConstraintMatrices, ConstraintMatrixEvalError};
 
-use super::rv64;
+use super::rv64::{
+    self, NUM_R1CS_INPUTS, V_FLAG_ADD_OPERANDS, V_FLAG_ADVICE, V_FLAG_ASSERT,
+    V_FLAG_DO_NOT_UPDATE_UNEXPANDED_PC, V_FLAG_IS_COMPRESSED, V_FLAG_IS_FIRST_IN_SEQUENCE,
+    V_FLAG_IS_LAST_IN_SEQUENCE, V_FLAG_JUMP, V_FLAG_LOAD, V_FLAG_MULTIPLY_OPERANDS, V_FLAG_STORE,
+    V_FLAG_SUBTRACT_OPERANDS, V_FLAG_VIRTUAL_INSTRUCTION, V_FLAG_WRITE_LOOKUP_OUTPUT_TO_RD, V_IMM,
+    V_LEFT_INSTRUCTION_INPUT, V_LEFT_LOOKUP_OPERAND, V_LOOKUP_OUTPUT, V_NEXT_IS_FIRST_IN_SEQUENCE,
+    V_NEXT_IS_VIRTUAL, V_NEXT_PC, V_NEXT_UNEXPANDED_PC, V_PC, V_PRODUCT, V_RAM_ADDRESS,
+    V_RAM_READ_VALUE, V_RAM_WRITE_VALUE, V_RD_WRITE_VALUE, V_RIGHT_INSTRUCTION_INPUT,
+    V_RIGHT_LOOKUP_OPERAND, V_RS1_VALUE, V_RS2_VALUE, V_SHOULD_BRANCH, V_SHOULD_JUMP,
+    V_UNEXPANDED_PC,
+};
 
 #[cfg(feature = "field-inline")]
 use super::field_constraints;
@@ -42,37 +52,16 @@ pub const NUM_CONSTRAINTS_PER_CYCLE: usize =
 #[cfg(not(feature = "field-inline"))]
 pub const NUM_CONSTRAINTS_PER_CYCLE: usize = rv64::NUM_CONSTRAINTS_PER_CYCLE;
 
-#[cfg(feature = "field-inline")]
-pub const SPARTAN_OUTER_ROW_COUNT: usize =
-    rv64::NUM_EQ_CONSTRAINTS + field_constraints::NUM_EQ_CONSTRAINTS;
-
-#[cfg(not(feature = "field-inline"))]
-pub const SPARTAN_OUTER_ROW_COUNT: usize = rv64::NUM_EQ_CONSTRAINTS;
-
-#[cfg(feature = "field-inline")]
-pub const SPARTAN_PRODUCT_LANES: usize =
-    rv64::NUM_PRODUCT_CONSTRAINTS + field_constraints::NUM_PRODUCT_CONSTRAINTS;
-
-#[cfg(not(feature = "field-inline"))]
-pub const SPARTAN_PRODUCT_LANES: usize = rv64::NUM_PRODUCT_CONSTRAINTS;
-
-// The uni-skip geometry is owned by `jolt-claims` (it cannot depend on this
-// crate). These assertions pin the constraint tables built here to the row and
-// lane counts that geometry was derived from.
-const _: () = assert!(
-    SPARTAN_OUTER_ROW_COUNT == dimensions::SPARTAN_OUTER_ROW_COUNT,
-    "Spartan outer eq-constraint row count diverges from jolt-claims geometry"
-);
-const _: () = assert!(
-    SPARTAN_PRODUCT_LANES == dimensions::SPARTAN_PRODUCT_LANES,
-    "Spartan product lane count diverges from jolt-claims geometry"
-);
-
+// The uni-skip geometry and the composed row/lane counts are owned by
+// `jolt-claims` (it cannot depend on this crate); `rv64` and
+// `field_constraints` each statically assert their table against the count
+// they contribute.
 pub use dimensions::{
     OUTER_UNISKIP_DOMAIN_SIZE as SPARTAN_OUTER_UNISKIP_DOMAIN_SIZE,
     OUTER_UNISKIP_FIRST_ROUND_DEGREE as SPARTAN_OUTER_UNISKIP_FIRST_ROUND_DEGREE,
     PRODUCT_UNISKIP_DOMAIN_SIZE as SPARTAN_PRODUCT_UNISKIP_DOMAIN_SIZE,
     PRODUCT_UNISKIP_FIRST_ROUND_DEGREE as SPARTAN_PRODUCT_UNISKIP_FIRST_ROUND_DEGREE,
+    SPARTAN_OUTER_ROW_COUNT,
 };
 
 pub const SPARTAN_OUTER_REMAINDER_DEGREE: usize = 3;
@@ -158,42 +147,42 @@ const _: () = {
 /// name. `None` for virtual polynomials that are not R1CS inputs.
 const fn rv64_input_column(input: JoltVirtualPolynomial) -> Option<usize> {
     match input {
-        JoltVirtualPolynomial::LeftInstructionInput => Some(rv64::V_LEFT_INSTRUCTION_INPUT),
-        JoltVirtualPolynomial::RightInstructionInput => Some(rv64::V_RIGHT_INSTRUCTION_INPUT),
-        JoltVirtualPolynomial::Product => Some(rv64::V_PRODUCT),
-        JoltVirtualPolynomial::ShouldBranch => Some(rv64::V_SHOULD_BRANCH),
-        JoltVirtualPolynomial::PC => Some(rv64::V_PC),
-        JoltVirtualPolynomial::UnexpandedPC => Some(rv64::V_UNEXPANDED_PC),
-        JoltVirtualPolynomial::Imm => Some(rv64::V_IMM),
-        JoltVirtualPolynomial::RamAddress => Some(rv64::V_RAM_ADDRESS),
-        JoltVirtualPolynomial::Rs1Value => Some(rv64::V_RS1_VALUE),
-        JoltVirtualPolynomial::Rs2Value => Some(rv64::V_RS2_VALUE),
-        JoltVirtualPolynomial::RdWriteValue => Some(rv64::V_RD_WRITE_VALUE),
-        JoltVirtualPolynomial::RamReadValue => Some(rv64::V_RAM_READ_VALUE),
-        JoltVirtualPolynomial::RamWriteValue => Some(rv64::V_RAM_WRITE_VALUE),
-        JoltVirtualPolynomial::LeftLookupOperand => Some(rv64::V_LEFT_LOOKUP_OPERAND),
-        JoltVirtualPolynomial::RightLookupOperand => Some(rv64::V_RIGHT_LOOKUP_OPERAND),
-        JoltVirtualPolynomial::NextUnexpandedPC => Some(rv64::V_NEXT_UNEXPANDED_PC),
-        JoltVirtualPolynomial::NextPC => Some(rv64::V_NEXT_PC),
-        JoltVirtualPolynomial::NextIsVirtual => Some(rv64::V_NEXT_IS_VIRTUAL),
-        JoltVirtualPolynomial::NextIsFirstInSequence => Some(rv64::V_NEXT_IS_FIRST_IN_SEQUENCE),
-        JoltVirtualPolynomial::LookupOutput => Some(rv64::V_LOOKUP_OUTPUT),
-        JoltVirtualPolynomial::ShouldJump => Some(rv64::V_SHOULD_JUMP),
+        JoltVirtualPolynomial::LeftInstructionInput => Some(V_LEFT_INSTRUCTION_INPUT),
+        JoltVirtualPolynomial::RightInstructionInput => Some(V_RIGHT_INSTRUCTION_INPUT),
+        JoltVirtualPolynomial::Product => Some(V_PRODUCT),
+        JoltVirtualPolynomial::ShouldBranch => Some(V_SHOULD_BRANCH),
+        JoltVirtualPolynomial::PC => Some(V_PC),
+        JoltVirtualPolynomial::UnexpandedPC => Some(V_UNEXPANDED_PC),
+        JoltVirtualPolynomial::Imm => Some(V_IMM),
+        JoltVirtualPolynomial::RamAddress => Some(V_RAM_ADDRESS),
+        JoltVirtualPolynomial::Rs1Value => Some(V_RS1_VALUE),
+        JoltVirtualPolynomial::Rs2Value => Some(V_RS2_VALUE),
+        JoltVirtualPolynomial::RdWriteValue => Some(V_RD_WRITE_VALUE),
+        JoltVirtualPolynomial::RamReadValue => Some(V_RAM_READ_VALUE),
+        JoltVirtualPolynomial::RamWriteValue => Some(V_RAM_WRITE_VALUE),
+        JoltVirtualPolynomial::LeftLookupOperand => Some(V_LEFT_LOOKUP_OPERAND),
+        JoltVirtualPolynomial::RightLookupOperand => Some(V_RIGHT_LOOKUP_OPERAND),
+        JoltVirtualPolynomial::NextUnexpandedPC => Some(V_NEXT_UNEXPANDED_PC),
+        JoltVirtualPolynomial::NextPC => Some(V_NEXT_PC),
+        JoltVirtualPolynomial::NextIsVirtual => Some(V_NEXT_IS_VIRTUAL),
+        JoltVirtualPolynomial::NextIsFirstInSequence => Some(V_NEXT_IS_FIRST_IN_SEQUENCE),
+        JoltVirtualPolynomial::LookupOutput => Some(V_LOOKUP_OUTPUT),
+        JoltVirtualPolynomial::ShouldJump => Some(V_SHOULD_JUMP),
         JoltVirtualPolynomial::OpFlags(flag) => Some(match flag {
-            CircuitFlags::AddOperands => rv64::V_FLAG_ADD_OPERANDS,
-            CircuitFlags::SubtractOperands => rv64::V_FLAG_SUBTRACT_OPERANDS,
-            CircuitFlags::MultiplyOperands => rv64::V_FLAG_MULTIPLY_OPERANDS,
-            CircuitFlags::Load => rv64::V_FLAG_LOAD,
-            CircuitFlags::Store => rv64::V_FLAG_STORE,
-            CircuitFlags::Jump => rv64::V_FLAG_JUMP,
-            CircuitFlags::WriteLookupOutputToRD => rv64::V_FLAG_WRITE_LOOKUP_OUTPUT_TO_RD,
-            CircuitFlags::VirtualInstruction => rv64::V_FLAG_VIRTUAL_INSTRUCTION,
-            CircuitFlags::Assert => rv64::V_FLAG_ASSERT,
-            CircuitFlags::DoNotUpdateUnexpandedPC => rv64::V_FLAG_DO_NOT_UPDATE_UNEXPANDED_PC,
-            CircuitFlags::Advice => rv64::V_FLAG_ADVICE,
-            CircuitFlags::IsCompressed => rv64::V_FLAG_IS_COMPRESSED,
-            CircuitFlags::IsFirstInSequence => rv64::V_FLAG_IS_FIRST_IN_SEQUENCE,
-            CircuitFlags::IsLastInSequence => rv64::V_FLAG_IS_LAST_IN_SEQUENCE,
+            CircuitFlags::AddOperands => V_FLAG_ADD_OPERANDS,
+            CircuitFlags::SubtractOperands => V_FLAG_SUBTRACT_OPERANDS,
+            CircuitFlags::MultiplyOperands => V_FLAG_MULTIPLY_OPERANDS,
+            CircuitFlags::Load => V_FLAG_LOAD,
+            CircuitFlags::Store => V_FLAG_STORE,
+            CircuitFlags::Jump => V_FLAG_JUMP,
+            CircuitFlags::WriteLookupOutputToRD => V_FLAG_WRITE_LOOKUP_OUTPUT_TO_RD,
+            CircuitFlags::VirtualInstruction => V_FLAG_VIRTUAL_INSTRUCTION,
+            CircuitFlags::Assert => V_FLAG_ASSERT,
+            CircuitFlags::DoNotUpdateUnexpandedPC => V_FLAG_DO_NOT_UPDATE_UNEXPANDED_PC,
+            CircuitFlags::Advice => V_FLAG_ADVICE,
+            CircuitFlags::IsCompressed => V_FLAG_IS_COMPRESSED,
+            CircuitFlags::IsFirstInSequence => V_FLAG_IS_FIRST_IN_SEQUENCE,
+            CircuitFlags::IsLastInSequence => V_FLAG_IS_LAST_IN_SEQUENCE,
         }),
         JoltVirtualPolynomial::NextIsNoop
         | JoltVirtualPolynomial::Rd
@@ -229,12 +218,12 @@ const fn rv64_input_column(input: JoltVirtualPolynomial) -> Option<usize> {
     reason = "const evaluation: `index < NUM_R1CS_INPUTS` is the loop bound, and a failure would be a compile error"
 )]
 const _: () = {
-    assert!(SPARTAN_OUTER_R1CS_INPUTS.len() == rv64::NUM_R1CS_INPUTS);
+    assert!(SPARTAN_OUTER_R1CS_INPUTS.len() == NUM_R1CS_INPUTS);
     let mut index = 0;
-    while index < rv64::NUM_R1CS_INPUTS {
+    while index < NUM_R1CS_INPUTS {
         match rv64_input_column(SPARTAN_OUTER_R1CS_INPUTS[index]) {
             Some(column) => assert!(
-                column == rv64::V_LEFT_INSTRUCTION_INPUT + index,
+                column == V_LEFT_INSTRUCTION_INPUT + index,
                 "SPARTAN_OUTER_R1CS_INPUTS order disagrees with the rv64 column layout"
             ),
             None => panic!("SPARTAN_OUTER_R1CS_INPUTS names a polynomial without an rv64 column"),
@@ -305,8 +294,8 @@ pub fn spartan_outer_row_weights<F: JoltField>(
 }
 
 pub fn spartan_outer_opening_columns() -> Vec<usize> {
-    let columns = (0..rv64::NUM_R1CS_INPUTS)
-        .map(|index| rv64::V_LEFT_INSTRUCTION_INPUT + index)
+    let columns = (0..NUM_R1CS_INPUTS)
+        .map(|index| V_LEFT_INSTRUCTION_INPUT + index)
         .collect::<Vec<_>>();
 
     #[cfg(feature = "field-inline")]
@@ -590,7 +579,7 @@ mod tests {
         );
         assert_eq!(
             spartan_outer_opening_columns(),
-            (rv64::V_LEFT_INSTRUCTION_INPUT..=rv64::NUM_R1CS_INPUTS).collect::<Vec<_>>()
+            (V_LEFT_INSTRUCTION_INPUT..=NUM_R1CS_INPUTS).collect::<Vec<_>>()
         );
     }
 
@@ -704,7 +693,7 @@ mod tests {
             );
         }
         assert_eq!(
-            spartan_outer_opening_columns()[rv64::NUM_R1CS_INPUTS..],
+            spartan_outer_opening_columns()[NUM_R1CS_INPUTS..],
             (FIELD_INLINE_COLUMN_BASE..FIELD_INLINE_COLUMN_BASE + FIELD_INLINE_APPENDED_COLUMNS)
                 .collect::<Vec<_>>()
         );
@@ -742,7 +731,7 @@ mod tests {
             .expect("field-inline output claim evaluates");
         assert_eq!(
             opening_count,
-            rv64::NUM_R1CS_INPUTS + FIELD_INLINE_APPENDED_COLUMNS
+            NUM_R1CS_INPUTS + FIELD_INLINE_APPENDED_COLUMNS
         );
         // The factored publics: the tau kernel, one Az and one Bz weight per
         // opening (appended field-inline columns included), and the two

--- a/crates/jolt-r1cs/src/constraints/jolt.rs
+++ b/crates/jolt-r1cs/src/constraints/jolt.rs
@@ -1,10 +1,13 @@
 //! Compile-time Jolt R1CS composition.
 
+use jolt_claims::protocols::jolt::geometry::{dimensions, spartan::SPARTAN_OUTER_R1CS_INPUTS};
+use jolt_claims::protocols::jolt::JoltVirtualPolynomial;
 use jolt_field::JoltField;
 use jolt_poly::{
     lagrange::{centered_lagrange_evals, centered_lagrange_kernel, CenteredIntegerDomainError},
     EqPolynomial,
 };
+use jolt_riscv::CircuitFlags;
 use thiserror::Error as ThisError;
 
 #[cfg(feature = "field-inline")]
@@ -46,24 +49,35 @@ pub const SPARTAN_OUTER_ROW_COUNT: usize =
 #[cfg(not(feature = "field-inline"))]
 pub const SPARTAN_OUTER_ROW_COUNT: usize = rv64::NUM_EQ_CONSTRAINTS;
 
-pub const SPARTAN_OUTER_UNISKIP_DOMAIN_SIZE: usize = SPARTAN_OUTER_ROW_COUNT.div_ceil(2);
-pub const SPARTAN_OUTER_UNISKIP_FIRST_ROUND_DEGREE: usize =
-    3 * SPARTAN_OUTER_UNISKIP_DOMAIN_SIZE - 3;
+#[cfg(feature = "field-inline")]
+pub const SPARTAN_PRODUCT_LANES: usize =
+    rv64::NUM_PRODUCT_CONSTRAINTS + field_constraints::NUM_PRODUCT_CONSTRAINTS;
+
+#[cfg(not(feature = "field-inline"))]
+pub const SPARTAN_PRODUCT_LANES: usize = rv64::NUM_PRODUCT_CONSTRAINTS;
+
+// The uni-skip geometry is owned by `jolt-claims` (it cannot depend on this
+// crate). These assertions pin the constraint tables built here to the row and
+// lane counts that geometry was derived from.
+const _: () = assert!(
+    SPARTAN_OUTER_ROW_COUNT == dimensions::SPARTAN_OUTER_ROW_COUNT,
+    "Spartan outer eq-constraint row count diverges from jolt-claims geometry"
+);
+const _: () = assert!(
+    SPARTAN_PRODUCT_LANES == dimensions::SPARTAN_PRODUCT_LANES,
+    "Spartan product lane count diverges from jolt-claims geometry"
+);
+
+pub use dimensions::{
+    OUTER_UNISKIP_DOMAIN_SIZE as SPARTAN_OUTER_UNISKIP_DOMAIN_SIZE,
+    OUTER_UNISKIP_FIRST_ROUND_DEGREE as SPARTAN_OUTER_UNISKIP_FIRST_ROUND_DEGREE,
+    PRODUCT_UNISKIP_DOMAIN_SIZE as SPARTAN_PRODUCT_UNISKIP_DOMAIN_SIZE,
+    PRODUCT_UNISKIP_FIRST_ROUND_DEGREE as SPARTAN_PRODUCT_UNISKIP_FIRST_ROUND_DEGREE,
+};
+
 pub const SPARTAN_OUTER_REMAINDER_DEGREE: usize = 3;
 pub const SPARTAN_OUTER_SECOND_GROUP_ROW_COUNT: usize =
     SPARTAN_OUTER_ROW_COUNT - SPARTAN_OUTER_UNISKIP_DOMAIN_SIZE;
-pub const SPARTAN_PRODUCT_BASE_LANES: usize = 3;
-
-#[cfg(feature = "field-inline")]
-pub const SPARTAN_PRODUCT_FIELD_INLINE_LANES: usize = field_constraints::NUM_PRODUCT_CONSTRAINTS;
-
-#[cfg(not(feature = "field-inline"))]
-pub const SPARTAN_PRODUCT_FIELD_INLINE_LANES: usize = 0;
-
-pub const SPARTAN_PRODUCT_UNISKIP_DOMAIN_SIZE: usize =
-    SPARTAN_PRODUCT_BASE_LANES + SPARTAN_PRODUCT_FIELD_INLINE_LANES;
-pub const SPARTAN_PRODUCT_UNISKIP_FIRST_ROUND_DEGREE: usize =
-    3 * (SPARTAN_PRODUCT_UNISKIP_DOMAIN_SIZE - 1);
 
 #[cfg(not(feature = "field-inline"))]
 pub const SPARTAN_OUTER_FIRST_GROUP_ROWS: [usize; SPARTAN_OUTER_UNISKIP_DOMAIN_SIZE] =
@@ -107,6 +121,127 @@ pub const SPARTAN_OUTER_SECOND_GROUP_ROWS: [usize; SPARTAN_OUTER_SECOND_GROUP_RO
     rv64::NUM_EQ_CONSTRAINTS + field_constraints::ROW_STORE_TO_X,
     rv64::NUM_EQ_CONSTRAINTS + field_constraints::ROW_LOAD_IMM,
 ];
+
+/// Bitmask of `rows`, panicking at compile time on a repeated row.
+#[expect(
+    clippy::indexing_slicing,
+    reason = "const evaluation: `index < rows.len()` is the loop bound, and a failure would be a compile error"
+)]
+const fn row_group_mask(rows: &[usize]) -> u64 {
+    let mut mask = 0u64;
+    let mut index = 0;
+    while index < rows.len() {
+        let bit = 1u64 << rows[index];
+        assert!(mask & bit == 0, "Spartan outer row group repeats a row");
+        mask |= bit;
+        index += 1;
+    }
+    mask
+}
+
+// The two row groups must partition `0..SPARTAN_OUTER_ROW_COUNT`: a dropped
+// row silently unweights its constraint and a duplicated one double-weights
+// it, and the prover shares `spartan_outer_row_weights`, so such proofs would
+// still verify.
+const _: () = {
+    assert!(SPARTAN_OUTER_ROW_COUNT <= u64::BITS as usize);
+    let first = row_group_mask(&SPARTAN_OUTER_FIRST_GROUP_ROWS);
+    let second = row_group_mask(&SPARTAN_OUTER_SECOND_GROUP_ROWS);
+    assert!(first & second == 0, "Spartan outer row groups overlap");
+    assert!(
+        first | second == (1u64 << SPARTAN_OUTER_ROW_COUNT) - 1,
+        "Spartan outer row groups do not cover every constraint row"
+    );
+};
+
+/// The RV64 witness column each Spartan outer R1CS input is opened as, by
+/// name. `None` for virtual polynomials that are not R1CS inputs.
+const fn rv64_input_column(input: JoltVirtualPolynomial) -> Option<usize> {
+    match input {
+        JoltVirtualPolynomial::LeftInstructionInput => Some(rv64::V_LEFT_INSTRUCTION_INPUT),
+        JoltVirtualPolynomial::RightInstructionInput => Some(rv64::V_RIGHT_INSTRUCTION_INPUT),
+        JoltVirtualPolynomial::Product => Some(rv64::V_PRODUCT),
+        JoltVirtualPolynomial::ShouldBranch => Some(rv64::V_SHOULD_BRANCH),
+        JoltVirtualPolynomial::PC => Some(rv64::V_PC),
+        JoltVirtualPolynomial::UnexpandedPC => Some(rv64::V_UNEXPANDED_PC),
+        JoltVirtualPolynomial::Imm => Some(rv64::V_IMM),
+        JoltVirtualPolynomial::RamAddress => Some(rv64::V_RAM_ADDRESS),
+        JoltVirtualPolynomial::Rs1Value => Some(rv64::V_RS1_VALUE),
+        JoltVirtualPolynomial::Rs2Value => Some(rv64::V_RS2_VALUE),
+        JoltVirtualPolynomial::RdWriteValue => Some(rv64::V_RD_WRITE_VALUE),
+        JoltVirtualPolynomial::RamReadValue => Some(rv64::V_RAM_READ_VALUE),
+        JoltVirtualPolynomial::RamWriteValue => Some(rv64::V_RAM_WRITE_VALUE),
+        JoltVirtualPolynomial::LeftLookupOperand => Some(rv64::V_LEFT_LOOKUP_OPERAND),
+        JoltVirtualPolynomial::RightLookupOperand => Some(rv64::V_RIGHT_LOOKUP_OPERAND),
+        JoltVirtualPolynomial::NextUnexpandedPC => Some(rv64::V_NEXT_UNEXPANDED_PC),
+        JoltVirtualPolynomial::NextPC => Some(rv64::V_NEXT_PC),
+        JoltVirtualPolynomial::NextIsVirtual => Some(rv64::V_NEXT_IS_VIRTUAL),
+        JoltVirtualPolynomial::NextIsFirstInSequence => Some(rv64::V_NEXT_IS_FIRST_IN_SEQUENCE),
+        JoltVirtualPolynomial::LookupOutput => Some(rv64::V_LOOKUP_OUTPUT),
+        JoltVirtualPolynomial::ShouldJump => Some(rv64::V_SHOULD_JUMP),
+        JoltVirtualPolynomial::OpFlags(flag) => Some(match flag {
+            CircuitFlags::AddOperands => rv64::V_FLAG_ADD_OPERANDS,
+            CircuitFlags::SubtractOperands => rv64::V_FLAG_SUBTRACT_OPERANDS,
+            CircuitFlags::MultiplyOperands => rv64::V_FLAG_MULTIPLY_OPERANDS,
+            CircuitFlags::Load => rv64::V_FLAG_LOAD,
+            CircuitFlags::Store => rv64::V_FLAG_STORE,
+            CircuitFlags::Jump => rv64::V_FLAG_JUMP,
+            CircuitFlags::WriteLookupOutputToRD => rv64::V_FLAG_WRITE_LOOKUP_OUTPUT_TO_RD,
+            CircuitFlags::VirtualInstruction => rv64::V_FLAG_VIRTUAL_INSTRUCTION,
+            CircuitFlags::Assert => rv64::V_FLAG_ASSERT,
+            CircuitFlags::DoNotUpdateUnexpandedPC => rv64::V_FLAG_DO_NOT_UPDATE_UNEXPANDED_PC,
+            CircuitFlags::Advice => rv64::V_FLAG_ADVICE,
+            CircuitFlags::IsCompressed => rv64::V_FLAG_IS_COMPRESSED,
+            CircuitFlags::IsFirstInSequence => rv64::V_FLAG_IS_FIRST_IN_SEQUENCE,
+            CircuitFlags::IsLastInSequence => rv64::V_FLAG_IS_LAST_IN_SEQUENCE,
+        }),
+        JoltVirtualPolynomial::NextIsNoop
+        | JoltVirtualPolynomial::Rd
+        | JoltVirtualPolynomial::Rs1Ra
+        | JoltVirtualPolynomial::Rs2Ra
+        | JoltVirtualPolynomial::RdWa
+        | JoltVirtualPolynomial::InstructionRaf
+        | JoltVirtualPolynomial::InstructionRafFlag
+        | JoltVirtualPolynomial::InstructionRa(_)
+        | JoltVirtualPolynomial::RegistersVal
+        | JoltVirtualPolynomial::RamRa
+        | JoltVirtualPolynomial::RamVal
+        | JoltVirtualPolynomial::RamValInit
+        | JoltVirtualPolynomial::RamValFinal
+        | JoltVirtualPolynomial::RamHammingWeight
+        | JoltVirtualPolynomial::UnivariateSkip
+        | JoltVirtualPolynomial::InstructionFlags(_)
+        | JoltVirtualPolynomial::LookupTableFlag(_)
+        | JoltVirtualPolynomial::BytecodeValClaim(_)
+        | JoltVirtualPolynomial::BytecodeReadRafAddrClaim
+        | JoltVirtualPolynomial::BooleanityAddrClaim
+        | JoltVirtualPolynomial::BytecodeClaimReductionIntermediate
+        | JoltVirtualPolynomial::ProgramImageInitContributionRw
+        | JoltVirtualPolynomial::FusedInc => None,
+    }
+}
+
+// `SPARTAN_OUTER_R1CS_INPUTS` (the opening order) and the `rv64::V_*` columns
+// (the constraint tables) are otherwise tied only by position: a reorder of
+// either relabels the constraint system identically for prover and verifier.
+#[expect(
+    clippy::indexing_slicing,
+    reason = "const evaluation: `index < NUM_R1CS_INPUTS` is the loop bound, and a failure would be a compile error"
+)]
+const _: () = {
+    assert!(SPARTAN_OUTER_R1CS_INPUTS.len() == rv64::NUM_R1CS_INPUTS);
+    let mut index = 0;
+    while index < rv64::NUM_R1CS_INPUTS {
+        match rv64_input_column(SPARTAN_OUTER_R1CS_INPUTS[index]) {
+            Some(column) => assert!(
+                column == rv64::V_LEFT_INSTRUCTION_INPUT + index,
+                "SPARTAN_OUTER_R1CS_INPUTS order disagrees with the rv64 column layout"
+            ),
+            None => panic!("SPARTAN_OUTER_R1CS_INPUTS names a polynomial without an rv64 column"),
+        }
+        index += 1;
+    }
+};
 
 pub fn spartan_outer_constraints<F: JoltField>() -> ConstraintMatrices<F> {
     let constraints = rv64::rv64_spartan_outer_constraints();

--- a/crates/jolt-r1cs/src/constraints/rv64.rs
+++ b/crates/jolt-r1cs/src/constraints/rv64.rs
@@ -68,6 +68,13 @@ pub const NUM_EQ_CONSTRAINTS: usize = 19;
 pub const NUM_PRODUCT_CONSTRAINTS: usize = 3;
 pub const NUM_CONSTRAINTS_PER_CYCLE: usize = NUM_EQ_CONSTRAINTS + NUM_PRODUCT_CONSTRAINTS; // 22
 
+// The uni-skip geometry in `jolt-claims` is derived from these counts.
+const _: () = assert!(
+    NUM_EQ_CONSTRAINTS == RV64_SPARTAN_OUTER_ROW_COUNT
+        && NUM_PRODUCT_CONSTRAINTS == RV64_SPARTAN_PRODUCT_LANES,
+    "RV64 constraint table diverges from the jolt-claims Spartan geometry"
+);
+
 pub const fn const_column() -> usize {
     V_CONST
 }
@@ -84,6 +91,9 @@ pub const fn input_column(input_index: usize) -> Option<usize> {
 const TWOS_COMPLEMENT_BIAS: i128 = 0x1_0000_0000_0000_0000;
 
 use crate::constraint::SparseRow;
+use jolt_claims::protocols::jolt::geometry::dimensions::{
+    RV64_SPARTAN_OUTER_ROW_COUNT, RV64_SPARTAN_PRODUCT_LANES,
+};
 use jolt_field::Field;
 
 type ConstraintRows<F> = (Vec<SparseRow<F>>, Vec<SparseRow<F>>, Vec<SparseRow<F>>);

--- a/crates/jolt-verifier/src/config.rs
+++ b/crates/jolt-verifier/src/config.rs
@@ -6,6 +6,9 @@
 //! proof self-describes these choices and [`validate_proof_config`] rejects a
 //! mismatch fail-closed.
 
+use common::constants::{ONEHOT_CHUNK_THRESHOLD_LOG_T, XLEN};
+use jolt_claims::protocols::jolt::geometry::dimensions::REGISTER_ADDRESS_BITS;
+use jolt_claims::protocols::jolt::{JoltOneHotConfig, JoltReadWriteConfig};
 use serde::{Deserialize, Serialize};
 
 use crate::VerifierError;
@@ -101,6 +104,67 @@ pub fn validate_proof_config(
     }
 
     Ok(())
+}
+
+/// Smallest accepted padded trace length: one cycle variable, so every
+/// cycle-indexed sumcheck has at least one round. The prover pads far higher
+/// (its PCS floor); this is the verifier-side floor.
+pub const MIN_TRACE_LENGTH: usize = 2;
+
+/// The full instruction lookup key width: two `XLEN`-bit operands.
+const LOOKUP_ADDRESS_BITS: usize = 2 * XLEN;
+
+/// The one-hot chunking regime below the trace-length threshold: 4-bit
+/// committed chunks and `LOOKUP_ADDRESS_BITS / 8`-bit virtual-RA chunks.
+pub const NARROW_ONE_HOT_CONFIG: JoltOneHotConfig = JoltOneHotConfig {
+    log_k_chunk: 4,
+    lookups_ra_virtual_log_k_chunk: 16,
+};
+
+/// The one-hot chunking regime at or above the threshold: 8-bit committed
+/// chunks and `LOOKUP_ADDRESS_BITS / 4`-bit virtual-RA chunks.
+pub const WIDE_ONE_HOT_CONFIG: JoltOneHotConfig = JoltOneHotConfig {
+    log_k_chunk: 8,
+    lookups_ra_virtual_log_k_chunk: 32,
+};
+
+const _: () = assert!(
+    NARROW_ONE_HOT_CONFIG.lookup_virtual_chunk_bits() * 8 == LOOKUP_ADDRESS_BITS
+        && WIDE_ONE_HOT_CONFIG.lookup_virtual_chunk_bits() * 4 == LOOKUP_ADDRESS_BITS
+);
+
+/// The one-hot chunking policy: [`NARROW_ONE_HOT_CONFIG`] below
+/// [`ONEHOT_CHUNK_THRESHOLD_LOG_T`], [`WIDE_ONE_HOT_CONFIG`] at or above it.
+/// The prover derives its wire config from this; the verifier admits either
+/// regime at any trace length ([`is_admissible_one_hot_config`]), since the
+/// wide regime is also exercised below the threshold (the legacy parity
+/// fixtures force it, and the packed setup pins `K` independently).
+pub const fn one_hot_config_policy(log_t: usize) -> JoltOneHotConfig {
+    if log_t < ONEHOT_CHUNK_THRESHOLD_LOG_T {
+        NARROW_ONE_HOT_CONFIG
+    } else {
+        WIDE_ONE_HOT_CONFIG
+    }
+}
+
+/// Whether a proof-carried one-hot config is one of the two policy regimes.
+pub fn is_admissible_one_hot_config(config: JoltOneHotConfig) -> bool {
+    config == NARROW_ONE_HOT_CONFIG || config == WIDE_ONE_HOT_CONFIG
+}
+
+/// The read-write checking phase-split policy: every cycle variable in phase
+/// 1 and every address variable in phase 2, for RAM (`ram_log_k` address bits)
+/// and registers ([`REGISTER_ADDRESS_BITS`]). The prover derives its wire
+/// config from this and the verifier requires an exact match. `None` when a
+/// round count does not fit the wire's `u8`.
+pub fn read_write_config_policy(log_t: usize, ram_log_k: usize) -> Option<JoltReadWriteConfig> {
+    let log_t = u8::try_from(log_t).ok()?;
+    Some(JoltReadWriteConfig {
+        ram_rw_phase1_num_rounds: log_t,
+        ram_rw_phase2_num_rounds: u8::try_from(ram_log_k).ok()?,
+        registers_rw_phase1_num_rounds: log_t,
+        registers_rw_phase2_num_rounds: u8::try_from(REGISTER_ADDRESS_BITS).ok()?,
+    })
 }
 
 #[cfg(test)]

--- a/crates/jolt-verifier/src/error.rs
+++ b/crates/jolt-verifier/src/error.rs
@@ -1,7 +1,8 @@
 //! Verifier error types.
 
 use jolt_claims::protocols::jolt::{
-    JoltChallengeId, JoltCommittedPolynomial, JoltDerivedId, JoltOpeningId, JoltRelationId,
+    JoltChallengeId, JoltCommittedPolynomial, JoltDerivedId, JoltOneHotConfig, JoltOpeningId,
+    JoltReadWriteConfig, JoltRelationId,
 };
 
 use crate::config::JoltProtocolConfig;
@@ -50,11 +51,20 @@ pub enum VerifierError {
     #[error("public output length {got} exceeds configured maximum {max}")]
     OutputTooLarge { got: usize, max: usize },
 
-    #[error("invalid trace length {got}; expected a power of two no larger than {max}")]
-    InvalidTraceLength { got: usize, max: usize },
+    #[error("invalid trace length {got}; expected a power of two in [{min}, {max}]")]
+    InvalidTraceLength { got: usize, min: usize, max: usize },
 
     #[error("invalid RAM domain size {got}; expected a power of two in [{min}, {max}]")]
     InvalidRamK { got: usize, min: usize, max: usize },
+
+    #[error("read-write config {got:?} does not match the phase-split policy {expected:?}")]
+    InvalidReadWriteConfig {
+        expected: JoltReadWriteConfig,
+        got: JoltReadWriteConfig,
+    },
+
+    #[error("one-hot config {got:?} is not an admissible chunking regime")]
+    InvalidOneHotConfig { got: JoltOneHotConfig },
 
     #[error("invalid verifier memory layout: {reason}")]
     InvalidMemoryLayout { reason: String },

--- a/crates/jolt-verifier/src/stages/stage2/verify.rs
+++ b/crates/jolt-verifier/src/stages/stage2/verify.rs
@@ -100,6 +100,15 @@ where
     let log_k = crate::num::ilog2(checked.ram_K);
     let trace_dimensions = TraceDimensions::new(log_t);
     let read_write_dimensions = proof.rw_config.ram_dimensions(log_t, log_k);
+    // Eager: `output_check_rounds` and the RAF dimensions subtract the
+    // proof-supplied phase-1 round count before any lazy point-derivation
+    // check would catch an oversized split.
+    read_write_dimensions
+        .validate_phase_split()
+        .map_err(|error| VerifierError::StageClaimPublicInputFailed {
+            stage: JoltRelationId::RamReadWriteChecking,
+            reason: error.to_string(),
+        })?;
     let product_dimensions = SpartanProductDimensions::new(log_t);
     let raf_dimensions =
         RamRafEvaluationDimensions::try_from(read_write_dimensions).map_err(|error| {

--- a/crates/jolt-verifier/src/verifier.rs
+++ b/crates/jolt-verifier/src/verifier.rs
@@ -19,7 +19,10 @@ use jolt_transcript::{AppendToTranscript, Label, LabelWithCount, Transcript, U64
 #[cfg(not(feature = "akita"))]
 use crate::proof::JoltCommitments;
 use crate::{
-    config::{validate_proof_config, JoltProtocolConfig, ZkConfig, JOLT_VERIFIER_CONFIG},
+    config::{
+        is_admissible_one_hot_config, read_write_config_policy, validate_proof_config,
+        JoltProtocolConfig, ZkConfig, JOLT_VERIFIER_CONFIG, MIN_TRACE_LENGTH,
+    },
     num,
     preprocessing::JoltVerifierPreprocessing,
     proof::{JoltProof, TracePolynomialOrder},
@@ -341,6 +344,7 @@ where
     let trace_length = proof.trace_length;
     let ram_k = proof.ram_K;
     let trace_polynomial_order = proof.trace_polynomial_order;
+    let rw_config = proof.rw_config;
     let one_hot_config = proof.one_hot_config;
     #[cfg(not(feature = "akita"))]
     let untrusted_advice_commitment_present = proof.untrusted_advice_commitment.is_some();
@@ -376,32 +380,15 @@ where
         });
     }
 
-    if !trace_length.is_power_of_two() || trace_length > program.max_padded_trace_length() {
-        return Err(VerifierError::InvalidTraceLength {
-            got: trace_length,
-            max: program.max_padded_trace_length(),
-        });
-    }
-
-    let min_ram_k = compute_min_ram_k(
-        program.min_bytecode_address(),
-        program.program_image_len_words(),
-        memory_layout,
-    )
-    .map_err(|error| VerifierError::InvalidMemoryLayout {
-        reason: error.to_string(),
-    })?;
-    let max_ram_k =
-        compute_max_ram_k(memory_layout).map_err(|error| VerifierError::InvalidMemoryLayout {
-            reason: error.to_string(),
-        })?;
-    if !ram_k.is_power_of_two() || ram_k < min_ram_k || ram_k > max_ram_k {
-        return Err(VerifierError::InvalidRamK {
-            got: ram_k,
-            min: min_ram_k,
-            max: max_ram_k,
-        });
-    }
+    validate_proof_shape(
+        program,
+        ProofShape {
+            trace_length,
+            ram_k,
+            rw_config,
+            one_hot_config,
+        },
+    )?;
 
     let mut normalized_public_io = public_io.clone();
     normalized_public_io.outputs.truncate(
@@ -483,6 +470,81 @@ where
         vc_capacity,
         precommitted,
     })
+}
+
+/// The prover-chosen geometry a proof carries on the wire.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct ProofShape {
+    trace_length: usize,
+    ram_k: usize,
+    rw_config: JoltReadWriteConfig,
+    one_hot_config: JoltOneHotConfig,
+}
+
+/// Rejects a wire geometry outside the preprocessing's bounds or off the
+/// prover's derivation policy. Every in-bounds geometry proves the same
+/// statement (stage 8 pins commitment counts and claim lengths to the derived
+/// layout), so this closes prover degrees of freedom in the Fiat-Shamir
+/// statement rather than a soundness gap.
+fn validate_proof_shape<PCS: CommitmentScheme>(
+    program: &crate::preprocessing::ProgramPreprocessing<PCS>,
+    shape: ProofShape,
+) -> Result<(), VerifierError> {
+    let memory_layout = program.memory_layout();
+    let max_trace_length = program.max_padded_trace_length();
+    if !shape.trace_length.is_power_of_two()
+        || shape.trace_length < MIN_TRACE_LENGTH
+        || shape.trace_length > max_trace_length
+    {
+        return Err(VerifierError::InvalidTraceLength {
+            got: shape.trace_length,
+            min: MIN_TRACE_LENGTH,
+            max: max_trace_length,
+        });
+    }
+
+    let min_ram_k = compute_min_ram_k(
+        program.min_bytecode_address(),
+        program.program_image_len_words(),
+        memory_layout,
+    )
+    .map_err(|error| VerifierError::InvalidMemoryLayout {
+        reason: error.to_string(),
+    })?;
+    let max_ram_k =
+        compute_max_ram_k(memory_layout).map_err(|error| VerifierError::InvalidMemoryLayout {
+            reason: error.to_string(),
+        })?;
+    if !shape.ram_k.is_power_of_two() || shape.ram_k < min_ram_k || shape.ram_k > max_ram_k {
+        return Err(VerifierError::InvalidRamK {
+            got: shape.ram_k,
+            min: min_ram_k,
+            max: max_ram_k,
+        });
+    }
+
+    // `ilog2` of a `usize` is below 64, so the policy's round counts always
+    // fit the wire's `u8`; the fallback keeps this path panic-free.
+    let expected_rw_config =
+        read_write_config_policy(num::ilog2(shape.trace_length), num::ilog2(shape.ram_k)).ok_or(
+            VerifierError::InvalidTraceLength {
+                got: shape.trace_length,
+                min: MIN_TRACE_LENGTH,
+                max: max_trace_length,
+            },
+        )?;
+    if shape.rw_config != expected_rw_config {
+        return Err(VerifierError::InvalidReadWriteConfig {
+            expected: expected_rw_config,
+            got: shape.rw_config,
+        });
+    }
+    if !is_admissible_one_hot_config(shape.one_hot_config) {
+        return Err(VerifierError::InvalidOneHotConfig {
+            got: shape.one_hot_config,
+        });
+    }
+    Ok(())
 }
 
 #[cfg(not(feature = "akita"))]
@@ -948,6 +1010,7 @@ pub fn validate_inputs_from_parts<PCS, VC>(
     trace_length: usize,
     ram_k: usize,
     trace_polynomial_order: TracePolynomialOrder,
+    rw_config: JoltReadWriteConfig,
     one_hot_config: JoltOneHotConfig,
     trusted_advice_commitment_present: bool,
     #[cfg(not(feature = "akita"))] untrusted_advice_commitment_present: bool,
@@ -979,34 +1042,15 @@ where
         });
     }
 
-    if !trace_length.is_power_of_two()
-        || trace_length > preprocessing.program.max_padded_trace_length()
-    {
-        return Err(VerifierError::InvalidTraceLength {
-            got: trace_length,
-            max: preprocessing.program.max_padded_trace_length(),
-        });
-    }
-
-    let min_ram_k = compute_min_ram_k(
-        preprocessing.program.min_bytecode_address(),
-        preprocessing.program.program_image_len_words(),
-        memory_layout,
-    )
-    .map_err(|error| VerifierError::InvalidMemoryLayout {
-        reason: error.to_string(),
-    })?;
-    let max_ram_k =
-        compute_max_ram_k(memory_layout).map_err(|error| VerifierError::InvalidMemoryLayout {
-            reason: error.to_string(),
-        })?;
-    if !ram_k.is_power_of_two() || ram_k < min_ram_k || ram_k > max_ram_k {
-        return Err(VerifierError::InvalidRamK {
-            got: ram_k,
-            min: min_ram_k,
-            max: max_ram_k,
-        });
-    }
+    validate_proof_shape(
+        &preprocessing.program,
+        ProofShape {
+            trace_length,
+            ram_k,
+            rw_config,
+            one_hot_config,
+        },
+    )?;
 
     let vc_capacity = if zk {
         Some(validate_zk_vector_commitment_setup::<PCS, VC>(
@@ -1156,7 +1200,7 @@ mod tests {
     use super::*;
     use crate::proof::{ClearProofClaims, JoltProofClaims, JoltStageProofs};
     use common::jolt_device::{JoltDevice, MemoryConfig};
-    use jolt_claims::protocols::jolt::{JoltOneHotConfig, JoltReadWriteConfig};
+    use jolt_claims::protocols::jolt::JoltReadWriteConfig;
     #[cfg(feature = "zk")]
     use jolt_crypto::PedersenSetup;
     use jolt_crypto::{Bn254G1, Commitment, Pedersen, VectorCommitmentOpening};
@@ -1349,6 +1393,57 @@ mod tests {
     }
 
     #[test]
+    fn validate_inputs_rejects_single_cycle_trace() {
+        let preprocessing = test_preprocessing();
+        let public_io = JoltDevice {
+            memory_layout: preprocessing.program.memory_layout().clone(),
+            ..JoltDevice::default()
+        };
+        let mut proof = proof_with_zk(false, clear_claims());
+        proof.trace_length = 1;
+
+        assert!(matches!(
+            validate_inputs(&preprocessing, &public_io, &proof, false),
+            Err(VerifierError::InvalidTraceLength { got: 1, min: 2, .. })
+        ));
+    }
+
+    #[test]
+    fn validate_inputs_rejects_off_policy_read_write_config() {
+        let preprocessing = test_preprocessing();
+        let public_io = JoltDevice {
+            memory_layout: preprocessing.program.memory_layout().clone(),
+            ..JoltDevice::default()
+        };
+        let mut proof = proof_with_zk(false, clear_claims());
+        // Still a valid phase split (phase1 <= log_t), just not the policy's.
+        proof.rw_config.ram_rw_phase1_num_rounds = 0;
+
+        assert!(matches!(
+            validate_inputs(&preprocessing, &public_io, &proof, false),
+            Err(VerifierError::InvalidReadWriteConfig { .. })
+        ));
+    }
+
+    #[test]
+    fn validate_inputs_rejects_inadmissible_one_hot_config() {
+        let preprocessing = test_preprocessing();
+        let public_io = JoltDevice {
+            memory_layout: preprocessing.program.memory_layout().clone(),
+            ..JoltDevice::default()
+        };
+        let mut proof = proof_with_zk(false, clear_claims());
+        // Passes every structural chunking check (nonzero, 2 | 16) but is not a
+        // policy regime.
+        proof.one_hot_config.log_k_chunk = 2;
+
+        assert!(matches!(
+            validate_inputs(&preprocessing, &public_io, &proof, false),
+            Err(VerifierError::InvalidOneHotConfig { .. })
+        ));
+    }
+
+    #[test]
     fn validate_inputs_rejects_zero_based_ram_remap() {
         let mut memory_layout = test_memory_layout();
         // A layout whose remap is zero-based: `unmap(0) = lowest_address = 0`
@@ -1456,18 +1551,15 @@ mod tests {
             joint_opening_proof: (),
             untrusted_advice_commitment: None,
             claims,
-            trace_length: 1,
+            trace_length: 2,
             ram_K: 4,
             rw_config: JoltReadWriteConfig {
-                ram_rw_phase1_num_rounds: 0,
-                ram_rw_phase2_num_rounds: 0,
-                registers_rw_phase1_num_rounds: 0,
-                registers_rw_phase2_num_rounds: 0,
+                ram_rw_phase1_num_rounds: 1,
+                ram_rw_phase2_num_rounds: 2,
+                registers_rw_phase1_num_rounds: 1,
+                registers_rw_phase2_num_rounds: 7,
             },
-            one_hot_config: JoltOneHotConfig {
-                log_k_chunk: 0,
-                lookups_ra_virtual_log_k_chunk: 0,
-            },
+            one_hot_config: crate::config::NARROW_ONE_HOT_CONFIG,
             trace_polynomial_order: crate::proof::TracePolynomialOrder::CycleMajor,
         }
     }

--- a/crates/jolt-verifier/src/verifier.rs
+++ b/crates/jolt-verifier/src/verifier.rs
@@ -24,7 +24,7 @@ use crate::{
         JoltProtocolConfig, ZkConfig, JOLT_VERIFIER_CONFIG, MIN_TRACE_LENGTH,
     },
     num,
-    preprocessing::JoltVerifierPreprocessing,
+    preprocessing::{JoltVerifierPreprocessing, ProgramPreprocessing},
     proof::{JoltProof, TracePolynomialOrder},
     stages::{
         stage1, stage2, stage3, stage4, stage5, stage6a, stage6b, stage7, stage8,
@@ -487,7 +487,7 @@ struct ProofShape {
 /// layout), so this closes prover degrees of freedom in the Fiat-Shamir
 /// statement rather than a soundness gap.
 fn validate_proof_shape<PCS: CommitmentScheme>(
-    program: &crate::preprocessing::ProgramPreprocessing<PCS>,
+    program: &ProgramPreprocessing<PCS>,
     shape: ProofShape,
 ) -> Result<(), VerifierError> {
     let memory_layout = program.memory_layout();
@@ -1198,6 +1198,7 @@ mod tests {
     use std::sync::Arc;
 
     use super::*;
+    use crate::config::NARROW_ONE_HOT_CONFIG;
     use crate::proof::{ClearProofClaims, JoltProofClaims, JoltStageProofs};
     use common::jolt_device::{JoltDevice, MemoryConfig};
     use jolt_claims::protocols::jolt::JoltReadWriteConfig;
@@ -1215,8 +1216,6 @@ mod tests {
     };
     use jolt_transcript::Transcript;
     use num_traits::Zero;
-
-    use crate::preprocessing::ProgramPreprocessing;
 
     #[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
     struct TestPcs;
@@ -1559,7 +1558,7 @@ mod tests {
                 registers_rw_phase1_num_rounds: 1,
                 registers_rw_phase2_num_rounds: 7,
             },
-            one_hot_config: crate::config::NARROW_ONE_HOT_CONFIG,
+            one_hot_config: NARROW_ONE_HOT_CONFIG,
             trace_polynomial_order: crate::proof::TracePolynomialOrder::CycleMajor,
         }
     }

--- a/crates/jolt-verifier/tests/soundness/tampering/preamble.rs
+++ b/crates/jolt-verifier/tests/soundness/tampering/preamble.rs
@@ -42,6 +42,34 @@ fn excessive_trace_length_rejects_now() {
 
 #[cfg(all(feature = "prover-fixtures", not(feature = "zk")))]
 #[test]
+fn off_policy_read_write_config_rejects_now() {
+    let base = standard_muldiv_case();
+    tamper_manifest::assert_verifier_fixture_tamper_rejects(
+        tamper_manifest::required_target("proof.rw_config"),
+        &base,
+        |case| {
+            // Still a valid phase split, so only the policy check rejects it.
+            case.proof.rw_config.ram_rw_phase1_num_rounds -= 1;
+        },
+    );
+}
+
+#[cfg(all(feature = "prover-fixtures", not(feature = "zk")))]
+#[test]
+fn inadmissible_one_hot_config_rejects_now() {
+    let base = standard_muldiv_case();
+    tamper_manifest::assert_verifier_fixture_tamper_rejects(
+        tamper_manifest::required_target("proof.one_hot_config"),
+        &base,
+        |case| {
+            // Divides the 16-bit virtual chunk, so only the regime check rejects it.
+            case.proof.one_hot_config.log_k_chunk = 2;
+        },
+    );
+}
+
+#[cfg(all(feature = "prover-fixtures", not(feature = "zk")))]
+#[test]
 fn invalid_ram_domain_rejects_now() {
     let base = standard_muldiv_case();
     tamper_manifest::assert_verifier_fixture_tamper_rejects(

--- a/crates/jolt-verifier/tests/support/tamper_manifest.rs
+++ b/crates/jolt-verifier/tests/support/tamper_manifest.rs
@@ -240,18 +240,18 @@ pub const PREAMBLE_TARGETS: &[TamperTarget] = &[
     checked_standard(
         "proof.rw_config",
         "proof.rw_config",
-        VerifierPhase::Stage2,
+        VerifierPhase::Preamble,
         MutationStrategy::OffsetScalar,
         TamperCoverage::Active,
-        "stage 2 consumes RAM read-write phase lengths when slicing batched points",
+        "input validation requires the read-write phase split to match the verifier's policy",
     ),
-    later_standard(
+    checked_standard(
         "proof.one_hot_config",
         "proof.one_hot_config",
-        VerifierPhase::Stage6,
+        VerifierPhase::Preamble,
         MutationStrategy::OffsetScalar,
-        TamperCoverage::Deferred,
-        "one-hot configuration is transcript-bound now but substantively checked by later RA virtualization stages",
+        TamperCoverage::Active,
+        "input validation requires the one-hot config to be an admissible chunking regime",
     ),
     checked_standard(
         "proof.trace_polynomial_order",

--- a/specs/byte-addressable-memory.md
+++ b/specs/byte-addressable-memory.md
@@ -416,10 +416,12 @@ Verified shape of the blast radius:
 - **Three hand-duplicated constraint catalogs move in lockstep**: legacy
   (`zkvm/r1cs/{inputs,constraints}.rs` plus the *positionally index-addressed* evaluators in
   `r1cs/evaluation.rs` with hand-picked accumulator widths), `crates/jolt-claims`
-  (`geometry/spartan.rs` — `SPARTAN_OUTER_RV64_ROW_COUNT`, `FIRST_GROUP_ROWS`, and the bare
-  `OUTER_UNISKIP_DOMAIN_SIZE = 10` literal), and `crates/jolt-r1cs` (`constraints/rv64.rs`
-  `V_*` column indices + all rows re-implemented by integer index). Only tests, not types,
-  enforce agreement.
+  (`geometry/spartan.rs` — `SPARTAN_OUTER_R1CS_INPUTS`; `geometry/dimensions.rs` — the row
+  and lane counts the uni-skip geometry derives from), and `crates/jolt-r1cs`
+  (`constraints/rv64.rs` `V_*` column indices + all rows re-implemented by integer index).
+  `crates/jolt-r1cs/src/constraints/jolt.rs` statically asserts its table sizes against the
+  jolt-claims counts, the row-group partition, and the `SPARTAN_OUTER_R1CS_INPUTS` ↔ `V_*`
+  binding; the legacy catalog is still only test-checked.
 - **BlindFold is mostly generic** (the outer output-claim constraint scans constraint groups at
   runtime); the hand-enumerated exceptions are `spartan/product.rs` factor openings,
   `spartan/shift.rs` shifted-poly vectors, and `spartan/instruction_input.rs`'s output


### PR DESCRIPTION
Addresses findings G3, G4, G5, and G6 (bullets 1, 2, 4) from the Jolt verifier soundness review. None of these is an exploitable soundness break; each closes a gap that was held shut by an invariant elsewhere.

## Changes

**G3 — dominant precommitted anchor containment** (`jolt-claims` `committed_openings.rs`)
- `final_opening_point` assembles the native point first. When a precommitted anchor spans more variables than the trace domain, every native challenge (stage-7 address block, stage-6b cycle block) must appear in it, since `commitment_embedding_scale` embeds by challenge value. New error: `DominantAnchorMissingNativeChallenge`.
- The address-major branch now runs the same hamming-weight cycle-suffix prefix check the cycle-major branch had (`CycleMajorCyclePrefixMismatch` → `CyclePrefixMismatch`).

**G4 — Dory `(nu, sigma)` pinned** (`jolt-dory` `scheme.rs`)
- `verify` and `verify_zk` reject a proof whose split is not `sigma = ceil(n/2)`. Commit, open, and verify share one `balanced_split` owner.

**G5 — geometry validated against policy** (`jolt-verifier` `config.rs`, `verifier.rs`, stage 2; `jolt-prover` `config.rs`)
- The read-write phase-split and one-hot chunking policies move into `jolt_verifier::config`; the prover derives its wire config from the same functions.
- `validate_inputs` and `validate_inputs_from_parts` (which gains an `rw_config` parameter) share a `validate_proof_shape` helper: `rw_config` must match the policy exactly, `one_hot_config` must be one of the two regimes `{4,16}` / `{8,32}`, and `trace_length ≥ 2`.
- Stage 2 calls `validate_phase_split` eagerly before the RAF dimensions constructor subtracts the phase-1 round count.
- The `preprocessing_digest` recompute item is intentionally not included.

**G6 — R1CS composition invariants asserted** (`jolt-claims` `dimensions.rs`, `jolt-r1cs` `jolt.rs`)
- `jolt-claims` owns the uni-skip geometry, derived from row/lane counts that are correct under `field-inline` (previously hard-coded to 10/27 and diverging from `jolt-r1cs`'s 14/39). `jolt-r1cs` re-exports the constants and statically asserts its constraint-table sizes match.
- Compile-time assert that `SPARTAN_OUTER_{FIRST,SECOND}_GROUP_ROWS` partition `0..SPARTAN_OUTER_ROW_COUNT`.
- Compile-time assert binding `SPARTAN_OUTER_R1CS_INPUTS` order to the `rv64::V_*` columns by name (`rv64_input_column`).

## Design note

The one-hot check is regime membership rather than an exact match to the `log_T < 25` threshold: the legacy parity fixtures (`dory_byte_diff` wide-geometry arm) and the Akita e2e deliberately force the wide regime below the threshold. The read-write config check is exact.

## Validation

| Check | Result |
|---|---|
| `cargo clippy --all --features host` and `host,zk`, all targets | clean |
| Unit tests: jolt-claims, jolt-r1cs, jolt-dory, jolt-verifier, jolt-prover | 390 passed |
| `jolt-prover --features prover-fixtures` (incl. address-major and committed-advice anchor arms) | 21 passed |
| `jolt-verifier --features prover-fixtures` (incl. new `rw_config` / `one_hot_config` tamper tests) | 128 passed |
| `jolt-prover --features prover-fixtures,zk` e2e (run serially) | 6 passed |
| `zk_muldiv_blindfold_shape_audit_matches_modular_protocol` | fails 227 vs 221 here and identically on unmodified `origin/main` (pre-existing, noted in the review) |

New tests: `unbalanced_matrix_split_rejected` / `zk_unbalanced_matrix_split_rejected` (jolt-dory); `final_opening_point_rejects_hamming_cycle_suffix_mismatch_in_both_orders`, `final_opening_point_rejects_dominant_anchor_missing_native_challenge` (jolt-claims); `validate_inputs_rejects_{single_cycle_trace,off_policy_read_write_config,inadmissible_one_hot_config}` and the `off_policy_read_write_config_rejects_now` / `inadmissible_one_hot_config_rejects_now` fixture tamper tests (jolt-verifier).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
