### PR TITLE
feat(inlines): expose Blake2b::compress for single-block callers

### DIFF
--- a/jolt-inlines/blake2/src/sdk.rs
+++ b/jolt-inlines/blake2/src/sdk.rs
@@ -168,6 +168,21 @@ impl Blake2b {
         Self::digest_from_state(initial_state_with_params(salt, persona), input)
     }
 
+    /// One BLAKE2b compression on the inline: mixes the 16-word message block
+    /// `m` into the state `h` in place, with byte counter `t` and final-block
+    /// flag `last`. 12 rounds, 64-bit counter: the EIP-152 `BLAKE2F` primitive
+    /// for `rounds == 12` with a zero high counter word.
+    #[inline(always)]
+    pub fn compress(h: &mut [u64; STATE_VECTOR_LEN], m: &[u64; MSG_BLOCK_LEN], t: u64, last: bool) {
+        let mut block = [0u64; MSG_BLOCK_LEN + 2];
+        block[..MSG_BLOCK_LEN].copy_from_slice(m);
+        block[MSG_BLOCK_LEN] = t;
+        block[MSG_BLOCK_LEN + 1] = last as u64;
+        // SAFETY: `h` is 8 and `block` 18 aligned u64s, exactly what the
+        // inline reads and writes.
+        unsafe { blake2b_compress(h.as_mut_ptr(), block.as_ptr()) }
+    }
+
     #[inline(always)]
     fn digest_from_state(mut h: [u64; STATE_VECTOR_LEN], input: &[u8]) -> [u8; OUTPUT_SIZE] {
         let len = input.len();
@@ -526,6 +541,49 @@ mod digest_tests {
                 "Blake2b test failed for case: {test_name} (input length: {} bytes)",
                 input.len()
             );
+        }
+    }
+
+    /// EIP-152 vectors 5 (final) and 6 (not final): 12 rounds, h = BLAKE2b-512
+    /// IV with the parameter block, m = "abc" zero-padded, t = 3.
+    #[test]
+    fn test_blake2b_compress_eip152_vectors() {
+        let mut h = IV;
+        h[0] ^= 0x0101_0000 ^ 64;
+        let mut m = [0u64; MSG_BLOCK_LEN];
+        m[0] = 0x0063_6261;
+        let expected: [(bool, [u64; STATE_VECTOR_LEN]); 2] = [
+            (
+                true,
+                [
+                    0x0d4d_1c98_3fa5_80ba,
+                    0xe9f6_129f_b697_276a,
+                    0xb7c4_5a68_142f_214c,
+                    0xd1a2_ffdb_6fbb_124b,
+                    0x2d79_ab2a_39c5_877d,
+                    0x95cc_3345_ded5_52c2,
+                    0x5a92_f1db_a88a_d318,
+                    0x2399_00d4_ed86_23b9,
+                ],
+            ),
+            (
+                false,
+                [
+                    0x2c56_0a19_d369_ab75,
+                    0x7527_1c8f_d8f8_ae51,
+                    0x2cc4_7072_4044_6987,
+                    0x5287_d226_2c25_4498,
+                    0xf2a2_5e6d_7f3e_7498,
+                    0x1bd3_9c03_26d2_e8d3,
+                    0x66d6_d3f2_c46a_424e,
+                    0x3547_de6f_11c2_10a6,
+                ],
+            ),
+        ];
+        for (last, want) in expected {
+            let mut got = h;
+            Blake2b::compress(&mut got, &m, 3, last);
+            assert_eq!(got, want, "last = {last}");
         }
     }
 


### PR DESCRIPTION
## Why

`jolt-inlines-blake2` exposes only the hashing API (`Blake2b::new/update/finalize/digest`). The EIP-152 `BLAKE2F` precompile is the raw compression function with caller-supplied state, message words, counter and final flag, which that API cannot express. The single-compression entry point `blake2b_compress` is `pub(crate)`, so a guest that wants BLAKE2F on the inline today has to re-emit the `.insn` by hand and duplicate the 18-word `rs2` layout (jeth does this in `crates/core/src/crypto.rs`).

## What

- `Blake2b::compress(h: &mut [u64; 8], m: &[u64; 16], t: u64, last: bool)`: a safe, typed wrapper over the existing `blake2b_compress`. Packs `[m, t, last]` into the 18-word block the inline reads at `rs2` and updates `h` in place at `rs1`. Same three cfg arms as the raw function (guest `.insn`, `host` model, panic elsewhere) come for free.
- Test `test_blake2b_compress_eip152_vectors`: EIP-152 vectors 5 (final) and 6 (not final) through the new function under `--features host`.

No change to the inline sequence, opcode table, or hashing API.

## Checks

```
cargo fmt -p jolt-inlines-blake2 -- --check
cargo clippy -p jolt-inlines-blake2 --features host -q --all-targets -- -D warnings
cargo clippy -p jolt-inlines-blake2 -q -- -D warnings
cargo nextest run -p jolt-inlines-blake2 --features host --cargo-quiet   # 21 passed
```
