### PR TITLE
docs(book): document Dory and Akita commitment backends

### DIFF
--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -23,6 +23,7 @@
         - [Batched opening proof](./how/architecture/opening-proof.md)
     - [Twist and Shout](./how/twist-shout.md)
     - [Dory](./how/dory.md)
+    - [Akita](./how/akita.md)
     - [BlindFold (Zero Knowledge)](./how/blindfold.md)
     - [Optimizations](./how/optimizations/optimizations.md)
         - [Batched sumcheck](./how/optimizations/batched-sumcheck.md)

--- a/book/src/how/akita.md
+++ b/book/src/how/akita.md
@@ -1,0 +1,61 @@
+# Akita
+
+Akita is Jolt's lattice-based [polynomial commitment](./appendix/pcs.md) backend. Jolt integrates the [Akita PCS](https://github.com/LayerZero-Labs/akita) through the `jolt-akita` crate. It is an alternative to the elliptic-curve [Dory](./dory.md) backend and uses a packed witness layout and native batched openings.
+
+The `akita` Cargo feature selects this protocol at compile time. The current implementation supports clear proofs, including trusted and untrusted advice and committed programs. It does **not** support zero knowledge: `akita` and `zk` are mutually exclusive, and enabling both produces a compile error. [BlindFold](./blindfold.md) currently applies to the Dory backend.
+
+## Field and witness representation
+
+Jolt's Akita path uses `AkitaField`, the upstream `fp128` configuration's alias for `jolt_field::Prime128OffsetA7F7`. Its modulus is
+
+$$
+p = 2^{128} - 2^{32} + 22537.
+$$
+
+The RISC-V execution model and sumcheck-based approach remain shared with Dory, but the commitment layout changes. Akita does not provide the additive commitment homomorphism used by Dory's [random-linear-combination opening](./optimizations/batched-openings.md). Jolt instead packs the trace's one-hot columns into one physical polynomial, called `OneHotTrace`.
+
+This object contains the instruction, bytecode, and RAM address columns, together with balanced-digit increment columns and a signed carry. The increment columns encode a fused increment value derived by the sumcheck relations; Akita does not separately commit the `RdInc` and `RamInc` polynomials used by Dory. The supported address chunk widths are four or eight bits, corresponding to one-hot domains of size 16 or 256. The prover supplies selected row indices to Akita's native one-hot commitment path.
+
+Advice and committed-program data have their own commitments. Trusted and untrusted advice use dense word polynomials. In committed-program mode, bytecode chunks and the initial program image are committed as bounded dense objects and opened directly. These objects are separate from `OneHotTrace` because they have their own sizes, layouts, and commitment lifetimes.
+
+## Packing and opening
+
+Prefix packing assigns each logical polynomial a fixed slot in a larger multilinear polynomial. For logical polynomials $P_0, \ldots, P_{m-1}$ evaluated at a common point $\mathbf{x}$, the packed polynomial is
+
+$$
+P(\mathbf{s}, \mathbf{x})
+  = \sum_{i=0}^{m-1} \operatorname{eq}(\mathbf{s}, i)\,P_i(\mathbf{x}),
+$$
+
+where $\mathbf{s}$ selects a slot and $\operatorname{eq}$ is the [multilinear equality polynomial](./optimizations/eq.md). Jolt binds the layout and logical evaluation claims to the transcript before sampling the selector point. This reduces the trace's logical claims to one evaluation of the already committed physical polynomial.
+
+At stage 8, that evaluation joins the advice and committed-program evaluations in one native Akita grouped opening. Each group can have its own evaluation point and shape. The canonical order is:
+
+1. Untrusted advice, when present.
+2. Trusted advice, when present.
+3. Bytecode chunks in index order, followed by the initial program image, in committed-program mode.
+4. `OneHotTrace`.
+
+The verifier derives the expected layouts and roles from preprocessing and protocol configuration. It checks the assembled statement before invoking Akita verification. This replaces Dory's commitment-level linear combination with a grouped proof over the original commitments.
+
+## Setup and protocol selection
+
+Akita uses transparent setup. Jolt supplies versioned schedule catalogs as `.aks` artifacts under `crates/jolt-akita/schedules/`. Preprocessing provisions the grouped schedules needed by the program and advice configuration; the resulting verifier setup carries the catalog used during verification. The proof selects a schedule by digest from that catalog rather than supplying new schedule parameters.
+
+Both prover and verifier must be built for the same protocol. The `akita` feature selects packed commitments and little-endian scalar challenges. A compiled verifier accepts only its selected protocol configuration and rejects a mismatching proof. Dory and Akita proofs therefore require matching preprocessing and verifier builds.
+
+## Implementation
+
+The main implementation paths are:
+
+- `crates/jolt-akita/`: PCS adapter, native one-hot commitments, grouped openings, and schedule catalogs.
+- `crates/jolt-claims/src/protocols/jolt/lattice/`: canonical layouts and Akita-specific sumcheck relations.
+- `crates/jolt-openings/src/prefix.rs`: prefix packing and claim reduction.
+- `crates/jolt-prover/src/akita/`: witness assembly, commitments, and the final grouped opening.
+- `crates/jolt-verifier/src/stages/stage8/packed.rs`: verifier assembly of the final opening claims.
+
+The modular prover's end-to-end suite covers arithmetic execution, both one-hot chunk sizes, advice, committed programs, and rejection of modified claims. Run it with:
+
+```bash
+cargo nextest run -p jolt-prover --features prover-fixtures,akita --test akita_e2e --cargo-quiet
+```

