### PR TITLE
fix(riscv): enforce absolute LD/SD alignment

### DIFF
--- a/crates/jolt-lookup-tables/src/instructions/riscv/ld.rs
+++ b/crates/jolt-lookup-tables/src/instructions/riscv/ld.rs
@@ -3,14 +3,38 @@ use crate::traits::LookupQuery;
 use jolt_riscv::instructions::Ld;
 use jolt_riscv::JoltCycle;
 
-impl_lookup_table!(Ld, None);
+impl_lookup_table!(Ld, Some(DoublewordAlignment));
 
 impl<const XLEN: usize, C: JoltCycle> LookupQuery<XLEN> for Ld<C> {
     fn to_instruction_inputs(&self) -> (u64, i128) {
-        (0, 0)
+        super::doubleword_memory_instruction_inputs::<XLEN, _>(&self.0)
+    }
+
+    fn to_lookup_operands(&self) -> (u64, u128) {
+        super::doubleword_memory_lookup_operands::<XLEN, _>(&self.0)
+    }
+
+    fn to_lookup_index(&self) -> u128 {
+        LookupQuery::<XLEN>::to_lookup_operands(self).1
     }
 
     fn to_lookup_output(&self) -> u64 {
-        0
+        super::doubleword_memory_lookup_output::<XLEN, _>(&self.0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{instruction_inputs_match_constraint_test, materialize_entry_test};
+
+    #[test]
+    fn materialize_entry_ld() {
+        materialize_entry_test!(Ld, tracer::instruction::ld::LD);
+    }
+
+    #[test]
+    fn instruction_inputs_match_constraint_ld() {
+        instruction_inputs_match_constraint_test!(Ld, tracer::instruction::ld::LD);
     }
 }

--- a/crates/jolt-lookup-tables/src/instructions/riscv/mod.rs
+++ b/crates/jolt-lookup-tables/src/instructions/riscv/mod.rs
@@ -4,6 +4,29 @@
 //! (W-suffix, multi-byte loads/stores, plain shifts, MULH/MULHSU, DIV/REM, NOOP)
 //! live in tracer as virtual sequences and never reach this layer.
 
+use jolt_riscv::{JoltCycle, JoltInstructionRow};
+
+fn doubleword_memory_instruction_inputs<const XLEN: usize, C: JoltCycle>(cycle: &C) -> (u64, i128) {
+    let mask = (1u128 << XLEN).wrapping_sub(1) as u64;
+    let instruction: JoltInstructionRow = cycle.instruction().into();
+    (
+        cycle.rs1_val().unwrap_or(0) & mask,
+        instruction.operands.imm,
+    )
+}
+
+fn doubleword_memory_lookup_operands<const XLEN: usize, C: JoltCycle>(cycle: &C) -> (u64, u128) {
+    let (address, offset) = doubleword_memory_instruction_inputs::<XLEN, _>(cycle);
+    (0, address.wrapping_add(offset as u64).into())
+}
+
+fn doubleword_memory_lookup_output<const XLEN: usize, C: JoltCycle>(cycle: &C) -> u64 {
+    doubleword_memory_lookup_operands::<XLEN, _>(cycle)
+        .1
+        .is_multiple_of(8)
+        .into()
+}
+
 pub mod add;
 pub mod addi;
 pub mod addiw;

--- a/crates/jolt-lookup-tables/src/instructions/riscv/sd.rs
+++ b/crates/jolt-lookup-tables/src/instructions/riscv/sd.rs
@@ -3,14 +3,38 @@ use crate::traits::LookupQuery;
 use jolt_riscv::instructions::Sd;
 use jolt_riscv::JoltCycle;
 
-impl_lookup_table!(Sd, None);
+impl_lookup_table!(Sd, Some(DoublewordAlignment));
 
 impl<const XLEN: usize, C: JoltCycle> LookupQuery<XLEN> for Sd<C> {
     fn to_instruction_inputs(&self) -> (u64, i128) {
-        (0, 0)
+        super::doubleword_memory_instruction_inputs::<XLEN, _>(&self.0)
+    }
+
+    fn to_lookup_operands(&self) -> (u64, u128) {
+        super::doubleword_memory_lookup_operands::<XLEN, _>(&self.0)
+    }
+
+    fn to_lookup_index(&self) -> u128 {
+        LookupQuery::<XLEN>::to_lookup_operands(self).1
     }
 
     fn to_lookup_output(&self) -> u64 {
-        0
+        super::doubleword_memory_lookup_output::<XLEN, _>(&self.0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{instruction_inputs_match_constraint_test, materialize_entry_test};
+
+    #[test]
+    fn materialize_entry_sd() {
+        materialize_entry_test!(Sd, tracer::instruction::sd::SD);
+    }
+
+    #[test]
+    fn instruction_inputs_match_constraint_sd() {
+        instruction_inputs_match_constraint_test!(Sd, tracer::instruction::sd::SD);
     }
 }

--- a/crates/jolt-lookup-tables/src/tables/doubleword_alignment.rs
+++ b/crates/jolt-lookup-tables/src/tables/doubleword_alignment.rs
@@ -1,0 +1,72 @@
+use jolt_field::JoltField;
+use serde::{Deserialize, Serialize};
+
+use crate::challenge_ops::{ChallengeOps, FieldOps};
+use crate::tables::prefixes::{PrefixEval, Prefixes};
+use crate::tables::suffixes::{SuffixEval, Suffixes};
+use crate::tables::PrefixSuffixDecomposition;
+use crate::traits::LookupTable;
+
+#[derive(Copy, Clone, Default, Debug, Serialize, Deserialize, PartialEq, Eq, Hash)]
+pub struct DoublewordAlignmentTable<const XLEN: usize>;
+
+impl<const XLEN: usize> LookupTable for DoublewordAlignmentTable<XLEN> {
+    fn materialize_entry(&self, index: u128) -> u64 {
+        index.is_multiple_of(8).into()
+    }
+
+    fn evaluate_mle<F, C>(&self, r: &[C]) -> F
+    where
+        C: ChallengeOps<F>,
+        F: JoltField + FieldOps<C>,
+    {
+        let lsb0 = r[r.len() - 1];
+        let lsb1 = r[r.len() - 2];
+        let lsb2 = r[r.len() - 3];
+        (F::one() - lsb0) * (F::one() - lsb1) * (F::one() - lsb2)
+    }
+}
+
+impl<const XLEN: usize> PrefixSuffixDecomposition<XLEN> for DoublewordAlignmentTable<XLEN> {
+    fn prefixes(&self) -> &'static [Prefixes] {
+        &[Prefixes::ThreeLsb]
+    }
+
+    fn suffixes(&self) -> &'static [Suffixes] {
+        &[Suffixes::ThreeLsb]
+    }
+
+    #[expect(clippy::unwrap_used)]
+    fn combine<F: JoltField>(&self, prefixes: &[PrefixEval<F>], suffixes: &[SuffixEval<F>]) -> F {
+        debug_assert_eq!(self.suffixes().len(), suffixes.len());
+        let [three_lsb] = suffixes.try_into().unwrap();
+        prefixes[Prefixes::ThreeLsb] * three_lsb
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tables::test_utils::{
+        mle_full_hypercube_test, mle_random_test, prefix_suffix_materialization_test,
+        prefix_suffix_test,
+    };
+    use crate::XLEN;
+    use jolt_field::Fr;
+
+    #[test]
+    fn mle_random() {
+        mle_random_test::<XLEN, Fr, DoublewordAlignmentTable<XLEN>>();
+    }
+
+    #[test]
+    fn prefix_suffix() {
+        prefix_suffix_test::<XLEN, Fr, DoublewordAlignmentTable<XLEN>>();
+        prefix_suffix_materialization_test::<XLEN, Fr, DoublewordAlignmentTable<XLEN>>(2, 20);
+    }
+
+    #[test]
+    fn mle_full_hypercube() {
+        mle_full_hypercube_test::<8, Fr, DoublewordAlignmentTable<8>>();
+    }
+}

--- a/crates/jolt-lookup-tables/src/tables/mod.rs
+++ b/crates/jolt-lookup-tables/src/tables/mod.rs
@@ -18,6 +18,7 @@ use crate::traits::LookupTable;
 pub mod align_addr;
 pub mod and;
 pub mod andn;
+pub mod doubleword_alignment;
 pub mod equal;
 pub mod halfword_alignment;
 pub mod lower_half_word;
@@ -70,6 +71,7 @@ pub use suffixes::{SuffixEval, Suffixes};
 use align_addr::AlignAddrTable;
 use and::AndTable;
 use andn::AndnTable;
+use doubleword_alignment::DoublewordAlignmentTable;
 use equal::EqualTable;
 use halfword_alignment::HalfwordAlignmentTable;
 use lower_half_word::LowerHalfWordTable;
@@ -192,6 +194,7 @@ pub enum LookupTableKind<const XLEN: usize> {
     ShiftDataH(ShiftDataHTable<XLEN>),
     ShiftDataW(ShiftDataWTable<XLEN>),
     VirtualXORROTL1(VirtualXORROTL1Table<XLEN>),
+    DoublewordAlignment(DoublewordAlignmentTable<XLEN>),
 }
 
 /// Dispatches a method call to the inner table for every
@@ -256,6 +259,7 @@ macro_rules! dispatch {
             Self::ShiftDataH($t) => $expr,
             Self::ShiftDataW($t) => $expr,
             Self::VirtualXORROTL1($t) => $expr,
+            Self::DoublewordAlignment($t) => $expr,
         }
     };
 }

--- a/crates/jolt-lookup-tables/src/tables/prefixes/mod.rs
+++ b/crates/jolt-lookup-tables/src/tables/prefixes/mod.rs
@@ -43,6 +43,7 @@ pub mod sign_extension_right_operand;
 pub mod sign_extension_upper_half;
 pub mod sign_extension_w;
 pub mod srlw_sext;
+pub mod three_lsb;
 pub mod two_lsb;
 pub mod upper_word;
 pub mod window_sign;
@@ -60,6 +61,7 @@ use std::ops::Index;
 use crate::lookup_bits::LookupBits;
 use align_addr::AlignAddrPrefix;
 use pow2_offset::Pow2OffsetPrefix;
+use three_lsb::ThreeLsbPrefix;
 
 /// A prefix polynomial evaluated at binary points during materialization.
 ///
@@ -185,6 +187,7 @@ pub enum Prefixes {
     XorRotL1Acc,
     XorRotL1Straddle,
     XorRotL1Wrap,
+    ThreeLsb,
 }
 
 /// Total number of prefix variants.
@@ -262,6 +265,7 @@ macro_rules! dispatch_prefix {
             Prefixes::XorRotL1Acc => xor_rotl1::XorRotL1AccPrefix::$method($($args),*),
             Prefixes::XorRotL1Straddle => xor_rotl1::XorRotL1StraddlePrefix::$method($($args),*),
             Prefixes::XorRotL1Wrap => xor_rotl1::XorRotL1WrapPrefix::$method($($args),*),
+            Prefixes::ThreeLsb => ThreeLsbPrefix::$method($($args),*),
         }
     };
 }