--- a/book/src/how/appendix/pcs.md
+++ b/book/src/how/appendix/pcs.md
@@ -19,7 +19,18 @@ In the context of a larger proof system like Jolt, polynomial commitment schemes
 ## Role in Jolt
 
 In Jolt, the prover commits to several witness polynomials derived from the execution trace being proven.
-These polynomial commitments are used extensively to tie together the various algebraic claims generated during proving. Jolt currently uses **Dory** as its polynomial commitment scheme. Dory provides an efficient method for committing to and opening one-hot polynomials, while supporting [batch openings](../optimizations/batched-openings.md) across many claims with relatively low overhead.
+These polynomial commitments tie together the various algebraic claims generated during proving. Jolt supports two backends:
+
+| | [Dory](../dory.md) | [Akita](../akita.md) |
+|---|---|---|
+| Cryptographic construction | Elliptic curve pairings over BN254 | Lattice commitments |
+| Proof field | BN254 scalar field | 128-bit prime field |
+| Trace commitments | Separate commitments to witness polynomials | One packed `OneHotTrace` commitment containing address and increment columns |
+| Final opening | Random linear combination using additive homomorphism | Native grouped opening across trace, advice, and committed-program objects |
+| Zero knowledge in Jolt | Available with `zk` via [BlindFold](../blindfold.md) | Not currently supported |
+| Selection | Default | `akita` Cargo feature |
+
+Both backends use transparent setup and exploit Jolt's small, sparse witness values. They share the sumcheck and lookup architecture, but their commitment layouts and final [opening proofs](../architecture/opening-proof.md) differ. The prover and verifier must be built for the same protocol; `akita` and `zk` are mutually exclusive. See [backend selection](../../usage/quickstart.md#choosing-a-commitment-backend) for commands and SDK availability.
 
 ## Further Reading
 

--- a/book/src/how/architecture/architecture.md
+++ b/book/src/how/architecture/architecture.md
@@ -129,7 +129,7 @@ The `ProverOpeningAccumulator` (resp. `VerifierOpeningAccumulator`) is responsib
 The opening accumulator contains a mapping from `OpeningId` to claimed polynomial evaluation.
 As sumchecks are proven, their output claims (for both virtual and committed polynomials) are inserted into the map. Later sumchecks can then consume the virtual polynomial openings as input claims.
 