--- a/crates/jolt-lookup-tables/src/tables/prefixes/three_lsb.rs
+++ b/crates/jolt-lookup-tables/src/tables/prefixes/three_lsb.rs
@@ -1,0 +1,22 @@
+use jolt_field::JoltField;
+
+use crate::lookup_bits::LookupBits;
+
+use super::{PrefixEval, Prefixes, SparseDensePrefix};
+
+pub enum ThreeLsbPrefix {}
+
+impl<F: JoltField> SparseDensePrefix<F> for ThreeLsbPrefix {
+    fn default_checkpoint() -> F {
+        F::one()
+    }
+
+    fn evaluate(checkpoints: &[PrefixEval<F>], b: LookupBits, suffix_len: usize) -> F {
+        let bound_bits = 3usize.saturating_sub(suffix_len).min(b.len());
+        if b.trailing_zeros() >= bound_bits as u32 {
+            checkpoints[Prefixes::ThreeLsb]
+        } else {
+            F::zero()
+        }
+    }
+}

--- a/crates/jolt-lookup-tables/src/tables/suffixes/mod.rs
+++ b/crates/jolt-lookup-tables/src/tables/suffixes/mod.rs
@@ -49,6 +49,7 @@ mod sign_extension;
 mod sign_extension_right_operand;
 mod sign_extension_upper_half;
 mod sign_extension_w;
+mod three_lsb;
 mod two_lsb;
 mod upper_word;
 mod window_sign;
@@ -101,6 +102,7 @@ use sign_extension::SignExtensionSuffix;
 use sign_extension_right_operand::SignExtensionRightOperandSuffix;
 use sign_extension_upper_half::SignExtensionUpperHalfSuffix;
 use sign_extension_w::SignExtensionWSuffix;
+use three_lsb::ThreeLsbSuffix;
 use two_lsb::TwoLsbSuffix;
 use upper_word::UpperWordSuffix;
 pub(crate) use window_sign::window_sign_bit;
@@ -196,6 +198,7 @@ pub enum Suffixes {
     XorRotL1Pairs,
     TopYBit,
     BottomXBit,
+    ThreeLsb,
 }
 
 /// Total number of suffix variants.
@@ -218,6 +221,7 @@ impl Suffixes {
                 | Suffixes::RightOperandIsZero
                 | Suffixes::Lsb
                 | Suffixes::TwoLsb
+                | Suffixes::ThreeLsb
                 | Suffixes::DivByZero
                 | Suffixes::OverflowBitsZero
                 | Suffixes::WindowSign
@@ -292,6 +296,7 @@ impl Suffixes {
             Suffixes::XorRotL1Pairs => XorRotL1PairsSuffix::suffix_mle(b),
             Suffixes::TopYBit => TopYBitSuffix::suffix_mle(b),
             Suffixes::BottomXBit => BottomXBitSuffix::suffix_mle(b),
+            Suffixes::ThreeLsb => ThreeLsbSuffix::suffix_mle(b),
         }
     }
 

--- a/crates/jolt-lookup-tables/src/tables/suffixes/three_lsb.rs
+++ b/crates/jolt-lookup-tables/src/tables/suffixes/three_lsb.rs
@@ -1,0 +1,10 @@
+use super::SparseDenseSuffix;
+use crate::lookup_bits::LookupBits;
+
+pub struct ThreeLsbSuffix;
+
+impl SparseDenseSuffix for ThreeLsbSuffix {
+    fn suffix_mle(b: LookupBits) -> u64 {
+        (b.is_empty() || u128::from(b).trailing_zeros() >= 3).into()
+    }
+}

--- a/crates/jolt-lookup-tables/tests/prover_lookup_table_abi.rs
+++ b/crates/jolt-lookup-tables/tests/prover_lookup_table_abi.rs
@@ -281,6 +281,12 @@ fn modular_lookup_table_indices_match_prover_abi() {
                 Default::default(),
             )),
         ),
+        (
+            LookupTableKind::<XLEN>::DoublewordAlignment(Default::default()).index(),
+            prover_index(ProverLookupTables::<XLEN>::DoublewordAlignment(
+                Default::default(),
+            )),
+        ),
     ];
 
     assert_eq!(ProverLookupTables::<XLEN>::COUNT, cases.len());

--- a/crates/jolt-prover-legacy/src/zkvm/instruction/ld.rs
+++ b/crates/jolt-prover-legacy/src/zkvm/instruction/ld.rs
@@ -1,20 +1,22 @@
-use crate::zkvm::instruction::NUM_INSTRUCTION_FLAGS;
+use crate::zkvm::instruction::{InstructionFlags, NUM_INSTRUCTION_FLAGS};
 use tracer::instruction::{ld::LD, RISCVCycle};
 