-While virtual polynomial claims are used internally and passed between sumchecks, committed polynomial claims are tracked because they must ultimately be verified via a batched [Dory](../dory.md) opening proof at the end of the protocol.
+While virtual polynomial claims are used internally and passed between sumchecks, committed polynomial claims are tracked because they must ultimately be verified via the selected backend's [batched opening proof](./opening-proof.md). [Dory](../dory.md) uses a random linear combination of commitments; [Akita](../akita.md) uses a native grouped opening over packed trace and precommitted objects.
 
 The `input_claim` and `cache_openings` methods on the `SumcheckInstanceProver` and `SumcheckInstanceVerifier` traits provide hooks to the respective accumulator objects.
 `input_claim` effectively declares the in-edges for the sumcheck instance, while `cache_openings` effectively declares the out-edges.

--- a/book/src/how/architecture/opening-proof.md
+++ b/book/src/how/architecture/opening-proof.md
@@ -2,9 +2,10 @@
 
 The final stage ([stage 8](./architecture.md)) of Jolt is the batched opening proof.
 Over the course of the preceding stages, we obtain polynomial evaluation claims that must be proven using the [polynomial commitment scheme](../appendix/pcs.md)'s opening proof.
-Instead of proving these openings "just-in-time", we **accumulate** them and defer the opening proof to the last stage (see `ProverOpeningAccumulator` and `VerifierOpeningAccumulator` for how this accumulation is implemented).
+Instead of proving these openings "just-in-time", we **accumulate** them and defer the opening proof to the last stage (see `ProverOpeningAccumulator` and `VerifierOpeningAccumulator` in the legacy prover for this accumulation).
 By waiting until the end, we can [batch-prove](../optimizations/batched-openings.md) all of the openings, instead of proving them individually.
-This is important because the [Dory](../dory.md) opening proof is relatively expensive for the prover, so we want to avoid doing it multiple times.
+Jolt supports two commitment backends: the elliptic-curve-based [Dory](../dory.md) backend combines commitments homomorphically, while the lattice-based [Akita](../akita.md) backend uses prefix packing and a native grouped opening proof.
+Both amortize the cost of proving the accumulated evaluation claims in Stage 8.
 
 ## Claim reduction sumchecks
 
@@ -13,7 +14,7 @@ Throughout the earlier stages of Jolt, various components generate multiple poly
 These claim reduction sumchecks serve two purposes:
 
 1. Reduce the number of claims that need to be virtualized by a subsequent sumcheck. E.g. if the same virtual polynomial $P$ is opened at two different points $r_1$ and $r_2$, a claim reduction can be applied to avoid running two instances of the sumcheck that virtualized $P$. 