-use crate::zkvm::lookup_table::LookupTables;
+use crate::zkvm::lookup_table::{doubleword_alignment::DoublewordAlignmentTable, LookupTables};
 
 use super::{CircuitFlags, Flags, InstructionLookup, LookupQuery, NUM_CIRCUIT_FLAGS};
 
 impl<const XLEN: usize> InstructionLookup<XLEN> for LD {
     fn lookup_table(&self) -> Option<LookupTables<XLEN>> {
-        None
+        Some(DoublewordAlignmentTable.into())
     }
 }
 
 impl Flags for LD {
     fn circuit_flags(&self) -> [bool; NUM_CIRCUIT_FLAGS] {
         let mut flags = [false; NUM_CIRCUIT_FLAGS];
+        flags[CircuitFlags::AddOperands] = true;
         flags[CircuitFlags::Load] = true;
+        flags[CircuitFlags::Assert] = true;
         flags[CircuitFlags::VirtualInstruction] = self.virtual_sequence_remaining.is_some();
         flags[CircuitFlags::DoNotUpdateUnexpandedPC] =
             self.virtual_sequence_remaining.unwrap_or(0) != 0;
@@ -24,16 +26,58 @@ impl Flags for LD {
     }
 
     fn instruction_flags(&self) -> [bool; NUM_INSTRUCTION_FLAGS] {
-        [false; NUM_INSTRUCTION_FLAGS]
+        let mut flags = [false; NUM_INSTRUCTION_FLAGS];
+        flags[InstructionFlags::LeftOperandIsRs1Value] = true;
+        flags[InstructionFlags::RightOperandIsImm] = true;
+        flags
     }
 }
 
 impl<const XLEN: usize> LookupQuery<XLEN> for RISCVCycle<LD> {
+    fn to_lookup_operands(&self) -> (u64, u128) {
+        let (address, offset) = LookupQuery::<XLEN>::to_instruction_inputs(self);
+        (0, (address as i128 + offset) as u128)
+    }
+
+    fn to_lookup_index(&self) -> u128 {
+        LookupQuery::<XLEN>::to_lookup_operands(self).1
+    }
+
     fn to_instruction_inputs(&self) -> (u64, i128) {
-        (0, 0)
+        match XLEN {
+            #[cfg(test)]
+            8 => (
+                self.register_state.rs1 as u8 as u64,
+                self.instruction.operands.imm as u8 as i128,
+            ),
+            32 => (
+                self.register_state.rs1 as u32 as u64,
+                self.instruction.operands.imm as u32 as i128,
+            ),
+            64 => (
+                self.register_state.rs1,
+                self.instruction.operands.imm as i128,
+            ),
+            _ => panic!("{XLEN}-bit word size is unsupported"),
+        }
     }
 
     fn to_lookup_output(&self) -> u64 {
-        0
+        LookupQuery::<XLEN>::to_lookup_index(self)
+            .is_multiple_of(8)
+            .into()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::zkvm::instruction::test::materialize_entry_test;
+
+    use super::*;
+    use ark_bn254::Fr;
+
+    #[test]
+    fn materialize_entry() {
+        materialize_entry_test::<Fr, LD>();
     }
 }

--- a/crates/jolt-prover-legacy/src/zkvm/instruction/mod.rs
+++ b/crates/jolt-prover-legacy/src/zkvm/instruction/mod.rs
@@ -291,6 +291,9 @@ impl<const XLEN: usize> InstructionLookup<XLEN> for JoltInstructionRow {
             JoltInstructionKind::VirtualAssertWordAlignment => {
                 LookupTables::WordAlignment(Default::default())
             }
+            JoltInstructionKind::LD | JoltInstructionKind::SD => {
+                LookupTables::DoublewordAlignment(Default::default())
+            }
             JoltInstruction::VirtualZeroExtendWord(_) => {
                 LookupTables::LowerHalfWord(Default::default())
             }
@@ -391,8 +394,6 @@ impl<const XLEN: usize> InstructionLookup<XLEN> for JoltInstructionRow {
             | JoltInstruction::FieldStoreToX(_)
             | JoltInstruction::FieldLoadImm(_) => return None,
             JoltInstructionKind::NoOp
-            | JoltInstructionKind::LD
-            | JoltInstructionKind::SD
             | JoltInstructionKind::FENCE
             | JoltInstruction::VirtualHostIO(_) => return None,
         })

--- a/crates/jolt-prover-legacy/src/zkvm/instruction/sd.rs
+++ b/crates/jolt-prover-legacy/src/zkvm/instruction/sd.rs
@@ -1,20 +1,22 @@
-use crate::zkvm::instruction::NUM_INSTRUCTION_FLAGS;
+use crate::zkvm::instruction::{InstructionFlags, NUM_INSTRUCTION_FLAGS};
 use tracer::instruction::{sd::SD, RISCVCycle};
 
-use crate::zkvm::lookup_table::LookupTables;
+use crate::zkvm::lookup_table::{doubleword_alignment::DoublewordAlignmentTable, LookupTables};
 
 use super::{CircuitFlags, Flags, InstructionLookup, LookupQuery, NUM_CIRCUIT_FLAGS};
 
 impl<const XLEN: usize> InstructionLookup<XLEN> for SD {
     fn lookup_table(&self) -> Option<LookupTables<XLEN>> {
-        None
+        Some(DoublewordAlignmentTable.into())
     }
 }
 
 impl Flags for SD {
     fn circuit_flags(&self) -> [bool; NUM_CIRCUIT_FLAGS] {
         let mut flags = [false; NUM_CIRCUIT_FLAGS];
+        flags[CircuitFlags::AddOperands] = true;
         flags[CircuitFlags::Store] = true;
+        flags[CircuitFlags::Assert] = true;
         flags[CircuitFlags::VirtualInstruction] = self.virtual_sequence_remaining.is_some();
         flags[CircuitFlags::DoNotUpdateUnexpandedPC] =
             self.virtual_sequence_remaining.unwrap_or(0) != 0;
@@ -24,16 +26,58 @@ impl Flags for SD {
     }
 
     fn instruction_flags(&self) -> [bool; NUM_INSTRUCTION_FLAGS] {
-        [false; NUM_INSTRUCTION_FLAGS]
+        let mut flags = [false; NUM_INSTRUCTION_FLAGS];
+        flags[InstructionFlags::LeftOperandIsRs1Value] = true;
+        flags[InstructionFlags::RightOperandIsImm] = true;
+        flags
     }
 }
 
 impl<const XLEN: usize> LookupQuery<XLEN> for RISCVCycle<SD> {
+    fn to_lookup_operands(&self) -> (u64, u128) {
+        let (address, offset) = LookupQuery::<XLEN>::to_instruction_inputs(self);
+        (0, (address as i128 + offset) as u128)
+    }
+
+    fn to_lookup_index(&self) -> u128 {
+        LookupQuery::<XLEN>::to_lookup_operands(self).1
+    }
+
     fn to_instruction_inputs(&self) -> (u64, i128) {
-        (0, 0)
+        match XLEN {
+            #[cfg(test)]
+            8 => (
+                self.register_state.rs1 as u8 as u64,
+                self.instruction.operands.imm as u8 as i128,
+            ),
+            32 => (
+                self.register_state.rs1 as u32 as u64,
+                self.instruction.operands.imm as u32 as i128,
+            ),
+            64 => (
+                self.register_state.rs1,
+                self.instruction.operands.imm as i128,
+            ),
+            _ => panic!("{XLEN}-bit word size is unsupported"),
+        }
     }
 
     fn to_lookup_output(&self) -> u64 {
-        0
+        LookupQuery::<XLEN>::to_lookup_index(self)
+            .is_multiple_of(8)
+            .into()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::zkvm::instruction::test::materialize_entry_test;
+
+    use super::*;
+    use ark_bn254::Fr;
+
+    #[test]
+    fn materialize_entry() {
+        materialize_entry_test::<Fr, SD>();
     }
 }

--- a/crates/jolt-prover-legacy/src/zkvm/lookup_table/doubleword_alignment.rs
+++ b/crates/jolt-prover-legacy/src/zkvm/lookup_table/doubleword_alignment.rs
@@ -1,0 +1,69 @@
+use serde::{Deserialize, Serialize};
+
+use super::prefixes::PrefixEval;
+use super::suffixes::{SuffixEval, Suffixes};
+use super::JoltLookupTable;
+use super::PrefixSuffixDecomposition;
+use crate::field::{ChallengeFieldOps, FieldChallengeOps, JoltField};
+use crate::zkvm::lookup_table::prefixes::Prefixes;
+
+#[derive(Copy, Clone, Default, Debug, Serialize, Deserialize, PartialEq)]
+pub struct DoublewordAlignmentTable<const XLEN: usize>;
+
+impl<const XLEN: usize> JoltLookupTable for DoublewordAlignmentTable<XLEN> {
+    fn materialize_entry(&self, index: u128) -> u64 {
+        index.is_multiple_of(8).into()
+    }
+
+    fn evaluate_mle<F, C>(&self, r: &[C]) -> F
+    where
+        C: ChallengeFieldOps<F>,
+        F: JoltField + FieldChallengeOps<C>,
+    {
+        let lsb0 = r[r.len() - 1];
+        let lsb1 = r[r.len() - 2];
+        let lsb2 = r[r.len() - 3];
+        (F::one() - lsb0) * (F::one() - lsb1) * (F::one() - lsb2)
+    }
+}
+
+impl<const XLEN: usize> PrefixSuffixDecomposition<XLEN> for DoublewordAlignmentTable<XLEN> {
+    fn suffixes(&self) -> Vec<Suffixes> {
+        vec![Suffixes::ThreeLsb]
+    }
+
+    fn combine<F: JoltField>(&self, prefixes: &[PrefixEval<F>], suffixes: &[SuffixEval<F>]) -> F {
+        debug_assert_eq!(self.suffixes().len(), suffixes.len());
+        let [three_lsb] = suffixes.try_into().unwrap();
+        prefixes[Prefixes::ThreeLsb] * three_lsb
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use ark_bn254::Fr;
+
+    use crate::zkvm::lookup_table::test::{
+        lookup_table_mle_full_hypercube_test, lookup_table_mle_random_test, prefix_suffix_test,
+        prefix_suffix_test_with_phase_size,
+    };
+    use common::constants::XLEN;
+
+    use super::DoublewordAlignmentTable;
+
+    #[test]
+    fn mle_full_hypercube() {
+        lookup_table_mle_full_hypercube_test::<Fr, DoublewordAlignmentTable<8>>();
+    }
+
+    #[test]
+    fn mle_random() {
+        lookup_table_mle_random_test::<Fr, DoublewordAlignmentTable<XLEN>>();
+    }
+
+    #[test]
+    fn prefix_suffix() {
+        prefix_suffix_test::<XLEN, Fr, DoublewordAlignmentTable<XLEN>>();
+        prefix_suffix_test_with_phase_size::<XLEN, Fr, DoublewordAlignmentTable<XLEN>>(2, 20);
+    }
+}

--- a/crates/jolt-prover-legacy/src/zkvm/lookup_table/mod.rs
+++ b/crates/jolt-prover-legacy/src/zkvm/lookup_table/mod.rs
@@ -1,6 +1,7 @@
 use align_addr::AlignAddrTable;
 use and::AndTable;
 use andn::AndnTable;
+use doubleword_alignment::DoublewordAlignmentTable;
 use equal::EqualTable;
 use halfword_alignment::HalfwordAlignmentTable;
 use lower_half_word::LowerHalfWordTable;
@@ -89,6 +90,7 @@ pub mod suffixes;
 pub mod align_addr;
 pub mod and;
 pub mod andn;
+pub mod doubleword_alignment;
 pub mod equal;
 pub mod halfword_alignment;
 pub mod lower_half_word;
@@ -199,6 +201,7 @@ pub enum LookupTables<const XLEN: usize> {
     ShiftDataH(ShiftDataHTable<XLEN>),
     ShiftDataW(ShiftDataWTable<XLEN>),
     VirtualXORROTL1(VirtualXORROTL1Table<XLEN>),
+    DoublewordAlignment(DoublewordAlignmentTable<XLEN>),
 }
 
 impl<const XLEN: usize> LookupTables<XLEN> {
@@ -266,6 +269,7 @@ impl<const XLEN: usize> LookupTables<XLEN> {
             LookupTables::ShiftDataH(table) => table.materialize(),
             LookupTables::ShiftDataW(table) => table.materialize(),
             LookupTables::VirtualXORROTL1(table) => table.materialize(),
+            LookupTables::DoublewordAlignment(table) => table.materialize(),
         }
     }
 
@@ -326,6 +330,7 @@ impl<const XLEN: usize> LookupTables<XLEN> {
             LookupTables::ShiftDataH(table) => table.materialize_entry(index),
             LookupTables::ShiftDataW(table) => table.materialize_entry(index),
             LookupTables::VirtualXORROTL1(table) => table.materialize_entry(index),
+            LookupTables::DoublewordAlignment(table) => table.materialize_entry(index),
         }
     }
 
@@ -390,6 +395,7 @@ impl<const XLEN: usize> LookupTables<XLEN> {
             LookupTables::ShiftDataH(table) => table.evaluate_mle(r),
             LookupTables::ShiftDataW(table) => table.evaluate_mle(r),
             LookupTables::VirtualXORROTL1(table) => table.evaluate_mle(r),
+            LookupTables::DoublewordAlignment(table) => table.evaluate_mle(r),
         }
     }
 
@@ -450,6 +456,7 @@ impl<const XLEN: usize> LookupTables<XLEN> {
             LookupTables::ShiftDataH(table) => table.suffixes(),
             LookupTables::ShiftDataW(table) => table.suffixes(),
             LookupTables::VirtualXORROTL1(table) => table.suffixes(),
+            LookupTables::DoublewordAlignment(table) => table.suffixes(),
         }
     }
 
@@ -514,6 +521,7 @@ impl<const XLEN: usize> LookupTables<XLEN> {
             LookupTables::ShiftDataH(table) => table.combine(prefixes, suffixes),
             LookupTables::ShiftDataW(table) => table.combine(prefixes, suffixes),
             LookupTables::VirtualXORROTL1(table) => table.combine(prefixes, suffixes),
+            LookupTables::DoublewordAlignment(table) => table.combine(prefixes, suffixes),
         }
     }
 }

--- a/crates/jolt-prover-legacy/src/zkvm/lookup_table/prefixes/mod.rs
+++ b/crates/jolt-prover-legacy/src/zkvm/lookup_table/prefixes/mod.rs
@@ -22,6 +22,7 @@ use srlw_sext::SrlwSextPrefix;
 use std::{fmt::Display, ops::Index};
 use strum::EnumCount;
 use strum_macros::{EnumCount as EnumCountMacro, EnumIter};
+use three_lsb::ThreeLsbPrefix;
 
 use align_addr::AlignAddrPrefix;
 use and::AndPrefix;
@@ -92,6 +93,7 @@ pub mod sign_extension_right_operand;
 pub mod sign_extension_upper_half;
 pub mod sign_extension_w;
 pub mod srlw_sext;
+pub mod three_lsb;
 pub mod two_lsb;
 pub mod upper_word;
 pub mod window_sign;
@@ -211,6 +213,7 @@ pub enum Prefixes {
     XorRotL1Acc,
     XorRotL1Straddle,
     XorRotL1Wrap,
+    ThreeLsb,
 }
 
 #[derive(Clone, Copy, Allocative)]
@@ -386,6 +389,7 @@ impl Prefixes {
                 OffsetScalePrefix::<XLEN, 4>::prefix_mle(checkpoints, r_x, c, b, j)
             }
             Prefixes::AlignAddr => AlignAddrPrefix::<XLEN>::prefix_mle(checkpoints, r_x, c, b, j),
+            Prefixes::ThreeLsb => ThreeLsbPrefix::<XLEN>::prefix_mle(checkpoints, r_x, c, b, j),
         };
         PrefixEval(eval)
     }