-2. Reduce the number of claims that need to be proven via PCS opening proof. While we can leverage the homomorphic properties of Dory in the [Multiple polynomials, same point](../optimizations/batched-openings.md#multiple-polynomials-same-point) subprotocol, we must first reduce multiple opening points to a single, unified opening point.
+2. Reduce the number of claims that need to be proven via PCS opening proof. Dory's homomorphic batching and Akita's prefix packing both use claims at a common point. Akita's independently committed objects can retain their own opening points in the final grouped proof.
 
 The claim reduction sumchecks can be found in `crates/jolt-prover-legacy/src/zkvm/claim_reductions/` and include:
 
@@ -22,9 +23,9 @@ The claim reduction sumchecks can be found in `crates/jolt-prover-legacy/src/zkv
 - **RAM RA** (`ram_ra.rs`): Consolidates the four RAM read-address (RA) claims from various RAM-related sumchecks (raf evaluation, read-write checking, Val evaluation, Val-final evaluation) into a single claim for the RA virtualization sumcheck.
 - **Increments** (`increments.rs`): Reduces claims related to increment checks.
 - **Hamming weight** (`hamming_weight.rs`): Reduces hamming weight-related claims.
-- **Advice** (`advice.rs`): Reduces claims from advice polynomials.
-- **Bytecode** (`bytecode.rs`): Reduces committed bytecode openings into the shared Stage 8 final opening layout.
-- **Program image** (`program_image.rs`): Reduces the committed initial-memory image into the same final opening layout.
+- **Advice** (`advice.rs`, Dory only): Reduces claims from advice polynomials. Akita obtains its advice opening claims directly from Stage 4's RAM value check.
+- **Bytecode** (`bytecode.rs`): Reduces committed bytecode openings for Stage 8.
+- **Program image** (`program_image.rs`): Reduces committed initial-memory image openings for Stage 8.
 
 ### How claim reduction sumchecks work
 
@@ -36,7 +37,15 @@ A claim reduction sumcheck takes multiple polynomial evaluation claims, potentia
    $$\sum_{\mathbf{x}} \text{eq}(\mathbf{r}_1, \mathbf{x}) \cdot P_1(\mathbf{x}) + \gamma \cdot \text{eq}(\mathbf{r}_2, \mathbf{x}) \cdot P_2(\mathbf{x}) + \ldots = v_1 + \gamma \cdot v_2 + \ldots$$
 4. **Output**: Polynomial evaluation claims of the form $P_i(\mathbf{r}') = v'_i$ for a **single**, unified point $\mathbf{r}'$ derived from the sumcheck challenges.
 
-## Final reduction
+## Akita grouped opening
+
+Akita commits the trace as one physical polynomial, `OneHotTrace`, with a fixed-capacity prefix selecting among its logical one-hot columns. The committed variable order is `(slot || cycle || address)`. After the preceding stages produce column evaluations at a common `(cycle || address)` point, Stage 8 binds those evaluations and their layout to the transcript, samples the slot selector, and reduces them to one evaluation of `OneHotTrace`. This [prefix-packing reduction](../optimizations/batched-openings.md#prefix-packing-and-native-grouped-openings-akita) does not require a homomorphic combination of commitments.
+
+Advice and committed-program data are independent dense commitment objects: optional untrusted and trusted advice, one `BytecodeChunk(i)` per committed bytecode chunk, and a `ProgramImageInit` object. Stage 8 reduces the claims for each object separately, then opens all present objects together with `OneHotTrace` in one native Akita proof. Each group retains its own shape and opening point. The canonical order is untrusted advice, trusted advice, bytecode chunks, program image, and finally `OneHotTrace`, omitting absent objects. Group roles, commitments, points, and evaluations are bound to the transcript before the backend proof.
+
+The modular prover implements this in `crates/jolt-prover/src/akita/stage8.rs`, with the verifier counterpart in `crates/jolt-verifier/src/stages/stage8/packed.rs`. `AkitaNativeBatching` in `crates/jolt-akita/src/native_batching.rs` validates the groups and invokes the native backend opening. The Dory matrix embeddings described below apply only to the Dory backend.
+
+## Final reduction with Dory
 
 After the claim reduction sumchecks have consolidated related claims, we perform a final reduction to prepare for the Dory opening. 
 

--- a/book/src/how/architecture/r1cs_constraints.md
+++ b/book/src/how/architecture/r1cs_constraints.md
@@ -24,7 +24,7 @@ This is critical because RAM and registers operate as independent Twist memory c
 While Jolt's design uniquely leverages lookups for most RISC-V instructions, arithmetic instructions are the exception to this rule.
 Most arithmetic instructions (addition, subtraction, multiplication) are primarily constrained using R1CS constraints, with the lookup only serving to truncate potential overflow bits.
 
-For these instructions, we can emulate the 64-bit arithmetic using native field arithmetic, since Jolt's elliptic curve scalar field is big enough to perform these operations without overflow.
+For these instructions, we can emulate the 64-bit arithmetic using native field arithmetic, since Jolt's proof field is big enough to perform these operations without overflow. The field is the BN254 scalar field with [Dory](../dory.md), or a 128-bit prime field with [Akita](../akita.md).
 E.g. to add two 64-bit numbers `x` and `y`, we can add their $\mathbb{F}_r$ equivalents $x$ and $y$, knowing that $x + y \in \mathbb{F}_r$ will be equivalent to the desired 65-bit sum.
 We then employ a range-check lookup to truncate the potential overflow bit, thus matching the behavior of the RISC-V spec.
 

--- a/book/src/how/blindfold.md
+++ b/book/src/how/blindfold.md
@@ -1,5 +1,7 @@
 # Zero Knowledge: BlindFold
 
+BlindFold is available with Jolt's [Dory](./dory.md) backend by enabling the `zk` Cargo feature. The [Akita](./akita.md) backend currently supports only proofs without zero knowledge; combining `akita` and `zk` is rejected at compile time. This chapter describes the Dory ZK protocol.
+
 Jolt achieves zero-knowledge natively via the **[BlindFold](https://eprint.iacr.org/2025/2094)** protocol — a folding-based scheme that makes all sumcheck proofs ZK without SNARK composition. Unlike approaches that require per-round sigma protocols or expensive homomorphic operations on commitments, BlindFold defers all verification to a single small R1CS instance proved via Nova folding + Spartan, keeping most of the work in the field arithmetic layer.
 
 The core idea: instead of the prover sending sumcheck round polynomial coefficients in the clear, it sends **Pedersen commitments** to them. The sumcheck verifier's algebraic consistency checks are encoded into a small **verifier R1CS** circuit, and a single Nova fold + Spartan proof over this R1CS proves all rounds were executed correctly without revealing the witness.

--- a/book/src/how/dory.md
+++ b/book/src/how/dory.md
@@ -1,6 +1,8 @@
 # Dory
 
-Dory is the [polynomial commitment scheme](./appendix/pcs.md) used in Jolt. It is based on the scheme described in [Lee21](https://eprint.iacr.org/2020/1274) and implemented in the [`a16z/dory`](https://github.com/a16z/dory/) repository.
+Dory is Jolt's default elliptic curve [polynomial commitment backend](./appendix/pcs.md), using pairings over BN254 and its scalar field. It is based on the scheme described in [Lee21](https://eprint.iacr.org/2020/1274) and implemented in the [`a16z/dory`](https://github.com/a16z/dory/) repository. Jolt also supports the lattice-based [Akita](./akita.md) backend.
+
+Dory supports both ordinary proofs and zero-knowledge proofs via [BlindFold](./blindfold.md), selected with the `zk` Cargo feature. The matrix layout, group operations, and homomorphic batching described in this chapter apply to Dory.
 
 ## Background: AFGHO commitments
 
@@ -88,7 +90,9 @@ In Jolt, witness polynomials can be committed in a **streaming** fashion: rather
 
 ## Implementation
 
-The Jolt implementation of Dory lives in `crates/jolt-prover-legacy/src/poly/commitment/dory/` and wraps the [`a16z/dory`](https://github.com/a16z/dory/) library. Key files:
+The modular implementation lives in `crates/jolt-dory/` and wraps the [`a16z/dory`](https://github.com/a16z/dory/) library. `DoryScheme` implements the commitment, streaming, additive-homomorphism, and ZK opening traits from `crates/jolt-openings/`. The prover orchestrates witness commitments and the final batched opening in `crates/jolt-prover/src/dory/`.
+
+The legacy integration remains in `crates/jolt-prover-legacy/src/poly/commitment/dory/`. Key files:
 
 - `commitment_scheme.rs` &mdash; Implements the `CommitmentScheme` and `StreamingCommitmentScheme` traits.
 - `dory_globals.rs` &mdash; Manages per-context Dory matrix dimensions ($\nu$, $\sigma$) and coefficient layout.

--- a/book/src/how/how-it-works.md
+++ b/book/src/how/how-it-works.md
@@ -22,6 +22,7 @@ This section is comprised of the following subsections:
     - [Batched opening proof](./architecture/opening-proof.md)
 - [Twist and Shout](./twist-shout.md)
 - [Dory](./dory.md)
+- [Akita](./akita.md)
 - [BlindFold (Zero Knowledge)](./blindfold.md)
 - [Optimizations](./optimizations/optimizations.md)
     - [Batched sumcheck](./optimizations/batched-sumcheck.md)

--- a/book/src/how/optimizations/batched-openings.md
+++ b/book/src/how/optimizations/batched-openings.md
@@ -1,6 +1,6 @@
 # Batched openings
 
-Jolt uses techniques to batch multiple polynomial openings into a single opening claim to amortize the cost of [Dory](../dory.md) opening proof.
+Jolt batches polynomial evaluation claims to amortize the cost of its final opening proof. The elliptic-curve-based [Dory](../dory.md) backend uses homomorphic batching; the lattice-based [Akita](../akita.md) backend uses prefix packing followed by a native grouped opening proof.
 There are different notions of "batched openings", each necessitating its own subprotocol.
 
 ## Multiple polynomials, same point
@@ -9,6 +9,8 @@ $$f(x), g(x), \dots$$
 
 If the polynomials are committed using an additively homomorphic commitment scheme (e.g. Dory), then this case can be reduced to a single opening claim.
 See Section 16.1 of [Proof, Arguments, and Zero-Knowledge](https://people.cs.georgetown.edu/jthaler/ProofsArgsAndZK.pdf) for details of this subprotocol.
+
+This is the final batching step for Dory. Akita uses the [prefix-packing reduction](#prefix-packing-and-native-grouped-openings-akita) below for its committed trace.
 
 ## Multiple polynomials, multiple points
 
@@ -43,3 +45,15 @@ $$f(x), f(y), \dots$$
 
 Though this can be considered a special case of the above, there is also a subprotocol specific for this type of batched opening: see Section 4.5.2 of [Proof, Arguments, and Zero-Knowledge](https://people.cs.georgetown.edu/jthaler/ProofsArgsAndZK.pdf).
 We do not use this subprotocol in Jolt.
+
+## Prefix packing and native grouped openings (Akita)
+
+Akita's trace commitment contains one physical polynomial, `OneHotTrace`, whose prefix selects among logical one-hot columns. All column claims use a common suffix point $x$ in `(cycle || address)` order. For columns $P_i$ at their assigned slots $i$, Jolt reduces their evaluations to a physical opening claim at $(s, x)$ with value
+
+$$
+v = \sum_i \widetilde{\textsf{eq}}(s, i) \cdot P_i(x).
+$$
+
+The slot-selector challenge $s$ is sampled after the layout, common point, and logical evaluations have been absorbed into the transcript. `PrefixPackedLayout::reduce_claims` in `crates/jolt-openings/src/prefix.rs` implements this reduction. Unused slots are omitted from the logical claim; the physical opening requires their aggregate contribution at the sampled selector to vanish.
+
+Advice and committed-program objects have separate dense commitments. Their reduced claims join `OneHotTrace` in Akita's native grouped opening proof, with each object retaining its own shape and opening point. This supports a single backend proof for the whole batch without combining those commitments homomorphically. See the [Stage 8 description](../architecture/opening-proof.md#akita-grouped-opening) for the group order and implementation.

--- a/book/src/intro.md
+++ b/book/src/intro.md
@@ -4,6 +4,8 @@
 
 Jolt is **fast** (state-of-the-art performance on CPU) and relatively **simple** (thanks to its lookup-centric architecture).
 
+Jolt supports two polynomial commitment backends: **[Dory](./how/dory.md)**, the default elliptic curve backend, and **[Akita](./how/akita.md)**, a lattice backend. Both support the sumcheck and lookup architecture; they use different fields, commitment layouts, and opening protocols. See [backend selection](./usage/quickstart.md#choosing-a-commitment-backend) for usage and current zero-knowledge support.
+
 **AI coding agents**: Install the Jolt [agent skill](https://vercel.com/docs/agent-resources/skills) to let Claude Code, Cursor, Codex, etc. wrap Rust functions in Jolt proofs: `npx skills add a16z/jolt`
 
 This book has the following top-level sections:
@@ -44,4 +46,4 @@ Updates:
 Jolt was initially forked from Srinath Setty's work on [`microsoft/Spartan`](https://github.com/microsoft/spartan), specifically the [`arkworks-rs/Spartan`](https://github.com/arkworks-rs/spartan) fork in order to use the excellent `arkworks-rs` field and curve implementations.
 Jolt uses its own [fork](https://github.com/a16z/arkworks-algebra) of `arkworks-algebra` with certain optimizations, including some described [here](./how/optimizations/small-value.md).
 Jolt's R1CS is also proven using a version of Spartan (forked from the [microsoft/Spartan2](https://github.com/microsoft/Spartan2) codebase) optimized for Jolt's uniform R1CS constraints.
-Jolt uses [Dory](https://github.com/a16z/dory/) as its PCS, inspired by the Space and Time Labs implementation [`spaceandtimefdn/sxt-dory`](https://github.com/spaceandtimefdn/sxt-dory).
+Jolt's elliptic curve backend uses [Dory](https://github.com/a16z/dory/), inspired by the Space and Time Labs implementation [`spaceandtimefdn/sxt-dory`](https://github.com/spaceandtimefdn/sxt-dory). Its lattice backend uses [Akita](https://github.com/LayerZero-Labs/akita).

--- a/book/src/usage/guests_hosts/hosts.md
+++ b/book/src/usage/guests_hosts/hosts.md
@@ -2,6 +2,8 @@
 
 Hosts are where we can invoke the Jolt prover to prove functions defined within the guest.
 
+The generated SDK host APIs described here currently use the [Dory](../../how/dory.md) backend. For the lattice [Akita](../../how/akita.md) backend, see the [modular prover profiling commands](../profiling/zkvm_profiling.md).
+
 The host imports the guest package, and will have automatically generated functions to build each of the Jolt functions. For the SHA3 example we looked at in the [guest](./guests.md) section, the `jolt::provable` procedural macro generates several functions that can be invoked from the host (shown below):
 
 - `compile_sha3(target_dir)` compiles the SHA3 guest to RISC-V.

--- a/book/src/usage/profiling/zkvm_profiling.md
+++ b/book/src/usage/profiling/zkvm_profiling.md
@@ -11,6 +11,22 @@ cargo run --release -p jolt-prover --features profiling -- \
     profile --name sha2-chain --format chrome
 ```
 
+Run these commands from a Jolt checkout. The command above uses the default
+elliptic-curve backend, [Dory](../../how/dory.md). Add the `akita` Cargo
+feature to use the lattice backend, [Akita](../../how/akita.md):
+
+```bash
+cargo run --release -p jolt-prover --features profiling,akita -- \
+    profile --name fibonacci --backend optimized --format chrome
+```
+
+The `akita` feature selects the protocol for both proving and verification
+at compile time. Jolt's Akita integration currently supports
+non-zero-knowledge proofs only; `akita` and `zk` cannot be enabled together.
+The Akita harness loads its schedule catalogs from
+`crates/jolt-akita/schedules/` by default. Set `JOLT_AKITA_SCHEDULE_DIR` to
+use another directory containing those `.aks` files.
+
 Workloads and default scales (`--scale <log2 trace length>` overrides):
 
 | `--name` | default scale |
@@ -20,7 +36,8 @@ Workloads and default scales (`--scale <log2 trace length>` overrides):
 | `sha3-chain` | 2^22 |
 | `btreemap` | 2^20 |
 
-`--backend` selects the prover backend (both subcommands): `reference`
+`--backend` selects the kernel implementation for either Dory or Akita
+(both subcommands): `reference`
 (default) is the naive test oracle — absolute numbers are provisional,
 attribution is meaningful relatively — while `optimized` is the performance
 tier (legacy-parity prover performance), slotting into the same
@@ -28,9 +45,10 @@ instrumented seams.
 
 Artifacts are grouped by run: each invocation writes into
 `benchmark-runs/{timestamp}_{trace_name}/` (with `{trace_name}` =
-`modular_{workload}_{scale}`, hyphens in the workload mapped to
-underscores; optimized runs append `_optimized`, keeping their artifact set
-next to the reference one), and `benchmark-runs/latest_{trace_name}` is symlinked to the
+`modular_{workload}_{scale}` for Dory or
+`modular_{workload}_akita_{scale}` for Akita, with hyphens in the workload
+mapped to underscores; optimized runs append `_optimized`), and
+`benchmark-runs/latest_{trace_name}` is symlinked to the
 newest successful run — the stable path every example below reads. All
 paths are under the current working directory. The directory name carries
 the run identity, so the files inside use fixed names:
@@ -38,6 +56,11 @@ the run identity, so the files inside use fixed names:
 - `trace.json` — chrome trace. Open in
   [Perfetto](https://ui.perfetto.dev/) or query with `trace_processor` SQL.
 - `summary.json` — schema-versioned aggregates (see below).
+
+For example, the Akita command above writes its summary to
+`benchmark-runs/latest_modular_fibonacci_akita_16_optimized/summary.json`.
+The query examples below use Dory's reference paths; substitute the
+corresponding Akita or optimized path for those runs.
 
 The run also compiles and traces the guest, derives the PCS setup, proves it,
 and verifies the proof. PCS setup and `prove()` are timed separately. The
@@ -58,8 +81,17 @@ cargo run --release -p jolt-prover --features profiling -- \
 # --benchmarks fibonacci,sha2-chain limits the workload set
 ```
 
+Use the same Cargo feature to sweep Akita workloads:
+
+```bash
+cargo run --release -p jolt-prover --features profiling,akita -- \
+    benchmark --min-scale 18 --max-scale 21 --backend optimized --resume
+```
+
 Results accumulate in `benchmark-runs/modular_timings.csv` (per-run CSVs live
-in the run directories). In addition to prover throughput and proof size, the
+in the run directories). Akita rows append `_akita` to the workload name,
+and `--resume` checks the selected protocol and kernel implementation's
+artifact path. In addition to prover throughput and proof size, the
 CSV records `setup_time_s`, `verifier_parallel_time_s`,
 `verifier_single_thread_time_s`, and the explicit parallel worker count.
 Existing CSVs using the previous header are migrated in place with empty
@@ -176,7 +208,7 @@ self-contained page:
 ```bash
 cargo run --release -p jolt-prover --features profiling,allocative -- \
     profile --name fibonacci --format chrome
-open benchmark-runs/latest_modular_fibonacci_13/memory.html
+open benchmark-runs/latest_modular_fibonacci_16/memory.html
 ```
 
 **`memory.html`** is the human view — one time axis carrying
@@ -196,7 +228,7 @@ so heap attribution is one `jq` away:
 ```bash
 jq '.heap | map_values({gib: (.total_bytes / 1073741824),
                         top: (.roots | to_entries | max_by(.value) | .key)})' \
-    benchmark-runs/latest_modular_fibonacci_13/summary.json
+    benchmark-runs/latest_modular_fibonacci_16/summary.json
 ```
 
 One snapshot per driver batch, taken right after every member kernel's

--- a/book/src/usage/quickstart.md
+++ b/book/src/usage/quickstart.md
@@ -1,5 +1,17 @@
 # Quickstart
 
+## Choosing a commitment backend
+
+Jolt has two polynomial commitment backends: elliptic-curve-based
+[Dory](../how/dory.md) and lattice-based [Akita](../how/akita.md).
+This quickstart uses Dory, the default backend. The generated SDK project
+currently supports Dory; to run Akita from a Jolt checkout, see the
+[profiling commands](./profiling/zkvm_profiling.md).
+
+Dory supports optional zero-knowledge proofs through the `zk` feature and
+BlindFold. Jolt's Akita integration currently supports non-zero-knowledge
+proofs only; the `akita` and `zk` features are mutually exclusive.
+
 ## AI Coding Skill
 
 Install the Jolt [agent skill](https://vercel.com/docs/agent-resources/skills) to let AI coding agents (Claude Code, Cursor, Codex, etc.) wrap Rust functions in Jolt proofs for you:


### PR DESCRIPTION
The book described Dory as Jolt's only polynomial commitment backend. Document both the default elliptic curve Dory backend and the lattice Akita backend, with an Akita chapter and a comparison of their fields, trace commitments, and opening protocols.

Update the introduction, navigation, architecture, and batching explanations; scope BlindFold and the generated SDK APIs to Dory; and add Akita profiling commands and artifact paths. Explain compile-time backend selection and the current incompatibility between `akita` and `zk`.

Validation:
- Built the book with the CI versions: mdBook 0.4.10 and mdbook-katex 0.9.4.
- Checked all 40 added local links and anchors, Akita navigation, and rendered equations.
- `git diff --check origin/main...HEAD` passed.
- Checked backend and command descriptions against the implementation. Rust tests and profiling workloads were not run for this documentation-only change.