@@ -801,6 +805,13 @@ impl Prefixes {
                 suffix_len,
             ),
             Prefixes::AlignAddr => AlignAddrPrefix::<XLEN>::update_prefix_checkpoint(
+                checkpoints,
+                r_x,
+                r_y,
+                j,
+                suffix_len,
+            ),
+            Prefixes::ThreeLsb => ThreeLsbPrefix::<XLEN>::update_prefix_checkpoint(
                 checkpoints,
                 r_x,
                 r_y,

--- a/crates/jolt-prover-legacy/src/zkvm/lookup_table/prefixes/three_lsb.rs
+++ b/crates/jolt-prover-legacy/src/zkvm/lookup_table/prefixes/three_lsb.rs
@@ -1,0 +1,79 @@
+use crate::field::{ChallengeFieldOps, FieldChallengeOps};
+use crate::zkvm::instruction_lookups::LOG_K;
+use crate::zkvm::lookup_table::prefixes::Prefixes;
+use crate::{field::JoltField, utils::lookup_bits::LookupBits};
+
+use super::{PrefixCheckpoint, SparseDensePrefix};
+
+pub enum ThreeLsbPrefix<const XLEN: usize> {}
+
+impl<const XLEN: usize, F: JoltField> SparseDensePrefix<F> for ThreeLsbPrefix<XLEN> {
+    fn prefix_mle<C>(
+        checkpoints: &[PrefixCheckpoint<F>],
+        r_x: Option<C>,
+        c: u32,
+        b: LookupBits,
+        j: usize,
+    ) -> F
+    where
+        C: ChallengeFieldOps<F>,
+        F: FieldChallengeOps<C>,
+    {
+        let suffix_len = LOG_K - j - b.len() - 1;
+        if j == 2 * XLEN - 1 {
+            debug_assert_eq!(b.len(), 0);
+            checkpoints[Prefixes::ThreeLsb].unwrap()
+                * (F::one() - F::from_u32(c))
+                * (F::one() - r_x.unwrap())
+        } else if j == 2 * XLEN - 2 {
+            debug_assert_eq!(b.len(), 1);
+            let bit0 = u32::from(b) & 1;
+            checkpoints[Prefixes::ThreeLsb].unwrap()
+                * (F::one() - F::from_u32(bit0))
+                * (F::one() - F::from_u32(c))
+        } else if j == 2 * XLEN - 3 {
+            if suffix_len == 2 {
+                debug_assert_eq!(b.len(), 0);
+                F::one() - F::from_u32(c)
+            } else {
+                debug_assert_eq!(suffix_len, 0);
+                debug_assert_eq!(b.len(), 2);
+                if u32::from(b).trailing_zeros() >= 2 {
+                    F::one() - F::from_u32(c)
+                } else {
+                    F::zero()
+                }
+            }
+        } else if suffix_len < 3 {
+            let prefix_alignment_bits = 3 - suffix_len;
+            if u32::from(b).trailing_zeros() >= prefix_alignment_bits as u32 {
+                F::one()
+            } else {
+                F::zero()
+            }
+        } else {
+            F::one()
+        }
+    }
+
+    fn update_prefix_checkpoint<C>(
+        checkpoints: &[PrefixCheckpoint<F>],
+        r_x: C,
+        r_y: C,
+        j: usize,
+        _suffix_len: usize,
+    ) -> PrefixCheckpoint<F>
+    where
+        C: ChallengeFieldOps<F>,
+        F: FieldChallengeOps<C>,
+    {
+        if j == 2 * XLEN - 3 {
+            Some(F::one() - r_y).into()
+        } else if j == 2 * XLEN - 1 {
+            Some(checkpoints[Prefixes::ThreeLsb].unwrap() * (F::one() - r_x) * (F::one() - r_y))
+                .into()
+        } else {
+            checkpoints[Prefixes::ThreeLsb].into()
+        }
+    }
+}

--- a/crates/jolt-prover-legacy/src/zkvm/lookup_table/suffixes/mod.rs
+++ b/crates/jolt-prover-legacy/src/zkvm/lookup_table/suffixes/mod.rs
@@ -33,6 +33,7 @@ use sign_extension::SignExtensionSuffix;
 use sign_extension_upper_half::SignExtensionUpperHalfSuffix;
 use sign_extension_w::SignExtensionWSuffix;
 use strum_macros::{EnumCount as EnumCountMacro, EnumIter};
+use three_lsb::ThreeLsbSuffix;
 
 use align_addr::AlignAddrSuffix;
 use and::AndSuffix;
@@ -90,6 +91,7 @@ pub mod sign_extension;
 pub mod sign_extension_right_operand;
 pub mod sign_extension_upper_half;
 pub mod sign_extension_w;
+pub mod three_lsb;
 pub mod two_lsb;
 pub mod upper_word;
 pub mod window_sign;
@@ -173,6 +175,7 @@ pub enum Suffixes {
     XorRotL1Pairs,
     TopYBit,
     BottomXBit,
+    ThreeLsb,
 }
 
 pub type SuffixEval<F: JoltField> = F;
@@ -194,6 +197,7 @@ impl Suffixes {
                 | Suffixes::RightOperandIsZero
                 | Suffixes::Lsb
                 | Suffixes::TwoLsb
+                | Suffixes::ThreeLsb
                 | Suffixes::DivByZero
                 | Suffixes::OverflowBitsZero
                 | Suffixes::WindowSign
@@ -271,6 +275,7 @@ impl Suffixes {
             Suffixes::XorRotL1Pairs => XorRotL1PairsSuffix::suffix_mle(b),
             Suffixes::TopYBit => TopYBitSuffix::suffix_mle(b),
             Suffixes::BottomXBit => BottomXBitSuffix::suffix_mle(b),
+            Suffixes::ThreeLsb => ThreeLsbSuffix::suffix_mle(b),
         }
     }
 }

--- a/crates/jolt-prover-legacy/src/zkvm/lookup_table/suffixes/three_lsb.rs
+++ b/crates/jolt-prover-legacy/src/zkvm/lookup_table/suffixes/three_lsb.rs
@@ -1,0 +1,10 @@
+use crate::utils::lookup_bits::LookupBits;
+use crate::zkvm::lookup_table::suffixes::SparseDenseSuffix;
+
+pub struct ThreeLsbSuffix;
+
+impl SparseDenseSuffix for ThreeLsbSuffix {
+    fn suffix_mle(b: LookupBits) -> u64 {
+        (b.len() == 0 || u128::from(b).trailing_zeros() >= 3).into()
+    }
+}

--- a/crates/jolt-prover/tests/doubleword_alignment.rs
+++ b/crates/jolt-prover/tests/doubleword_alignment.rs
@@ -1,0 +1,327 @@
+#[cfg(all(
+    feature = "prover-fixtures",
+    not(feature = "akita"),
+    not(feature = "zk")
+))]
+#[expect(clippy::expect_used, reason = "integration tests should fail loudly")]
+mod tests {
+    use std::sync::Arc;
+
+    use common::{
+        constants::RAM_START_ADDRESS,
+        jolt_device::{JoltDevice, MemoryLayout},
+    };
+    use jolt_crypto::{Bn254G1, Pedersen};
+    use jolt_dory::DoryScheme;
+    use jolt_field::Fr;
+    use jolt_openings::CommitmentScheme;
+    use jolt_program::{
+        execution::{JoltProgram, MemoryImage, OwnedTrace, TraceOutput},
+        preprocess::JoltProgramPreprocessing,
+    };
+    use jolt_prover::{JoltBackend, JoltProverPreprocessing, ProverConfig};
+    use jolt_riscv::{
+        CapturedState, JoltInstructionKind as Kind, JoltInstructionRow, JoltTraceRow, LoadState,
+        NonMemoryState, NormalizedOperands, StoreState, RV64IMAC_JOLT,
+    };
+    use jolt_transcript::LegacyBlake2bTranscript;
+    use jolt_verifier::{preprocessing::ProgramPreprocessing, JoltVerifierPreprocessing};
+    use jolt_witness::{JoltVmWitnessConfig, JoltVmWitnessInputs, TraceBackend};
+
+    const MAX_TRACE_LENGTH: usize = 1 << 16;
+
+    fn program_image() -> Vec<(u64, u8)> {
+        [
+            0x7fff_f0b7_u32,
+            0x0040_8093,
+            0x0000_b103,
+            0x0010_0193,
+            0x0030_b423,
+            0x0000_00e7,
+        ]
+        .into_iter()
+        .flat_map(u32::to_le_bytes)
+        .enumerate()
+        .map(|(offset, byte)| (RAM_START_ADDRESS + offset as u64, byte))
+        .collect()
+    }
+
+    fn instruction(
+        instruction_kind: Kind,
+        address: usize,
+        operands: NormalizedOperands,
+    ) -> JoltInstructionRow {
+        JoltInstructionRow {
+            instruction_kind,
+            address,
+            operands,
+            virtual_sequence_remaining: None,
+            is_first_in_sequence: false,
+            is_compressed: false,
+        }
+    }
+
+    // Verifier preprocessing accepts public/deserialized layouts without
+    // requiring the lowest remapped address to be eight-byte aligned.
+    fn misaligned_remap_layout() -> MemoryLayout {
+        let lowest = RAM_START_ADDRESS - 0xffc;
+        MemoryLayout {
+            program_size: 24,
+            max_trusted_advice_size: 0,
+            trusted_advice_start: lowest,
+            trusted_advice_end: lowest,
+            max_untrusted_advice_size: 0,
+            untrusted_advice_start: lowest,
+            untrusted_advice_end: lowest,
+            max_input_size: 0,
+            max_output_size: 0,
+            input_start: lowest,
+            input_end: lowest,
+            output_start: lowest,
+            output_end: lowest,
+            stack_size: 0,
+            stack_end: RAM_START_ADDRESS + 24,
+            heap_size: 40,
+            heap_end: RAM_START_ADDRESS + 64,
+            panic: lowest,
+            termination: lowest + 8,
+            io_end: lowest + 16,
+        }
+    }
+
+    #[test]
+    fn misaligned_doubleword_access_is_rejected() {
+        let lowest = RAM_START_ADDRESS - 0xffc;
+        assert_eq!(lowest % 8, 4);
+        let addresses = (0..6)
+            .map(|index| RAM_START_ADDRESS as usize + 4 * index)
+            .collect::<Vec<_>>();
+        let instructions = vec![
+            instruction(
+                Kind::LUI,
+                addresses[0],
+                NormalizedOperands {
+                    rd: Some(1),
+                    imm: 0x7fff_f000,
+                    ..Default::default()
+                },
+            ),
+            instruction(
+                Kind::ADDI,
+                addresses[1],
+                NormalizedOperands {
+                    rs1: Some(1),
+                    rd: Some(1),
+                    imm: 4,
+                    ..Default::default()
+                },
+            ),
+            instruction(
+                Kind::LD,
+                addresses[2],
+                NormalizedOperands {
+                    rs1: Some(1),
+                    rd: Some(2),
+                    ..Default::default()
+                },
+            ),
+            instruction(
+                Kind::ADDI,
+                addresses[3],
+                NormalizedOperands {
+                    rs1: Some(0),
+                    rd: Some(3),
+                    imm: 1,
+                    ..Default::default()
+                },
+            ),
+            instruction(
+                Kind::SD,
+                addresses[4],
+                NormalizedOperands {
+                    rs1: Some(1),
+                    rs2: Some(3),
+                    imm: 8,
+                    ..Default::default()
+                },
+            ),
+            instruction(
+                Kind::JALR,
+                addresses[5],
+                NormalizedOperands {
+                    rs1: Some(0),
+                    rd: Some(1),
+                    ..Default::default()
+                },
+            ),
+        ];
+        let layout = misaligned_remap_layout();
+        assert_eq!(layout.remapped_word_address(lowest), Ok(0));
+        assert_eq!(layout.remapped_word_address(lowest + 8), Ok(1));
+        let mut program_preprocessing = JoltProgramPreprocessing::new(
+            instructions.clone(),
+            program_image(),
+            layout.clone(),
+            addresses[0] as u64,
+            MAX_TRACE_LENGTH,
+            RV64IMAC_JOLT,
+        )
+        .expect("program preprocessing");
+        // Pack the program image by the custom remap so the RAM value-check
+        // cannot reject this witness for an unrelated initial-state mismatch.
+        let image_start = layout
+            .remapped_word_address(RAM_START_ADDRESS)
+            .expect("program image start");
+        let mut remapped_image = vec![0_u64; 4];
+        for (address, byte) in program_image() {
+            let index = layout.remapped_word_address(address).expect("image byte") - image_start;
+            remapped_image[index as usize] |= u64::from(byte) << (8 * (address & 7));
+        }
+        program_preprocessing.ram.bytecode_words = remapped_image;
+        let program_preprocessing = Arc::new(program_preprocessing);
+        let pc = |index: usize| {
+            program_preprocessing
+                .bytecode
+                .get_pc(&instructions[index])
+                .expect("instruction must have a bytecode slot") as u32
+        };
+        let rows = vec![
+            JoltTraceRow::from_components(
+                CapturedState::NonMemory(NonMemoryState {
+                    rd_write_value: 0x7fff_f000,
+                    ..Default::default()
+                }),
+                &instructions[0],
+                pc(0),
+            )
+            .expect("LUI row"),
+            JoltTraceRow::from_components(
+                CapturedState::NonMemory(NonMemoryState {
+                    rs1_value: 0x7fff_f000,
+                    rd_pre_value: 0x7fff_f000,
+                    rd_write_value: lowest,
+                    ..Default::default()
+                }),
+                &instructions[1],
+                pc(1),
+            )
+            .expect("ADDI address row"),
+            JoltTraceRow::from_components(
+                CapturedState::Load(LoadState {
+                    rs1_value: lowest,
+                    ram_address: lowest,
+                    rd_pre_value: 0,
+                    rd_write_value: 0,
+                }),
+                &instructions[2],
+                pc(2),
+            )
+            .expect("misaligned LD row"),
+            JoltTraceRow::from_components(
+                CapturedState::NonMemory(NonMemoryState {
+                    rd_write_value: 1,
+                    ..Default::default()
+                }),
+                &instructions[3],
+                pc(3),
+            )
+            .expect("ADDI value row"),
+            JoltTraceRow::from_components(
+                CapturedState::Store(StoreState {
+                    rs1_value: lowest,
+                    rs2_value: 1,
+                    ram_read_value: 0,
+                    ram_address: lowest + 8,
+                }),
+                &instructions[4],
+                pc(4),
+            )
+            .expect("misaligned SD row"),
+            JoltTraceRow::from_components(
+                CapturedState::NonMemory(NonMemoryState {
+                    rd_pre_value: lowest,
+                    rd_write_value: addresses[5] as u64 + 4,
+                    ..Default::default()
+                }),
+                &instructions[5],
+                pc(5),
+            )
+            .expect("JALR row"),
+        ];
+
+        let config = ProverConfig::derive_compact::<Fr>(
+            &rows,
+            &layout,
+            program_preprocessing.ram.min_bytecode_address,
+            program_preprocessing.ram.bytecode_words.len(),
+            MAX_TRACE_LENGTH,
+        )
+        .expect("proof config");
+        let public_io = JoltDevice {
+            memory_layout: layout.clone(),
+            ..Default::default()
+        };
+        let trace = TraceOutput::new(
+            Arc::new(rows),
+            public_io.clone(),
+            Some(MemoryImage {
+                bytes: program_image(),
+            }),
+            None,
+        );
+        let program = Arc::new(JoltProgram::from_parts(
+            Vec::new(),
+            instructions,
+            program_image(),
+            RAM_START_ADDRESS + 24,
+            RAM_START_ADDRESS,
+        ));
+        let witness = TraceBackend::<OwnedTrace>::from_compact(
+            JoltVmWitnessConfig::new(
+                config.trace_length.ilog2() as usize,
+                config.ram_K,
+                config.one_hot_config,
+            ),
+            JoltVmWitnessInputs::new(&program, &program_preprocessing, trace),
+        );
+
+        let total_vars = config.commitment_total_vars(&layout, false, false, None);
+        let pcs_setup = DoryScheme::setup_prover(total_vars);
+        let verifier_preprocessing = JoltVerifierPreprocessing::new(
+            ProgramPreprocessing::Full(program_preprocessing),
+            [0; 32],
+            DoryScheme::verifier_setup(&pcs_setup),
+            None,
+        );
+        let prover_preprocessing = JoltProverPreprocessing::<DoryScheme, Pedersen<Bn254G1>> {
+            verifier: verifier_preprocessing,
+            pcs_setup,
+            committed_program: None,
+        };
+        let proof = jolt_prover::dory::prove::<
+            Fr,
+            DoryScheme,
+            Pedersen<Bn254G1>,
+            LegacyBlake2bTranscript<Fr>,
+            _,
+        >(
+            &JoltBackend::reference(),
+            &prover_preprocessing,
+            &config,
+            None,
+            &witness,
+            &public_io,
+        );
+        let rejected = match proof {
+            Ok(proof) => jolt_verifier::verify::<
+                Fr,
+                DoryScheme,
+                Pedersen<Bn254G1>,
+                LegacyBlake2bTranscript<Fr>,
+            >(&prover_preprocessing.verifier, &public_io, &proof, None)
+            .is_err(),
+            Err(_) => true,
+        };
+        assert!(rejected, "misaligned LD/SD proof was accepted");
+    }
+}

--- a/crates/jolt-riscv/src/instructions/i/ld.rs
+++ b/crates/jolt-riscv/src/instructions/i/ld.rs
@@ -3,6 +3,6 @@ use crate::jolt_instruction;
 jolt_instruction!(
     /// RV64I LD: load doubleword (64 bits). Identity operation.
     Ld,
-    circuit flags: [Load],
-    instruction flags: []
+    circuit flags: [AddOperands, Load, Assert],
+    instruction flags: [LeftOperandIsRs1Value, RightOperandIsImm]
 );

--- a/crates/jolt-riscv/src/instructions/i/sd.rs
+++ b/crates/jolt-riscv/src/instructions/i/sd.rs
@@ -3,6 +3,6 @@ use crate::jolt_instruction;
 jolt_instruction!(
     /// RV64I SD: store doubleword (full 64 bits). Identity operation.
     Sd,
-    circuit flags: [Store],
-    instruction flags: []
+    circuit flags: [AddOperands, Store, Assert],
+    instruction flags: [LeftOperandIsRs1Value, RightOperandIsImm]
 );

--- a/crates/jolt-riscv/src/instructions/mod.rs
+++ b/crates/jolt-riscv/src/instructions/mod.rs
@@ -744,6 +744,21 @@ mod tests {
     }
 
     #[test]
+    fn doubleword_memory_accesses_are_alignment_assertions() {
+        for instr in [
+            JoltInstruction::Ld(Ld(JoltInstructionRow::default())),
+            JoltInstruction::Sd(Sd(JoltInstructionRow::default())),
+        ] {
+            let circuit_flags = instr.circuit_flags();
+            let instruction_flags = instr.instruction_flags();
+            assert!(circuit_flags[CircuitFlags::AddOperands]);
+            assert!(circuit_flags[CircuitFlags::Assert]);
+            assert!(instruction_flags[InstructionFlags::LeftOperandIsRs1Value]);
+            assert!(instruction_flags[InstructionFlags::RightOperandIsImm]);
+        }
+    }
+
+    #[test]
     fn phase_specific_instruction_kinds_are_distinct() {
         let source_kind = crate::SourceInstructionKind::AMOADDW;
 


### PR DESCRIPTION
## Summary

this PR enforces absolute eight-byte alignment for RV64 LD and SD, independently of the RAM remapping base.

## Changes

- Adds a DoublewordAlignment lookup to the modular and legacy provers.
- Binds the lookup to rs1 + imm.
- Requires the alignment result through the existing assertion constraint.
- Adds an end-to-end regression using a six-instruction RV64 trace with a misaligned RAM remapping base.

## Testing

- Modular clear suite: 22/22 passed.
- Modular ZK suite: 14/14 passed.
- Legacy muldiv with host: 3/3 passed.
- Legacy muldiv with host,zk: 3/3 passed.
- Workspace clippy passed with host and host,zk.
- cargo fmt -q passed.

## Security Considerations

For layouts generated by MemoryLayout::new, RAM RAF and the R1CS address constraint already enforce alignment because the remapping base is eight-byte aligned.

Caller-constructed or deserialized verifier preprocessing can contain a remapping base where `lowest_address % 8 == 4`. In that case, RAM RAF admits addresses congruent to four modulo eight, allowing architecturally misaligned LD and SD executions.

The regression demonstrates that the previous verifier accepts such a proof, while this change rejects the same witness.

## Breaking Changes

The lookup-table ABI changes by appending `DoublewordAlignment`. This means proofs and preprocessing artifacts created against the previous lookup-table catalog are not compatible with this version.